### PR TITLE
docs(scope): document v1 boundaries

### DIFF
--- a/docs/scope.md
+++ b/docs/scope.md
@@ -1,0 +1,76 @@
+# v1 Scope and Deferred Work
+
+v1 proves that the Dotfiles CLI can install repository-owned configuration safely before the project expands into package management, update orchestration, or larger application configuration. These boundaries protect installer correctness, preserve the Source of Truth, and prevent Machine-Specific Configuration from leaking into shared Managed Configuration.
+
+## Quick review path
+
+1. Use **v1 includes** to confirm what the first usable release must support.
+2. Use **deferred work** to reject scope creep during v1 implementation.
+3. Use **why these boundaries exist** when deciding whether a new request belongs in v1 or later.
+
+## v1 includes
+
+| Area | v1 boundary |
+|------|-------------|
+| Safe installation | The Dotfiles CLI owns installation through an Install Manifest, computes an Install Plan before changing files, supports dry-run behavior, detects Conflicts, and keeps non-interactive behavior conservative. |
+| Conflict safety | Conflict Resolution supports explicit choices such as `skip`, `replace`, `adopt`, and `diff`; replacement requires a Backup Set first, and adoption must be explicit to avoid contaminating the Source of Truth. |
+| Status | `dots status` reports Dotfiles Status, including whether Managed Entries are installed, missing, conflicting, skipped, drifted, or unsupported. |
+| Diagnostics | `dots doctor` reports platform, dependency, secret, and configuration concerns without pretending that guardrails are a complete audit. |
+| Dependency guidance | `dots deps check` and `dots deps plan` detect missing Dependencies and produce an OS-aware Dependency Plan. v1 gives guidance only; it does not install packages. |
+| Backups list | `dots backups list` exposes Backup Sets and Backup Metadata so preserved files can be audited after installation. |
+| Release artifacts | GitHub Releases publish platform-specific Release Artifacts for macOS amd64/arm64 and Linux amd64/arm64. |
+| Bootstrapper support | The Bootstrapper downloads the matching Release Artifact, performs Checksum Verification, installs or locates `dots`, and delegates setup to the Dotfiles CLI. |
+| MVP Configuration Set | v1 proves the installer with zsh, git, starship, and tmux before migrating larger application configurations. |
+
+## Deferred to v1.1 or later
+
+| Deferred item | Earliest target | Why it is deferred |
+|---------------|-----------------|--------------------|
+| Homebrew Distribution | v1.1 or phase 2 | GitHub Releases and checksum-based bootstrapping must be stable before adding tap, formula, or bottle maintenance. |
+| Automatic dependency installation | Later than v1 | Installing packages introduces package-manager selection, sudo behavior, distro differences, repositories, taps, version constraints, and higher operational risk. |
+| `dots update` | v1.1 | Updating the Installed Repository introduces Git state, local changes, versioning, and post-update conflict handling. |
+| Neovim and larger application configurations | Later than v1 | Larger app configs introduce plugin, language-server, and dependency complexity that distracts from proving installer correctness. |
+| Windows support | Later than v1 | v1 focuses on macOS and Linux Supported Platforms only. Windows needs separate path, shell, package, and platform behavior decisions. |
+| Official WSL support | Later than v1 | WSL has mixed Windows/Linux filesystem and dependency concerns that should not be treated as generic Linux during the first release. |
+| NixOS specialization | Later than v1 | NixOS requires specialized package and system-configuration assumptions that do not fit the v1 advisory Dependency Plan. |
+| Alpine/musl specialization | Later than v1 | Alpine and musl introduce distribution and binary compatibility concerns outside the initial Linux amd64/arm64 release target. |
+| Automatic backup restore | Optional or later | v1 must make Backup Sets visible and reliable first; restore behavior can be added after backup metadata and status behavior are proven. |
+| Full visual TUI snapshot testing | Later than v1 | v1 tests TUI state transitions, but installer correctness matters more than pixel-perfect terminal rendering. |
+
+## Why these boundaries exist
+
+### Installer safety comes before convenience
+
+The Bootstrapper is intentionally thin. It downloads, verifies, and launches the Dotfiles CLI; it does not duplicate manifest parsing, conflict handling, backup behavior, or configuration installation. That keeps the risky filesystem logic inside testable Go code instead of spreading it across shell entrypoints.
+
+### Source of Truth integrity matters more than speed
+
+The repository-owned Source of Truth must not absorb accidental local state. Adoption exists for explicit migrations only. Machine-Specific Configuration belongs in Local Extension Points, ignored files, or external secret stores, not in shared Managed Configuration.
+
+### Dependency guidance is safer than dependency mutation
+
+A Dependency Plan helps the user understand missing tools without allowing v1 to mutate package-manager state. That boundary avoids surprise installs, sudo prompts, repository changes, and distro-specific behavior before the installer foundation is stable.
+
+### Distribution starts with verifiable artifacts
+
+v1 distribution starts with GitHub Release Artifacts plus Checksum Verification because the Bootstrapper can verify exactly what it downloads. Homebrew Distribution is valuable, but it adds packaging maintenance after the artifact contract is already proven.
+
+### The MVP Configuration Set keeps the feedback loop tight
+
+zsh, git, starship, and tmux are enough to prove symlink, template, copy, Local Extension Point, dependency, status, backup, and conflict behavior. Pulling Neovim or larger apps into v1 would blur whether failures come from installer design or application-specific complexity.
+
+## Alignment references
+
+- [PRD: Dotfiles CLI and bootstrapper](https://github.com/yersonargotev/dots/issues/1) — product scope, user stories, implementation decisions, testing decisions, and out-of-scope items.
+- [`CONTEXT.md`](../CONTEXT.md) — canonical vocabulary for Source of Truth, Managed Entry, Install Plan, Backup Set, Drift, Homebrew Distribution, Deferred Configuration, and related terms.
+- [`docs/adr/0001-bootstrap-with-go-cli.md`](adr/0001-bootstrap-with-go-cli.md) — architectural decision record for the Bootstrapper, Go CLI, manifest contract, backups, status, dependencies, supported platforms, and distribution sequence.
+- [`docs/release.md`](release.md) — release workflow and Checksum Verification contract for Bootstrapper-ready artifacts.
+
+## Scope checklist
+
+Use this checklist when reviewing v1 issues or PRs:
+
+- [ ] The change strengthens safe installation, status, diagnostics, dependency guidance, backups, release artifacts, or checksum Bootstrapper support.
+- [ ] The change does not add Homebrew Distribution, automatic dependency installation, `dots update`, or larger Deferred Configuration to v1.
+- [ ] The change preserves Source of Truth integrity and does not make Machine-Specific Configuration part of shared Managed Configuration.
+- [ ] The change uses the project vocabulary from `CONTEXT.md` and the tradeoffs recorded in the ADR.


### PR DESCRIPTION
Closes #11

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [x] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Documents the v1 scope boundary for the first usable Dotfiles CLI release.
- Lists deferred v1.1+ work so future contributors and agents do not expand v1 accidentally.
- Links the boundary rationale back to installer safety, Source of Truth integrity, and Machine-Specific Configuration isolation.

## Changes

| File | Change |
|------|--------|
| `docs/scope.md` | Adds the v1 includes, deferred work table, architectural rationale, alignment references, and review checklist. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: not applicable, documentation-only change.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
