### PR TITLE
feat(update): add dots update for the Installed Repository

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -101,7 +101,7 @@ A workstation state where a managed target no longer matches the repository-owne
 _Avoid_: local change, mismatch, dirty config
 
 **Dotfiles Update**:
-The future workflow that updates the Installed Repository and reapplies or rechecks managed configuration. It is documented for v1.1 rather than required for the first v1 MVP.
+The `dots update` workflow that fast-forwards the Installed Repository to its upstream and re-runs the safe install flow so managed configuration stays aligned with the Source of Truth. It refuses to touch a repository with local changes and only ever applies a clean fast-forward, never a merge or rebase. Shipped in v1.1.
 _Avoid_: sync, pull, upgrade
 
 **Repository Layout**:

--- a/docs/scope.md
+++ b/docs/scope.md
@@ -28,7 +28,7 @@ v1 proves that the Dotfiles CLI can install repository-owned configuration safel
 |---------------|-----------------|--------------------|
 | Homebrew Distribution | v1.1 or phase 2 | GitHub Releases and checksum-based bootstrapping must be stable before adding tap, formula, or bottle maintenance. |
 | Automatic dependency installation | Later than v1 | Installing packages introduces package-manager selection, sudo behavior, distro differences, repositories, taps, version constraints, and higher operational risk. |
-| `dots update` | v1.1 | Updating the Installed Repository introduces Git state, local changes, versioning, and post-update conflict handling. |
+| `dots update` | v1.1 — **shipped** | Updating the Installed Repository introduces Git state, local changes, versioning, and post-update conflict handling. Delivered in v1.1; see [`docs/update.md`](update.md). |
 | Neovim and larger application configurations | Later than v1 | Larger app configs introduce plugin, language-server, and dependency complexity that distracts from proving installer correctness. |
 | Windows support | Later than v1 | v1 focuses on macOS and Linux Supported Platforms only. Windows needs separate path, shell, package, and platform behavior decisions. |
 | Official WSL support | Later than v1 | WSL has mixed Windows/Linux filesystem and dependency concerns that should not be treated as generic Linux during the first release. |

--- a/docs/update.md
+++ b/docs/update.md
@@ -1,0 +1,67 @@
+# `dots update`
+
+`dots update` refreshes the [Installed Repository](../CONTEXT.md#installed-repository) (default `~/.local/share/dots`) and re-runs the safe install flow so managed configuration stays aligned with the [Source of Truth](../CONTEXT.md). It reuses the existing Install Plan, Conflict Resolution, and Backup Set machinery rather than reimplementing filesystem logic — the only behavior unique to `update` is advancing the repository's Git state.
+
+## What it does
+
+1. **Validates Git state.** The source root must be a Git work tree. If it is not, `update` stops with an error instead of guessing.
+2. **Refuses to overwrite local work.** If the repository has any uncommitted changes (modified, staged, or untracked files), `update` reports the dirty state and stops. It never stashes, resets, or discards local changes on your behalf.
+3. **Fast-forwards only.** `update` fetches the upstream and advances the branch with `git merge --ff-only`. If the branch has diverged from its upstream, it cannot be fast-forwarded; `update` reports the divergence and asks you to resolve it manually with Git. It never performs an automatic merge or rebase.
+4. **Recomputes the Install Plan.** After the fast-forward, the manifest is loaded from the updated repository (so a manifest change pulled from upstream is honored) and a fresh Install Plan is computed against the current workstation state, surfacing any new Conflicts or Drift.
+5. **Applies safely.** The post-update install resolves conflicts exactly like `dots install`: interactive TUI by default, text prompts with `--no-tui`, or the conservative skip default with `--yes`. Any `replace` still creates a [Backup Set](../CONTEXT.md) before touching an existing target.
+
+## Versioning model
+
+`update` is intentionally a thin layer over Git. The "version" of your managed configuration is the Git revision of the Installed Repository — `update` reports the short revision it moved from and to, plus the one-line summaries of the commits it applied:
+
+```
+Updated Installed Repository a1b2c3d -> e4f5a6b:
+  e4f5a6b add tmux config
+```
+
+Because the update path is fast-forward only, the local revision is always a strict ancestor of the new revision. This keeps the model auditable (you can always inspect the exact commits applied) and avoids dots ever rewriting history or fabricating merge commits. To roll back, use Git directly in the Installed Repository.
+
+## Post-update conflict handling
+
+A fast-forward changes the Source of Truth, so targets that were previously aligned can become Conflicts or Drift after an update. `update` surfaces these in the recomputed Install Plan and resolves them with the same rules as `install`:
+
+| Decision | Effect | Backup Set |
+|----------|--------|------------|
+| `skip` (default when non-interactive) | Leaves the existing target untouched | — |
+| `replace` | Replaces the target with the updated Source of Truth | Created first |
+| `adopt` | Copies the local target into the Source of Truth | Created for symlink strategy |
+
+Non-interactive runs (`--yes`) default every conflict to `skip`, so an unattended `update` never silently overwrites a workstation file.
+
+## Flags
+
+`update` accepts the same path, profile, and safety flags as `install`:
+
+| Flag | Purpose |
+|------|---------|
+| `--dry-run` | Fetch and report the available fast-forward and the Install Plan without fast-forwarding the working tree or installing files. |
+| `--file`, `--profile` | Select the manifest and profile to install after updating. |
+| `--source-root` | Installed Repository to update (default `~/.local/share/dots`). |
+| `--home` | Target home directory; use a sandbox path to avoid touching real config. |
+| `--state-root` | State directory for Installation Metadata and Backup Sets. |
+| `--yes` | Apply safe actions without prompting; conflicts default to `skip`. |
+| `--no-tui` | Use text prompts instead of the interactive TUI for conflict resolution. |
+
+## Dry run
+
+`dots update --dry-run` fetches the upstream and reports the commits a fast-forward would apply, then renders the current Install Plan, without modifying the repository working tree or installing anything:
+
+```
+Installed Repository can fast-forward a1b2c3d -> e4f5a6b:
+  e4f5a6b add tmux config
+
+(dry run: working tree and managed files not modified)
+```
+
+Because no fast-forward is applied in a dry run, the rendered plan reflects the **current** Source of Truth, not the post-update state. Run `update` without `--dry-run` to apply the fast-forward and compute the plan against the updated repository.
+
+## References
+
+- [`docs/scope.md`](scope.md) — `dots update` was deferred from v1 and delivered in v1.1.
+- [`CONTEXT.md`](../CONTEXT.md) — vocabulary for Installed Repository, Source of Truth, Conflict, Drift, and Backup Set.
+- [`docs/adr/0001-bootstrap-with-go-cli.md`](adr/0001-bootstrap-with-go-cli.md) — the Go CLI and thin-Git-wrapper tradeoffs.

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -60,27 +60,7 @@ func newInstallCommand() *cobra.Command {
 				return nil
 			}
 
-			var decisions map[string]install.ConflictDecision
-			switch {
-			case yes:
-				// Non-interactive: conflicts deliberately default to skip.
-			case noTUI:
-				decisions, err = promptConflictDecisions(cmd, p, paths.Home, paths.SourceRoot)
-				if err != nil {
-					return err
-				}
-			default:
-				decisions, err = resolveConflictsTUI(cmd, p, paths.Home, paths.SourceRoot)
-				if errors.Is(err, tui.ErrCanceled) {
-					fmt.Fprintln(cmd.OutOrStdout(), "Conflict resolution canceled; no changes applied.")
-					return nil
-				}
-				if err != nil {
-					return err
-				}
-			}
-
-			return install.Apply(p, install.Options{SourceRoot: paths.SourceRoot, Home: paths.Home, StateRoot: paths.StateRoot, ConflictDecisions: decisions})
+			return resolveAndApply(cmd, p, paths, yes, noTUI)
 		},
 	}
 
@@ -93,6 +73,37 @@ func newInstallCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&yes, "yes", false, "apply safe install actions without prompting; conflicts default to skip")
 	cmd.Flags().BoolVar(&noTUI, "no-tui", false, "use text prompts instead of the interactive TUI for conflict resolution")
 	return cmd
+}
+
+// resolveAndApply resolves the plan's conflicts (via the TUI, text prompts, or
+// the conservative --yes default) and applies it with Backup Set protection. It
+// is shared by install and update so post-update installation reuses identical
+// Conflict Resolution and filesystem machinery instead of reimplementing it.
+func resolveAndApply(cmd *cobra.Command, p plan.Plan, paths resolvedPaths, yes, noTUI bool) error {
+	var (
+		decisions map[string]install.ConflictDecision
+		err       error
+	)
+	switch {
+	case yes:
+		// Non-interactive: conflicts deliberately default to skip.
+	case noTUI:
+		decisions, err = promptConflictDecisions(cmd, p, paths.Home, paths.SourceRoot)
+		if err != nil {
+			return err
+		}
+	default:
+		decisions, err = resolveConflictsTUI(cmd, p, paths.Home, paths.SourceRoot)
+		if errors.Is(err, tui.ErrCanceled) {
+			fmt.Fprintln(cmd.OutOrStdout(), "Conflict resolution canceled; no changes applied.")
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	return install.Apply(p, install.Options{SourceRoot: paths.SourceRoot, Home: paths.Home, StateRoot: paths.StateRoot, ConflictDecisions: decisions})
 }
 
 // resolveConflictsTUI launches the Bubble Tea conflict resolver for the plan's

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -17,6 +17,7 @@ func NewRootCommand() *cobra.Command {
 	root.AddCommand(newManifestCommand())
 	root.AddCommand(newPlanCommand())
 	root.AddCommand(newInstallCommand())
+	root.AddCommand(newUpdateCommand())
 	root.AddCommand(newStatusCommand())
 	root.AddCommand(newBackupsCommand())
 	root.AddCommand(newDepsCommand())

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1,0 +1,147 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"runtime"
+
+	"github.com/spf13/cobra"
+	"github.com/yersonargotev/dots/internal/gitrepo"
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/plan"
+)
+
+func newUpdateCommand() *cobra.Command {
+	var (
+		file       string
+		profile    string
+		sourceRoot string
+		home       string
+		stateRoot  string
+		dryRun     bool
+		yes        bool
+		noTUI      bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update the Installed Repository and re-run the safe install flow",
+		Long: "update fast-forwards the Installed Repository (default ~/.local/share/dots) to its " +
+			"upstream, then recomputes the Install Plan so managed configuration stays aligned with " +
+			"the Source of Truth. It refuses to touch a repository with local changes and only ever " +
+			"applies a clean fast-forward, never a merge or rebase. Conflicts during the post-update " +
+			"install are resolved exactly like dots install, creating a Backup Set before any replacement.",
+		// Domain failures (dirty repo, divergence, conflicts) are user-facing
+		// conditions, not command misuse, so do not dump the usage block.
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			paths, err := resolvePaths(home, sourceRoot, stateRoot)
+			if err != nil {
+				return err
+			}
+
+			if !gitrepo.IsRepo(paths.SourceRoot) {
+				return fmt.Errorf("installed repository %s is not a git repository; clone the Source of Truth before updating", paths.SourceRoot)
+			}
+			clean, err := gitrepo.IsClean(paths.SourceRoot)
+			if err != nil {
+				return err
+			}
+			if !clean {
+				return fmt.Errorf("installed repository %s has local changes; commit or discard them before updating", paths.SourceRoot)
+			}
+
+			out := cmd.OutOrStdout()
+			if err := refreshRepository(out, paths.SourceRoot, dryRun); err != nil {
+				return err
+			}
+
+			// Load the manifest after the fast-forward so a manifest change pulled
+			// from upstream is honored by the recomputed plan. The default
+			// manifest belongs to the Installed Repository, not the caller's cwd;
+			// explicit --file values keep their normal caller-relative behavior.
+			manifestPath := file
+			if !cmd.Flags().Changed("file") {
+				manifestPath = filepath.Join(paths.SourceRoot, file)
+			}
+			m, err := manifest.LoadFile(manifestPath)
+			if err != nil {
+				return err
+			}
+			p, err := plan.Build(*m, plan.Options{
+				Profile:    profile,
+				OS:         runtime.GOOS,
+				SourceRoot: paths.SourceRoot,
+				Home:       paths.Home,
+			})
+			if err != nil {
+				return err
+			}
+
+			renderPlan(out, p)
+			if dryRun {
+				return nil
+			}
+
+			return resolveAndApply(cmd, p, paths, yes, noTUI)
+		},
+	}
+
+	cmd.Flags().StringVarP(&file, "file", "f", "dots.yaml", "manifest file to install after updating")
+	cmd.Flags().StringVarP(&profile, "profile", "p", "default", "profile to install after updating")
+	cmd.Flags().StringVar(&sourceRoot, "source-root", "", "installed repository root to update (default ~/.local/share/dots)")
+	cmd.Flags().StringVar(&home, "home", "", "target home directory to install into (default: the current user's home); use a sandbox path to avoid touching real config")
+	cmd.Flags().StringVar(&stateRoot, "state-root", "", "state directory for Installation Metadata and Backup Sets (default ~/.local/state/dots)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "fetch and report the available update and Install Plan without fast-forwarding the working tree or installing files")
+	cmd.Flags().BoolVar(&yes, "yes", false, "apply safe install actions without prompting; conflicts default to skip")
+	cmd.Flags().BoolVar(&noTUI, "no-tui", false, "use text prompts instead of the interactive TUI for conflict resolution")
+	return cmd
+}
+
+// refreshRepository previews (dry run) or applies (real run) the fast-forward
+// update of the Installed Repository, reporting exactly what changed. It maps
+// the gitrepo divergence sentinel to a user-facing message that points back to
+// manual resolution, keeping dots out of automatic merge/rebase behavior.
+func refreshRepository(out io.Writer, sourceRoot string, dryRun bool) error {
+	var (
+		upd gitrepo.Update
+		err error
+	)
+	if dryRun {
+		upd, err = gitrepo.Preview(sourceRoot)
+	} else {
+		upd, err = gitrepo.FastForward(sourceRoot)
+	}
+	if errors.Is(err, gitrepo.ErrNotFastForward) {
+		return fmt.Errorf("installed repository %s has diverged from its upstream and cannot be fast-forwarded; resolve it manually with git", sourceRoot)
+	}
+	if err != nil {
+		return err
+	}
+	renderUpdate(out, upd, dryRun)
+	return nil
+}
+
+// renderUpdate writes a deterministic summary of the fast-forward so the user
+// sees which commits were (or would be) applied before the Install Plan.
+func renderUpdate(out io.Writer, upd gitrepo.Update, dryRun bool) {
+	if !upd.Changed() {
+		fmt.Fprintf(out, "Installed Repository already up to date at %s.\n\n", upd.OldRev)
+		return
+	}
+
+	if dryRun {
+		fmt.Fprintf(out, "Installed Repository can fast-forward %s -> %s:\n", upd.OldRev, upd.NewRev)
+	} else {
+		fmt.Fprintf(out, "Updated Installed Repository %s -> %s:\n", upd.OldRev, upd.NewRev)
+	}
+	for _, line := range upd.Incoming {
+		fmt.Fprintf(out, "  %s\n", line)
+	}
+	if dryRun {
+		fmt.Fprintln(out, "\n(dry run: working tree and managed files not modified)")
+	}
+	fmt.Fprintln(out)
+}

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -1,0 +1,357 @@
+package cli_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/backups"
+	"github.com/yersonargotev/dots/internal/cli"
+)
+
+func TestUpdateFastForwardsRepoThenInstalls(t *testing.T) {
+	requireGitCLI(t)
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	origin, sourceRoot := newInstalledRepo(t, map[string]string{
+		"configs/zsh/zshrc": "export A=1\n",
+		"dots.yaml": `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+`,
+	})
+
+	// The upstream gains a brand-new managed file and a manifest entry for it.
+	advanceUpstream(t, origin, "add tmux config", map[string]string{
+		"configs/tmux/tmux.conf": "set -g mouse on\n",
+		"dots.yaml": `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+  - source: configs/tmux/tmux.conf
+    target: ~/.tmux.conf
+    strategy: symlink
+    tags: [core]
+`,
+	})
+
+	out := runUpdate(t, "--file", filepath.Join(sourceRoot, "dots.yaml"),
+		"--home", home, "--source-root", sourceRoot, "--state-root", stateRoot)
+
+	// The working tree advanced: the pulled source now exists.
+	pulled := filepath.Join(sourceRoot, "configs/tmux/tmux.conf")
+	if _, err := os.Stat(pulled); err != nil {
+		t.Fatalf("update did not fast-forward the repository: %v", err)
+	}
+	// The newly managed target is installed.
+	target := filepath.Join(home, ".tmux.conf")
+	dest, err := os.Readlink(target)
+	if err != nil {
+		t.Fatalf("update did not install the new managed target: %v", err)
+	}
+	if dest != pulled {
+		t.Fatalf("symlink target = %q, want %q", dest, pulled)
+	}
+	for _, want := range []string{"add tmux config", `Plan for profile "default"`} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("update output missing %q\noutput:\n%s", want, out)
+		}
+	}
+}
+
+func TestUpdateDryRunReportsIncomingWithoutModifying(t *testing.T) {
+	requireGitCLI(t)
+	home := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	origin, sourceRoot := newInstalledRepo(t, map[string]string{
+		"configs/zsh/zshrc": "export A=1\n",
+		"dots.yaml": `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+`,
+	})
+	advanceUpstream(t, origin, "add tmux config", map[string]string{
+		"configs/tmux/tmux.conf": "set -g mouse on\n",
+	})
+
+	out := runUpdate(t, "--dry-run", "--file", filepath.Join(sourceRoot, "dots.yaml"),
+		"--home", home, "--source-root", sourceRoot)
+
+	// Dry run must not advance the working tree...
+	if _, err := os.Stat(filepath.Join(sourceRoot, "configs/tmux/tmux.conf")); !os.IsNotExist(err) {
+		t.Fatalf("dry-run modified the working tree; stat err = %v", err)
+	}
+	// ...and must not install anything.
+	if _, err := os.Lstat(filepath.Join(home, ".zshrc")); !os.IsNotExist(err) {
+		t.Fatalf("dry-run installed a target; lstat err = %v", err)
+	}
+	for _, want := range []string{"add tmux config", `Plan for profile "default"`} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("dry-run output missing %q\noutput:\n%s", want, out)
+		}
+	}
+}
+
+func TestUpdateDefaultManifestLoadsFromSourceRoot(t *testing.T) {
+	requireGitCLI(t)
+	home := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	_, sourceRoot := newInstalledRepo(t, map[string]string{
+		"configs/zsh/zshrc": "export A=1\n",
+		"dots.yaml": `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+`,
+	})
+
+	t.Chdir(t.TempDir())
+
+	out := runUpdate(t, "--dry-run", "--home", home, "--source-root", sourceRoot)
+
+	if !strings.Contains(out, `Plan for profile "default"`) {
+		t.Fatalf("update output missing default manifest plan\noutput:\n%s", out)
+	}
+	if _, err := os.Lstat(filepath.Join(home, ".zshrc")); !os.IsNotExist(err) {
+		t.Fatalf("dry-run installed a target; lstat err = %v", err)
+	}
+}
+
+func TestUpdateStopsOnDirtyRepo(t *testing.T) {
+	requireGitCLI(t)
+	home := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	_, sourceRoot := newInstalledRepo(t, map[string]string{
+		"configs/zsh/zshrc": "export A=1\n",
+		"dots.yaml": `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+`,
+	})
+	// A local edit makes the Installed Repository dirty.
+	localPath := filepath.Join(sourceRoot, "configs/zsh/zshrc")
+	if err := os.WriteFile(localPath, []byte("local edit\n"), 0o600); err != nil {
+		t.Fatalf("write local edit: %v", err)
+	}
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"update", "--file", filepath.Join(sourceRoot, "dots.yaml"),
+		"--home", home, "--source-root", sourceRoot})
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("update Execute() error = nil, want dirty-repo error\noutput:\n%s", out.String())
+	}
+	// The local edit must be preserved, never overwritten.
+	got, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read local edit: %v", err)
+	}
+	if string(got) != "local edit\n" {
+		t.Fatalf("local edit overwritten: got %q", got)
+	}
+}
+
+func TestUpdateFailsWhenSourceRootNotGitRepo(t *testing.T) {
+	requireGitCLI(t)
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	writeCLISource(t, sourceRoot, "configs/zsh/zshrc", "export A=1\n")
+	manifestPath := writeCLIManifest(t, sourceRoot, `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+`)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"update", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("update Execute() error = nil, want not-a-git-repository error")
+	}
+}
+
+func TestUpdateReplaceConflictCreatesBackupSet(t *testing.T) {
+	requireGitCLI(t)
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	_, sourceRoot := newInstalledRepo(t, map[string]string{
+		"configs/git/gitconfig": "managed\n",
+		"dots.yaml": `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/git/gitconfig
+    target: ~/.gitconfig
+    strategy: copy
+    tags: [core]
+`,
+	})
+	target := filepath.Join(home, ".gitconfig")
+	if err := os.WriteFile(target, []byte("local\n"), 0o600); err != nil {
+		t.Fatalf("write local target: %v", err)
+	}
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetIn(strings.NewReader("r\n"))
+	cmd.SetArgs([]string{"update", "--no-tui", "--file", filepath.Join(sourceRoot, "dots.yaml"),
+		"--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("update Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(got) != "managed\n" {
+		t.Fatalf("target contents = %q, want managed source after replace", got)
+	}
+	meta, err := backups.Load(backups.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load Backup Metadata: %v", err)
+	}
+	if len(meta.Sets) != 1 {
+		t.Fatalf("Backup Sets = %d, want 1 after post-update replace", len(meta.Sets))
+	}
+}
+
+// --- helpers ---
+
+func requireGitCLI(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available on PATH")
+	}
+}
+
+func runUpdate(t *testing.T, args ...string) string {
+	t.Helper()
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(append([]string{"update"}, args...))
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("update Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+	return out.String()
+}
+
+// newInstalledRepo writes files into a non-bare origin repository, commits them,
+// and clones it into a working directory that becomes the Installed Repository.
+func newInstalledRepo(t *testing.T, files map[string]string) (origin, clone string) {
+	t.Helper()
+	origin = t.TempDir()
+	runGit(t, origin, "init", "-b", "main")
+	gitIdentity(t, origin)
+	writeRepoFiles(t, origin, files)
+	runGit(t, origin, "add", "-A")
+	runGit(t, origin, "commit", "-m", "initial")
+
+	clone = t.TempDir()
+	runGit(t, "", "clone", origin, clone)
+	gitIdentity(t, clone)
+	return origin, clone
+}
+
+func advanceUpstream(t *testing.T, origin, message string, files map[string]string) {
+	t.Helper()
+	writeRepoFiles(t, origin, files)
+	runGit(t, origin, "add", "-A")
+	runGit(t, origin, "commit", "-m", message)
+}
+
+func writeRepoFiles(t *testing.T, root string, files map[string]string) {
+	t.Helper()
+	// Deterministic order keeps commits reproducible across runs.
+	paths := make([]string, 0, len(files))
+	for rel := range files {
+		paths = append(paths, rel)
+	}
+	sort.Strings(paths)
+	for _, rel := range paths {
+		full := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir for %s: %v", full, err)
+		}
+		if err := os.WriteFile(full, []byte(files[rel]), 0o600); err != nil {
+			t.Fatalf("write %s: %v", full, err)
+		}
+	}
+}
+
+func gitIdentity(t *testing.T, dir string) {
+	t.Helper()
+	runGit(t, dir, "config", "user.email", "dots@test.local")
+	runGit(t, dir, "config", "user.name", "dots test")
+	runGit(t, dir, "config", "commit.gpgsign", "false")
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	cmd.Env = append(os.Environ(),
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"GIT_CONFIG_SYSTEM=/dev/null",
+		"GIT_TERMINAL_PROMPT=0",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}

--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -1,0 +1,177 @@
+// Package gitrepo is a thin wrapper around the system git binary used to update
+// the Installed Repository before re-running the install flow. It deliberately
+// avoids a heavy in-process Git library: dots already shells out to git in its
+// bootstrapper, and a fast-forward-only update needs only a handful of plumbing
+// commands.
+package gitrepo
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// ErrNotFastForward reports that the Installed Repository cannot be advanced by
+// a clean fast-forward because the local branch has diverged from its upstream.
+// dots refuses to merge or rebase automatically so it never rewrites local work.
+var ErrNotFastForward = errors.New("installed repository cannot be fast-forwarded")
+
+// Update describes the fast-forward an update did apply (FastForward) or would
+// apply (Preview), so callers can report exactly what changed.
+type Update struct {
+	OldRev   string
+	NewRev   string
+	Incoming []string
+}
+
+// Changed reports whether the update moves (or would move) HEAD.
+func (u Update) Changed() bool {
+	return u.OldRev != u.NewRev
+}
+
+// IsRepo reports whether dir is inside a Git work tree.
+func IsRepo(dir string) bool {
+	out, err := run(dir, "rev-parse", "--is-inside-work-tree")
+	return err == nil && strings.TrimSpace(out) == "true"
+}
+
+// IsClean reports whether dir has no uncommitted changes. Any porcelain output,
+// including untracked files, is treated as dirty so an update never silently
+// overwrites local state.
+func IsClean(dir string) (bool, error) {
+	out, err := run(dir, "status", "--porcelain")
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(out) == "", nil
+}
+
+// Preview fetches remote refs and reports the fast-forward an update would apply
+// without modifying the working tree. It returns ErrNotFastForward when the
+// local branch has diverged from upstream.
+func Preview(dir string) (Update, error) {
+	old, err := head(dir)
+	if err != nil {
+		return Update{}, err
+	}
+	if err := fetch(dir); err != nil {
+		return Update{}, err
+	}
+	upstream, err := upstreamRev(dir)
+	if err != nil {
+		return Update{}, err
+	}
+	if old == upstream {
+		return Update{OldRev: old, NewRev: old}, nil
+	}
+	if !canFastForward(dir) {
+		return Update{}, ErrNotFastForward
+	}
+	incoming, err := incomingCommits(dir)
+	if err != nil {
+		return Update{}, err
+	}
+	return Update{OldRev: old, NewRev: upstream, Incoming: incoming}, nil
+}
+
+// FastForward fetches and advances dir to its upstream via merge --ff-only. It
+// returns ErrNotFastForward when the local branch cannot be fast-forwarded,
+// leaving the working tree untouched.
+func FastForward(dir string) (Update, error) {
+	old, err := head(dir)
+	if err != nil {
+		return Update{}, err
+	}
+	if err := fetch(dir); err != nil {
+		return Update{}, err
+	}
+	upstream, err := upstreamRev(dir)
+	if err != nil {
+		return Update{}, err
+	}
+	if old == upstream {
+		return Update{OldRev: old, NewRev: old}, nil
+	}
+	// Capture the incoming commits before merging so the report reflects exactly
+	// what the fast-forward applied.
+	incoming, err := incomingCommits(dir)
+	if err != nil {
+		return Update{}, err
+	}
+	if _, err := run(dir, "merge", "--ff-only", "@{u}"); err != nil {
+		return Update{}, ErrNotFastForward
+	}
+	newRev, err := head(dir)
+	if err != nil {
+		return Update{}, err
+	}
+	return Update{OldRev: old, NewRev: newRev, Incoming: incoming}, nil
+}
+
+func head(dir string) (string, error) {
+	out, err := run(dir, "rev-parse", "--short", "HEAD")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}
+
+func upstreamRev(dir string) (string, error) {
+	out, err := run(dir, "rev-parse", "--short", "@{u}")
+	if err != nil {
+		return "", fmt.Errorf("resolve upstream for %s: %w", dir, err)
+	}
+	return strings.TrimSpace(out), nil
+}
+
+func fetch(dir string) error {
+	if _, err := run(dir, "fetch", "--quiet"); err != nil {
+		return fmt.Errorf("fetch updates for %s: %w", dir, err)
+	}
+	return nil
+}
+
+func canFastForward(dir string) bool {
+	// HEAD must be an ancestor of upstream for a fast-forward to be possible.
+	_, err := run(dir, "merge-base", "--is-ancestor", "HEAD", "@{u}")
+	return err == nil
+}
+
+func incomingCommits(dir string) ([]string, error) {
+	out, err := run(dir, "log", "--pretty=%h %s", "HEAD..@{u}")
+	if err != nil {
+		return nil, fmt.Errorf("list incoming commits for %s: %w", dir, err)
+	}
+	trimmed := strings.TrimSpace(out)
+	if trimmed == "" {
+		return nil, nil
+	}
+	return strings.Split(trimmed, "\n"), nil
+}
+
+// run executes a git subcommand in dir and returns its standard output. Git
+// prompts are disabled so update fails deterministically instead of hanging when
+// credentials or remote access need user input.
+func run(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	cmd.Env = append(os.Environ(),
+		"GIT_TERMINAL_PROMPT=0",
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			return "", err
+		}
+		return "", fmt.Errorf("%s", msg)
+	}
+	return stdout.String(), nil
+}

--- a/internal/gitrepo/gitrepo_test.go
+++ b/internal/gitrepo/gitrepo_test.go
@@ -1,0 +1,208 @@
+package gitrepo_test
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/gitrepo"
+)
+
+func TestIsRepoTrueForCheckout(t *testing.T) {
+	requireGit(t)
+	_, clone := setupRemoteAndClone(t)
+
+	if !gitrepo.IsRepo(clone) {
+		t.Fatalf("IsRepo(%q) = false, want true for a git checkout", clone)
+	}
+}
+
+func TestIsRepoFalseForPlainDirectory(t *testing.T) {
+	requireGit(t)
+	dir := t.TempDir()
+
+	if gitrepo.IsRepo(dir) {
+		t.Fatalf("IsRepo(%q) = true, want false for a non-git directory", dir)
+	}
+}
+
+func TestIsCleanTrueForFreshClone(t *testing.T) {
+	requireGit(t)
+	_, clone := setupRemoteAndClone(t)
+
+	clean, err := gitrepo.IsClean(clone)
+	if err != nil {
+		t.Fatalf("IsClean() error = %v", err)
+	}
+	if !clean {
+		t.Fatalf("IsClean() = false, want true for a fresh clone")
+	}
+}
+
+func TestIsCleanFalseWithLocalChange(t *testing.T) {
+	requireGit(t)
+	_, clone := setupRemoteAndClone(t)
+
+	// A local modification to a tracked file must be detected as dirty so the
+	// updater refuses to overwrite local work.
+	writeFile(t, filepath.Join(clone, "configs/zsh/zshrc"), "local edit\n")
+
+	clean, err := gitrepo.IsClean(clone)
+	if err != nil {
+		t.Fatalf("IsClean() error = %v", err)
+	}
+	if clean {
+		t.Fatalf("IsClean() = true, want false after a local change")
+	}
+}
+
+func TestFastForwardAdvancesToUpstream(t *testing.T) {
+	requireGit(t)
+	origin, clone := setupRemoteAndClone(t)
+
+	// Advance the upstream with a new managed file so the fast-forward has
+	// something to apply.
+	writeFile(t, filepath.Join(origin, "configs/git/gitconfig"), "[user]\n")
+	gitExec(t, origin, "add", "-A")
+	gitExec(t, origin, "commit", "-m", "add gitconfig")
+
+	upd, err := gitrepo.FastForward(clone)
+	if err != nil {
+		t.Fatalf("FastForward() error = %v", err)
+	}
+	if !upd.Changed() {
+		t.Fatalf("FastForward() Changed() = false, want true after upstream advanced")
+	}
+	if upd.OldRev == "" || upd.NewRev == "" || upd.OldRev == upd.NewRev {
+		t.Fatalf("FastForward() revs = %q -> %q, want distinct non-empty revs", upd.OldRev, upd.NewRev)
+	}
+	if len(upd.Incoming) != 1 {
+		t.Fatalf("FastForward() Incoming = %v, want 1 incoming commit", upd.Incoming)
+	}
+	// The working tree must actually contain the pulled file.
+	if _, err := os.Stat(filepath.Join(clone, "configs/git/gitconfig")); err != nil {
+		t.Fatalf("fast-forward did not materialize upstream file: %v", err)
+	}
+}
+
+func TestFastForwardUpToDateReportsNoChange(t *testing.T) {
+	requireGit(t)
+	_, clone := setupRemoteAndClone(t)
+
+	upd, err := gitrepo.FastForward(clone)
+	if err != nil {
+		t.Fatalf("FastForward() error = %v", err)
+	}
+	if upd.Changed() {
+		t.Fatalf("FastForward() Changed() = true, want false when already up to date")
+	}
+	if len(upd.Incoming) != 0 {
+		t.Fatalf("FastForward() Incoming = %v, want none when up to date", upd.Incoming)
+	}
+}
+
+func TestPreviewReportsIncomingWithoutModifyingWorkingTree(t *testing.T) {
+	requireGit(t)
+	origin, clone := setupRemoteAndClone(t)
+
+	writeFile(t, filepath.Join(origin, "configs/git/gitconfig"), "[user]\n")
+	gitExec(t, origin, "add", "-A")
+	gitExec(t, origin, "commit", "-m", "add gitconfig")
+
+	upd, err := gitrepo.Preview(clone)
+	if err != nil {
+		t.Fatalf("Preview() error = %v", err)
+	}
+	if !upd.Changed() {
+		t.Fatalf("Preview() Changed() = false, want true when an update is available")
+	}
+	if len(upd.Incoming) != 1 {
+		t.Fatalf("Preview() Incoming = %v, want 1 incoming commit", upd.Incoming)
+	}
+	// Preview must not touch the working tree.
+	if _, err := os.Stat(filepath.Join(clone, "configs/git/gitconfig")); !os.IsNotExist(err) {
+		t.Fatalf("Preview() modified the working tree; stat err = %v", err)
+	}
+}
+
+func TestFastForwardReturnsErrNotFastForwardOnDivergence(t *testing.T) {
+	requireGit(t)
+	origin, clone := setupRemoteAndClone(t)
+
+	// Diverge: a local commit and an upstream commit that touch the same file.
+	writeFile(t, filepath.Join(clone, "configs/zsh/zshrc"), "local change\n")
+	gitExec(t, clone, "add", "-A")
+	gitExec(t, clone, "commit", "-m", "local change")
+
+	writeFile(t, filepath.Join(origin, "configs/zsh/zshrc"), "upstream change\n")
+	gitExec(t, origin, "add", "-A")
+	gitExec(t, origin, "commit", "-m", "upstream change")
+
+	_, err := gitrepo.FastForward(clone)
+	if !errors.Is(err, gitrepo.ErrNotFastForward) {
+		t.Fatalf("FastForward() error = %v, want ErrNotFastForward on divergence", err)
+	}
+}
+
+// --- helpers ---
+
+func requireGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available on PATH")
+	}
+}
+
+// setupRemoteAndClone creates a non-bare origin repository with an initial
+// managed file and clones it into a separate working directory. The clone's
+// upstream tracks origin/main, so fetching the advanced origin exercises the
+// fast-forward path without any network access.
+func setupRemoteAndClone(t *testing.T) (origin, clone string) {
+	t.Helper()
+	origin = t.TempDir()
+	gitExec(t, origin, "init", "-b", "main")
+	configIdentity(t, origin)
+	writeFile(t, filepath.Join(origin, "configs/zsh/zshrc"), "export A=1\n")
+	gitExec(t, origin, "add", "-A")
+	gitExec(t, origin, "commit", "-m", "initial")
+
+	clone = t.TempDir()
+	gitExec(t, "", "clone", origin, clone)
+	configIdentity(t, clone)
+	return origin, clone
+}
+
+func configIdentity(t *testing.T, dir string) {
+	t.Helper()
+	gitExec(t, dir, "config", "user.email", "dots@test.local")
+	gitExec(t, dir, "config", "user.name", "dots test")
+	gitExec(t, dir, "config", "commit.gpgsign", "false")
+}
+
+func gitExec(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	cmd.Env = append(os.Environ(),
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"GIT_CONFIG_SYSTEM=/dev/null",
+		"GIT_TERMINAL_PROMPT=0",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir for %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
Closes #19

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds `dots update` for fast-forward-only Installed Repository updates.
- Reuses the existing Install Plan, Conflict Resolution, and Backup Set flow after updating.
- Documents the versioning model, dry-run behavior, and post-update conflict handling.

## Changes

| File | Change |
|------|--------|
| `internal/gitrepo/` | Adds a thin wrapper around the system `git` binary for repo checks, clean-state checks, update previews, and `--ff-only` fast-forwards. |
| `internal/cli/install.go` | Extracts shared conflict-resolution and apply flow into `resolveAndApply` so `install` and `update` use the same safe machinery. |
| `internal/cli/update.go` | Adds the `dots update` command and wires update preview/apply, plan recomputation, dry-run behavior, and post-update install application. |
| `internal/cli/root.go` | Registers the new `update` command. |
| `internal/cli/update_test.go` | Covers fast-forward update, dry-run safety, dirty repo refusal, default manifest resolution from `sourceRoot`, non-repo errors, and backup creation on replace. |
| `internal/gitrepo/gitrepo_test.go` | Covers Git wrapper behavior using temporary Git repositories. |
| `docs/update.md` | Documents update semantics, versioning model, dry-run behavior, and conflict handling. |
| `CONTEXT.md`, `docs/scope.md` | Marks `dots update` as delivered in v1.1 and links the new docs. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp>`
- [x] Regression: `go test -count=1 ./internal/cli -run TestUpdateDefaultManifestLoadsFromSourceRoot`
- [x] Git wrapper integration: `go test -count=1 ./internal/gitrepo`
- [x] Fresh post-fix review found no blocking issues.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
