### PR TITLE
docs(agents): add safety rule and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,47 @@
+Closes #<issue-number>
+
+## PR Type
+
+Check exactly one and add the matching `type:*` label to the PR.
+
+- [ ] Bug fix (`type:bug`)
+- [ ] New feature (`type:feature`)
+- [ ] Documentation only (`type:docs`)
+- [ ] Code refactoring (`type:refactor`)
+- [ ] Maintenance/tooling (`type:chore`)
+- [ ] Breaking change (`type:breaking-change`)
+
+## Summary
+
+-
+-
+-
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `path/to/file` | What changed and why. |
+
+## Test Plan
+
+- [ ] `go test ./...`
+- [ ] `go vet ./...`
+- [ ] `gofmt -l .`
+- [ ] `go run ./cmd/dots manifest validate --file dots.yaml`
+- [ ] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp>`
+
+## Dotfiles Safety
+
+- [ ] I did not run `dots install` against the real home directory.
+- [ ] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
+- [ ] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.
+
+## Contributor Checklist
+
+- [ ] Linked an approved / `ready-for-agent` issue with `Closes #<issue-number>`.
+- [ ] Added exactly one `type:*` label.
+- [ ] Kept the PR scoped to one reviewable work unit.
+- [ ] Updated docs or agent instructions when workflow behavior changed.
+- [ ] Used conventional commit format.
+- [ ] Did not add `Co-Authored-By` or AI attribution trailers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,20 @@
 
 ### Issue tracker
 
-Issues and PRDs are tracked in GitHub Issues for `yersonargotev/dotfiles`. See `docs/agents/issue-tracker.md`.
+Issues and PRDs are tracked in GitHub Issues for `yersonargotev/dots`. See `docs/agents/issue-tracker.md`.
 
 ### Triage labels
 
 This repo uses the default triage labels: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, and `wontfix`. See `docs/agents/triage-labels.md`.
+
+
+### Dotfiles validation safety
+
+Never validate dotfiles behavior against the user's real home configuration. Do not run `dots install` against the real `$HOME`, and do not write to live files such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`. Use temporary directories plus explicit flags like `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.
+
+### Pull requests
+
+Use `.github/PULL_REQUEST_TEMPLATE.md` for PR descriptions. Include `Closes #<issue-number>`, exactly one `type:*` label, validation evidence, and the dotfiles safety checklist when config paths are involved.
 
 ### Domain docs
 


### PR DESCRIPTION
Closes #14

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [x] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds dotfiles validation safety guidance to `AGENTS.md`.
- Adds a repository PR template with linked issue, type label, validation, and safety checklist requirements.
- Keeps the change documentation-only with no runtime dotfiles behavior changes.

## Changes

| File | Change |
|------|--------|
| `AGENTS.md` | Documents that dotfiles validation must use temporary homes and explicit safety flags, never the real home configuration. |
| `.github/PULL_REQUEST_TEMPLATE.md` | Adds PR requirements for issue linkage, type labels, validation evidence, dotfiles safety, scoped work, conventional commits, and no AI attribution. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: not applicable; documentation-only change with no runtime dotfiles behavior change.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
