### PR TITLE
feat(bootstrap): add checksum-verified installer entrypoint

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -48,6 +48,26 @@ shasum -a 256 -c checksums.txt
 
 On Linux, `sha256sum -c checksums.txt` is equivalent.
 
+## Bootstrapper install
+
+Install a published v0.x release with the checksum-verified Bootstrapper:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/yersonargotev/dots/main/scripts/install.sh | DOTS_VERSION=v0.1.0 bash
+```
+
+The Bootstrapper downloads `checksums.txt` and the matching platform artifact from GitHub Releases, verifies the SHA-256 checksum, installs the executable as `~/.local/bin/dots`, and then delegates setup to:
+
+```bash
+~/.local/bin/dots install
+```
+
+For development checkouts, pass the Installed Repository override through the Bootstrapper instead of duplicating install behavior in shell:
+
+```bash
+DOTS_VERSION=v0.1.0 DOTS_SOURCE_ROOT="$PWD" bash scripts/install.sh
+```
+
 ## Release details
 
 | Topic | Decision |
@@ -64,5 +84,5 @@ On Linux, `sha256sum -c checksums.txt` is equivalent.
 - [ ] The workflow completed from the tag commit.
 - [ ] All four platform artifacts are attached to the GitHub Release.
 - [ ] `checksums.txt` contains one SHA-256 entry for each artifact.
-- [ ] The Bootstrapper can later map its detected `goos/goarch` to the matching artifact name.
+- [ ] The Bootstrapper maps its detected `goos/goarch` to the matching artifact name.
 - [ ] No Homebrew Distribution step was added.

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -1,0 +1,267 @@
+package bootstrap_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestBootstrapperInstallsVerifiedArtifactAndDelegatesToDotsInstall(t *testing.T) {
+	root := repoRoot(t)
+	version := "v0.99.0"
+	artifact := "dots_v0.99.0_darwin_arm64"
+	releaseRoot := t.TempDir()
+	versionDir := filepath.Join(releaseRoot, version)
+	if err := os.MkdirAll(versionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	logPath := filepath.Join(t.TempDir(), "dots-args.log")
+	artifactBody := fmt.Sprintf("#!/usr/bin/env bash\nset -euo pipefail\nprintf '%%s\\n' \"$*\" > %q\n", logPath)
+	writeFile(t, filepath.Join(versionDir, artifact), artifactBody, 0o644)
+	writeFile(t, filepath.Join(versionDir, "checksums.txt"), fmt.Sprintf("%s  %s\n", sha256Hex([]byte(artifactBody)), artifact), 0o644)
+
+	server := httptest.NewServer(http.FileServer(http.Dir(releaseRoot)))
+	t.Cleanup(server.Close)
+
+	installDir := filepath.Join(t.TempDir(), "bin")
+	sourceRoot := filepath.Join(t.TempDir(), "checkout")
+	cmd := exec.Command("bash", filepath.Join(root, "scripts", "install.sh"))
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(),
+		"HOME="+t.TempDir(),
+		"DOTS_VERSION="+version,
+		"DOTS_RELEASE_BASE_URL="+server.URL,
+		"DOTS_INSTALL_DIR="+installDir,
+		"DOTS_SOURCE_ROOT="+sourceRoot,
+		"DOTS_OS=darwin",
+		"DOTS_ARCH=arm64",
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bootstrap install failed: %v\n%s", err, output)
+	}
+
+	installed := filepath.Join(installDir, "dots")
+	info, err := os.Stat(installed)
+	if err != nil {
+		t.Fatalf("expected installed dots binary: %v\noutput:\n%s", err, output)
+	}
+	if info.Mode()&0o111 == 0 {
+		t.Fatalf("installed dots should be executable, mode=%v", info.Mode())
+	}
+
+	gotArgs, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("expected bootstrapper to delegate to installed dots: %v\noutput:\n%s", err, output)
+	}
+	wantArgs := "install --source-root " + sourceRoot
+	if strings.TrimSpace(string(gotArgs)) != wantArgs {
+		t.Fatalf("delegated args = %q, want %q", strings.TrimSpace(string(gotArgs)), wantArgs)
+	}
+}
+
+func TestBootstrapperDelegatesWithoutSourceRootForDefaultInstalledRepository(t *testing.T) {
+	root := repoRoot(t)
+	version := "v0.99.0"
+	artifact := "dots_v0.99.0_linux_arm64"
+	releaseRoot := t.TempDir()
+	versionDir := filepath.Join(releaseRoot, version)
+	if err := os.MkdirAll(versionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	logPath := filepath.Join(t.TempDir(), "dots-args.log")
+	artifactBody := fmt.Sprintf("#!/usr/bin/env bash\nset -euo pipefail\nprintf '%%s\\n' \"$*\" > %q\n", logPath)
+	writeFile(t, filepath.Join(versionDir, artifact), artifactBody, 0o644)
+	writeFile(t, filepath.Join(versionDir, "checksums.txt"), fmt.Sprintf("%s  %s\n", sha256Hex([]byte(artifactBody)), artifact), 0o644)
+
+	server := httptest.NewServer(http.FileServer(http.Dir(releaseRoot)))
+	t.Cleanup(server.Close)
+
+	cmd := exec.Command("bash", filepath.Join(root, "scripts", "install.sh"))
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(),
+		"HOME="+t.TempDir(),
+		"DOTS_VERSION="+version,
+		"DOTS_RELEASE_BASE_URL="+server.URL,
+		"DOTS_INSTALL_DIR="+filepath.Join(t.TempDir(), "bin"),
+		"DOTS_OS=linux",
+		"DOTS_ARCH=arm64",
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bootstrap install failed: %v\n%s", err, output)
+	}
+
+	gotArgs, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("expected bootstrapper to delegate to installed dots: %v\noutput:\n%s", err, output)
+	}
+	if strings.TrimSpace(string(gotArgs)) != "install" {
+		t.Fatalf("delegated args = %q, want %q", strings.TrimSpace(string(gotArgs)), "install")
+	}
+}
+
+func TestBootstrapperRejectsChecksumMismatchBeforeInstallOrDelegation(t *testing.T) {
+	root := repoRoot(t)
+	version := "v0.99.0"
+	artifact := "dots_v0.99.0_linux_amd64"
+	releaseRoot := t.TempDir()
+	versionDir := filepath.Join(releaseRoot, version)
+	if err := os.MkdirAll(versionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	logPath := filepath.Join(t.TempDir(), "dots-args.log")
+	artifactBody := fmt.Sprintf("#!/usr/bin/env bash\nset -euo pipefail\nprintf '%%s\\n' \"$*\" > %q\n", logPath)
+	writeFile(t, filepath.Join(versionDir, artifact), artifactBody, 0o644)
+	writeFile(t, filepath.Join(versionDir, "checksums.txt"), fmt.Sprintf("%s  %s\n", strings.Repeat("0", 64), artifact), 0o644)
+
+	server := httptest.NewServer(http.FileServer(http.Dir(releaseRoot)))
+	t.Cleanup(server.Close)
+
+	installDir := filepath.Join(t.TempDir(), "bin")
+	cmd := exec.Command("bash", filepath.Join(root, "scripts", "install.sh"))
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(),
+		"HOME="+t.TempDir(),
+		"DOTS_VERSION="+version,
+		"DOTS_RELEASE_BASE_URL="+server.URL,
+		"DOTS_INSTALL_DIR="+installDir,
+		"DOTS_OS=linux",
+		"DOTS_ARCH=amd64",
+	)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("bootstrap should reject checksum mismatch\n%s", output)
+	}
+	if !strings.Contains(string(output), "checksum mismatch") {
+		t.Fatalf("checksum mismatch should be explained, got:\n%s", output)
+	}
+	if _, err := os.Stat(filepath.Join(installDir, "dots")); !os.IsNotExist(err) {
+		t.Fatalf("checksum mismatch should not install dots; stat error: %v", err)
+	}
+	if _, err := os.Stat(logPath); !os.IsNotExist(err) {
+		t.Fatalf("checksum mismatch should not delegate to dots install; stat error: %v", err)
+	}
+}
+
+func TestBootstrapperRejectsUnsupportedPlatformBeforeDownloading(t *testing.T) {
+	root := repoRoot(t)
+	releaseHits := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		releaseHits++
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(server.Close)
+
+	cmd := exec.Command("bash", filepath.Join(root, "scripts", "install.sh"))
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(),
+		"HOME="+t.TempDir(),
+		"DOTS_VERSION=v0.99.0",
+		"DOTS_RELEASE_BASE_URL="+server.URL,
+		"DOTS_INSTALL_DIR="+filepath.Join(t.TempDir(), "bin"),
+		"DOTS_OS=windows",
+		"DOTS_ARCH=amd64",
+	)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("bootstrap should reject unsupported platforms\n%s", output)
+	}
+	if !strings.Contains(string(output), "unsupported operating system") {
+		t.Fatalf("unsupported platform should be explained, got:\n%s", output)
+	}
+	if releaseHits != 0 {
+		t.Fatalf("unsupported platform should fail before downloading; got %d release requests", releaseHits)
+	}
+}
+
+func TestBootstrapperSelectsSupportedReleaseArtifacts(t *testing.T) {
+	root := repoRoot(t)
+	version := "v0.99.0"
+	releaseRoot := t.TempDir()
+	versionDir := filepath.Join(releaseRoot, version)
+	if err := os.MkdirAll(versionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name     string
+		os       string
+		arch     string
+		artifact string
+	}{
+		{name: "macos amd64", os: "Darwin", arch: "x86_64", artifact: "dots_v0.99.0_darwin_amd64"},
+		{name: "macos arm64", os: "Darwin", arch: "arm64", artifact: "dots_v0.99.0_darwin_arm64"},
+		{name: "linux amd64", os: "Linux", arch: "x86_64", artifact: "dots_v0.99.0_linux_amd64"},
+		{name: "linux arm64", os: "Linux", arch: "aarch64", artifact: "dots_v0.99.0_linux_arm64"},
+	}
+
+	var checksumLines []string
+	for _, tt := range cases {
+		artifactBody := "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n"
+		writeFile(t, filepath.Join(versionDir, tt.artifact), artifactBody, 0o644)
+		checksumLines = append(checksumLines, fmt.Sprintf("%s  %s", sha256Hex([]byte(artifactBody)), tt.artifact))
+	}
+	writeFile(t, filepath.Join(versionDir, "checksums.txt"), strings.Join(checksumLines, "\n")+"\n", 0o644)
+
+	server := httptest.NewServer(http.FileServer(http.Dir(releaseRoot)))
+	t.Cleanup(server.Close)
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			installDir := filepath.Join(t.TempDir(), "bin")
+			cmd := exec.Command("bash", filepath.Join(root, "scripts", "install.sh"))
+			cmd.Dir = root
+			cmd.Env = append(os.Environ(),
+				"HOME="+t.TempDir(),
+				"DOTS_VERSION="+version,
+				"DOTS_RELEASE_BASE_URL="+server.URL,
+				"DOTS_INSTALL_DIR="+installDir,
+				"DOTS_OS="+tt.os,
+				"DOTS_ARCH="+tt.arch,
+			)
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("bootstrap install failed: %v\n%s", err, output)
+			}
+			if !strings.Contains(string(output), "Downloading "+tt.artifact) {
+				t.Fatalf("bootstrap should download %s, got:\n%s", tt.artifact, output)
+			}
+		})
+	}
+}
+
+func writeFile(t *testing.T, path, content string, mode os.FileMode) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), mode); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot resolve test file path")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Install the dots CLI from a checksum-verified GitHub Release Artifact, then delegate setup to dots install.
+
+Environment:
+  DOTS_VERSION           Release tag to install, for example v0.1.0. Required.
+  DOTS_RELEASE_BASE_URL  Release asset base URL. Defaults to https://github.com/yersonargotev/dots/releases/download.
+  DOTS_INSTALL_DIR       Directory where the dots command is installed. Defaults to ~/.local/bin.
+  DOTS_SOURCE_ROOT       Optional development checkout/Installed Repository override passed to dots install.
+  DOTS_OS                Test override for platform OS detection.
+  DOTS_ARCH              Test override for platform architecture detection.
+USAGE
+}
+
+fail() {
+  echo "dots bootstrap: $*" >&2
+  exit 1
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+version="${DOTS_VERSION:-}"
+release_base_url="${DOTS_RELEASE_BASE_URL:-https://github.com/yersonargotev/dots/releases/download}"
+install_dir="${DOTS_INSTALL_DIR:-$HOME/.local/bin}"
+source_root="${DOTS_SOURCE_ROOT:-}"
+
+if [[ -z "$version" ]]; then
+  fail "DOTS_VERSION is required, for example DOTS_VERSION=v0.1.0"
+fi
+
+case "${DOTS_OS:-$(uname -s)}" in
+  Darwin|darwin) goos="darwin" ;;
+  Linux|linux) goos="linux" ;;
+  *) fail "unsupported operating system: ${DOTS_OS:-$(uname -s)}" ;;
+esac
+
+case "${DOTS_ARCH:-$(uname -m)}" in
+  x86_64|amd64) goarch="amd64" ;;
+  arm64|aarch64) goarch="arm64" ;;
+  *) fail "unsupported architecture: ${DOTS_ARCH:-$(uname -m)}" ;;
+esac
+
+artifact="dots_${version}_${goos}_${goarch}"
+asset_base="${release_base_url%/}/${version}"
+
+download() {
+  local url="$1"
+  local output="$2"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$url" -o "$output"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -qO "$output" "$url"
+  else
+    fail "curl or wget is required to download release artifacts"
+  fi
+}
+
+sha256_file() {
+  local file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$file" | awk '{print $1}'
+  else
+    fail "sha256sum or shasum is required for checksum verification"
+  fi
+}
+
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+checksums_path="$tmp_dir/checksums.txt"
+artifact_path="$tmp_dir/$artifact"
+
+echo "Downloading checksums for $version"
+download "$asset_base/checksums.txt" "$checksums_path"
+
+echo "Downloading $artifact"
+download "$asset_base/$artifact" "$artifact_path"
+
+expected_checksum="$(awk -v artifact="$artifact" '$2 == artifact { print $1 }' "$checksums_path")"
+if [[ -z "$expected_checksum" ]]; then
+  fail "checksums.txt does not contain an entry for $artifact"
+fi
+
+actual_checksum="$(sha256_file "$artifact_path")"
+if [[ "$actual_checksum" != "$expected_checksum" ]]; then
+  fail "checksum mismatch for $artifact"
+fi
+
+mkdir -p "$install_dir"
+install_path="$install_dir/dots"
+install -m 0755 "$artifact_path" "$install_path"
+
+echo "Installed dots to $install_path"
+
+args=(install)
+if [[ -n "$source_root" ]]; then
+  args+=(--source-root "$source_root")
+fi
+
+exec "$install_path" "${args[@]}"


### PR DESCRIPTION
Closes #10

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds a thin checksum-verified `scripts/install.sh` Bootstrapper for published `dots` release artifacts.
- Verifies SHA-256 checksums before installing or executing the downloaded binary.
- Delegates setup to `dots install`, with `DOTS_SOURCE_ROOT` support for development checkout overrides.

## Changes

| File | Change |
|------|--------|
| `scripts/install.sh` | Adds the checksum-verified Bootstrapper entrypoint with macOS/Linux amd64/arm64 platform detection, artifact download, verification, install, and CLI delegation. |
| `internal/bootstrap/bootstrap_test.go` | Adds script-level behavior coverage for verified install/delegation, default Installed Repository behavior, checksum mismatch, unsupported platform rejection, and supported artifact selection. |
| `docs/release.md` | Documents Bootstrapper usage and development checkout override behavior. |

## Test Plan

- [x] `shellcheck scripts/install.sh`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp>`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
