### PR TITLE
feat(config): add MVP shell tool entries

### DIFF
--- a/configs/git/gitconfig
+++ b/configs/git/gitconfig
@@ -1,0 +1,11 @@
+# Repository-managed Git configuration.
+# Machine-specific identity belongs in ~/.gitconfig.local.
+
+[init]
+	defaultBranch = main
+
+[pull]
+	rebase = false
+
+[include]
+	path = ~/.gitconfig.local

--- a/configs/starship/starship.toml
+++ b/configs/starship/starship.toml
@@ -1,0 +1,7 @@
+# Repository-managed Starship prompt configuration.
+
+add_newline = false
+
+[character]
+success_symbol = "[❯](bold green)"
+error_symbol = "[❯](bold red)"

--- a/configs/tmux/tmux.conf
+++ b/configs/tmux/tmux.conf
@@ -1,0 +1,9 @@
+# Repository-managed tmux configuration.
+
+set -g mouse on
+set -g history-limit 10000
+set -g base-index 1
+setw -g pane-base-index 1
+
+# Local Extension Point: ~/.tmux.conf.local is private and machine-specific.
+if-shell "test -f ~/.tmux.conf.local" "source-file ~/.tmux.conf.local"

--- a/configs/zsh/zshrc
+++ b/configs/zsh/zshrc
@@ -5,3 +5,8 @@
 if command -v starship >/dev/null 2>&1; then
   eval "$(starship init zsh)"
 fi
+
+# Local Extension Point: ~/.zshrc.local is private and machine-specific.
+if [ -r "${HOME}/.zshrc.local" ]; then
+  . "${HOME}/.zshrc.local"
+fi

--- a/dots.yaml
+++ b/dots.yaml
@@ -18,8 +18,45 @@ entries:
         apt: zsh
         dnf: zsh
         pacman: zsh
+  - source: configs/git/gitconfig
+    target: ~/.gitconfig
+    strategy: symlink
+    tags:
+      - core
+    os:
+      - darwin
+      - linux
+    dependencies:
+      - name: git
+        brew: git
+        apt: git
+        dnf: git
+        pacman: git
+  - source: configs/starship/starship.toml
+    target: ~/.config/starship.toml
+    strategy: symlink
+    tags:
+      - core
+    os:
+      - darwin
+      - linux
+    dependencies:
       - name: starship
         brew: starship
         apt: starship
         dnf: starship
         pacman: starship
+  - source: configs/tmux/tmux.conf
+    target: ~/.tmux.conf
+    strategy: symlink
+    tags:
+      - core
+    os:
+      - darwin
+      - linux
+    dependencies:
+      - name: tmux
+        brew: tmux
+        apt: tmux
+        dnf: tmux
+        pacman: tmux

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/plan"
 )
 
 func TestLoadFileAcceptsMinimalValidManifest(t *testing.T) {
@@ -336,6 +337,169 @@ entries:
 				t.Fatalf("LoadFile() error = %q, want %q", err.Error(), tt.want)
 			}
 		})
+	}
+}
+
+func TestRepositoryManifestIncludesMVPConfigurationSet(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", ".."))
+	manifestPath := filepath.Join(root, "dots.yaml")
+
+	got, err := manifest.LoadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("LoadFile(%q) error = %v", manifestPath, err)
+	}
+
+	entriesByTarget := map[string]manifest.Entry{}
+	for _, entry := range got.Entries {
+		entriesByTarget[entry.Target] = entry
+		if strings.Contains(entry.Source, "nvim") || strings.Contains(entry.Target, "nvim") {
+			t.Fatalf("repository manifest includes deferred Neovim configuration: %#v", entry)
+		}
+		for _, dep := range entry.Dependencies {
+			if dep.Name == "nvim" || dep.Name == "neovim" {
+				t.Fatalf("repository manifest includes deferred Neovim dependency: %#v", dep)
+			}
+		}
+	}
+
+	tests := []struct {
+		name     string
+		target   string
+		source   string
+		strategy string
+		dep      string
+	}{
+		{name: "zsh", target: "~/.zshrc", source: "configs/zsh/zshrc", strategy: "symlink", dep: "zsh"},
+		{name: "git", target: "~/.gitconfig", source: "configs/git/gitconfig", strategy: "symlink", dep: "git"},
+		{name: "starship", target: "~/.config/starship.toml", source: "configs/starship/starship.toml", strategy: "symlink", dep: "starship"},
+		{name: "tmux", target: "~/.tmux.conf", source: "configs/tmux/tmux.conf", strategy: "symlink", dep: "tmux"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entry, ok := entriesByTarget[tt.target]
+			if !ok {
+				t.Fatalf("repository manifest missing MVP entry for target %q", tt.target)
+			}
+			if entry.Source != tt.source {
+				t.Errorf("Source = %q, want %q", entry.Source, tt.source)
+			}
+			if entry.Strategy != tt.strategy {
+				t.Errorf("Strategy = %q, want %q", entry.Strategy, tt.strategy)
+			}
+			if !hasString(entry.Tags, "core") {
+				t.Errorf("Tags = %#v, want core tag", entry.Tags)
+			}
+			if !sameStrings(entry.OS, []string{"darwin", "linux"}) {
+				t.Errorf("OS = %#v, want [darwin linux]", entry.OS)
+			}
+			if !hasDependency(entry.Dependencies, tt.dep) {
+				t.Errorf("Dependencies = %#v, want %q", entry.Dependencies, tt.dep)
+			}
+		})
+	}
+}
+
+func hasString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func sameStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func hasDependency(deps []manifest.Dependency, want string) bool {
+	for _, dep := range deps {
+		if dep.Name == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRepositoryManagedConfigsExposeLocalExtensionPoints(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", ".."))
+
+	tests := []struct {
+		name     string
+		path     string
+		contains []string
+	}{
+		{
+			name: "zsh has private local include",
+			path: "configs/zsh/zshrc",
+			contains: []string{
+				"Local Extension Point",
+				"${HOME}/.zshrc.local",
+			},
+		},
+		{
+			name: "git has private local include",
+			path: "configs/git/gitconfig",
+			contains: []string{
+				"Machine-specific identity belongs in ~/.gitconfig.local",
+				"path = ~/.gitconfig.local",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content, err := os.ReadFile(filepath.Join(root, tt.path))
+			if err != nil {
+				t.Fatalf("ReadFile(%q) error = %v", tt.path, err)
+			}
+			for _, want := range tt.contains {
+				if !strings.Contains(string(content), want) {
+					t.Fatalf("%s does not contain %q", tt.path, want)
+				}
+			}
+		})
+	}
+}
+
+func TestRepositoryManifestPlansMVPConfigurationSetSafely(t *testing.T) {
+	root, err := filepath.Abs(filepath.Clean(filepath.Join("..", "..")))
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+	manifestPath := filepath.Join(root, "dots.yaml")
+
+	got, err := manifest.LoadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("LoadFile(%q) error = %v", manifestPath, err)
+	}
+
+	p, err := plan.Build(*got, plan.Options{
+		Profile:    "default",
+		OS:         "darwin",
+		SourceRoot: root,
+		Home:       t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	if len(p.Actions) != 4 {
+		t.Fatalf("len(Actions) = %d, want 4", len(p.Actions))
+	}
+	for _, action := range p.Actions {
+		if action.Status != plan.StatusCreate {
+			t.Fatalf("Action for %s has Status = %q, want %q", action.Target, action.Status, plan.StatusCreate)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #8

## PR Type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Adds the MVP Configuration Set entries for zsh, git, starship, and tmux to `dots.yaml`.
- Adds repository-owned config sources with Local Extension Points for shell/git private configuration.
- Adds repository-level regression tests proving the MVP manifest can be planned safely without pulling in Neovim.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Declares zsh, git, starship, and tmux managed entries with core profile tags, OS filters, symlink strategy, and dependencies. |
| `configs/zsh/zshrc` | Adds `~/.zshrc.local` as a private Local Extension Point. |
| `configs/git/gitconfig` | Adds shared Git defaults and `~/.gitconfig.local` include for machine-specific identity. |
| `configs/starship/starship.toml` | Adds minimal shared Starship prompt configuration. |
| `configs/tmux/tmux.conf` | Adds minimal shared tmux configuration and `~/.tmux.conf.local` extension point. |
| `internal/manifest/manifest_test.go` | Adds repository-level tests for MVP entries, source existence, Local Extension Points, Neovim deferral, and safe planning. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp>`
- [x] Independent fresh-context validation in sub-agent; no writes to real home configuration.

## Safety Notes

- Did not run `dots install` against the real home.
- Validation used temporary directories for planning to avoid touching active shell/tmux/git/starship configuration.

## Contributor Checklist

- [x] Linked an approved issue / ready-for-agent issue.
- [x] Added exactly one `type:*` label.
- [x] Ran relevant validation commands.
- [x] Docs updated if behavior changed: not required; the repository manifest and tests define this slice.
- [x] Conventional commit format.
- [x] No `Co-Authored-By` trailers.
