### PR TITLE
docs(readme): add project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,35 @@
 # dots
 
-`dots` is a safe Dotfiles CLI for installing repository-owned shell, git, starship, and tmux configuration. It plans before changing files, detects conflicts, and keeps install behavior inside the tested Go CLI instead of duplicating it in shell scripts.
+`dots` is a safe Dotfiles CLI for installing repository-owned shell, git, starship, and tmux configuration. It treats this repository as the Source of Truth, reads an Install Manifest, shows an Install Plan before changing files, and preserves user-owned configuration with Backup Sets instead of overwriting blindly.
 
-## Quick install
+The Bootstrapper in [`scripts/install.sh`](scripts/install.sh) installs the released `dots` binary, verifies the matching SHA-256 checksum, and then delegates setup to the tested Go CLI. That keeps install behavior in one place instead of duplicating dangerous filesystem logic in shell.
 
-Choose one install path. Both paths install the same checksum-verified GitHub Release Artifact for your platform.
+## Install
+
+### Bootstrapper
+
+Pin the version explicitly so the Bootstrapper downloads a known Release Artifact and verifies it against the published checksum manifest:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/yersonargotev/dots/main/scripts/install.sh | DOTS_VERSION=v0.1.0 bash
+```
+
+The Bootstrapper:
+
+1. Detects the current Supported Platform.
+2. Downloads the matching GitHub Release Artifact and `checksums.txt`.
+3. Performs Checksum Verification before installing the binary to `~/.local/bin/dots`.
+4. Runs `dots install` so the Dotfiles CLI owns the Install Plan and file changes.
+
+Requirements: `curl` or `wget`, plus `sha256sum` or `shasum`. Make sure `~/.local/bin` is on your `PATH` after install.
 
 ### Homebrew
+
+macOS and Linux users can also install the same checksum-backed release through the Homebrew Distribution:
 
 ```bash
 brew install yersonargotev/tap/dots
 ```
-
-If you prefer tapping first, run `brew tap yersonargotev/tap` and then `brew install dots`.
 
 Verify the binary is available:
 
@@ -20,35 +37,68 @@ Verify the binary is available:
 dots --help
 ```
 
-Then run the installer from the CLI:
+## Quickstart
+
+Start with a dry run. The CLI should show the Install Plan without writing files:
+
+```bash
+dots install --dry-run
+```
+
+Then inspect the current machine state:
+
+```bash
+dots status
+dots doctor
+```
+
+Check Dependencies without letting `dots` mutate your package managers:
+
+```bash
+dots deps check
+dots deps plan
+```
+
+List Backup Metadata created by safe installs or restores:
+
+```bash
+dots backups list
+```
+
+When the plan looks right, run the install for real:
 
 ```bash
 dots install
 ```
 
-### Bootstrapper
+## Core concepts
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/yersonargotev/dots/main/scripts/install.sh | DOTS_VERSION=v0.1.0 bash
-```
+| Concept | Meaning |
+|---------|---------|
+| Source of Truth | This repository's tracked dotfiles and manifest are the canonical desired state. |
+| Install Manifest | The manifest that maps repository files to home-directory targets. |
+| Managed Entry | A target file or link managed by `dots`, such as `.zshrc`, `.gitconfig`, Starship, or tmux config. |
+| Install Plan | The preview of create, replace, skip, or conflict actions before install applies changes. |
+| Installation Metadata | Local state used to remember what `dots` installed. |
+| Backup Set | A preserved copy of user-owned files before a restore or overwrite path changes them. |
+| Dependency Plan | Guidance for missing tools; `dots` reports, but does not install, system packages. |
 
-The Bootstrapper downloads `checksums.txt`, verifies the matching Release Artifact, installs `dots` to `~/.local/bin/dots`, and delegates setup to `dots install`.
+## Supported platforms
 
-## Release artifacts
+Release artifacts are published for:
 
-Each release publishes raw binaries for:
+| OS | Architecture |
+|----|--------------|
+| macOS | `amd64`, `arm64` |
+| Linux | `amd64`, `arm64` |
 
-| Platform | Artifact suffix |
-|----------|-----------------|
-| macOS amd64 | `darwin_amd64` |
-| macOS arm64 | `darwin_arm64` |
-| Linux amd64 | `linux_amd64` |
-| Linux arm64 | `linux_arm64` |
+## v1 scope boundary
 
-Homebrew and the Bootstrapper use those same artifacts plus the published SHA-256 manifest.
+The v1 scope focuses on the MVP Configuration Set: zsh, git, starship, and tmux. It does not include Windows, official WSL support, NixOS-specific behavior, Alpine/musl specialization, automatic dependency installation, Neovim configuration, or arbitrary manifest hooks.
 
-## Maintainer docs
+## Canonical docs
 
-- [`docs/release.md`](docs/release.md) — release workflow, checksums, Homebrew tap automation, and Bootstrapper install.
-- [`docs/scope.md`](docs/scope.md) — current scope boundaries and deferred work.
-- [`CONTEXT.md`](CONTEXT.md) — domain vocabulary and architecture context.
+- [`CONTEXT.md`](CONTEXT.md) — domain vocabulary, architecture context, and project model.
+- [`docs/scope.md`](docs/scope.md) — v1 scope, non-goals, and deferred work.
+- [`docs/release.md`](docs/release.md) — release workflow, checksums, Homebrew, and Bootstrapper details.
+- [`docs/adr/0001-bootstrap-with-go-cli.md`](docs/adr/0001-bootstrap-with-go-cli.md) — ADR for bootstrapping with the Go CLI.


### PR DESCRIPTION
Closes #23

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [x] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Expands the top-level README into a public entry point for the Dotfiles CLI.
- Documents checksum-verified Bootstrapper install with pinned `DOTS_VERSION` and Homebrew alternative.
- Adds quickstart commands, core vocabulary, supported platforms, v1 scope boundary, and canonical docs links.

## Changes

| File | Change |
|------|--------|
| `README.md` | Adds install, quickstart, core concepts, supported platforms, v1 scope, and canonical documentation links for new users. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [ ] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp>` — not run; docs-only README change does not change dotfiles behavior.

Additional validation:

- [x] `git diff --check`
- [x] README acceptance smoke check for issue #23 required terms, commands, links, platforms, and v1 scope.
- [x] Fresh-context review confirmed issue #23 acceptance criteria pass with no blockers.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
