### PR TITLE
feat(dist): add Homebrew tap distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,57 @@ jobs:
       - name: Build release artifacts and checksums.txt
         run: scripts/build-release-artifacts.sh --version "${{ steps.release.outputs.tag }}" --out-dir dist
 
+      - name: Require Homebrew tap token
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${HOMEBREW_TAP_TOKEN:-}" ]]; then
+            echo "HOMEBREW_TAP_TOKEN is required to update yersonargotev/homebrew-tap before publishing release assets" >&2
+            exit 1
+          fi
+
+      - name: Check out Homebrew tap
+        uses: actions/checkout@v5
+        with:
+          repository: yersonargotev/homebrew-tap
+          path: homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+      - name: Generate Homebrew formula from release checksums
+        run: |
+          scripts/generate-homebrew-formula.sh \
+            --version "${{ steps.release.outputs.tag }}" \
+            --checksums dist/checksums.txt \
+            --out homebrew-tap/Formula/dots.rb \
+            --repo yersonargotev/dots \
+            --homepage https://github.com/yersonargotev/dots \
+            --desc "Safe dotfiles installer"
+
+      - name: Prepare Homebrew tap formula update
+        id: prepare_tap
+        working-directory: homebrew-tap
+        env:
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/dots.rb
+          if git diff --cached --quiet; then
+            echo "Homebrew formula already matches $RELEASE_TAG"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git commit -m "feat: update dots formula to ${RELEASE_TAG}"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Prove Homebrew tap push permission
+        working-directory: homebrew-tap
+        run: |
+          set -euo pipefail
+          git push --dry-run origin HEAD:main
+
       - name: Create GitHub Release if needed
         env:
           GH_TOKEN: ${{ github.token }}
@@ -70,3 +121,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
         run: gh release upload "$RELEASE_TAG" dist/* --clobber
+
+      - name: Push prepared Homebrew tap formula update
+        working-directory: homebrew-tap
+        env:
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          TAP_UPDATE_CHANGED: ${{ steps.prepare_tap.outputs.changed }}
+        run: |
+          set -euo pipefail
+          if [[ "$TAP_UPDATE_CHANGED" != "true" ]]; then
+            echo "Homebrew formula already matches $RELEASE_TAG"
+            exit 0
+          fi
+          git push origin HEAD:main

--- a/README.md
+++ b/README.md
@@ -1,0 +1,54 @@
+# dots
+
+`dots` is a safe Dotfiles CLI for installing repository-owned shell, git, starship, and tmux configuration. It plans before changing files, detects conflicts, and keeps install behavior inside the tested Go CLI instead of duplicating it in shell scripts.
+
+## Quick install
+
+Choose one install path. Both paths install the same checksum-verified GitHub Release Artifact for your platform.
+
+### Homebrew
+
+```bash
+brew install yersonargotev/tap/dots
+```
+
+If you prefer tapping first, run `brew tap yersonargotev/tap` and then `brew install dots`.
+
+Verify the binary is available:
+
+```bash
+dots --help
+```
+
+Then run the installer from the CLI:
+
+```bash
+dots install
+```
+
+### Bootstrapper
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/yersonargotev/dots/main/scripts/install.sh | DOTS_VERSION=v0.1.0 bash
+```
+
+The Bootstrapper downloads `checksums.txt`, verifies the matching Release Artifact, installs `dots` to `~/.local/bin/dots`, and delegates setup to `dots install`.
+
+## Release artifacts
+
+Each release publishes raw binaries for:
+
+| Platform | Artifact suffix |
+|----------|-----------------|
+| macOS amd64 | `darwin_amd64` |
+| macOS arm64 | `darwin_arm64` |
+| Linux amd64 | `linux_amd64` |
+| Linux arm64 | `linux_arm64` |
+
+Homebrew and the Bootstrapper use those same artifacts plus the published SHA-256 manifest.
+
+## Maintainer docs
+
+- [`docs/release.md`](docs/release.md) — release workflow, checksums, Homebrew tap automation, and Bootstrapper install.
+- [`docs/scope.md`](docs/scope.md) — current scope boundaries and deferred work.
+- [`CONTEXT.md`](CONTEXT.md) — domain vocabulary and architecture context.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,6 +1,6 @@
 # Publish a v0.x Release
 
-This workflow publishes Bootstrapper-ready `dots` Release Artifacts for macOS and Linux. Each release includes one raw binary per Supported Platform plus `checksums.txt` for Checksum Verification.
+This workflow publishes `dots` Release Artifacts for macOS and Linux, then updates the Homebrew tap from the same checksum manifest. The Bootstrapper and Homebrew formula use the same raw binaries, so package distribution never becomes a second source of install logic.
 
 ## Quick path
 
@@ -19,6 +19,7 @@ This workflow publishes Bootstrapper-ready `dots` Release Artifacts for macOS an
    - `dots_v0.1.0_linux_amd64`
    - `dots_v0.1.0_linux_arm64`
    - `checksums.txt`
+4. Verify the tap repository has an updated `Formula/dots.rb` commit for the same tag.
 
 ## Manual dispatch
 
@@ -26,7 +27,7 @@ Use manual dispatch when the tag already exists but the release needs to be rebu
 
 1. Go to **Actions → Release → Run workflow**.
 2. Enter the existing tag, for example `v0.1.0`.
-3. Run the workflow. It checks out that tag, rebuilds the four artifacts, recreates `checksums.txt`, and uploads assets with `--clobber`.
+3. Run the workflow. It checks out that tag, rebuilds the four artifacts, recreates `checksums.txt`, verifies `HOMEBREW_TAP_TOKEN` is present, checks out the Homebrew tap, regenerates and locally commits `Formula/dots.rb` when changed, dry-run pushes that prepared tap state, uploads assets with `--clobber`, and only then pushes the prepared tap commit.
 
 ## Checksum Verification contract
 
@@ -47,6 +48,34 @@ shasum -a 256 -c checksums.txt
 ```
 
 On Linux, `sha256sum -c checksums.txt` is equivalent.
+
+## Homebrew install
+
+Install the latest tap formula:
+
+```bash
+brew install yersonargotev/tap/dots
+dots --help
+dots install
+```
+
+Equivalent tapped form: `brew tap yersonargotev/tap`, then `brew install dots`.
+
+The formula selects the correct Release Artifact for macOS/Linux and amd64/arm64, marks each raw executable URL with `using: :nounzip`, verifies the published SHA-256 checksum from the generated formula, installs the downloaded binary as `dots`, and runs `dots --help` in `brew test`.
+
+The release workflow proves tap write access before it mutates the public GitHub Release, but it does not publish the tap update until the release assets exist:
+
+1. It verifies `HOMEBREW_TAP_TOKEN` is present and checks out `yersonargotev/homebrew-tap`.
+2. It generates `Formula/dots.rb` with `scripts/generate-homebrew-formula.sh`. The script reads `dist/checksums.txt` and requires exactly the four supported artifact entries.
+3. It stages and commits the formula update locally when the tap formula changed.
+4. It dry-run pushes the prepared local tap state before creating or uploading GitHub Release assets.
+5. After the release assets upload succeeds, it pushes the already-prepared tap commit, or no-ops if the formula already matched the tag.
+
+Maintainer setup:
+
+- Create or maintain the `yersonargotev/homebrew-tap` repository.
+- Store a token with write access to that tap as this repository secret: `HOMEBREW_TAP_TOKEN`.
+- Do not use `GITHUB_TOKEN` for the tap push; it is scoped to this repository.
 
 ## Bootstrapper install
 
@@ -76,7 +105,7 @@ DOTS_VERSION=v0.1.0 DOTS_SOURCE_ROOT="$PWD" bash scripts/install.sh
 | Artifacts | Raw `dots` binaries named `dots_<version>_<goos>_<goarch>`. |
 | Platforms | `darwin/amd64`, `darwin/arm64`, `linux/amd64`, and `linux/arm64`. |
 | Checksums | One `checksums.txt` file covers every Release Artifact. |
-| Homebrew Distribution | Deferred. Do not add tap, formula, or bottle steps in this slice. |
+| Homebrew Distribution | `scripts/generate-homebrew-formula.sh` generates `Formula/dots.rb` from the release tag and `checksums.txt`; the workflow locally prepares the tap commit, dry-run proves that prepared state can be pushed, then pushes it to `yersonargotev/homebrew-tap` with `HOMEBREW_TAP_TOKEN` after release assets upload. |
 
 ## First v0.x checklist
 
@@ -85,4 +114,5 @@ DOTS_VERSION=v0.1.0 DOTS_SOURCE_ROOT="$PWD" bash scripts/install.sh
 - [ ] All four platform artifacts are attached to the GitHub Release.
 - [ ] `checksums.txt` contains one SHA-256 entry for each artifact.
 - [ ] The Bootstrapper maps its detected `goos/goarch` to the matching artifact name.
-- [ ] No Homebrew Distribution step was added.
+- [ ] `Formula/dots.rb` in `yersonargotev/homebrew-tap` points at the same tag and checksums.
+- [ ] `HOMEBREW_TAP_TOKEN` is configured before relying on automatic tap updates.

--- a/docs/scope.md
+++ b/docs/scope.md
@@ -20,13 +20,13 @@ v1 proves that the Dotfiles CLI can install repository-owned configuration safel
 | Backups list | `dots backups list` exposes Backup Sets and Backup Metadata so preserved files can be audited after installation. |
 | Release artifacts | GitHub Releases publish platform-specific Release Artifacts for macOS amd64/arm64 and Linux amd64/arm64. |
 | Bootstrapper support | The Bootstrapper downloads the matching Release Artifact, performs Checksum Verification, installs or locates `dots`, and delegates setup to the Dotfiles CLI. |
+| Homebrew Distribution | The release workflow generates a tap formula from the same Release Artifacts and checksum manifest, then publishes it to `yersonargotev/homebrew-tap`. |
 | MVP Configuration Set | v1 proves the installer with zsh, git, starship, and tmux before migrating larger application configurations. |
 
 ## Deferred to v1.1 or later
 
 | Deferred item | Earliest target | Why it is deferred |
 |---------------|-----------------|--------------------|
-| Homebrew Distribution | v1.1 or phase 2 | GitHub Releases and checksum-based bootstrapping must be stable before adding tap, formula, or bottle maintenance. |
 | Automatic dependency installation | Later than v1 | Installing packages introduces package-manager selection, sudo behavior, distro differences, repositories, taps, version constraints, and higher operational risk. |
 | `dots update` | v1.1 — **shipped** | Updating the Installed Repository introduces Git state, local changes, versioning, and post-update conflict handling. Delivered in v1.1; see [`docs/update.md`](update.md). |
 | Neovim and larger application configurations | Later than v1 | Larger app configs introduce plugin, language-server, and dependency complexity that distracts from proving installer correctness. |
@@ -53,7 +53,7 @@ A Dependency Plan helps the user understand missing tools without allowing v1 to
 
 ### Distribution starts with verifiable artifacts
 
-v1 distribution starts with GitHub Release Artifacts plus Checksum Verification because the Bootstrapper can verify exactly what it downloads. Homebrew Distribution is valuable, but it adds packaging maintenance after the artifact contract is already proven.
+v1 distribution starts with GitHub Release Artifacts plus Checksum Verification because every install path can verify exactly what it downloads. Homebrew Distribution now uses that same artifact contract: the formula is generated from `checksums.txt`, selects the correct macOS/Linux amd64/arm64 binary, and delegates all setup behavior to the installed `dots` CLI.
 
 ### The MVP Configuration Set keeps the feedback loop tight
 
@@ -70,7 +70,7 @@ zsh, git, starship, and tmux are enough to prove symlink, template, copy, Local 
 
 Use this checklist when reviewing v1 issues or PRs:
 
-- [ ] The change strengthens safe installation, status, diagnostics, dependency guidance, backups, release artifacts, or checksum Bootstrapper support.
-- [ ] The change does not add Homebrew Distribution, automatic dependency installation, `dots update`, or larger Deferred Configuration to v1.
+- [ ] The change strengthens safe installation, status, diagnostics, dependency guidance, backups, release artifacts, checksum Bootstrapper support, or Homebrew Distribution.
+- [ ] The change does not add automatic dependency installation, larger Deferred Configuration, or unsupported platform behavior to v1.
 - [ ] The change preserves Source of Truth integrity and does not make Machine-Specific Configuration part of shared Managed Configuration.
 - [ ] The change uses the project vocabulary from `CONTEXT.md` and the tradeoffs recorded in the ADR.

--- a/internal/release/release_automation_test.go
+++ b/internal/release/release_automation_test.go
@@ -48,14 +48,97 @@ func TestReleaseWorkflowPublishesBootstrapperConsumableArtifacts(t *testing.T) {
 		"scripts/build-release-artifacts.sh",
 		"gh release upload",
 		"checksums.txt",
+		"scripts/generate-homebrew-formula.sh",
+		"HOMEBREW_TAP_TOKEN",
+		"yersonargotev/homebrew-tap",
+		"Formula/dots.rb",
 	} {
 		if !strings.Contains(text, want) {
-			t.Fatalf("release workflow should contain %q so GitHub Releases get versioned assets plus checksums", want)
+			t.Fatalf("release workflow should contain %q so GitHub Releases and the Homebrew tap stay in sync", want)
 		}
 	}
-	if strings.Contains(strings.ToLower(text), "homebrew") {
-		t.Fatalf("release workflow should not configure Homebrew distribution in this slice")
-	}
+}
+
+func TestReleaseWorkflowProvesTapAccessBeforePublishingReleaseAssets(t *testing.T) {
+	root := repoRoot(t)
+	workflow := readWorkflow(t, filepath.Join(root, ".github", "workflows", "release.yml"))
+	steps := workflowSteps(t, workflow)
+
+	buildIndex := workflowStepIndex(t, steps, "build release artifacts and checksums", func(step map[string]any) bool {
+		run := stepRun(step)
+		return strings.Contains(run, "scripts/build-release-artifacts.sh") &&
+			strings.Contains(run, "--out-dir dist")
+	})
+	requireTapTokenIndex := workflowStepIndex(t, steps, "required Homebrew tap token guard", func(step map[string]any) bool {
+		run := stepRun(step)
+		return strings.Contains(fmt.Sprint(stepEnv(step)["HOMEBREW_TAP_TOKEN"]), "HOMEBREW_TAP_TOKEN") &&
+			strings.Contains(run, "HOMEBREW_TAP_TOKEN is required") &&
+			strings.Contains(run, "yersonargotev/homebrew-tap")
+	})
+	tapCheckoutIndex := workflowStepIndex(t, steps, "token-backed Homebrew tap checkout", func(step map[string]any) bool {
+		with := stepWith(step)
+		return stepUses(step) == "actions/checkout@v5" &&
+			with["repository"] == "yersonargotev/homebrew-tap" &&
+			with["path"] == "homebrew-tap" &&
+			strings.Contains(fmt.Sprint(with["token"]), "HOMEBREW_TAP_TOKEN")
+	})
+	formulaIndex := workflowStepIndex(t, steps, "Homebrew formula generation from release checksums", func(step map[string]any) bool {
+		run := stepRun(step)
+		return strings.Contains(run, "scripts/generate-homebrew-formula.sh") &&
+			strings.Contains(run, "--checksums dist/checksums.txt") &&
+			strings.Contains(run, "--out homebrew-tap/Formula/dots.rb")
+	})
+	prepareTapIndex := workflowStepIndex(t, steps, "local Homebrew tap formula commit preparation", func(step map[string]any) bool {
+		run := stepRun(step)
+		return stepWorkingDirectory(step) == "homebrew-tap" &&
+			strings.Contains(run, `git config user.name "github-actions[bot]"`) &&
+			strings.Contains(run, `git config user.email "github-actions[bot]@users.noreply.github.com"`) &&
+			strings.Contains(run, "git add Formula/dots.rb") &&
+			strings.Contains(run, "git diff --cached --quiet") &&
+			strings.Contains(run, `echo "changed=false" >> "$GITHUB_OUTPUT"`) &&
+			strings.Contains(run, `echo "changed=true" >> "$GITHUB_OUTPUT"`) &&
+			strings.Contains(run, `git commit -m "feat: update dots formula to ${RELEASE_TAG}"`)
+	})
+	tapPushAccessProofIndex := workflowStepIndex(t, steps, "non-mutating Homebrew tap push permission proof against prepared local state", func(step map[string]any) bool {
+		run := stepRun(step)
+		return stepWorkingDirectory(step) == "homebrew-tap" &&
+			strings.Contains(run, "git push --dry-run origin HEAD:main") &&
+			!strings.Contains(run, "git commit") &&
+			!strings.Contains(run, "git add Formula/dots.rb")
+	})
+	createReleaseIndex := workflowStepIndex(t, steps, "GitHub Release creation", func(step map[string]any) bool {
+		run := stepRun(step)
+		return strings.Contains(run, "gh release create") &&
+			strings.Contains(fmt.Sprint(stepEnv(step)["GH_TOKEN"]), "github.token")
+	})
+	uploadIndex := workflowStepIndex(t, steps, "GitHub Release asset upload", func(step map[string]any) bool {
+		run := stepRun(step)
+		return strings.Contains(run, "gh release upload") &&
+			strings.Contains(run, "dist/*") &&
+			strings.Contains(run, "--clobber")
+	})
+	pushTapIndex := workflowStepIndex(t, steps, "final Homebrew tap formula push", func(step map[string]any) bool {
+		run := stepRun(step)
+		return stepWorkingDirectory(step) == "homebrew-tap" &&
+			strings.Contains(fmt.Sprint(stepEnv(step)["TAP_UPDATE_CHANGED"]), "prepare_tap.outputs.changed") &&
+			strings.Contains(run, `[[ "$TAP_UPDATE_CHANGED" != "true" ]]`) &&
+			strings.Contains(run, "git push origin HEAD:main") &&
+			!strings.Contains(run, "git push --dry-run") &&
+			!strings.Contains(run, "git commit")
+	})
+
+	assertStepBefore(t, steps, buildIndex, formulaIndex, "formula generation must consume freshly built artifacts and dist/checksums.txt")
+	assertStepBefore(t, steps, requireTapTokenIndex, tapCheckoutIndex, "the workflow must reject a missing HOMEBREW_TAP_TOKEN before falling back to anonymous tap checkout")
+	assertStepBefore(t, steps, requireTapTokenIndex, createReleaseIndex, "a missing HOMEBREW_TAP_TOKEN must fail before creating a GitHub Release")
+	assertStepBefore(t, steps, requireTapTokenIndex, uploadIndex, "a missing HOMEBREW_TAP_TOKEN must fail before re-uploading release assets")
+	assertStepBefore(t, steps, tapCheckoutIndex, formulaIndex, "the tap checkout must exist before writing Formula/dots.rb into it")
+	assertStepBefore(t, steps, formulaIndex, prepareTapIndex, "the generated formula must be staged before preparing a local tap commit")
+	assertStepBefore(t, steps, prepareTapIndex, tapPushAccessProofIndex, "the workflow must dry-run push the already-prepared local tap state, not the untouched checkout")
+	assertStepBefore(t, steps, tapPushAccessProofIndex, createReleaseIndex, "token-backed tap push permission must be proven before creating a GitHub Release")
+	assertStepBefore(t, steps, tapPushAccessProofIndex, uploadIndex, "token-backed tap push permission must be proven before re-uploading release assets")
+	assertStepBefore(t, steps, uploadIndex, pushTapIndex, "the tap update must not be published until release assets exist")
+	assertStepBefore(t, steps, tapPushAccessProofIndex, pushTapIndex, "token-backed tap push permission must be proven before the mutating tap push")
+	assertStepBefore(t, steps, prepareTapIndex, pushTapIndex, "the final tap push must publish the already-prepared commit instead of creating a new commit after assets upload")
 }
 
 func TestBuildReleaseArtifactsCreatesChecksummedSupportedPlatforms(t *testing.T) {
@@ -159,6 +242,157 @@ func TestBuildReleaseArtifactsValidatesReleaseVersionLikeWorkflow(t *testing.T) 
 	})
 }
 
+func TestGenerateHomebrewFormulaUsesChecksummedReleaseArtifacts(t *testing.T) {
+	root := repoRoot(t)
+	checksumsPath := filepath.Join(t.TempDir(), "checksums.txt")
+	checksums := strings.Join([]string{
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  dots_v0.99.0_darwin_amd64",
+		"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  dots_v0.99.0_darwin_arm64",
+		"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc  dots_v0.99.0_linux_amd64",
+		"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd  dots_v0.99.0_linux_arm64",
+	}, "\n") + "\n"
+	if err := os.WriteFile(checksumsPath, []byte(checksums), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	outputPath := filepath.Join(t.TempDir(), "Formula", "dots.rb")
+
+	cmd := exec.Command(
+		"bash",
+		filepath.Join(root, "scripts", "generate-homebrew-formula.sh"),
+		"--version", "v0.99.0",
+		"--checksums", checksumsPath,
+		"--out", outputPath,
+		"--repo", "yersonargotev/dots",
+		"--homepage", "https://github.com/yersonargotev/dots",
+		"--desc", "Safe dotfiles installer",
+	)
+	cmd.Dir = root
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("generate formula: %v\n%s", err, output)
+	}
+
+	formula, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(formula)
+	for _, want := range []string{
+		"class Dots < Formula",
+		`desc "Safe dotfiles installer"`,
+		`homepage "https://github.com/yersonargotev/dots"`,
+		`version "0.99.0"`,
+		`url "https://github.com/yersonargotev/dots/releases/download/v0.99.0/dots_v0.99.0_darwin_amd64", using: :nounzip`,
+		`sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"`,
+		`url "https://github.com/yersonargotev/dots/releases/download/v0.99.0/dots_v0.99.0_darwin_arm64", using: :nounzip`,
+		`sha256 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"`,
+		`url "https://github.com/yersonargotev/dots/releases/download/v0.99.0/dots_v0.99.0_linux_amd64", using: :nounzip`,
+		`sha256 "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"`,
+		`url "https://github.com/yersonargotev/dots/releases/download/v0.99.0/dots_v0.99.0_linux_arm64", using: :nounzip`,
+		`sha256 "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"`,
+		`bin.install downloaded_binary => "dots"`,
+		`system "#{bin}/dots", "--help"`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("formula should contain %q\nformula:\n%s", want, text)
+		}
+	}
+	if got := strings.Count(text, "using: :nounzip"); got != len(supportedReleasePlatforms) {
+		t.Fatalf("formula should mark every raw executable URL as using: :nounzip; got %d occurrences in:\n%s", got, text)
+	}
+}
+
+func TestGenerateHomebrewFormulaFailsClearlyWhenChecksumEntryIsMissing(t *testing.T) {
+	root := repoRoot(t)
+	checksumsPath := filepath.Join(t.TempDir(), "checksums.txt")
+	checksums := strings.Join([]string{
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  dots_v0.99.0_darwin_amd64",
+		"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  dots_v0.99.0_darwin_arm64",
+		"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc  dots_v0.99.0_linux_amd64",
+	}, "\n") + "\n"
+	if err := os.WriteFile(checksumsPath, []byte(checksums), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	outputPath := filepath.Join(t.TempDir(), "Formula", "dots.rb")
+
+	cmd := exec.Command(
+		"bash",
+		filepath.Join(root, "scripts", "generate-homebrew-formula.sh"),
+		"--version", "v0.99.0",
+		"--checksums", checksumsPath,
+		"--out", outputPath,
+	)
+	cmd.Dir = root
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("generate formula should fail when a checksum entry is missing\n%s", output)
+	}
+	if !strings.Contains(string(output), "missing checksum entry for dots_v0.99.0_linux_arm64") {
+		t.Fatalf("failure should name the missing artifact, got:\n%s", output)
+	}
+	if _, err := os.Stat(outputPath); !os.IsNotExist(err) {
+		t.Fatalf("formula should not be written with incomplete checksums; stat error: %v", err)
+	}
+}
+
+func TestGenerateHomebrewFormulaFailsClearlyWhenChecksumManifestIsNotExact(t *testing.T) {
+	root := repoRoot(t)
+
+	baseChecksums := []string{
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  dots_v0.99.0_darwin_amd64",
+		"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  dots_v0.99.0_darwin_arm64",
+		"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc  dots_v0.99.0_linux_amd64",
+		"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd  dots_v0.99.0_linux_arm64",
+	}
+
+	tests := []struct {
+		name      string
+		extraLine string
+		wantError string
+	}{
+		{
+			name:      "rejects unexpected release artifact",
+			extraLine: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee  dots_v0.99.0_linux_386",
+			wantError: "unexpected checksum entry for dots_v0.99.0_linux_386",
+		},
+		{
+			name:      "rejects duplicate expected artifact",
+			extraLine: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff  dots_v0.99.0_darwin_amd64",
+			wantError: "duplicate checksum entry for dots_v0.99.0_darwin_amd64",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checksumsPath := filepath.Join(t.TempDir(), "checksums.txt")
+			checksums := strings.Join(append(baseChecksums, tt.extraLine), "\n") + "\n"
+			if err := os.WriteFile(checksumsPath, []byte(checksums), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			outputPath := filepath.Join(t.TempDir(), "Formula", "dots.rb")
+
+			cmd := exec.Command(
+				"bash",
+				filepath.Join(root, "scripts", "generate-homebrew-formula.sh"),
+				"--version", "v0.99.0",
+				"--checksums", checksumsPath,
+				"--out", outputPath,
+			)
+			cmd.Dir = root
+			output, err := cmd.CombinedOutput()
+			if err == nil {
+				t.Fatalf("generate formula should fail when the checksum manifest is not exact\n%s", output)
+			}
+			if !strings.Contains(string(output), tt.wantError) {
+				t.Fatalf("failure should explain the manifest mismatch, got:\n%s", output)
+			}
+			if _, err := os.Stat(outputPath); !os.IsNotExist(err) {
+				t.Fatalf("formula should not be written with invalid checksum manifest; stat error: %v", err)
+			}
+		})
+	}
+}
+
 func fakeGoBuild(t *testing.T) (string, string) {
 	t.Helper()
 	dir := t.TempDir()
@@ -216,6 +450,92 @@ func readWorkflow(t *testing.T, path string) map[string]any {
 		t.Fatalf("parse workflow YAML: %v", err)
 	}
 	return workflow
+}
+
+func workflowSteps(t *testing.T, workflow map[string]any) []map[string]any {
+	t.Helper()
+	jobs := mapAt(t, workflow, "jobs")
+	release := mapAt(t, jobs, "release")
+	value, ok := release["steps"]
+	if !ok {
+		t.Fatal("release job should define steps")
+	}
+	items, ok := value.([]any)
+	if !ok {
+		t.Fatalf("release steps should be a list, got %T", value)
+	}
+
+	steps := make([]map[string]any, 0, len(items))
+	for index, item := range items {
+		step, ok := item.(map[string]any)
+		if !ok {
+			t.Fatalf("release step %d should be a map, got %T", index, item)
+		}
+		steps = append(steps, step)
+	}
+	return steps
+}
+
+func workflowStepIndex(t *testing.T, steps []map[string]any, description string, match func(map[string]any) bool) int {
+	t.Helper()
+	for index, step := range steps {
+		if match(step) {
+			return index
+		}
+	}
+	t.Fatalf("release workflow missing step for %s", description)
+	return -1
+}
+
+func assertStepBefore(t *testing.T, steps []map[string]any, before, after int, reason string) {
+	t.Helper()
+	if before >= after {
+		t.Fatalf("%s: step %q should appear before %q", reason, stepName(steps[before]), stepName(steps[after]))
+	}
+}
+
+func stepName(step map[string]any) string {
+	if name, ok := step["name"].(string); ok {
+		return name
+	}
+	return "<unnamed>"
+}
+
+func stepRun(step map[string]any) string {
+	if run, ok := step["run"].(string); ok {
+		return run
+	}
+	return ""
+}
+
+func stepUses(step map[string]any) string {
+	if uses, ok := step["uses"].(string); ok {
+		return uses
+	}
+	return ""
+}
+
+func stepWith(step map[string]any) map[string]any {
+	with, ok := step["with"].(map[string]any)
+	if !ok {
+		return map[string]any{}
+	}
+	return with
+}
+
+func stepEnv(step map[string]any) map[string]any {
+	env, ok := step["env"].(map[string]any)
+	if !ok {
+		return map[string]any{}
+	}
+	return env
+}
+
+func stepWorkingDirectory(step map[string]any) string {
+	if dir, ok := step["working-directory"].(string); ok {
+		return dir
+	}
+	return ""
 }
 
 func mapAt(t *testing.T, m map[string]any, key string) map[string]any {

--- a/scripts/generate-homebrew-formula.sh
+++ b/scripts/generate-homebrew-formula.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Generate a Homebrew formula for dots from a release checksum manifest.
+
+Usage:
+  scripts/generate-homebrew-formula.sh --version <v0.x.y> --checksums <checksums.txt> --out <Formula/dots.rb> [options]
+
+Options:
+  --version   Release tag used in artifact filenames, for example v0.1.0.
+  --checksums Path to the release checksums.txt manifest.
+  --out       Output formula path.
+  --repo      GitHub repository in owner/name form. Defaults to yersonargotev/dots.
+  --homepage  Formula homepage. Defaults to https://github.com/<repo>.
+  --desc      Formula description. Defaults to Safe dotfiles installer.
+  -h, --help  Show this help.
+USAGE
+}
+
+fail() {
+  echo "generate-homebrew-formula: $*" >&2
+  exit 1
+}
+
+ruby_escape() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  printf '%s' "$value"
+}
+
+version="${RELEASE_VERSION:-}"
+checksums_path=""
+out_path=""
+repo="yersonargotev/dots"
+homepage=""
+desc="Safe dotfiles installer"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      version="${2:-}"
+      shift 2
+      ;;
+    --checksums)
+      checksums_path="${2:-}"
+      shift 2
+      ;;
+    --out)
+      out_path="${2:-}"
+      shift 2
+      ;;
+    --repo)
+      repo="${2:-}"
+      shift 2
+      ;;
+    --homepage)
+      homepage="${2:-}"
+      shift 2
+      ;;
+    --desc)
+      desc="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+release_version_regex='^v0\.[0-9]+(\.[0-9]+)?(-[0-9A-Za-z.-]+)?$'
+if [[ ! "$version" =~ $release_version_regex ]]; then
+  fail "release version must be a v0.x tag such as v0.1.0; got '${version:-<empty>}'"
+fi
+if [[ -z "$checksums_path" ]]; then
+  fail "--checksums is required"
+fi
+if [[ ! -f "$checksums_path" ]]; then
+  fail "checksums file not found: $checksums_path"
+fi
+if [[ -z "$out_path" ]]; then
+  fail "--out is required"
+fi
+if [[ "$repo" != */* ]]; then
+  fail "--repo must be in owner/name form; got '$repo'"
+fi
+if [[ -z "$homepage" ]]; then
+  homepage="https://github.com/$repo"
+fi
+
+formula_version="${version#v}"
+asset_base="https://github.com/${repo}/releases/download/${version}"
+
+checksum_for() {
+  local artifact="$1"
+  awk -v artifact="$artifact" '$2 == artifact { print $1; exit }' "$checksums_path"
+}
+
+is_expected_artifact() {
+  local artifact="$1"
+  local expected
+  for expected in "${expected_artifacts[@]}"; do
+    if [[ "$artifact" == "$expected" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+validate_checksum_manifest() {
+  local line checksum artifact extra expected
+  local seen_artifacts=""
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ -z "${line//[[:space:]]/}" ]]; then
+      continue
+    fi
+
+    checksum=""
+    artifact=""
+    extra=""
+    read -r checksum artifact extra <<< "$line"
+    if [[ -z "$checksum" || -z "$artifact" || -n "$extra" ]]; then
+      fail "checksum line should be '<sha256>  <artifact>'; got '$line'"
+    fi
+    if [[ ! "$checksum" =~ ^[0-9A-Fa-f]{64}$ ]]; then
+      fail "checksum entry for $artifact is not a SHA-256 hex digest"
+    fi
+    if ! is_expected_artifact "$artifact"; then
+      fail "unexpected checksum entry for $artifact"
+    fi
+
+    if [[ " $seen_artifacts " == *" $artifact "* ]]; then
+      fail "duplicate checksum entry for $artifact"
+    fi
+    seen_artifacts="${seen_artifacts} ${artifact}"
+  done < "$checksums_path"
+
+  for expected in "${expected_artifacts[@]}"; do
+    if [[ " $seen_artifacts " != *" $expected "* ]]; then
+      fail "missing checksum entry for $expected"
+    fi
+  done
+}
+
+require_checksum() {
+  local artifact="$1"
+  local checksum
+  checksum="$(checksum_for "$artifact")"
+  if [[ -z "$checksum" ]]; then
+    fail "missing checksum entry for $artifact"
+  fi
+  if [[ ! "$checksum" =~ ^[0-9A-Fa-f]{64}$ ]]; then
+    fail "checksum entry for $artifact is not a SHA-256 hex digest"
+  fi
+  printf '%s' "$checksum"
+}
+
+darwin_amd64_artifact="dots_${version}_darwin_amd64"
+darwin_arm64_artifact="dots_${version}_darwin_arm64"
+linux_amd64_artifact="dots_${version}_linux_amd64"
+linux_arm64_artifact="dots_${version}_linux_arm64"
+
+expected_artifacts=(
+  "$darwin_amd64_artifact"
+  "$darwin_arm64_artifact"
+  "$linux_amd64_artifact"
+  "$linux_arm64_artifact"
+)
+
+validate_checksum_manifest
+
+darwin_amd64_sha="$(require_checksum "$darwin_amd64_artifact")"
+darwin_arm64_sha="$(require_checksum "$darwin_arm64_artifact")"
+linux_amd64_sha="$(require_checksum "$linux_amd64_artifact")"
+linux_arm64_sha="$(require_checksum "$linux_arm64_artifact")"
+
+mkdir -p "$(dirname "$out_path")"
+cat > "$out_path" <<FORMULA
+class Dots < Formula
+  desc "$(ruby_escape "$desc")"
+  homepage "$(ruby_escape "$homepage")"
+  version "$formula_version"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "${asset_base}/${darwin_arm64_artifact}", using: :nounzip
+      sha256 "$darwin_arm64_sha"
+    else
+      url "${asset_base}/${darwin_amd64_artifact}", using: :nounzip
+      sha256 "$darwin_amd64_sha"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "${asset_base}/${linux_arm64_artifact}", using: :nounzip
+      sha256 "$linux_arm64_sha"
+    else
+      url "${asset_base}/${linux_amd64_artifact}", using: :nounzip
+      sha256 "$linux_amd64_sha"
+    end
+  end
+
+  def downloaded_binary
+    os = OS.mac? ? "darwin" : "linux"
+    arch = Hardware::CPU.arm? ? "arm64" : "amd64"
+    "dots_v#{version}_#{os}_#{arch}"
+  end
+
+  def install
+    bin.install downloaded_binary => "dots"
+  end
+
+  test do
+    system "#{bin}/dots", "--help"
+  end
+end
+FORMULA
+
+echo "wrote Homebrew formula to $out_path"


### PR DESCRIPTION
Closes #20

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds Homebrew tap distribution for `dots` using the existing checksum-verified GitHub Release Artifacts.
- Generates `Formula/dots.rb` from `checksums.txt` and updates `yersonargotev/homebrew-tap` automatically on new tags.
- Documents Homebrew and bootstrapper install paths, and updates scope/release docs now that Homebrew Distribution is shipped.

## Size exception

- [x] `size:exception` approved by maintainer for this PR.

This PR exceeds the normal 400-line review budget because the distribution contract is tightly coupled across the formula generator, release workflow automation, regression tests, and user-facing docs. Splitting this into chained PRs would make review harder by separating the generator from the workflow and acceptance-criteria documentation it enables.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Adds Homebrew tap token validation, tap checkout, formula generation, prepared tap commit dry-run proof, release upload, and final tap push. |
| `scripts/generate-homebrew-formula.sh` | Generates `Formula/dots.rb` from a release tag and exact four-platform `checksums.txt`, using `using: :nounzip` for raw binaries. |
| `internal/release/release_automation_test.go` | Adds behavior coverage for formula generation, checksum manifest validation, raw binary Homebrew URLs, and workflow ordering semantics. |
| `README.md` | Documents Homebrew and bootstrapper install paths. |
| `docs/release.md` | Documents Homebrew tap automation, token setup, checksum contract, and release checklist updates. |
| `docs/scope.md` | Moves Homebrew Distribution from deferred scope into shipped distribution scope. |

## External tap state

- Created public tap repository: `yersonargotev/homebrew-tap`.
- Published initial `Formula/dots.rb` for `v0.1.0`.
- Updated tap formula to use `using: :nounzip` for all raw binary artifact URLs.
- Current validated tap commit: `9f78d40`.

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go build ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] `git diff --check`
- [x] `bash -n scripts/generate-homebrew-formula.sh scripts/build-release-artifacts.sh scripts/install.sh`
- [x] `shellcheck scripts/generate-homebrew-formula.sh scripts/build-release-artifacts.sh scripts/install.sh`
- [x] `ruby -c` on generated `Formula/dots.rb`
- [x] Generated `v0.1.0` formula from release `checksums.txt` and diffed it against the published tap formula.
- [x] Verified generated/published formula contains `using: :nounzip` on all four raw binary URLs.
- [x] `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml .github/workflows/release.yml`
- [x] Sandboxed plan only when dotfiles behavior changes: not applicable; this change does not change `dots install`, `dots plan`, or managed config behavior.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit, with maintainer-approved `size:exception` documented above.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
