### PR TITLE
feat(backups): add dots backups restore from a Backup Set

### DIFF
--- a/docs/backups.md
+++ b/docs/backups.md
@@ -1,0 +1,78 @@
+# `dots backups`
+
+`dots backups` inspects and restores the [Backup Sets](../CONTEXT.md) the Dotfiles CLI records under the state root (default `~/.local/state/dots/backups`). Every time `install` or `update` would overwrite an existing target — a `replace`, or an `adopt` with the symlink strategy — it first copies that target into a timestamped Backup Set and records [Backup Metadata](../CONTEXT.md) describing it. These commands read that history so preserved files can be audited and, in v1.1, returned to disk.
+
+## `dots backups list`
+
+`list` reports each recorded Backup Set: when it was created, why the backup was taken, and which targets it protected.
+
+```
+Backup Sets
+
+  ID: backup-20260608T134850.191732000Z
+  Created: 2026-06-08T13:48:50Z
+  Reason: pre-install conflict protection
+  Protected targets:
+    - /home/user/.zshrc
+
+Summary: 1 Backup Set
+```
+
+When no metadata exists yet, `list` reports that no Backup Sets are recorded in the state root rather than failing.
+
+## `dots backups restore <set>`
+
+`restore` returns the targets recorded in a Backup Set to the content preserved when the set was created. It is the safe inverse of the conflict `replace` path: nothing about a restore is one-way.
+
+```
+dots backups restore backup-20260608T134850.191732000Z
+```
+
+### What it does
+
+1. **Finds the Backup Set.** The single argument is the Backup Set ID (as shown by `list`). An unknown ID stops with an error naming the state root searched.
+2. **Checks provenance.** Backup Metadata records the `machine` and `repo` a set was captured on. If the set was captured on a different machine, `restore` refuses unless you pass `--force`. A set with no recorded machine (created before provenance tracking) is allowed, because there is nothing to mismatch.
+3. **Plans the change.** For each recorded target, `restore` reports whether it would `create` the target (currently absent) or `overwrite` it (currently present). A Backup Set whose preserved files are missing is reported before any target is touched.
+4. **Backs up what it would overwrite.** Before replacing any target that currently exists, `restore` records a new Backup Set with the reason `pre-restore safety backup`. A restore therefore never destroys the current state irreversibly — you can restore that safety set to undo it.
+5. **Restores the preserved content.** Regular files are written back with their preserved permissions; symlinks are recreated to their preserved destination.
+
+### Provenance and `--force`
+
+```
+Error: Backup Set backup-... was captured on machine "some-laptop" but this
+machine is "workstation"; re-run with --force to restore anyway
+```
+
+The machine check exists because a Backup Set holds files captured against one workstation's layout. Restoring another machine's set is occasionally legitimate (migrating a config), so `--force` is the explicit, auditable escape hatch rather than a silent default.
+
+### Flags
+
+| Flag | Purpose |
+|------|---------|
+| `--dry-run` | Report the provenance and the per-target `create`/`overwrite` plan without touching any files or recording a safety backup. |
+| `--force` | Restore even when the Backup Set was captured on a different machine. |
+| `--home` | Home directory used to resolve the default state root and to bound restore targets. Use a sandbox path to avoid touching real config. |
+| `--state-root` | State directory holding Backup Metadata and preserved files (default `~/.local/state/dots`). |
+
+### Dry run
+
+`dots backups restore <set> --dry-run` shows exactly what the restore would change and stops:
+
+```
+Restore Backup Set backup-20260608T134850.191732000Z
+  Created: 2026-06-08T13:48:50Z
+  Machine: workstation
+  Repo: /home/user/.local/share/dots
+  Reason: pre-install conflict protection
+
+Planned changes:
+  overwrite /home/user/.zshrc
+
+Dry run: no files changed.
+```
+
+## References
+
+- [`docs/scope.md`](scope.md) — automatic backup restore was deferred from v1 and delivered in v1.1.
+- [`CONTEXT.md`](../CONTEXT.md) — vocabulary for Backup Set, Backup Metadata, Source of Truth, Conflict, and Drift.
+- [`docs/adr/0001-bootstrap-with-go-cli.md`](adr/0001-bootstrap-with-go-cli.md) — the central backup location and `dots backups list`/`restore` design.

--- a/docs/scope.md
+++ b/docs/scope.md
@@ -34,7 +34,7 @@ v1 proves that the Dotfiles CLI can install repository-owned configuration safel
 | Official WSL support | Later than v1 | WSL has mixed Windows/Linux filesystem and dependency concerns that should not be treated as generic Linux during the first release. |
 | NixOS specialization | Later than v1 | NixOS requires specialized package and system-configuration assumptions that do not fit the v1 advisory Dependency Plan. |
 | Alpine/musl specialization | Later than v1 | Alpine and musl introduce distribution and binary compatibility concerns outside the initial Linux amd64/arm64 release target. |
-| Automatic backup restore | Optional or later | v1 must make Backup Sets visible and reliable first; restore behavior can be added after backup metadata and status behavior are proven. |
+| Automatic backup restore | v1.1 — **shipped** | v1 made Backup Sets visible and reliable via `dots backups list`; with Backup Metadata proven, `dots backups restore` returns targets to a preserved Backup Set, refuses sets from another machine without `--force`, supports `--dry-run`, and backs up overwritten targets first. Delivered in v1.1; see [`docs/backups.md`](backups.md). |
 | Full visual TUI snapshot testing | Later than v1 | v1 tests TUI state transitions, but installer correctness matters more than pixel-perfect terminal rendering. |
 
 ## Why these boundaries exist

--- a/internal/backups/backups.go
+++ b/internal/backups/backups.go
@@ -9,23 +9,54 @@ import (
 	"path/filepath"
 )
 
+// metadataVersion is the current Backup Metadata schema version.
+const metadataVersion = 1
+
 // Metadata is the machine-readable history of Backup Sets created by dots.
 type Metadata struct {
 	Version int         `json:"version"`
 	Sets    []BackupSet `json:"sets"`
 }
 
-// BackupSet describes one backup operation and the targets it protected.
+// BackupSet describes one backup operation and the targets it protected. Machine
+// and Repo record the provenance of the backup so restore can refuse to write a
+// set captured on a different workstation unless the operator forces it. They are
+// optional so Backup Sets recorded before provenance tracking still load.
 type BackupSet struct {
 	ID        string   `json:"id"`
 	CreatedAt string   `json:"createdAt"`
 	Reason    string   `json:"reason"`
+	Machine   string   `json:"machine,omitempty"`
+	Repo      string   `json:"repo,omitempty"`
 	Targets   []string `json:"targets"`
 }
 
 // Path returns the centralized Backup Metadata path under a state root.
 func Path(stateRoot string) string {
 	return filepath.Join(stateRoot, "backups", "metadata.json")
+}
+
+// SetDir returns the directory holding one Backup Set's preserved files.
+func SetDir(stateRoot, id string) string {
+	return filepath.Join(stateRoot, "backups", id)
+}
+
+// FilePath returns the stored backup file path for the target at the given
+// 1-based index within a Backup Set. The index keeps multiple targets that share
+// a base name distinct and stable across writes and reads.
+func FilePath(stateRoot, id string, index int, target string) string {
+	name := fmt.Sprintf("%06d-%s", index, filepath.Base(target))
+	return filepath.Join(SetDir(stateRoot, id), "files", name)
+}
+
+// FindSet returns the Backup Set with the given ID, if it exists.
+func (m Metadata) FindSet(id string) (BackupSet, bool) {
+	for _, set := range m.Sets {
+		if set.ID == id {
+			return set, true
+		}
+	}
+	return BackupSet{}, false
 }
 
 // Load reads Backup Metadata from path. Missing metadata means no Backup Sets

--- a/internal/backups/set.go
+++ b/internal/backups/set.go
@@ -14,6 +14,17 @@ type CreateOptions struct {
 	Repo    string
 }
 
+// MachineName identifies the workstation a Backup Set is created on so restore
+// can refuse to write a set captured elsewhere. An unknown hostname is reported
+// as an empty string rather than failing, letting callers decide how to treat it.
+func MachineName() string {
+	name, err := os.Hostname()
+	if err != nil {
+		return ""
+	}
+	return name
+}
+
 // CreateSet copies each target into a new Backup Set and appends it to the
 // Backup Metadata under stateRoot. Targets are preserved by content: regular
 // files keep their permissions and symlinks keep their destination. The created
@@ -144,8 +155,19 @@ func restoreItem(item RestoreItem) error {
 	if err := os.MkdirAll(filepath.Dir(item.Target), 0o755); err != nil {
 		return fmt.Errorf("create parent directory for %s: %w", item.Target, err)
 	}
-	if err := os.RemoveAll(item.Target); err != nil {
-		return fmt.Errorf("remove current target %s: %w", item.Target, err)
+	// A Backup Set only ever preserves regular files and symlinks, so restoring
+	// one must never recursively delete a directory tree that now sits at the
+	// target. Refuse a directory and remove only a file or symlink, which fails
+	// closed (os.Remove will not delete a non-empty directory).
+	if current, err := os.Lstat(item.Target); err == nil {
+		if current.IsDir() {
+			return fmt.Errorf("refusing to restore over directory %s", item.Target)
+		}
+		if err := os.Remove(item.Target); err != nil {
+			return fmt.Errorf("remove current target %s: %w", item.Target, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat current target %s: %w", item.Target, err)
 	}
 	if info.Mode()&os.ModeSymlink != 0 {
 		dest, err := os.Readlink(item.BackupFile)

--- a/internal/backups/set.go
+++ b/internal/backups/set.go
@@ -135,10 +135,73 @@ func PlanRestore(stateRoot string, set BackupSet) ([]RestoreItem, error) {
 	return items, nil
 }
 
-// ApplyRestore writes each preserved file back to its target, replacing any file
-// currently at that path. Callers are responsible for backing up overwritten
-// targets first via CreateSet; ApplyRestore performs only the write.
-func ApplyRestore(items []RestoreItem) error {
+// RestoreSafetyReason is the reason recorded on the Backup Set that Restore
+// captures for any target it would overwrite, so a restore is never one-way.
+const RestoreSafetyReason = "pre-restore safety backup"
+
+// RestoreOptions carries the provenance recorded on the pre-restore safety
+// Backup Set taken before overwriting existing targets.
+type RestoreOptions struct {
+	Machine string
+	Repo    string
+}
+
+// RestoreResult reports what Restore did: the per-target plan it executed and,
+// when any existing target was overwritten, the safety Backup Set it recorded
+// first (nil when nothing needed overwriting).
+type RestoreResult struct {
+	Items     []RestoreItem
+	SafetySet *BackupSet
+}
+
+// Restore returns the targets recorded in set to their preserved content. It is
+// the single safe entry point for writing a restore: it plans against the
+// current filesystem, records a pre-restore safety Backup Set for every target
+// it would overwrite, and only then writes the preserved files back. Bundling
+// the safety backup with the write here makes the "never overwrite without a
+// backup" invariant impossible for callers to skip — the write primitive is not
+// exported on its own.
+func Restore(stateRoot string, set BackupSet, opts RestoreOptions) (RestoreResult, error) {
+	items, err := PlanRestore(stateRoot, set)
+	if err != nil {
+		return RestoreResult{}, err
+	}
+	result := RestoreResult{Items: items}
+
+	if overwritten := overwriteTargets(items); len(overwritten) > 0 {
+		safety, err := CreateSet(stateRoot, overwritten, CreateOptions{
+			Reason:  RestoreSafetyReason,
+			Machine: opts.Machine,
+			Repo:    opts.Repo,
+		})
+		if err != nil {
+			return RestoreResult{}, err
+		}
+		result.SafetySet = &safety
+	}
+
+	if err := applyRestore(items); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+// overwriteTargets returns the targets whose current content Restore must back
+// up before replacing them.
+func overwriteTargets(items []RestoreItem) []string {
+	targets := make([]string, 0, len(items))
+	for _, item := range items {
+		if item.Action == RestoreOverwrite {
+			targets = append(targets, item.Target)
+		}
+	}
+	return targets
+}
+
+// applyRestore writes each preserved file back to its target. It is unexported
+// on purpose: callers reach it only through Restore, which takes the safety
+// backup first.
+func applyRestore(items []RestoreItem) error {
 	for _, item := range items {
 		if err := restoreItem(item); err != nil {
 			return err

--- a/internal/backups/set.go
+++ b/internal/backups/set.go
@@ -1,0 +1,171 @@
+package backups
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// CreateOptions carries the provenance recorded for a new Backup Set.
+type CreateOptions struct {
+	Reason  string
+	Machine string
+	Repo    string
+}
+
+// CreateSet copies each target into a new Backup Set and appends it to the
+// Backup Metadata under stateRoot. Targets are preserved by content: regular
+// files keep their permissions and symlinks keep their destination. The created
+// Backup Set is returned so callers can report or restore it later.
+func CreateSet(stateRoot string, targets []string, opts CreateOptions) (BackupSet, error) {
+	now := time.Now().UTC()
+	set := BackupSet{
+		ID:        "backup-" + now.Format("20060102T150405.000000000Z"),
+		CreatedAt: now.Format(time.RFC3339),
+		Reason:    opts.Reason,
+		Machine:   opts.Machine,
+		Repo:      opts.Repo,
+		Targets:   append([]string(nil), targets...),
+	}
+
+	for i, target := range targets {
+		backupFile := FilePath(stateRoot, set.ID, i+1, target)
+		if err := copyTarget(target, backupFile); err != nil {
+			return BackupSet{}, err
+		}
+	}
+
+	metadataPath := Path(stateRoot)
+	meta, err := Load(metadataPath)
+	if err != nil {
+		return BackupSet{}, err
+	}
+	meta.Version = metadataVersion
+	meta.Sets = append(meta.Sets, set)
+	if err := Save(metadataPath, meta); err != nil {
+		return BackupSet{}, err
+	}
+	return set, nil
+}
+
+// copyTarget preserves a single target into the Backup Set file location.
+func copyTarget(target, backupFile string) error {
+	info, err := os.Lstat(target)
+	if err != nil {
+		return fmt.Errorf("stat backup target %s: %w", target, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(backupFile), 0o755); err != nil {
+		return fmt.Errorf("create Backup Set directory: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		dest, err := os.Readlink(target)
+		if err != nil {
+			return fmt.Errorf("read backup symlink %s: %w", target, err)
+		}
+		if err := os.Symlink(dest, backupFile); err != nil {
+			return fmt.Errorf("backup symlink %s: %w", target, err)
+		}
+		return nil
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("backup target %s is not a regular file or symlink", target)
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		return fmt.Errorf("read backup target %s: %w", target, err)
+	}
+	if err := os.WriteFile(backupFile, data, info.Mode().Perm()); err != nil {
+		return fmt.Errorf("write backup target %s: %w", backupFile, err)
+	}
+	return nil
+}
+
+// RestoreAction describes what restoring a target will do to the current
+// workstation file at that path.
+type RestoreAction string
+
+const (
+	// RestoreCreate means the target is currently absent and will be created.
+	RestoreCreate RestoreAction = "create"
+	// RestoreOverwrite means the target currently exists and will be backed up
+	// before being replaced with the preserved content.
+	RestoreOverwrite RestoreAction = "overwrite"
+)
+
+// RestoreItem is one preserved file mapped back to its original target, with the
+// action restoring it would take against the current filesystem.
+type RestoreItem struct {
+	Target     string
+	BackupFile string
+	Action     RestoreAction
+}
+
+// PlanRestore computes, without changing anything, what restoring set would do.
+// It fails if any preserved file referenced by the set is missing, so a corrupt
+// Backup Set is reported before any target is touched.
+func PlanRestore(stateRoot string, set BackupSet) ([]RestoreItem, error) {
+	items := make([]RestoreItem, 0, len(set.Targets))
+	for i, target := range set.Targets {
+		backupFile := FilePath(stateRoot, set.ID, i+1, target)
+		if _, err := os.Lstat(backupFile); err != nil {
+			return nil, fmt.Errorf("preserved file for %s missing from Backup Set %s: %w", target, set.ID, err)
+		}
+
+		action := RestoreCreate
+		if _, err := os.Lstat(target); err == nil {
+			action = RestoreOverwrite
+		} else if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("stat restore target %s: %w", target, err)
+		}
+
+		items = append(items, RestoreItem{Target: target, BackupFile: backupFile, Action: action})
+	}
+	return items, nil
+}
+
+// ApplyRestore writes each preserved file back to its target, replacing any file
+// currently at that path. Callers are responsible for backing up overwritten
+// targets first via CreateSet; ApplyRestore performs only the write.
+func ApplyRestore(items []RestoreItem) error {
+	for _, item := range items {
+		if err := restoreItem(item); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func restoreItem(item RestoreItem) error {
+	info, err := os.Lstat(item.BackupFile)
+	if err != nil {
+		return fmt.Errorf("stat preserved file %s: %w", item.BackupFile, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(item.Target), 0o755); err != nil {
+		return fmt.Errorf("create parent directory for %s: %w", item.Target, err)
+	}
+	if err := os.RemoveAll(item.Target); err != nil {
+		return fmt.Errorf("remove current target %s: %w", item.Target, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		dest, err := os.Readlink(item.BackupFile)
+		if err != nil {
+			return fmt.Errorf("read preserved symlink %s: %w", item.BackupFile, err)
+		}
+		if err := os.Symlink(dest, item.Target); err != nil {
+			return fmt.Errorf("restore symlink %s: %w", item.Target, err)
+		}
+		return nil
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("preserved file %s is not a regular file or symlink", item.BackupFile)
+	}
+	data, err := os.ReadFile(item.BackupFile)
+	if err != nil {
+		return fmt.Errorf("read preserved file %s: %w", item.BackupFile, err)
+	}
+	if err := os.WriteFile(item.Target, data, info.Mode().Perm()); err != nil {
+		return fmt.Errorf("restore target %s: %w", item.Target, err)
+	}
+	return nil
+}

--- a/internal/backups/set_test.go
+++ b/internal/backups/set_test.go
@@ -126,8 +126,8 @@ func TestApplyRestoreReturnsTargetsToPreservedContent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PlanRestore() error = %v", err)
 	}
-	if err := ApplyRestore(items); err != nil {
-		t.Fatalf("ApplyRestore() error = %v", err)
+	if err := applyRestore(items); err != nil {
+		t.Fatalf("applyRestore() error = %v", err)
 	}
 
 	got, err := os.ReadFile(target)
@@ -169,15 +169,84 @@ func TestApplyRestoreRefusesDirectoryTarget(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PlanRestore() error = %v", err)
 	}
-	err = ApplyRestore(items)
+	err = applyRestore(items)
 	if err == nil {
-		t.Fatal("ApplyRestore() error = nil, want directory refusal")
+		t.Fatal("applyRestore() error = nil, want directory refusal")
 	}
 	if !strings.Contains(err.Error(), "directory") {
 		t.Fatalf("error %q does not mention directory", err)
 	}
 	if _, statErr := os.Stat(canary); statErr != nil {
 		t.Fatalf("directory tree was destroyed: %v", statErr)
+	}
+}
+
+func TestRestoreRecordsSafetyBackupBeforeOverwriting(t *testing.T) {
+	stateRoot := t.TempDir()
+	home := t.TempDir()
+	target := filepath.Join(home, ".zshrc")
+	if err := os.WriteFile(target, []byte("original\n"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	set, err := CreateSet(stateRoot, []string{target}, CreateOptions{Reason: "x"})
+	if err != nil {
+		t.Fatalf("CreateSet() error = %v", err)
+	}
+	if err := os.WriteFile(target, []byte("drifted\n"), 0o600); err != nil {
+		t.Fatalf("drift target: %v", err)
+	}
+
+	result, err := Restore(stateRoot, set, RestoreOptions{Machine: "m", Repo: "r"})
+	if err != nil {
+		t.Fatalf("Restore() error = %v", err)
+	}
+	if result.SafetySet == nil {
+		t.Fatal("Restore() recorded no safety Backup Set for an overwrite")
+	}
+	if result.SafetySet.Reason != RestoreSafetyReason {
+		t.Fatalf("safety reason = %q, want %q", result.SafetySet.Reason, RestoreSafetyReason)
+	}
+
+	// Target is restored.
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(got) != "original\n" {
+		t.Fatalf("restored content = %q, want original", got)
+	}
+	// The safety set preserved the drifted content, so the restore is reversible.
+	preserved, err := os.ReadFile(FilePath(stateRoot, result.SafetySet.ID, 1, target))
+	if err != nil {
+		t.Fatalf("read safety preserved: %v", err)
+	}
+	if string(preserved) != "drifted\n" {
+		t.Fatalf("safety preserved %q, want drifted", preserved)
+	}
+}
+
+func TestRestoreSkipsSafetyBackupWhenNothingOverwritten(t *testing.T) {
+	stateRoot := t.TempDir()
+	home := t.TempDir()
+	target := filepath.Join(home, ".zshrc")
+	if err := os.WriteFile(target, []byte("original\n"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	set, err := CreateSet(stateRoot, []string{target}, CreateOptions{Reason: "x"})
+	if err != nil {
+		t.Fatalf("CreateSet() error = %v", err)
+	}
+	if err := os.Remove(target); err != nil { // absent -> create, not overwrite
+		t.Fatalf("remove target: %v", err)
+	}
+
+	result, err := Restore(stateRoot, set, RestoreOptions{})
+	if err != nil {
+		t.Fatalf("Restore() error = %v", err)
+	}
+	if result.SafetySet != nil {
+		t.Fatalf("Restore() recorded an unnecessary safety Backup Set: %s", result.SafetySet.ID)
 	}
 }
 
@@ -201,8 +270,8 @@ func TestApplyRestoreRecreatesSymlinkTarget(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PlanRestore() error = %v", err)
 	}
-	if err := ApplyRestore(items); err != nil {
-		t.Fatalf("ApplyRestore() error = %v", err)
+	if err := applyRestore(items); err != nil {
+		t.Fatalf("applyRestore() error = %v", err)
 	}
 
 	dest, err := os.Readlink(target)

--- a/internal/backups/set_test.go
+++ b/internal/backups/set_test.go
@@ -3,6 +3,7 @@ package backups
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -135,6 +136,48 @@ func TestApplyRestoreReturnsTargetsToPreservedContent(t *testing.T) {
 	}
 	if string(got) != "original\n" {
 		t.Fatalf("restored content = %q, want original", got)
+	}
+}
+
+func TestApplyRestoreRefusesDirectoryTarget(t *testing.T) {
+	stateRoot := t.TempDir()
+	home := t.TempDir()
+	target := filepath.Join(home, ".config")
+	if err := os.WriteFile(target, []byte("was a file\n"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	set, err := CreateSet(stateRoot, []string{target}, CreateOptions{Reason: "x"})
+	if err != nil {
+		t.Fatalf("CreateSet() error = %v", err)
+	}
+
+	// The target is now a non-empty directory; restoring a preserved file must
+	// never recursively delete it.
+	if err := os.Remove(target); err != nil {
+		t.Fatalf("remove file target: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(target, "nested"), 0o755); err != nil {
+		t.Fatalf("mkdir dir target: %v", err)
+	}
+	canary := filepath.Join(target, "nested", "keep")
+	if err := os.WriteFile(canary, []byte("important\n"), 0o600); err != nil {
+		t.Fatalf("write canary: %v", err)
+	}
+
+	items, err := PlanRestore(stateRoot, set)
+	if err != nil {
+		t.Fatalf("PlanRestore() error = %v", err)
+	}
+	err = ApplyRestore(items)
+	if err == nil {
+		t.Fatal("ApplyRestore() error = nil, want directory refusal")
+	}
+	if !strings.Contains(err.Error(), "directory") {
+		t.Fatalf("error %q does not mention directory", err)
+	}
+	if _, statErr := os.Stat(canary); statErr != nil {
+		t.Fatalf("directory tree was destroyed: %v", statErr)
 	}
 }
 

--- a/internal/backups/set_test.go
+++ b/internal/backups/set_test.go
@@ -1,0 +1,172 @@
+package backups
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFilePathUsesIndexedBaseNameUnderSetDir(t *testing.T) {
+	stateRoot := filepath.Join("state", "dots")
+	got := FilePath(stateRoot, "backup-001", 2, "/home/user/.zshrc")
+	want := filepath.Join(stateRoot, "backups", "backup-001", "files", "000002-.zshrc")
+	if got != want {
+		t.Fatalf("FilePath() = %q, want %q", got, want)
+	}
+}
+
+func TestCreateSetPreservesFileAndRecordsProvenance(t *testing.T) {
+	stateRoot := t.TempDir()
+	home := t.TempDir()
+	target := filepath.Join(home, ".zshrc")
+	if err := os.WriteFile(target, []byte("local\n"), 0o640); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	set, err := CreateSet(stateRoot, []string{target}, CreateOptions{
+		Reason:  "pre-restore safety backup",
+		Machine: "workstation-1",
+		Repo:    "/src/dots",
+	})
+	if err != nil {
+		t.Fatalf("CreateSet() error = %v", err)
+	}
+	if set.Machine != "workstation-1" || set.Repo != "/src/dots" || set.Reason != "pre-restore safety backup" {
+		t.Fatalf("provenance not recorded: %+v", set)
+	}
+
+	preserved, err := os.ReadFile(FilePath(stateRoot, set.ID, 1, target))
+	if err != nil {
+		t.Fatalf("read preserved file: %v", err)
+	}
+	if string(preserved) != "local\n" {
+		t.Fatalf("preserved content = %q, want local", preserved)
+	}
+
+	meta, err := Load(Path(stateRoot))
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if meta.Version != metadataVersion {
+		t.Fatalf("Version = %d, want %d", meta.Version, metadataVersion)
+	}
+	if _, ok := meta.FindSet(set.ID); !ok {
+		t.Fatalf("created set %s not found in metadata", set.ID)
+	}
+}
+
+func TestPlanRestoreClassifiesTargetsAgainstCurrentFilesystem(t *testing.T) {
+	stateRoot := t.TempDir()
+	home := t.TempDir()
+	existing := filepath.Join(home, ".existing")
+	absent := filepath.Join(home, "nested", ".absent")
+	if err := os.WriteFile(existing, []byte("v1\n"), 0o600); err != nil {
+		t.Fatalf("write existing: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(absent), 0o755); err != nil {
+		t.Fatalf("mkdir absent parent: %v", err)
+	}
+	if err := os.WriteFile(absent, []byte("v1\n"), 0o600); err != nil {
+		t.Fatalf("write absent (for backup): %v", err)
+	}
+
+	set, err := CreateSet(stateRoot, []string{existing, absent}, CreateOptions{Reason: "x"})
+	if err != nil {
+		t.Fatalf("CreateSet() error = %v", err)
+	}
+	// Remove one target so PlanRestore sees it as a create, keep the other.
+	if err := os.Remove(absent); err != nil {
+		t.Fatalf("remove absent: %v", err)
+	}
+
+	items, err := PlanRestore(stateRoot, set)
+	if err != nil {
+		t.Fatalf("PlanRestore() error = %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("items = %d, want 2", len(items))
+	}
+	if items[0].Target != existing || items[0].Action != RestoreOverwrite {
+		t.Fatalf("item[0] = %+v, want overwrite of existing", items[0])
+	}
+	if items[1].Target != absent || items[1].Action != RestoreCreate {
+		t.Fatalf("item[1] = %+v, want create of absent", items[1])
+	}
+}
+
+func TestPlanRestoreFailsWhenPreservedFileMissing(t *testing.T) {
+	stateRoot := t.TempDir()
+	set := BackupSet{ID: "backup-broken", Targets: []string{"/home/user/.zshrc"}}
+	if _, err := PlanRestore(stateRoot, set); err == nil {
+		t.Fatal("PlanRestore() error = nil, want missing preserved file error")
+	}
+}
+
+func TestApplyRestoreReturnsTargetsToPreservedContent(t *testing.T) {
+	stateRoot := t.TempDir()
+	home := t.TempDir()
+	target := filepath.Join(home, "nested", ".zshrc")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("original\n"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	set, err := CreateSet(stateRoot, []string{target}, CreateOptions{Reason: "x"})
+	if err != nil {
+		t.Fatalf("CreateSet() error = %v", err)
+	}
+	if err := os.WriteFile(target, []byte("drifted\n"), 0o600); err != nil {
+		t.Fatalf("drift target: %v", err)
+	}
+
+	items, err := PlanRestore(stateRoot, set)
+	if err != nil {
+		t.Fatalf("PlanRestore() error = %v", err)
+	}
+	if err := ApplyRestore(items); err != nil {
+		t.Fatalf("ApplyRestore() error = %v", err)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read restored target: %v", err)
+	}
+	if string(got) != "original\n" {
+		t.Fatalf("restored content = %q, want original", got)
+	}
+}
+
+func TestApplyRestoreRecreatesSymlinkTarget(t *testing.T) {
+	stateRoot := t.TempDir()
+	home := t.TempDir()
+	target := filepath.Join(home, ".link")
+	if err := os.Symlink("/dev/null", target); err != nil {
+		t.Fatalf("symlink target: %v", err)
+	}
+
+	set, err := CreateSet(stateRoot, []string{target}, CreateOptions{Reason: "x"})
+	if err != nil {
+		t.Fatalf("CreateSet() error = %v", err)
+	}
+	if err := os.Remove(target); err != nil {
+		t.Fatalf("remove target: %v", err)
+	}
+
+	items, err := PlanRestore(stateRoot, set)
+	if err != nil {
+		t.Fatalf("PlanRestore() error = %v", err)
+	}
+	if err := ApplyRestore(items); err != nil {
+		t.Fatalf("ApplyRestore() error = %v", err)
+	}
+
+	dest, err := os.Readlink(target)
+	if err != nil {
+		t.Fatalf("readlink restored target: %v", err)
+	}
+	if dest != "/dev/null" {
+		t.Fatalf("restored symlink dest = %q, want /dev/null", dest)
+	}
+}

--- a/internal/cli/backups.go
+++ b/internal/cli/backups.go
@@ -136,24 +136,19 @@ func newBackupsRestoreCommand() *cobra.Command {
 				return nil
 			}
 
-			overwritten := overwriteTargets(items)
-			if len(overwritten) > 0 {
-				safety, err := backups.CreateSet(paths.StateRoot, overwritten, backups.CreateOptions{
-					Reason:  "pre-restore safety backup",
-					Machine: backups.MachineName(),
-					Repo:    set.Repo,
-				})
-				if err != nil {
-					return err
-				}
-				fmt.Fprintf(out, "\nBacked up %s to Backup Set %s before restoring.\n", pluralizeTargets(len(overwritten)), safety.ID)
-			}
-
-			if err := backups.ApplyRestore(items); err != nil {
+			result, err := backups.Restore(paths.StateRoot, set, backups.RestoreOptions{
+				Machine: backups.MachineName(),
+				Repo:    set.Repo,
+			})
+			if err != nil {
 				return err
 			}
 
-			fmt.Fprintf(out, "Restored %s from Backup Set %s.\n", pluralizeTargets(len(items)), set.ID)
+			if result.SafetySet != nil {
+				fmt.Fprintf(out, "\nBacked up %s to Backup Set %s before restoring.\n", pluralizeTargets(len(result.SafetySet.Targets)), result.SafetySet.ID)
+			}
+
+			fmt.Fprintf(out, "Restored %s from Backup Set %s.\n", pluralizeTargets(len(result.Items)), set.ID)
 			return nil
 		},
 	}
@@ -182,14 +177,4 @@ func ensureMachineMatch(set backups.BackupSet, force bool) error {
 		return nil
 	}
 	return fmt.Errorf("Backup Set %s was captured on machine %q but this machine is %q; re-run with --force to restore anyway", set.ID, set.Machine, current)
-}
-
-func overwriteTargets(items []backups.RestoreItem) []string {
-	targets := make([]string, 0, len(items))
-	for _, item := range items {
-		if item.Action == backups.RestoreOverwrite {
-			targets = append(targets, item.Target)
-		}
-	}
-	return targets
 }

--- a/internal/cli/backups.go
+++ b/internal/cli/backups.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/yersonargotev/dots/internal/backups"
@@ -11,10 +12,11 @@ import (
 func newBackupsCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "backups",
-		Short: "Inspect Backup Sets recorded by dots",
-		Long:  "backups reads centralized Backup Metadata from the configured state root and reports Backup Sets created by dots.",
+		Short: "Inspect and restore Backup Sets recorded by dots",
+		Long:  "backups reads centralized Backup Metadata from the configured state root and reports or restores Backup Sets created by dots.",
 	}
 	cmd.AddCommand(newBackupsListCommand())
+	cmd.AddCommand(newBackupsRestoreCommand())
 	return cmd
 }
 
@@ -63,4 +65,134 @@ func newBackupsListCommand() *cobra.Command {
 	cmd.Flags().StringVar(&home, "home", "", "home directory used to resolve the default state root (default: the current user's home)")
 	cmd.Flags().StringVar(&stateRoot, "state-root", "", "state directory for Backup Metadata (default ~/.local/state/dots)")
 	return cmd
+}
+
+func newBackupsRestoreCommand() *cobra.Command {
+	var (
+		home      string
+		stateRoot string
+		dryRun    bool
+		force     bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "restore <set>",
+		Short: "Restore a recorded Backup Set to its original targets",
+		Long: "restore returns the targets recorded in a Backup Set to the content preserved when the set was created. " +
+			"It refuses sets captured on a different machine unless --force is given, and backs up any current targets it would overwrite before restoring.",
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			setID := args[0]
+
+			paths, err := resolvePaths(home, "", stateRoot)
+			if err != nil {
+				return err
+			}
+
+			validatePaths := stateRoot == "" || plan.InsideRoot(paths.StateRoot, paths.Home)
+			if validatePaths {
+				if err := plan.ValidatePathInsideHomeNoSymlinkEscape(paths.StateRoot, paths.Home, "state root"); err != nil {
+					return err
+				}
+				if err := plan.ValidateFilePathInsideHomeNoSymlinkEscape(backups.Path(paths.StateRoot), paths.Home, "Backup Metadata"); err != nil {
+					return err
+				}
+			}
+
+			meta, err := backups.Load(backups.Path(paths.StateRoot))
+			if err != nil {
+				return err
+			}
+
+			set, ok := meta.FindSet(setID)
+			if !ok {
+				return fmt.Errorf("Backup Set %q not found in state root: %s", setID, paths.StateRoot)
+			}
+
+			if err := ensureMachineMatch(set, force); err != nil {
+				return err
+			}
+
+			if validatePaths {
+				for _, target := range set.Targets {
+					if err := plan.ValidateFilePathInsideHomeNoSymlinkEscape(target, paths.Home, "restore target"); err != nil {
+						return err
+					}
+				}
+			}
+
+			items, err := backups.PlanRestore(paths.StateRoot, set)
+			if err != nil {
+				return err
+			}
+
+			out := cmd.OutOrStdout()
+			renderRestorePlan(out, set, items)
+
+			if dryRun {
+				fmt.Fprintln(out, "\nDry run: no files changed.")
+				return nil
+			}
+
+			overwritten := overwriteTargets(items)
+			if len(overwritten) > 0 {
+				safety, err := backups.CreateSet(paths.StateRoot, overwritten, backups.CreateOptions{
+					Reason:  "pre-restore safety backup",
+					Machine: machineName(),
+					Repo:    set.Repo,
+				})
+				if err != nil {
+					return err
+				}
+				fmt.Fprintf(out, "\nBacked up %s to Backup Set %s before restoring.\n", pluralizeTargets(len(overwritten)), safety.ID)
+			}
+
+			if err := backups.ApplyRestore(items); err != nil {
+				return err
+			}
+
+			fmt.Fprintf(out, "Restored %s from Backup Set %s.\n", pluralizeTargets(len(items)), set.ID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&home, "home", "", "home directory used to resolve the default state root (default: the current user's home)")
+	cmd.Flags().StringVar(&stateRoot, "state-root", "", "state directory for Backup Metadata (default ~/.local/state/dots)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "report what restore would change without touching any files")
+	cmd.Flags().BoolVar(&force, "force", false, "restore even when the Backup Set was captured on a different machine")
+	return cmd
+}
+
+// ensureMachineMatch refuses a Backup Set captured on a different machine unless
+// the operator forces it. A set with no recorded machine (created before
+// provenance tracking) is allowed because there is nothing to mismatch.
+func ensureMachineMatch(set backups.BackupSet, force bool) error {
+	if force || set.Machine == "" {
+		return nil
+	}
+	current := machineName()
+	if current == "" || set.Machine == current {
+		return nil
+	}
+	return fmt.Errorf("Backup Set %s was captured on machine %q but this machine is %q; re-run with --force to restore anyway", set.ID, set.Machine, current)
+}
+
+func overwriteTargets(items []backups.RestoreItem) []string {
+	targets := make([]string, 0, len(items))
+	for _, item := range items {
+		if item.Action == backups.RestoreOverwrite {
+			targets = append(targets, item.Target)
+		}
+	}
+	return targets
+}
+
+// machineName identifies the current workstation for Backup Set provenance.
+func machineName() string {
+	name, err := os.Hostname()
+	if err != nil {
+		return ""
+	}
+	return name
 }

--- a/internal/cli/backups.go
+++ b/internal/cli/backups.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/yersonargotev/dots/internal/backups"
@@ -114,11 +113,13 @@ func newBackupsRestoreCommand() *cobra.Command {
 				return err
 			}
 
-			if validatePaths {
-				for _, target := range set.Targets {
-					if err := plan.ValidateFilePathInsideHomeNoSymlinkEscape(target, paths.Home, "restore target"); err != nil {
-						return err
-					}
+			// Restore writes to the recorded targets, so they must always be
+			// inside the home sandbox regardless of where the state root lives.
+			// Trusting an explicit external state root's *location* must never
+			// extend to trusting the *targets* recorded in its metadata.
+			for _, target := range set.Targets {
+				if err := plan.ValidateFilePathInsideHomeNoSymlinkEscape(target, paths.Home, "restore target"); err != nil {
+					return err
 				}
 			}
 
@@ -139,7 +140,7 @@ func newBackupsRestoreCommand() *cobra.Command {
 			if len(overwritten) > 0 {
 				safety, err := backups.CreateSet(paths.StateRoot, overwritten, backups.CreateOptions{
 					Reason:  "pre-restore safety backup",
-					Machine: machineName(),
+					Machine: backups.MachineName(),
 					Repo:    set.Repo,
 				})
 				if err != nil {
@@ -166,13 +167,18 @@ func newBackupsRestoreCommand() *cobra.Command {
 
 // ensureMachineMatch refuses a Backup Set captured on a different machine unless
 // the operator forces it. A set with no recorded machine (created before
-// provenance tracking) is allowed because there is nothing to mismatch.
+// provenance tracking) is allowed because there is nothing to mismatch. If the
+// current machine name cannot be determined it fails closed, requiring --force,
+// rather than silently treating an unknown machine as a match.
 func ensureMachineMatch(set backups.BackupSet, force bool) error {
 	if force || set.Machine == "" {
 		return nil
 	}
-	current := machineName()
-	if current == "" || set.Machine == current {
+	current := backups.MachineName()
+	if current == "" {
+		return fmt.Errorf("cannot determine current machine to verify Backup Set %s captured on %q; re-run with --force to restore anyway", set.ID, set.Machine)
+	}
+	if set.Machine == current {
 		return nil
 	}
 	return fmt.Errorf("Backup Set %s was captured on machine %q but this machine is %q; re-run with --force to restore anyway", set.ID, set.Machine, current)
@@ -186,13 +192,4 @@ func overwriteTargets(items []backups.RestoreItem) []string {
 		}
 	}
 	return targets
-}
-
-// machineName identifies the current workstation for Backup Set provenance.
-func machineName() string {
-	name, err := os.Hostname()
-	if err != nil {
-		return ""
-	}
-	return name
 }

--- a/internal/cli/backups_restore_test.go
+++ b/internal/cli/backups_restore_test.go
@@ -206,6 +206,47 @@ func TestBackupsRestoreBacksUpOverwrittenTargetFirst(t *testing.T) {
 	}
 }
 
+func TestBackupsRestoreRejectsTargetOutsideHome(t *testing.T) {
+	home := t.TempDir()
+	stateRoot := t.TempDir() // explicit external state root, outside home
+	outside := t.TempDir()
+	victim := filepath.Join(outside, ".victim")
+	if err := os.WriteFile(victim, []byte("do not touch\n"), 0o600); err != nil {
+		t.Fatalf("write victim: %v", err)
+	}
+
+	// Hand-crafted metadata whose target escapes the home sandbox. Trusting the
+	// external state root's location must not extend to trusting this target.
+	if err := os.MkdirAll(filepath.Join(stateRoot, "backups", "backup-evil", "files"), 0o755); err != nil {
+		t.Fatalf("mkdir set: %v", err)
+	}
+	preserved := backups.FilePath(stateRoot, "backup-evil", 1, victim)
+	if err := os.WriteFile(preserved, []byte("payload\n"), 0o600); err != nil {
+		t.Fatalf("write preserved: %v", err)
+	}
+	meta := backups.Metadata{Version: 1, Sets: []backups.BackupSet{{
+		ID: "backup-evil", CreatedAt: "2026-06-08T10:00:00Z", Reason: "x", Targets: []string{victim},
+	}}}
+	if err := backups.Save(backups.Path(stateRoot), meta); err != nil {
+		t.Fatalf("save metadata: %v", err)
+	}
+
+	out, err := runRestore(t, "backup-evil", "--home", home, "--state-root", stateRoot)
+	if err == nil {
+		t.Fatalf("restore Execute() error = nil, want out-of-home rejection\n%s", out)
+	}
+	if !strings.Contains(err.Error(), "escapes home") && !strings.Contains(err.Error(), "restore target") {
+		t.Fatalf("error %q does not report the out-of-home target", err)
+	}
+	got, err := os.ReadFile(victim)
+	if err != nil {
+		t.Fatalf("read victim: %v", err)
+	}
+	if string(got) != "do not touch\n" {
+		t.Fatalf("out-of-home target was modified: %q", got)
+	}
+}
+
 func TestBackupsRestoreUnknownSetReports(t *testing.T) {
 	home := t.TempDir()
 	stateRoot := t.TempDir()

--- a/internal/cli/backups_restore_test.go
+++ b/internal/cli/backups_restore_test.go
@@ -1,0 +1,220 @@
+package cli_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/backups"
+	"github.com/yersonargotev/dots/internal/cli"
+)
+
+// newPreservedSet writes target with content, captures it into a Backup Set
+// under a state root kept outside home, and returns the created set. The state
+// root is deliberately separate from home so the test exercises restore without
+// the in-home symlink validation that explicit external state roots skip.
+func newPreservedSet(t *testing.T, home, stateRoot, name, content, machine string) backups.BackupSet {
+	t.Helper()
+	target := filepath.Join(home, name)
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target parent: %v", err)
+	}
+	if err := os.WriteFile(target, []byte(content), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	set, err := backups.CreateSet(stateRoot, []string{target}, backups.CreateOptions{
+		Reason:  "pre-install conflict protection",
+		Machine: machine,
+		Repo:    "/src/dots",
+	})
+	if err != nil {
+		t.Fatalf("CreateSet: %v", err)
+	}
+	return set
+}
+
+func runRestore(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(append([]string{"backups", "restore"}, args...))
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+func TestBackupsRestoreReturnsTargetToPreservedContent(t *testing.T) {
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	set := newPreservedSet(t, home, stateRoot, ".zshrc", "original\n", "")
+
+	target := filepath.Join(home, ".zshrc")
+	if err := os.WriteFile(target, []byte("drifted\n"), 0o600); err != nil {
+		t.Fatalf("drift target: %v", err)
+	}
+
+	out, err := runRestore(t, set.ID, "--home", home, "--state-root", stateRoot)
+	if err != nil {
+		t.Fatalf("restore Execute() error = %v\n%s", err, out)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read restored target: %v", err)
+	}
+	if string(got) != "original\n" {
+		t.Fatalf("restored content = %q, want original", got)
+	}
+	if !strings.Contains(out, "Restored 1 target from Backup Set "+set.ID) {
+		t.Fatalf("missing restore summary in output:\n%s", out)
+	}
+}
+
+func TestBackupsRestoreDryRunChangesNothing(t *testing.T) {
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	set := newPreservedSet(t, home, stateRoot, ".zshrc", "original\n", "")
+
+	target := filepath.Join(home, ".zshrc")
+	if err := os.WriteFile(target, []byte("drifted\n"), 0o600); err != nil {
+		t.Fatalf("drift target: %v", err)
+	}
+
+	out, err := runRestore(t, set.ID, "--home", home, "--state-root", stateRoot, "--dry-run")
+	if err != nil {
+		t.Fatalf("restore --dry-run Execute() error = %v\n%s", err, out)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(got) != "drifted\n" {
+		t.Fatalf("dry run changed target content = %q, want drifted", got)
+	}
+	if !strings.Contains(out, "Dry run: no files changed.") {
+		t.Fatalf("missing dry run notice in output:\n%s", out)
+	}
+	if !strings.Contains(out, "overwrite") || !strings.Contains(out, target) {
+		t.Fatalf("dry run did not report planned overwrite:\n%s", out)
+	}
+
+	// A dry run must not record a safety Backup Set.
+	meta, err := backups.Load(backups.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load metadata: %v", err)
+	}
+	if len(meta.Sets) != 1 {
+		t.Fatalf("dry run recorded extra Backup Sets: %d", len(meta.Sets))
+	}
+}
+
+func TestBackupsRestoreRefusesForeignMachineWithoutForce(t *testing.T) {
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	set := newPreservedSet(t, home, stateRoot, ".zshrc", "original\n", "some-other-machine")
+
+	target := filepath.Join(home, ".zshrc")
+	if err := os.WriteFile(target, []byte("drifted\n"), 0o600); err != nil {
+		t.Fatalf("drift target: %v", err)
+	}
+
+	out, err := runRestore(t, set.ID, "--home", home, "--state-root", stateRoot)
+	if err == nil {
+		t.Fatalf("restore Execute() error = nil, want foreign-machine refusal\n%s", out)
+	}
+	if !strings.Contains(err.Error(), "--force") {
+		t.Fatalf("error %q does not mention --force", err)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(got) != "drifted\n" {
+		t.Fatalf("refused restore still changed target = %q", got)
+	}
+}
+
+func TestBackupsRestoreForceOverridesForeignMachine(t *testing.T) {
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	set := newPreservedSet(t, home, stateRoot, ".zshrc", "original\n", "some-other-machine")
+
+	target := filepath.Join(home, ".zshrc")
+	if err := os.WriteFile(target, []byte("drifted\n"), 0o600); err != nil {
+		t.Fatalf("drift target: %v", err)
+	}
+
+	if _, err := runRestore(t, set.ID, "--home", home, "--state-root", stateRoot, "--force"); err != nil {
+		t.Fatalf("restore --force Execute() error = %v", err)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read restored target: %v", err)
+	}
+	if string(got) != "original\n" {
+		t.Fatalf("forced restore content = %q, want original", got)
+	}
+}
+
+func TestBackupsRestoreBacksUpOverwrittenTargetFirst(t *testing.T) {
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	set := newPreservedSet(t, home, stateRoot, ".zshrc", "original\n", "")
+
+	target := filepath.Join(home, ".zshrc")
+	if err := os.WriteFile(target, []byte("drifted\n"), 0o600); err != nil {
+		t.Fatalf("drift target: %v", err)
+	}
+
+	out, err := runRestore(t, set.ID, "--home", home, "--state-root", stateRoot)
+	if err != nil {
+		t.Fatalf("restore Execute() error = %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "pre-restore") && !strings.Contains(out, "before restoring") {
+		t.Fatalf("missing safety backup notice in output:\n%s", out)
+	}
+
+	meta, err := backups.Load(backups.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load metadata: %v", err)
+	}
+	if len(meta.Sets) != 2 {
+		t.Fatalf("expected original + safety Backup Set, got %d", len(meta.Sets))
+	}
+
+	var safety backups.BackupSet
+	for _, s := range meta.Sets {
+		if s.ID != set.ID {
+			safety = s
+		}
+	}
+	if safety.Reason != "pre-restore safety backup" {
+		t.Fatalf("safety set reason = %q, want pre-restore safety backup", safety.Reason)
+	}
+	preserved, err := os.ReadFile(backups.FilePath(stateRoot, safety.ID, 1, target))
+	if err != nil {
+		t.Fatalf("read safety preserved file: %v", err)
+	}
+	if string(preserved) != "drifted\n" {
+		t.Fatalf("safety backup preserved %q, want the drifted content", preserved)
+	}
+}
+
+func TestBackupsRestoreUnknownSetReports(t *testing.T) {
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+
+	out, err := runRestore(t, "backup-missing", "--home", home, "--state-root", stateRoot)
+	if err == nil {
+		t.Fatalf("restore Execute() error = nil, want unknown-set error\n%s", out)
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("error %q does not report missing set", err)
+	}
+}

--- a/internal/cli/render_backups.go
+++ b/internal/cli/render_backups.go
@@ -36,3 +36,30 @@ func pluralizeBackupSets(n int) string {
 	}
 	return fmt.Sprintf("%d Backup Sets", n)
 }
+
+func pluralizeTargets(n int) string {
+	if n == 1 {
+		return "1 target"
+	}
+	return fmt.Sprintf("%d targets", n)
+}
+
+// renderRestorePlan writes the provenance of a Backup Set and the per-target
+// actions restoring it would take, so the operator can review before any write.
+func renderRestorePlan(w io.Writer, set backups.BackupSet, items []backups.RestoreItem) {
+	fmt.Fprintf(w, "Restore Backup Set %s\n", set.ID)
+	fmt.Fprintf(w, "  Created: %s\n", set.CreatedAt)
+	if set.Machine != "" {
+		fmt.Fprintf(w, "  Machine: %s\n", set.Machine)
+	}
+	if set.Repo != "" {
+		fmt.Fprintf(w, "  Repo: %s\n", set.Repo)
+	}
+	fmt.Fprintf(w, "  Reason: %s\n", set.Reason)
+
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Planned changes:")
+	for _, item := range items {
+		fmt.Fprintf(w, "  %-9s %s\n", item.Action, item.Target)
+	}
+}

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -369,7 +369,7 @@ func applyCreate(action plan.Action, source string) error {
 }
 
 func applyReplace(action plan.Action, source string, opts Options) error {
-	if err := createBackupSet(opts.StateRoot, action.Target); err != nil {
+	if err := createBackupSet(opts, action.Target); err != nil {
 		return err
 	}
 	if err := os.Remove(action.Target); err != nil {
@@ -388,7 +388,7 @@ func applyAdopt(action plan.Action, source string, opts Options) error {
 	if action.Strategy != "symlink" {
 		return nil
 	}
-	if err := createBackupSet(opts.StateRoot, action.Target); err != nil {
+	if err := createBackupSet(opts, action.Target); err != nil {
 		return err
 	}
 	if err := os.Remove(action.Target); err != nil {
@@ -454,58 +454,24 @@ func copyAdoptedTargetToSource(target, source string) error {
 	return nil
 }
 
-func createBackupSet(stateRoot, target string) error {
-	now := time.Now().UTC()
-	set := backups.BackupSet{
-		ID:        "backup-" + now.Format("20060102T150405.000000000Z"),
-		CreatedAt: now.Format(time.RFC3339),
-		Reason:    "pre-install conflict protection",
-		Targets:   []string{target},
-	}
-	backupFile := filepath.Join(stateRoot, "backups", set.ID, "files", "000001-"+filepath.Base(target))
-	if err := copyBackupTarget(target, backupFile); err != nil {
-		return err
-	}
-
-	metadataPath := backups.Path(stateRoot)
-	meta, err := backups.Load(metadataPath)
-	if err != nil {
-		return err
-	}
-	meta.Version = 1
-	meta.Sets = append(meta.Sets, set)
-	return backups.Save(metadataPath, meta)
+func createBackupSet(opts Options, target string) error {
+	_, err := backups.CreateSet(opts.StateRoot, []string{target}, backups.CreateOptions{
+		Reason:  "pre-install conflict protection",
+		Machine: machineName(),
+		Repo:    opts.SourceRoot,
+	})
+	return err
 }
 
-func copyBackupTarget(target, backupFile string) error {
-	info, err := os.Lstat(target)
+// machineName identifies the workstation a Backup Set was created on so restore
+// can refuse to write a set captured elsewhere. An unknown hostname is recorded
+// as an empty string rather than failing the install.
+func machineName() string {
+	name, err := os.Hostname()
 	if err != nil {
-		return fmt.Errorf("stat backup target %s: %w", target, err)
+		return ""
 	}
-	if err := os.MkdirAll(filepath.Dir(backupFile), 0o755); err != nil {
-		return fmt.Errorf("create Backup Set directory: %w", err)
-	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		dest, err := os.Readlink(target)
-		if err != nil {
-			return fmt.Errorf("read backup symlink %s: %w", target, err)
-		}
-		if err := os.Symlink(dest, backupFile); err != nil {
-			return fmt.Errorf("backup symlink %s: %w", target, err)
-		}
-		return nil
-	}
-	if !info.Mode().IsRegular() {
-		return fmt.Errorf("backup target %s is not a regular file or symlink", target)
-	}
-	data, err := os.ReadFile(target)
-	if err != nil {
-		return fmt.Errorf("read backup target %s: %w", target, err)
-	}
-	if err := os.WriteFile(backupFile, data, info.Mode().Perm()); err != nil {
-		return fmt.Errorf("write backup target %s: %w", backupFile, err)
-	}
-	return nil
+	return name
 }
 
 func copyRegularFile(source, target string) error {

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -457,21 +457,10 @@ func copyAdoptedTargetToSource(target, source string) error {
 func createBackupSet(opts Options, target string) error {
 	_, err := backups.CreateSet(opts.StateRoot, []string{target}, backups.CreateOptions{
 		Reason:  "pre-install conflict protection",
-		Machine: machineName(),
+		Machine: backups.MachineName(),
 		Repo:    opts.SourceRoot,
 	})
 	return err
-}
-
-// machineName identifies the workstation a Backup Set was created on so restore
-// can refuse to write a set captured elsewhere. An unknown hostname is recorded
-// as an empty string rather than failing the install.
-func machineName() string {
-	name, err := os.Hostname()
-	if err != nil {
-		return ""
-	}
-	return name
 }
 
 func copyRegularFile(source, target string) error {


### PR DESCRIPTION
## Summary

Implements `dots backups restore <set>` (issue #21, v1.1) — the safe inverse of the conflict `replace` path. Restores the targets recorded in a Backup Set to the content preserved when the set was created.

## Acceptance criteria

- [x] `dots backups restore <set>` restores files recorded in the selected Backup Set to their original targets (regular files with their permissions; symlinks recreated to their destination).
- [x] Restore reads Backup Metadata (created-at, repo, machine, targets, reason) and refuses sets that don't match the current machine unless `--force`.
- [x] `--dry-run` reports the per-target `create`/`overwrite` plan without touching any files.
- [x] Restoring over current managed targets records a `pre-restore safety backup` Backup Set first — never a destructive one-way restore.
- [x] Covered by tests against temp homes; never the real `$HOME`.

## Design note

Backup Set mechanics lived inside `internal/install` (`createBackupSet`, `copyBackupTarget`, a hardcoded `000001-` file prefix). Restore needs the inverse plus that same path convention, so the logic is now centralized in `internal/backups`:

- `backups.FilePath` is the single source of the file-naming convention (`stateRoot/backups/{id}/files/{index:06d}-{base}`), shared by install (write) and restore (read).
- `CreateSet` / `PlanRestore` / `ApplyRestore` own create and restore; `install` delegates to `CreateSet` instead of duplicating file-copy logic.
- Added `Machine`/`Repo` (json `omitempty`) to `BackupSet`; legacy sets without a machine are allowed without `--force`.

## Tests

`gofmt`, `go vet`, `go test ./...` all green. New tests: `internal/backups/set_test.go`, `internal/cli/backups_restore_test.go`. Verified end-to-end with the real binary (dry-run, restore, safety backup, foreign-machine refusal + `--force`).

## Docs

- `docs/backups.md` (new) documents `list` and `restore`.
- `docs/scope.md` marks automatic backup restore as shipped in v1.1.

Closes #21