### PR TITLE
feat(release): publish platform artifacts with checksums

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing v0.x tag to publish. Defaults to the selected ref name.
+        required: false
+        type: string
+  push:
+    tags:
+      - 'v0.*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and publish release artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Resolve release tag
+        id: release
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          tag="${INPUT_TAG:-${GITHUB_REF_NAME}}"
+          if [[ ! "$tag" =~ ^v0\.[0-9]+(\.[0-9]+)?(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Release tag must be a v0.x tag such as v0.1.0; got '$tag'" >&2
+            exit 1
+          fi
+          git fetch --tags --force
+          if ! git rev-parse --verify --quiet "${tag}^{commit}" >/dev/null; then
+            echo "Tag '$tag' does not exist in this repository" >&2
+            exit 1
+          fi
+          git checkout --detach "$tag"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Build release artifacts and checksums.txt
+        run: scripts/build-release-artifacts.sh --version "${{ steps.release.outputs.tag }}" --out-dir dist
+
+      - name: Create GitHub Release if needed
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Release $RELEASE_TAG already exists"
+          else
+            gh release create "$RELEASE_TAG" \
+              --title "$RELEASE_TAG" \
+              --notes "First usable v0.x release target for dots. Assets include macOS/Linux amd64/arm64 binaries plus checksums.txt for Bootstrapper verification."
+          fi
+
+      - name: Upload release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+        run: gh release upload "$RELEASE_TAG" dist/* --clobber

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,68 @@
+# Publish a v0.x Release
+
+This workflow publishes Bootstrapper-ready `dots` Release Artifacts for macOS and Linux. Each release includes one raw binary per Supported Platform plus `checksums.txt` for Checksum Verification.
+
+## Quick path
+
+1. Confirm the release candidate passes validation:
+   ```bash
+   go test ./...
+   ```
+2. Create and push a v0.x tag:
+   ```bash
+   git tag v0.1.0
+   git push origin v0.1.0
+   ```
+3. Open the GitHub release created by the `Release` workflow and verify these assets exist:
+   - `dots_v0.1.0_darwin_amd64`
+   - `dots_v0.1.0_darwin_arm64`
+   - `dots_v0.1.0_linux_amd64`
+   - `dots_v0.1.0_linux_arm64`
+   - `checksums.txt`
+
+## Manual dispatch
+
+Use manual dispatch when the tag already exists but the release needs to be rebuilt or re-uploaded.
+
+1. Go to **Actions → Release → Run workflow**.
+2. Enter the existing tag, for example `v0.1.0`.
+3. Run the workflow. It checks out that tag, rebuilds the four artifacts, recreates `checksums.txt`, and uploads assets with `--clobber`.
+
+## Checksum Verification contract
+
+`checksums.txt` uses the standard SHA-256 manifest format:
+
+```text
+<sha256>  dots_<version>_<goos>_<goarch>
+```
+
+A Bootstrapper can verify the downloaded artifact by selecting the line for its platform and comparing the SHA-256 of the downloaded binary before installing or executing it.
+
+Local maintainer check:
+
+```bash
+scripts/build-release-artifacts.sh --version v0.1.0 --out-dir dist
+cd dist
+shasum -a 256 -c checksums.txt
+```
+
+On Linux, `sha256sum -c checksums.txt` is equivalent.
+
+## Release details
+
+| Topic | Decision |
+|-------|----------|
+| Trigger | Push tags matching `v0.*`, or run the workflow manually with an existing v0.x tag. |
+| Artifacts | Raw `dots` binaries named `dots_<version>_<goos>_<goarch>`. |
+| Platforms | `darwin/amd64`, `darwin/arm64`, `linux/amd64`, and `linux/arm64`. |
+| Checksums | One `checksums.txt` file covers every Release Artifact. |
+| Homebrew Distribution | Deferred. Do not add tap, formula, or bottle steps in this slice. |
+
+## First v0.x checklist
+
+- [ ] The tag is a v0.x tag, such as `v0.1.0`.
+- [ ] The workflow completed from the tag commit.
+- [ ] All four platform artifacts are attached to the GitHub Release.
+- [ ] `checksums.txt` contains one SHA-256 entry for each artifact.
+- [ ] The Bootstrapper can later map its detected `goos/goarch` to the matching artifact name.
+- [ ] No Homebrew Distribution step was added.

--- a/internal/release/release_automation_test.go
+++ b/internal/release/release_automation_test.go
@@ -1,0 +1,301 @@
+package release_test
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+var supportedReleasePlatforms = []string{
+	"darwin/amd64",
+	"darwin/arm64",
+	"linux/amd64",
+	"linux/arm64",
+}
+
+func TestReleaseWorkflowPublishesBootstrapperConsumableArtifacts(t *testing.T) {
+	root := repoRoot(t)
+	workflow := readWorkflow(t, filepath.Join(root, ".github", "workflows", "release.yml"))
+
+	triggers := mapAt(t, workflow, "on")
+	push := mapAt(t, triggers, "push")
+	tags := stringSliceAt(t, push, "tags")
+	if !contains(tags, "v0.*") {
+		t.Fatalf("release workflow should run for v0.x tags; got tags %v", tags)
+	}
+	if _, ok := triggers["workflow_dispatch"]; !ok {
+		t.Fatalf("release workflow should support manual dispatch for the first v0.x release")
+	}
+
+	workflowText, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "release.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(workflowText)
+	for _, want := range []string{
+		"actions/checkout@v5",
+		"actions/setup-go@v6",
+		"scripts/build-release-artifacts.sh",
+		"gh release upload",
+		"checksums.txt",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("release workflow should contain %q so GitHub Releases get versioned assets plus checksums", want)
+		}
+	}
+	if strings.Contains(strings.ToLower(text), "homebrew") {
+		t.Fatalf("release workflow should not configure Homebrew distribution in this slice")
+	}
+}
+
+func TestBuildReleaseArtifactsCreatesChecksummedSupportedPlatforms(t *testing.T) {
+	if testing.Short() {
+		t.Skip("cross-compiles release artifacts")
+	}
+
+	root := repoRoot(t)
+	outDir := t.TempDir()
+	cmd := exec.Command("bash", filepath.Join(root, "scripts", "build-release-artifacts.sh"), "--version", "v0.99.0", "--out-dir", outDir)
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(), "HOME="+t.TempDir(), "GOCACHE="+t.TempDir(), "GOMODCACHE="+goEnv(t, "GOMODCACHE"))
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("build release artifacts: %v\n%s", err, output)
+	}
+
+	wantAssets := make([]string, 0, len(supportedReleasePlatforms))
+	for _, platform := range supportedReleasePlatforms {
+		parts := strings.Split(platform, "/")
+		wantAssets = append(wantAssets, fmt.Sprintf("dots_v0.99.0_%s_%s", parts[0], parts[1]))
+	}
+	sort.Strings(wantAssets)
+
+	entries, err := os.ReadDir(outDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var gotAssets []string
+	for _, entry := range entries {
+		if entry.IsDir() || entry.Name() == "checksums.txt" {
+			continue
+		}
+		gotAssets = append(gotAssets, entry.Name())
+	}
+	sort.Strings(gotAssets)
+	if strings.Join(gotAssets, "\n") != strings.Join(wantAssets, "\n") {
+		t.Fatalf("release assets mismatch\nwant:\n%s\ngot:\n%s", strings.Join(wantAssets, "\n"), strings.Join(gotAssets, "\n"))
+	}
+
+	checksums := readChecksums(t, filepath.Join(outDir, "checksums.txt"))
+	for _, asset := range wantAssets {
+		gotChecksum, ok := checksums[asset]
+		if !ok {
+			t.Fatalf("checksums.txt missing checksum for %s", asset)
+		}
+		if gotChecksum != sha256File(t, filepath.Join(outDir, asset)) {
+			t.Fatalf("checksum for %s does not match artifact bytes", asset)
+		}
+	}
+	if len(checksums) != len(wantAssets) {
+		t.Fatalf("checksums.txt should contain exactly release artifacts; got %d entries", len(checksums))
+	}
+}
+
+func TestBuildReleaseArtifactsValidatesReleaseVersionLikeWorkflow(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, "scripts", "build-release-artifacts.sh")
+
+	t.Run("accepts v0 release tags", func(t *testing.T) {
+		for _, version := range []string{"v0.1.0", "v0.2", "v0.1.0-rc.1"} {
+			t.Run(version, func(t *testing.T) {
+				fakeBin, logPath := fakeGoBuild(t)
+				outDir := t.TempDir()
+				cmd := exec.Command("bash", script, "--version", version, "--out-dir", outDir)
+				cmd.Dir = root
+				cmd.Env = append(os.Environ(), "PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+				output, err := cmd.CombinedOutput()
+				if err != nil {
+					t.Fatalf("build release artifacts should accept %s: %v\n%s", version, err, output)
+				}
+				if _, err := os.Stat(logPath); err != nil {
+					t.Fatalf("expected accepted version %s to reach go build: %v", version, err)
+				}
+			})
+		}
+	})
+
+	t.Run("rejects non-v0 and malformed versions before building", func(t *testing.T) {
+		for _, version := range []string{"v1.0.0", "0.1.0", "main", ""} {
+			t.Run(fmt.Sprintf("%q", version), func(t *testing.T) {
+				fakeBin, logPath := fakeGoBuild(t)
+				outDir := t.TempDir()
+				cmd := exec.Command("bash", script, "--version", version, "--out-dir", outDir)
+				cmd.Dir = root
+				cmd.Env = append(os.Environ(), "PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+				output, err := cmd.CombinedOutput()
+				if err == nil {
+					t.Fatalf("build release artifacts should reject version %q\n%s", version, output)
+				}
+				if !strings.Contains(string(output), "Release version must be a v0.x tag") {
+					t.Fatalf("rejection should explain v0.x requirement, got:\n%s", output)
+				}
+				if _, err := os.Stat(logPath); !os.IsNotExist(err) {
+					t.Fatalf("invalid version %q should fail before go build; stat error: %v", version, err)
+				}
+			})
+		}
+	})
+}
+
+func fakeGoBuild(t *testing.T) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "go-build.log")
+	goPath := filepath.Join(dir, "go")
+	script := fmt.Sprintf(`#!/usr/bin/env bash
+set -euo pipefail
+echo "$*" >> %q
+out=""
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "-o" ]]; then
+    out="${2:-}"
+    break
+  fi
+  shift
+done
+if [[ -n "$out" ]]; then
+  mkdir -p "$(dirname "$out")"
+  printf 'fake binary\n' > "$out"
+fi
+`, logPath)
+	if err := os.WriteFile(goPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir, logPath
+}
+
+func goEnv(t *testing.T, key string) string {
+	t.Helper()
+	cmd := exec.Command("go", "env", key)
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("go env %s: %v", key, err)
+	}
+	return strings.TrimSpace(string(output))
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot resolve test file path")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}
+
+func readWorkflow(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var workflow map[string]any
+	if err := yaml.Unmarshal(data, &workflow); err != nil {
+		t.Fatalf("parse workflow YAML: %v", err)
+	}
+	return workflow
+}
+
+func mapAt(t *testing.T, m map[string]any, key string) map[string]any {
+	t.Helper()
+	value, ok := m[key]
+	if !ok {
+		t.Fatalf("missing %q", key)
+	}
+	nested, ok := value.(map[string]any)
+	if !ok {
+		t.Fatalf("%q should be a map, got %T", key, value)
+	}
+	return nested
+}
+
+func stringSliceAt(t *testing.T, m map[string]any, key string) []string {
+	t.Helper()
+	value, ok := m[key]
+	if !ok {
+		t.Fatalf("missing %q", key)
+	}
+	items, ok := value.([]any)
+	if !ok {
+		t.Fatalf("%q should be a list, got %T", key, value)
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		text, ok := item.(string)
+		if !ok {
+			t.Fatalf("%q item should be a string, got %T", key, item)
+		}
+		out = append(out, text)
+	}
+	return out
+}
+
+func contains(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}
+
+func readChecksums(t *testing.T, path string) map[string]string {
+	t.Helper()
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+
+	checksums := map[string]string{}
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) != 2 {
+			t.Fatalf("checksum line should be '<sha256>  <asset>', got %q", scanner.Text())
+		}
+		if len(fields[0]) != sha256.Size*2 {
+			t.Fatalf("checksum for %s should be SHA-256 hex, got %q", fields[1], fields[0])
+		}
+		if strings.Contains(fields[1], string(os.PathSeparator)) {
+			t.Fatalf("checksum entry should use asset filename only, got %q", fields[1])
+		}
+		checksums[fields[1]] = fields[0]
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+	return checksums
+}
+
+func sha256File(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}

--- a/scripts/build-release-artifacts.sh
+++ b/scripts/build-release-artifacts.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Build dots release artifacts and a SHA-256 checksum manifest.
+
+Usage:
+  scripts/build-release-artifacts.sh --version <v0.x.y> [--out-dir <dir>]
+
+Options:
+  --version  Release tag embedded in artifact filenames, for example v0.1.0.
+  --out-dir  Output directory for release assets. Defaults to dist.
+  -h, --help Show this help.
+USAGE
+}
+
+version="${RELEASE_VERSION:-}"
+out_dir="${RELEASE_OUT_DIR:-dist}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      version="${2:-}"
+      shift 2
+      ;;
+    --out-dir)
+      out_dir="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+release_version_regex='^v0\.[0-9]+(\.[0-9]+)?(-[0-9A-Za-z.-]+)?$'
+if [[ ! "$version" =~ $release_version_regex ]]; then
+  echo "Release version must be a v0.x tag such as v0.1.0; got '${version:-<empty>}'" >&2
+  exit 2
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+mkdir -p "$out_dir"
+out_dir="$(cd "$out_dir" && pwd)"
+
+platforms=(
+  "darwin/amd64"
+  "darwin/arm64"
+  "linux/amd64"
+  "linux/arm64"
+)
+
+artifacts=()
+cd "$repo_root"
+for platform in "${platforms[@]}"; do
+  goos="${platform%/*}"
+  goarch="${platform#*/}"
+  artifact="dots_${version}_${goos}_${goarch}"
+  echo "building ${artifact}"
+  CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" \
+    go build -trimpath -ldflags="-s -w" -o "$out_dir/$artifact" ./cmd/dots
+  artifacts+=("$artifact")
+done
+
+(
+  cd "$out_dir"
+  : > checksums.txt
+  for artifact in "${artifacts[@]}"; do
+    if command -v sha256sum >/dev/null 2>&1; then
+      sha256sum "$artifact" >> checksums.txt
+    else
+      shasum -a 256 "$artifact" >> checksums.txt
+    fi
+  done
+)
+
+echo "wrote ${#artifacts[@]} artifacts and checksums.txt to $out_dir"


### PR DESCRIPTION
Closes #9

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds v0.x GitHub Release automation for Bootstrapper-consumable `dots` binaries.
- Builds macOS/Linux amd64/arm64 artifacts and publishes a SHA-256 `checksums.txt` manifest.
- Documents the first v0.x release path while keeping Homebrew Distribution deferred.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Adds tag/manual release workflow that builds artifacts, creates the GitHub Release if needed, and uploads assets. |
| `scripts/build-release-artifacts.sh` | Adds cross-platform build script for `darwin/amd64`, `darwin/arm64`, `linux/amd64`, and `linux/arm64`, including v0.x validation and checksums. |
| `internal/release/release_automation_test.go` | Adds behavior tests for workflow expectations, release artifact generation, checksum correctness, and local version validation. |
| `docs/release.md` | Documents the v0.x release process, expected assets, checksum verification contract, and Homebrew deferral. |

## Review Workload

- [x] `size:exception` accepted by maintainer for this PR.
- Reason: this is one cohesive release-automation work unit; splitting workflow, script, docs, and tests would make each slice less useful on its own.
- Review budget: 526 insertions across 4 files.

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `shellcheck scripts/build-release-artifacts.sh`
- [x] `bash -n scripts/build-release-artifacts.sh`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp>`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
