### PR TITLE
feat(deps): execute install actions with yes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,17 @@ dots status
 dots doctor
 ```
 
-Check Dependencies without letting `dots` mutate your package managers:
+Inspect and install missing Dependencies deliberately:
 
 ```bash
-dots deps check
-dots deps plan
+dots deps check          # report present and missing tools
+dots deps plan           # show OS-aware guidance only
+dots deps install --dry-run  # preview installable and manual actions
+dots deps install        # preview, then ask before executing package managers
+dots deps install --yes  # execute installable actions without prompting
 ```
+
+`dots deps install` executes package managers with direct argv only after confirmation. It does not bypass `sudo`, does not run manual-only guidance, and does not promise rollback, version constraints, reinstall, or upgrade behavior.
 
 List Backup Metadata created by safe installs or restores:
 
@@ -81,7 +86,8 @@ dots install
 | Install Plan | The preview of create, replace, skip, or conflict actions before install applies changes. |
 | Installation Metadata | Local state used to remember what `dots` installed. |
 | Backup Set | A preserved copy of user-owned files before a restore or overwrite path changes them. |
-| Dependency Plan | Guidance for missing tools; `dots` reports, but does not install, system packages. |
+| Dependency Plan | OS-aware guidance for missing tools, including which actions are installable and which remain manual. |
+| Dependency Install | A guarded workflow that previews missing Dependency actions, asks for confirmation by default, and executes only installable package-manager actions. |
 
 ## Supported platforms
 
@@ -94,7 +100,7 @@ Release artifacts are published for:
 
 ## v1 scope boundary
 
-The v1 scope focuses on the MVP Configuration Set: zsh, git, starship, and tmux. It does not include Windows, official WSL support, NixOS-specific behavior, Alpine/musl specialization, automatic dependency installation, Neovim configuration, or arbitrary manifest hooks.
+The v1 scope focuses on the MVP Configuration Set: zsh, git, starship, and tmux. It includes guarded dependency inspection and installation for supported package-manager tiers, but does not include Windows, official WSL support, NixOS-specific behavior, Alpine/musl specialization, Neovim configuration, arbitrary manifest hooks, dependency rollback, version constraints, reinstall, or upgrade orchestration.
 
 ## Canonical docs
 

--- a/docs/scope.md
+++ b/docs/scope.md
@@ -1,6 +1,6 @@
 # v1 Scope and Deferred Work
 
-v1 proves that the Dotfiles CLI can install repository-owned configuration safely before the project expands into package management, update orchestration, or larger application configuration. These boundaries protect installer correctness, preserve the Source of Truth, and prevent Machine-Specific Configuration from leaking into shared Managed Configuration.
+v1 proves that the Dotfiles CLI can install repository-owned configuration safely and handle missing Dependencies with explicit guardrails before the project expands into update orchestration or larger application configuration. These boundaries protect installer correctness, preserve the Source of Truth, and prevent Machine-Specific Configuration from leaking into shared Managed Configuration.
 
 ## Quick review path
 
@@ -16,7 +16,7 @@ v1 proves that the Dotfiles CLI can install repository-owned configuration safel
 | Conflict safety | Conflict Resolution supports explicit choices such as `skip`, `replace`, `adopt`, and `diff`; replacement requires a Backup Set first, and adoption must be explicit to avoid contaminating the Source of Truth. |
 | Status | `dots status` reports Dotfiles Status, including whether Managed Entries are installed, missing, conflicting, skipped, drifted, or unsupported. |
 | Diagnostics | `dots doctor` reports platform, dependency, secret, and configuration concerns without pretending that guardrails are a complete audit. |
-| Dependency guidance | `dots deps check` and `dots deps plan` detect missing Dependencies and produce an OS-aware Dependency Plan. v1 gives guidance only; it does not install packages. |
+| Dependency management | `dots deps check`, `dots deps plan`, and `dots deps install` detect missing Dependencies, show OS-aware guidance, preview installable actions, and execute package-manager commands only after `--yes` or interactive confirmation. Manual-only Dependencies remain manual. |
 | Backups list | `dots backups list` exposes Backup Sets and Backup Metadata so preserved files can be audited after installation. |
 | Release artifacts | GitHub Releases publish platform-specific Release Artifacts for macOS amd64/arm64 and Linux amd64/arm64. |
 | Bootstrapper support | The Bootstrapper downloads the matching Release Artifact, performs Checksum Verification, installs or locates `dots`, and delegates setup to the Dotfiles CLI. |
@@ -27,7 +27,7 @@ v1 proves that the Dotfiles CLI can install repository-owned configuration safel
 
 | Deferred item | Earliest target | Why it is deferred |
 |---------------|-----------------|--------------------|
-| Automatic dependency installation | Later than v1 | Installing packages introduces package-manager selection, sudo behavior, distro differences, repositories, taps, version constraints, and higher operational risk. |
+| Advanced dependency orchestration | Later than v1 | Rollback, version constraints, repository/tap/index refresh, reinstall, and upgrade behavior introduce package-manager state decisions beyond the guarded v1 install flow. |
 | `dots update` | v1.1 — **shipped** | Updating the Installed Repository introduces Git state, local changes, versioning, and post-update conflict handling. Delivered in v1.1; see [`docs/update.md`](update.md). |
 | Neovim and larger application configurations | Later than v1 | Larger app configs introduce plugin, language-server, and dependency complexity that distracts from proving installer correctness. |
 | Windows support | Later than v1 | v1 focuses on macOS and Linux Supported Platforms only. Windows needs separate path, shell, package, and platform behavior decisions. |
@@ -47,9 +47,9 @@ The Bootstrapper is intentionally thin. It downloads, verifies, and launches the
 
 The repository-owned Source of Truth must not absorb accidental local state. Adoption exists for explicit migrations only. Machine-Specific Configuration belongs in Local Extension Points, ignored files, or external secret stores, not in shared Managed Configuration.
 
-### Dependency guidance is safer than dependency mutation
+### Dependency installation stays behind explicit consent
 
-A Dependency Plan helps the user understand missing tools without allowing v1 to mutate package-manager state. That boundary avoids surprise installs, sudo prompts, repository changes, and distro-specific behavior before the installer foundation is stable.
+A Dependency Plan helps the user understand missing tools before any package-manager command runs. `dots deps install` uses the same preview, asks for confirmation by default, and executes direct argv-shaped package-manager actions only for installable Dependencies. It does not bypass `sudo`, does not execute manual guidance, and does not claim rollback, version constraints, reinstall, or upgrade behavior.
 
 ### Distribution starts with verifiable artifacts
 
@@ -70,7 +70,7 @@ zsh, git, starship, and tmux are enough to prove symlink, template, copy, Local 
 
 Use this checklist when reviewing v1 issues or PRs:
 
-- [ ] The change strengthens safe installation, status, diagnostics, dependency guidance, backups, release artifacts, checksum Bootstrapper support, or Homebrew Distribution.
-- [ ] The change does not add automatic dependency installation, larger Deferred Configuration, or unsupported platform behavior to v1.
+- [ ] The change strengthens safe installation, status, diagnostics, guarded dependency management, backups, release artifacts, checksum Bootstrapper support, or Homebrew Distribution.
+- [ ] The change does not add advanced dependency orchestration, larger Deferred Configuration, or unsupported platform behavior to v1.
 - [ ] The change preserves Source of Truth integrity and does not make Machine-Specific Configuration part of shared Managed Configuration.
 - [ ] The change uses the project vocabulary from `CONTEXT.md` and the tradeoffs recorded in the ADR.

--- a/internal/cli/deps.go
+++ b/internal/cli/deps.go
@@ -1,8 +1,10 @@
 package cli
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"runtime"
@@ -17,7 +19,7 @@ func newDepsCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "deps",
 		Short: "Inspect external tool Dependencies declared by managed entries",
-		Long:  "deps reports which external Dependencies a profile needs and offers OS-aware installation guidance. dots never installs packages automatically in v1.",
+		Long:  "deps reports which external Dependencies a profile needs, offers OS-aware installation guidance, and can execute missing install actions with explicit confirmation.",
 	}
 	cmd.AddCommand(newDepsCheckCommand())
 	cmd.AddCommand(newDepsPlanCommand())
@@ -111,17 +113,18 @@ func newDepsInstallCommand() *cobra.Command {
 		profile string
 		tier    string
 		dryRun  bool
+		yes     bool
 	)
 
 	cmd := &cobra.Command{
 		Use:          "install",
-		Short:        "Preview dependency install actions",
-		Long:         "install previews dependency install actions with --dry-run. Real package-manager execution is not implemented yet.",
+		Short:        "Install missing Dependencies with explicit confirmation",
+		Long:         "install previews dependency install actions with --dry-run or executes them with --yes. The default interactive confirmation flow is not implemented yet.",
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !dryRun {
-				return errors.New("deps install is not implemented yet; --dry-run is required in this release")
+			if !dryRun && !yes {
+				return errors.New("deps install requires --dry-run or --yes in this release")
 			}
 
 			m, err := manifest.LoadFile(file)
@@ -134,10 +137,25 @@ func newDepsInstallCommand() *cobra.Command {
 				return err
 			}
 
-			report, err := deps.InstallDryRun(*m, deps.Options{
+			options := deps.Options{
 				Profile: profile,
 				OS:      runtime.GOOS,
-			}, lookupCommand, resolvedTier)
+			}
+
+			if yes && !dryRun {
+				report, err := deps.Install(*m, options, lookupCommand, resolvedTier, depsExecRunner{
+					ctx:    cmd.Context(),
+					stdin:  cmd.InOrStdin(),
+					stdout: cmd.OutOrStdout(),
+					stderr: cmd.ErrOrStderr(),
+				})
+				if report.Profile != "" || len(report.Items) > 0 {
+					renderDepsInstall(cmd.OutOrStdout(), report)
+				}
+				return err
+			}
+
+			report, err := deps.InstallDryRun(*m, options, lookupCommand, resolvedTier)
 			if err != nil {
 				return err
 			}
@@ -151,7 +169,23 @@ func newDepsInstallCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&profile, "profile", "p", "default", "profile to inspect")
 	cmd.Flags().StringVar(&tier, "tier", "", "override the dependency install tier (homebrew, debian, fedora, arch, generic); default: auto-detect from the host")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview dependency install actions without executing package managers")
+	cmd.Flags().BoolVar(&yes, "yes", false, "execute dependency install actions without interactive confirmation")
 	return cmd
+}
+
+type depsExecRunner struct {
+	ctx    context.Context
+	stdin  io.Reader
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r depsExecRunner) Run(executable string, args []string) error {
+	cmd := exec.CommandContext(r.ctx, executable, args...)
+	cmd.Stdin = r.stdin
+	cmd.Stdout = r.stdout
+	cmd.Stderr = r.stderr
+	return cmd.Run()
 }
 
 // lookupCommand reports whether a command resolves on the current PATH. It is

--- a/internal/cli/deps.go
+++ b/internal/cli/deps.go
@@ -1,8 +1,8 @@
 package cli
 
 import (
+	"bufio"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -119,14 +119,10 @@ func newDepsInstallCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "install",
 		Short:        "Install missing Dependencies with explicit confirmation",
-		Long:         "install previews dependency install actions with --dry-run or executes them with --yes. The default interactive confirmation flow is not implemented yet.",
+		Long:         "install previews dependency install actions, asks for confirmation by default, and executes installable actions only after explicit approval. Use --dry-run to preview without prompting or --yes for non-interactive execution.",
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !dryRun && !yes {
-				return errors.New("deps install requires --dry-run or --yes in this release")
-			}
-
 			m, err := manifest.LoadFile(file)
 			if err != nil {
 				return err
@@ -142,26 +138,37 @@ func newDepsInstallCommand() *cobra.Command {
 				OS:      runtime.GOOS,
 			}
 
-			if yes && !dryRun {
-				report, err := deps.Install(*m, options, lookupCommand, resolvedTier, depsExecRunner{
-					ctx:    cmd.Context(),
-					stdin:  cmd.InOrStdin(),
-					stdout: cmd.OutOrStdout(),
-					stderr: cmd.ErrOrStderr(),
-				})
-				if report.Profile != "" || len(report.Items) > 0 {
-					renderDepsInstall(cmd.OutOrStdout(), report)
-				}
-				return err
-			}
-
 			report, err := deps.InstallDryRun(*m, options, lookupCommand, resolvedTier)
 			if err != nil {
 				return err
 			}
 
-			renderDepsInstallDryRun(cmd.OutOrStdout(), report)
-			return nil
+			if dryRun {
+				renderDepsInstallDryRun(cmd.OutOrStdout(), report)
+				return nil
+			}
+
+			if yes {
+				if !hasInstallablePreviewAction(report) {
+					renderDepsInstallPreview(cmd.OutOrStdout(), report)
+					return nil
+				}
+				return runDepsInstall(cmd, *m, options, resolvedTier)
+			}
+
+			renderDepsInstallPreview(cmd.OutOrStdout(), report)
+			if !hasInstallablePreviewAction(report) {
+				return nil
+			}
+			confirmed, err := confirmDepsInstall(cmd.InOrStdin(), cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			if !confirmed {
+				fmt.Fprintln(cmd.OutOrStdout(), "Dependency installation cancelled.")
+				return nil
+			}
+			return runDepsInstall(cmd, *m, options, resolvedTier)
 		},
 	}
 
@@ -171,6 +178,40 @@ func newDepsInstallCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview dependency install actions without executing package managers")
 	cmd.Flags().BoolVar(&yes, "yes", false, "execute dependency install actions without interactive confirmation")
 	return cmd
+}
+
+func runDepsInstall(cmd *cobra.Command, m manifest.Manifest, options deps.Options, tier deps.Tier) error {
+	report, err := deps.Install(m, options, lookupCommand, tier, depsExecRunner{
+		ctx:    cmd.Context(),
+		stdin:  cmd.InOrStdin(),
+		stdout: cmd.OutOrStdout(),
+		stderr: cmd.ErrOrStderr(),
+	})
+	if report.Profile != "" || len(report.Items) > 0 {
+		renderDepsInstall(cmd.OutOrStdout(), report)
+	}
+	return err
+}
+
+func confirmDepsInstall(r io.Reader, w io.Writer) (bool, error) {
+	fmt.Fprint(w, "Proceed with dependency installation? [y/N] ")
+	scanner := bufio.NewScanner(r)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return false, fmt.Errorf("read dependency install confirmation: %w", err)
+		}
+		return false, nil
+	}
+	answer := strings.ToLower(strings.TrimSpace(scanner.Text()))
+	switch answer {
+	case "y", "yes":
+		return true, nil
+	case "", "n", "no":
+		return false, nil
+	default:
+		fmt.Fprintf(w, "Response %q is not yes/y; cancelling.\n", answer)
+		return false, nil
+	}
 }
 
 type depsExecRunner struct {

--- a/internal/cli/deps_install_test.go
+++ b/internal/cli/deps_install_test.go
@@ -10,19 +10,55 @@ import (
 	"github.com/yersonargotev/dots/internal/cli"
 )
 
-func TestDepsInstallWithoutDryRunOrYesErrorsClearly(t *testing.T) {
+func TestDepsInstallDeclineDoesNotInvokePackageManager(t *testing.T) {
+	binDir := t.TempDir()
+	marker := binDir + "/brew-was-run"
+	brew := binDir + "/brew"
+	if err := os.WriteFile(brew, []byte("#!/bin/sh\ntouch \""+marker+"\"\n"), 0o700); err != nil {
+		t.Fatalf("write fake brew: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	manifestPath := writeDepsInstallManifest(t, `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+    dependencies:
+      - name: definitely-missing-starship
+        command: definitely-missing-starship-probe
+        brew: starship
+`)
+
 	cmd := cli.NewRootCommand()
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"deps", "install"})
+	cmd.SetIn(strings.NewReader("no\n"))
+	cmd.SetArgs([]string{"deps", "install", "--file", manifestPath, "--tier", "homebrew"})
 
-	err := cmd.Execute()
-	if err == nil {
-		t.Fatalf("Execute() error = nil, want unsupported install error")
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
 	}
-	if !strings.Contains(err.Error(), "--dry-run") || !strings.Contains(err.Error(), "--yes") {
-		t.Fatalf("error = %q, want --dry-run or --yes guidance", err.Error())
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("declined install invoked fake package manager; marker stat err = %v", err)
+	}
+
+	got := out.String()
+	for _, want := range []string{
+		`Dependency install preview for profile "default" (homebrew)`,
+		"would-install definitely-missing-starship",
+		"brew install starship",
+		"Proceed with dependency installation? [y/N]",
+		"Dependency installation cancelled.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("decline output missing %q\noutput:\n%s", want, got)
+		}
 	}
 }
 
@@ -39,6 +75,231 @@ func TestDepsInstallRejectsUnexpectedTrailingToken(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "starship") {
 		t.Fatalf("error = %q, want trailing token to be rejected", err.Error())
+	}
+}
+
+func TestDepsInstallInvalidOrEmptyConfirmationCancelsDeterministically(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		stdin      string
+		wantOutput string
+	}{
+		{name: "invalid", stdin: "maybe\n", wantOutput: `Response "maybe" is not yes/y; cancelling.`},
+		{name: "empty", stdin: "\n", wantOutput: "Dependency installation cancelled."},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			binDir := t.TempDir()
+			marker := binDir + "/brew-was-run"
+			brew := binDir + "/brew"
+			if err := os.WriteFile(brew, []byte("#!/bin/sh\ntouch \""+marker+"\"\n"), 0o700); err != nil {
+				t.Fatalf("write fake brew: %v", err)
+			}
+			t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+			manifestPath := writeDepsInstallManifest(t, `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+    dependencies:
+      - name: definitely-missing-starship
+        command: definitely-missing-starship-probe
+        brew: starship
+`)
+
+			cmd := cli.NewRootCommand()
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetIn(strings.NewReader(tt.stdin))
+			cmd.SetArgs([]string{"deps", "install", "--file", manifestPath, "--tier", "homebrew"})
+
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+			}
+			if _, err := os.Stat(marker); !os.IsNotExist(err) {
+				t.Fatalf("confirmation %q invoked fake package manager; marker stat err = %v", tt.stdin, err)
+			}
+			if got := out.String(); !strings.Contains(got, tt.wantOutput) {
+				t.Fatalf("output missing %q\noutput:\n%s", tt.wantOutput, got)
+			}
+		})
+	}
+}
+
+func TestDepsInstallWithNoMissingActionsDoesNotPrompt(t *testing.T) {
+	binDir := t.TempDir()
+	present := binDir + "/present-tool"
+	if err := os.WriteFile(present, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+		t.Fatalf("write fake present command: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+
+	manifestPath := writeDepsInstallManifest(t, `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+    dependencies:
+      - name: present-tool
+        command: present-tool
+        brew: present-tool
+`)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetIn(strings.NewReader("yes\n"))
+	cmd.SetArgs([]string{"deps", "install", "--file", manifestPath, "--tier", "homebrew"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+	got := out.String()
+	if strings.Contains(got, "Proceed with dependency installation?") {
+		t.Fatalf("output prompted despite no missing actions:\n%s", got)
+	}
+	if !strings.Contains(got, "All declared dependencies are already installed.") {
+		t.Fatalf("output missing all-installed message:\n%s", got)
+	}
+}
+
+func TestDepsInstallManualOnlyPreviewDoesNotPromptOrError(t *testing.T) {
+	binDir := t.TempDir()
+	brew := binDir + "/brew"
+	marker := binDir + "/brew-was-run"
+	if err := os.WriteFile(brew, []byte("#!/bin/sh\ntouch \""+marker+"\"\n"), 0o700); err != nil {
+		t.Fatalf("write fake brew: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+
+	manifestPath := writeDepsInstallManifest(t, `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+    dependencies:
+      - name: definitely-missing-manual
+        command: definitely-missing-manual-probe
+`)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetIn(strings.NewReader("yes\n"))
+	cmd.SetArgs([]string{"deps", "install", "--file", manifestPath, "--tier", "homebrew"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("manual-only preview invoked fake package manager; marker stat err = %v", err)
+	}
+
+	got := out.String()
+	for _, want := range []string{
+		`Dependency install preview for profile "default" (homebrew)`,
+		`manual        definitely-missing-manual no homebrew package declared for "definitely-missing-manual"; install it manually`,
+		"Summary: 0 installable, 1 manual",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("manual-only output missing %q\noutput:\n%s", want, got)
+		}
+	}
+	for _, unwanted := range []string{
+		"Proceed with dependency installation?",
+		"dependency to install",
+	} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("manual-only output contained %q\noutput:\n%s", unwanted, got)
+		}
+	}
+}
+
+func TestDepsInstallMixedManualAndInstallableExplainsManualBeforeConfirmation(t *testing.T) {
+	binDir := t.TempDir()
+	argsLog := binDir + "/brew-args"
+	probe := binDir + "/definitely-missing-starship-probe"
+	brew := binDir + "/brew"
+	script := fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$@" > %q
+cat > %q <<'PROBE'
+#!/bin/sh
+exit 0
+PROBE
+chmod +x %q
+`, argsLog, probe, probe)
+	if err := os.WriteFile(brew, []byte(script), 0o700); err != nil {
+		t.Fatalf("write fake brew: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	manifestPath := writeDepsInstallManifest(t, `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+    dependencies:
+      - name: definitely-missing-manual
+        command: definitely-missing-manual-probe
+      - name: definitely-missing-starship
+        command: definitely-missing-starship-probe
+        brew: starship
+`)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetIn(strings.NewReader("y\n"))
+	cmd.SetArgs([]string{"deps", "install", "--file", manifestPath, "--tier", "homebrew"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("Execute() error = nil, want unresolved manual dependency error\noutput:\n%s", out.String())
+	}
+	if !strings.Contains(err.Error(), "unresolved dependencies remain") {
+		t.Fatalf("Execute() error = %v, want unresolved dependencies remain", err)
+	}
+
+	args, readErr := os.ReadFile(argsLog)
+	if readErr != nil {
+		t.Fatalf("read fake brew args: %v", readErr)
+	}
+	if string(args) != "install\nstarship\n" {
+		t.Fatalf("fake brew args = %q, want only installable dependency", string(args))
+	}
+
+	got := out.String()
+	manualPreview := `manual        definitely-missing-manual no homebrew package declared for "definitely-missing-manual"; install it manually`
+	for _, want := range []string{
+		manualPreview,
+		"Proceed with dependency installation? [y/N]",
+		"installed  definitely-missing-starship",
+		"manual     definitely-missing-manual",
+		"Summary: 1 installed, 1 manual, 0 unresolved, 0 failed",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("mixed install output missing %q\noutput:\n%s", want, got)
+		}
 	}
 }
 
@@ -62,6 +323,7 @@ entries:
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
+	cmd.SetIn(strings.NewReader("yes\n"))
 	cmd.SetArgs([]string{"deps", "install", "--dry-run", "--file", manifestPath, "--tier", "homebrew"})
 
 	if err := cmd.Execute(); err != nil {
@@ -73,10 +335,82 @@ entries:
 		`Dependency install dry-run for profile "default" (homebrew)`,
 		"would-install definitely-missing-starship",
 		"brew install starship",
-		"Summary: 1 dependency to install",
+		"Summary: 1 installable, 0 manual",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("dry-run output missing %q\noutput:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "Proceed with dependency installation?") {
+		t.Fatalf("dry-run prompted unexpectedly:\n%s", got)
+	}
+}
+
+func TestDepsInstallConfirmYesExecutesFakePackageManagerAndRendersSummary(t *testing.T) {
+	binDir := t.TempDir()
+	argsLog := binDir + "/brew-args"
+	probe := binDir + "/definitely-missing-starship-probe"
+	brew := binDir + "/brew"
+	script := fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$@" > %q
+printf 'package stdout\n'
+printf 'package stderr\n' >&2
+cat > %q <<'PROBE'
+#!/bin/sh
+exit 0
+PROBE
+chmod +x %q
+`, argsLog, probe, probe)
+	if err := os.WriteFile(brew, []byte(script), 0o700); err != nil {
+		t.Fatalf("write fake brew: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	manifestPath := writeDepsInstallManifest(t, `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+    dependencies:
+      - name: definitely-missing-starship
+        command: definitely-missing-starship-probe
+        brew: starship
+`)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetIn(strings.NewReader("yes\n"))
+	cmd.SetArgs([]string{"deps", "install", "--file", manifestPath, "--tier", "homebrew"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+
+	args, err := os.ReadFile(argsLog)
+	if err != nil {
+		t.Fatalf("read fake brew args: %v", err)
+	}
+	if string(args) != "install\nstarship\n" {
+		t.Fatalf("fake brew args = %q, want direct argv install/starship", string(args))
+	}
+
+	got := out.String()
+	for _, want := range []string{
+		`Dependency install preview for profile "default" (homebrew)`,
+		"Proceed with dependency installation? [y/N]",
+		"package stdout",
+		"package stderr",
+		`Dependency install for profile "default" (homebrew)`,
+		"Summary: 1 installed, 0 manual, 0 unresolved, 0 failed",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("confirmed install output missing %q\noutput:\n%s", want, got)
 		}
 	}
 }
@@ -156,6 +490,9 @@ entries:
 		if !strings.Contains(got, want) {
 			t.Fatalf("install output missing %q\noutput:\n%s", want, got)
 		}
+	}
+	if strings.Contains(got, "Proceed with dependency installation?") {
+		t.Fatalf("--yes prompted unexpectedly:\n%s", got)
 	}
 }
 

--- a/internal/cli/deps_install_test.go
+++ b/internal/cli/deps_install_test.go
@@ -2,6 +2,7 @@ package cli_test
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -9,7 +10,7 @@ import (
 	"github.com/yersonargotev/dots/internal/cli"
 )
 
-func TestDepsInstallWithoutDryRunErrorsClearly(t *testing.T) {
+func TestDepsInstallWithoutDryRunOrYesErrorsClearly(t *testing.T) {
 	cmd := cli.NewRootCommand()
 	var out bytes.Buffer
 	cmd.SetOut(&out)
@@ -20,8 +21,8 @@ func TestDepsInstallWithoutDryRunErrorsClearly(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Execute() error = nil, want unsupported install error")
 	}
-	if !strings.Contains(err.Error(), "--dry-run is required") {
-		t.Fatalf("error = %q, want --dry-run guidance", err.Error())
+	if !strings.Contains(err.Error(), "--dry-run") || !strings.Contains(err.Error(), "--yes") {
+		t.Fatalf("error = %q, want --dry-run or --yes guidance", err.Error())
 	}
 }
 
@@ -76,6 +77,84 @@ entries:
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("dry-run output missing %q\noutput:\n%s", want, got)
+		}
+	}
+}
+
+func TestDepsInstallYesExecutesFakePackageManagerAndRendersSummary(t *testing.T) {
+	binDir := t.TempDir()
+	argsLog := binDir + "/brew-args"
+	stdinLog := binDir + "/brew-stdin"
+	probe := binDir + "/definitely-missing-starship-probe"
+	brew := binDir + "/brew"
+	script := fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$@" > %q
+cat > %q
+printf 'package stdout\n'
+printf 'package stderr\n' >&2
+cat > %q <<'PROBE'
+#!/bin/sh
+exit 0
+PROBE
+chmod +x %q
+`, argsLog, stdinLog, probe, probe)
+	if err := os.WriteFile(brew, []byte(script), 0o700); err != nil {
+		t.Fatalf("write fake brew: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	manifestPath := writeDepsInstallManifest(t, `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+    dependencies:
+      - name: definitely-missing-starship
+        command: definitely-missing-starship-probe
+        brew: starship
+`)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetIn(strings.NewReader("runner stdin\n"))
+	cmd.SetArgs([]string{"deps", "install", "--yes", "--file", manifestPath, "--tier", "homebrew"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+
+	args, err := os.ReadFile(argsLog)
+	if err != nil {
+		t.Fatalf("read fake brew args: %v", err)
+	}
+	if string(args) != "install\nstarship\n" {
+		t.Fatalf("fake brew args = %q, want direct argv install/starship", string(args))
+	}
+	stdin, err := os.ReadFile(stdinLog)
+	if err != nil {
+		t.Fatalf("read fake brew stdin: %v", err)
+	}
+	if string(stdin) != "runner stdin\n" {
+		t.Fatalf("fake brew stdin = %q, want cobra stdin passthrough", string(stdin))
+	}
+
+	got := out.String()
+	for _, want := range []string{
+		"package stdout",
+		"package stderr",
+		`Dependency install for profile "default" (homebrew)`,
+		"installed",
+		"definitely-missing-starship",
+		"Summary: 1 installed, 0 manual, 0 unresolved, 0 failed",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("install output missing %q\noutput:\n%s", want, got)
 		}
 	}
 }

--- a/internal/cli/render_deps.go
+++ b/internal/cli/render_deps.go
@@ -82,3 +82,36 @@ func renderDepsInstallDryRun(w io.Writer, report deps.InstallDryRunReport) {
 
 	fmt.Fprintf(w, "\nSummary: %s\n", pluralizeDeps(len(report.Items)))
 }
+
+// renderDepsInstall writes the stable dots summary after real package-manager
+// execution has already streamed through the command's stdio handles.
+func renderDepsInstall(w io.Writer, report deps.InstallReport) {
+	fmt.Fprintf(w, "\nDependency install for profile %q (%s)\n\n", report.Profile, report.Tier)
+
+	if len(report.Items) == 0 {
+		fmt.Fprintln(w, "All declared dependencies are already installed.")
+		return
+	}
+
+	var installed, manual, unresolved, failed int
+	for _, item := range report.Items {
+		hint := item.Manual
+		if item.Executable != "" {
+			parts := append([]string{item.Executable}, item.Args...)
+			hint = strings.Join(parts, " ")
+		}
+		fmt.Fprintf(w, "  %-10s %-24s %s\n", item.Status, item.Dependency, hint)
+		switch item.Status {
+		case deps.InstallStatusInstalled:
+			installed++
+		case deps.InstallStatusManual:
+			manual++
+		case deps.InstallStatusUnresolved:
+			unresolved++
+		case deps.InstallStatusFailed:
+			failed++
+		}
+	}
+
+	fmt.Fprintf(w, "\nSummary: %d installed, %d manual, %d unresolved, %d failed\n", installed, manual, unresolved, failed)
+}

--- a/internal/cli/render_deps.go
+++ b/internal/cli/render_deps.go
@@ -64,7 +64,15 @@ func pluralizeDeps(n int) string {
 // renderDepsInstallDryRun writes a deterministic preview of dependency install
 // actions without executing package managers.
 func renderDepsInstallDryRun(w io.Writer, report deps.InstallDryRunReport) {
-	fmt.Fprintf(w, "Dependency install dry-run for profile %q (%s)\n\n", report.Profile, report.Tier)
+	renderDepsInstallPreviewWithTitle(w, "Dependency install dry-run", report)
+}
+
+func renderDepsInstallPreview(w io.Writer, report deps.InstallDryRunReport) {
+	renderDepsInstallPreviewWithTitle(w, "Dependency install preview", report)
+}
+
+func renderDepsInstallPreviewWithTitle(w io.Writer, title string, report deps.InstallDryRunReport) {
+	fmt.Fprintf(w, "%s for profile %q (%s)\n\n", title, report.Profile, report.Tier)
 
 	if len(report.Items) == 0 {
 		fmt.Fprintln(w, "All declared dependencies are already installed.")
@@ -80,7 +88,24 @@ func renderDepsInstallDryRun(w io.Writer, report deps.InstallDryRunReport) {
 		fmt.Fprintf(w, "  %-13s %-24s %s\n", item.Status, item.Dependency, hint)
 	}
 
-	fmt.Fprintf(w, "\nSummary: %s\n", pluralizeDeps(len(report.Items)))
+	installable, manual := countInstallPreviewActions(report)
+	fmt.Fprintf(w, "\nSummary: %d installable, %d manual\n", installable, manual)
+}
+
+func hasInstallablePreviewAction(report deps.InstallDryRunReport) bool {
+	installable, _ := countInstallPreviewActions(report)
+	return installable > 0
+}
+
+func countInstallPreviewActions(report deps.InstallDryRunReport) (installable int, manual int) {
+	for _, item := range report.Items {
+		if item.Executable == "" {
+			manual++
+			continue
+		}
+		installable++
+	}
+	return installable, manual
 }
 
 // renderDepsInstall writes the stable dots summary after real package-manager

--- a/internal/cli/testdata/deps_install_dry_run_mixed.golden
+++ b/internal/cli/testdata/deps_install_dry_run_mixed.golden
@@ -3,4 +3,4 @@ Dependency install dry-run for profile "default" (debian)
   would-install starship                 sudo apt-get install starship
   manual        neovim                   no debian package declared for "neovim"; install it manually
 
-Summary: 2 dependencies to install
+Summary: 1 installable, 1 manual

--- a/internal/deps/deps.go
+++ b/internal/deps/deps.go
@@ -1,7 +1,7 @@
 // Package deps computes Dependency findings for a Profile: which external tools
-// a workstation needs for its Managed Entries, whether they are present, and
-// OS-aware advisory guidance for installing the missing ones. dots never
-// installs packages itself in v1; this package only inspects and advises.
+// a workstation needs for its Managed Entries, whether they are present,
+// OS-aware advisory guidance for installing the missing ones, and explicitly
+// confirmed package-manager execution.
 package deps
 
 import (

--- a/internal/deps/install.go
+++ b/internal/deps/install.go
@@ -1,6 +1,11 @@
 package deps
 
-import "github.com/yersonargotev/dots/internal/manifest"
+import (
+	"errors"
+	"fmt"
+
+	"github.com/yersonargotev/dots/internal/manifest"
+)
 
 // InstallPreviewStatus describes what a dry-run install would do for one
 // missing Dependency.
@@ -29,6 +34,38 @@ type InstallDryRunReport struct {
 	Items   []InstallPreview
 }
 
+// Runner executes one argv-shaped install action.
+type Runner interface {
+	Run(executable string, args []string) error
+}
+
+// InstallStatus describes the result of a real install action.
+type InstallStatus string
+
+const (
+	InstallStatusInstalled  InstallStatus = "installed"
+	InstallStatusManual     InstallStatus = "manual"
+	InstallStatusUnresolved InstallStatus = "unresolved"
+	InstallStatusFailed     InstallStatus = "failed"
+)
+
+// InstallItem is the result of one attempted dependency installation.
+type InstallItem struct {
+	Dependency string
+	Status     InstallStatus
+	Package    string
+	Executable string
+	Args       []string
+	Manual     string
+}
+
+// InstallReport records the stable dots summary for a real install run.
+type InstallReport struct {
+	Profile string
+	Tier    Tier
+	Items   []InstallItem
+}
+
 // InstallDryRun computes the install preview for missing Dependencies without
 // executing package managers.
 func InstallDryRun(m manifest.Manifest, opts Options, look Lookup, tier Tier) (InstallDryRunReport, error) {
@@ -53,4 +90,76 @@ func InstallDryRun(m manifest.Manifest, opts Options, look Lookup, tier Tier) (I
 		})
 	}
 	return report, nil
+}
+
+// Install executes missing executable install actions and re-probes each
+// dependency after a successful package-manager command.
+func Install(m manifest.Manifest, opts Options, look Lookup, tier Tier, runner Runner) (InstallReport, error) {
+	plan, err := Plan(m, opts, look, tier)
+	if err != nil {
+		return InstallReport{}, err
+	}
+
+	report := InstallReport{Profile: plan.Profile, Tier: plan.Tier}
+	unresolved := false
+	for _, action := range plan.Actions {
+		if action.Executable == "" {
+			unresolved = true
+			report.Items = append(report.Items, InstallItem{
+				Dependency: action.Dependency,
+				Status:     InstallStatusManual,
+				Manual:     action.Manual,
+			})
+			continue
+		}
+		args := installArgsWithConfirmation(action, tier)
+		if err := runner.Run(action.Executable, args); err != nil {
+			report.Items = append(report.Items, InstallItem{
+				Dependency: action.Dependency,
+				Status:     InstallStatusFailed,
+				Package:    action.Package,
+				Executable: action.Executable,
+				Args:       args,
+			})
+			return report, fmt.Errorf("install %q: %w", action.Dependency, err)
+		}
+		if !look(action.Probe) {
+			unresolved = true
+			report.Items = append(report.Items, InstallItem{
+				Dependency: action.Dependency,
+				Status:     InstallStatusUnresolved,
+				Package:    action.Package,
+				Executable: action.Executable,
+				Args:       args,
+			})
+			return report, errors.New("unresolved dependencies remain after install")
+		}
+		report.Items = append(report.Items, InstallItem{
+			Dependency: action.Dependency,
+			Status:     InstallStatusInstalled,
+			Package:    action.Package,
+			Executable: action.Executable,
+			Args:       args,
+		})
+	}
+	if unresolved {
+		return report, errors.New("unresolved dependencies remain after install")
+	}
+	return report, nil
+}
+
+func installArgsWithConfirmation(action InstallAction, tier Tier) []string {
+	args := append([]string(nil), action.Args...)
+	if len(args) == 0 {
+		return args
+	}
+	pkg := args[len(args)-1]
+	prefix := append([]string(nil), args[:len(args)-1]...)
+	switch tier {
+	case TierDebian, TierFedora:
+		prefix = append(prefix, "-y")
+	case TierArch:
+		prefix = append(prefix, "--noconfirm")
+	}
+	return append(prefix, pkg)
 }

--- a/internal/deps/install_test.go
+++ b/internal/deps/install_test.go
@@ -1,12 +1,248 @@
 package deps_test
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 
 	"github.com/yersonargotev/dots/internal/deps"
 	"github.com/yersonargotev/dots/internal/manifest"
 )
+
+func TestInstallYesExecutesInstallableActionsThroughRunner(t *testing.T) {
+	present := map[string]bool{"tmux": true}
+	look := func(command string) bool { return present[command] }
+	runner := &recordingRunner{
+		afterRun: func() {
+			present["starship"] = true
+		},
+	}
+
+	report, err := deps.Install(planManifest(), deps.Options{Profile: "default", OS: "darwin"}, look, deps.TierHomebrew, runner)
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+
+	if len(runner.calls) != 1 {
+		t.Fatalf("runner calls len = %d, want 1 (%#v)", len(runner.calls), runner.calls)
+	}
+	if runner.calls[0].executable != "brew" {
+		t.Fatalf("runner executable = %q, want brew", runner.calls[0].executable)
+	}
+	if !reflect.DeepEqual(runner.calls[0].args, []string{"install", "starship"}) {
+		t.Fatalf("runner args = %#v, want brew install starship", runner.calls[0].args)
+	}
+	if len(report.Items) != 1 || report.Items[0].Status != deps.InstallStatusInstalled {
+		t.Fatalf("report items = %#v, want one installed item", report.Items)
+	}
+}
+
+func TestInstallYesUsesPackageManagerConfirmationArgs(t *testing.T) {
+	tests := []struct {
+		name       string
+		tier       deps.Tier
+		executable string
+		args       []string
+	}{
+		{name: "homebrew", tier: deps.TierHomebrew, executable: "brew", args: []string{"install", "starship"}},
+		{name: "debian", tier: deps.TierDebian, executable: "sudo", args: []string{"apt-get", "install", "-y", "starship"}},
+		{name: "fedora", tier: deps.TierFedora, executable: "sudo", args: []string{"dnf", "install", "-y", "starship"}},
+		{name: "arch", tier: deps.TierArch, executable: "sudo", args: []string{"pacman", "-S", "--noconfirm", "starship"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			present := map[string]bool{"tmux": true}
+			runner := &recordingRunner{afterRun: func() { present["starship"] = true }}
+
+			if _, err := deps.Install(planManifest(), deps.Options{Profile: "default", OS: "darwin"}, func(command string) bool {
+				return present[command]
+			}, tt.tier, runner); err != nil {
+				t.Fatalf("Install() error = %v", err)
+			}
+
+			if len(runner.calls) != 1 {
+				t.Fatalf("runner calls len = %d, want 1", len(runner.calls))
+			}
+			if runner.calls[0].executable != tt.executable {
+				t.Fatalf("runner executable = %q, want %q", runner.calls[0].executable, tt.executable)
+			}
+			if !reflect.DeepEqual(runner.calls[0].args, tt.args) {
+				t.Fatalf("runner args = %#v, want %#v", runner.calls[0].args, tt.args)
+			}
+		})
+	}
+}
+
+func TestInstallYesExecutesMissingInstallableActionsInPlanOrder(t *testing.T) {
+	present := map[string]bool{"tmux": true, "nvim": true}
+	runner := &recordingRunner{}
+	runner.afterRun = func() {
+		last := runnerLastPackage(t, runner)
+		if last == "ripgrep" {
+			present["rg"] = true
+			return
+		}
+		present[last] = true
+	}
+
+	if _, err := deps.Install(installSelectionManifest(), deps.Options{Profile: "default", OS: "darwin"}, func(command string) bool {
+		return present[command]
+	}, deps.TierHomebrew, runner); err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+
+	got := make([]string, 0, len(runner.calls))
+	for _, call := range runner.calls {
+		got = append(got, call.args[len(call.args)-1])
+	}
+	want := []string{"starship", "ripgrep"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("runner package order = %#v, want %#v", got, want)
+	}
+}
+
+func TestInstallYesDoesNotRunManualActionsAndReportsUnresolved(t *testing.T) {
+	runner := &recordingRunner{}
+
+	report, err := deps.Install(manualOnlyManifest(), deps.Options{Profile: "default", OS: "linux"}, lookupSet(), deps.TierGeneric, runner)
+	if err == nil {
+		t.Fatalf("Install() error = nil, want unresolved manual dependency error")
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runner calls len = %d, want 0 for manual action (%#v)", len(runner.calls), runner.calls)
+	}
+	if len(report.Items) != 1 || report.Items[0].Status != deps.InstallStatusManual {
+		t.Fatalf("report items = %#v, want one manual item", report.Items)
+	}
+}
+
+func TestInstallYesReprobesAfterSuccessAndErrorsWhenStillMissing(t *testing.T) {
+	var probes []string
+	runner := &recordingRunner{}
+	look := func(command string) bool {
+		probes = append(probes, command)
+		return command == "tmux"
+	}
+
+	report, err := deps.Install(planManifest(), deps.Options{Profile: "default", OS: "darwin"}, look, deps.TierHomebrew, runner)
+	if err == nil {
+		t.Fatalf("Install() error = nil, want unresolved dependency error")
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("runner calls len = %d, want 1", len(runner.calls))
+	}
+	if len(report.Items) != 1 || report.Items[0].Status != deps.InstallStatusUnresolved {
+		t.Fatalf("report items = %#v, want one unresolved item", report.Items)
+	}
+	if !reflect.DeepEqual(probes, []string{"starship", "tmux", "starship"}) {
+		t.Fatalf("probes = %#v, want initial plan probes then starship re-probe", probes)
+	}
+}
+
+func TestInstallYesStopsOnFirstRunnerFailure(t *testing.T) {
+	runnerErr := errors.New("package manager failed")
+	runner := &recordingRunner{err: runnerErr}
+
+	report, err := deps.Install(installSelectionManifest(), deps.Options{Profile: "default", OS: "darwin"}, lookupSet("tmux", "nvim"), deps.TierHomebrew, runner)
+	if !errors.Is(err, runnerErr) {
+		t.Fatalf("Install() error = %v, want runner error", err)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("runner calls len = %d, want stop after first failure (%#v)", len(runner.calls), runner.calls)
+	}
+	if len(report.Items) != 1 || report.Items[0].Status != deps.InstallStatusFailed {
+		t.Fatalf("report items = %#v, want one failed item", report.Items)
+	}
+}
+
+func TestInstallYesSkipsAlreadyPresentDependenciesBeforeExecution(t *testing.T) {
+	runner := &recordingRunner{}
+
+	report, err := deps.Install(planManifest(), deps.Options{Profile: "default", OS: "darwin"}, lookupSet("tmux", "starship"), deps.TierHomebrew, runner)
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runner calls len = %d, want 0 for already-present dependencies", len(runner.calls))
+	}
+	if len(report.Items) != 0 {
+		t.Fatalf("report items len = %d, want 0 when no install actions are needed", len(report.Items))
+	}
+}
+
+func TestInstallYesAllowsProgressWithManualAndInstallableDependencies(t *testing.T) {
+	present := map[string]bool{}
+	runner := &recordingRunner{afterRun: func() { present["starship"] = true }}
+
+	report, err := deps.Install(mixedManualAndInstallableManifest(), deps.Options{Profile: "default", OS: "darwin"}, func(command string) bool {
+		return present[command]
+	}, deps.TierHomebrew, runner)
+	if err == nil {
+		t.Fatalf("Install() error = nil, want unresolved manual dependency error")
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("runner calls len = %d, want installable action to run despite manual dependency", len(runner.calls))
+	}
+	gotStatuses := []deps.InstallStatus{}
+	for _, item := range report.Items {
+		gotStatuses = append(gotStatuses, item.Status)
+	}
+	wantStatuses := []deps.InstallStatus{deps.InstallStatusManual, deps.InstallStatusInstalled}
+	if !reflect.DeepEqual(gotStatuses, wantStatuses) {
+		t.Fatalf("report statuses = %#v, want %#v", gotStatuses, wantStatuses)
+	}
+}
+
+func mixedManualAndInstallableManifest() manifest.Manifest {
+	return manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}},
+		Entries: []manifest.Entry{
+			{
+				Source: "configs/x", Target: "~/.x", Strategy: "symlink", Tags: []string{"core"},
+				Dependencies: []manifest.Dependency{
+					{Name: "neovim", Command: "nvim"},
+					{Name: "starship", Brew: "starship"},
+				},
+			},
+		},
+	}
+}
+
+func runnerLastPackage(t *testing.T, runner *recordingRunner) string {
+	t.Helper()
+	if len(runner.calls) == 0 {
+		t.Fatalf("runner has no calls")
+	}
+	args := runner.calls[len(runner.calls)-1].args
+	if len(args) == 0 {
+		t.Fatalf("runner last call has no args")
+	}
+	return args[len(args)-1]
+}
+
+type runnerCall struct {
+	executable string
+	args       []string
+}
+
+type recordingRunner struct {
+	calls    []runnerCall
+	afterRun func()
+	err      error
+}
+
+func (r *recordingRunner) Run(executable string, args []string) error {
+	r.calls = append(r.calls, runnerCall{executable: executable, args: append([]string(nil), args...)})
+	if r.err != nil {
+		return r.err
+	}
+	if r.afterRun != nil {
+		r.afterRun()
+	}
+	return nil
+}
 
 func TestInstallDryRunReportsInstallableActions(t *testing.T) {
 	report, err := deps.InstallDryRun(planManifest(), deps.Options{Profile: "default", OS: "darwin"}, lookupSet("tmux"), deps.TierHomebrew)

--- a/internal/deps/plan.go
+++ b/internal/deps/plan.go
@@ -13,6 +13,7 @@ import (
 // the active Tier.
 type InstallAction struct {
 	Dependency string
+	Probe      string
 	Package    string
 	Executable string
 	Args       []string
@@ -64,10 +65,11 @@ func Plan(m manifest.Manifest, opts Options, look Lookup, tier Tier) (PlanReport
 func actionFor(dep manifest.Dependency, tier Tier) InstallAction {
 	pkg, executable, args := tierPackage(dep, tier)
 	if pkg == "" {
-		return InstallAction{Dependency: dep.Name, Manual: manualNote(dep, tier)}
+		return InstallAction{Dependency: dep.Name, Probe: dep.Probe(), Manual: manualNote(dep, tier)}
 	}
 	return InstallAction{
 		Dependency: dep.Name,
+		Probe:      dep.Probe(),
 		Package:    pkg,
 		Executable: executable,
 		Args:       append(args, pkg),


### PR DESCRIPTION
Part of #24

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds explicit `dots deps install --yes` execution for structured dependency install actions.
- Keeps `deps install --dry-run` preview-only and keeps no-flag install conservative until the confirmation slice.
- Uses an injectable runner, direct argv execution, post-run re-probes, and stable dots summaries.

## Changes

| File | Change |
|------|--------|
| `internal/deps/install.go` | Adds real install report/status model, injectable runner execution, post-run convergence checks, and auto-confirm argv augmentation for `--yes`. |
| `internal/deps/plan.go` | Carries dependency probes in `InstallAction` so real execution can re-check each dependency. |
| `internal/deps/deps.go` | Updates package documentation for explicitly confirmed install execution. |
| `internal/cli/deps.go` | Adds `--yes` flag and wires direct `exec.CommandContext` runner with Cobra stdin/stdout/stderr passthrough. |
| `internal/cli/render_deps.go` | Adds stable summary rendering for real install runs. |
| `internal/deps/install_test.go` | Covers runner execution, argv per tier, order, re-probe, manual/unresolved/failure behavior, and already-present skips. |
| `internal/cli/deps_install_test.go` | Covers conservative default behavior, dry-run preservation, fake package-manager execution, and stdio passthrough. |

## Test Plan

- [x] `go test ./internal/deps ./internal/cli -run 'TestInstallYes|TestInstallDryRun|TestDepsInstall|TestRenderDeps'`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -w internal/deps/install.go internal/deps/plan.go internal/deps/deps.go internal/deps/install_test.go internal/cli/deps.go internal/cli/render_deps.go internal/cli/deps_install_test.go`
- [x] `go build -o /tmp/dots-slice3-build ./cmd/dots` then removed `/tmp/dots-slice3-build`
- [x] `git diff --check`
- [x] `grep -R "sh -c\|bash -c" internal/deps internal/cli` returned no matches

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Dependency install tests used fake/injected runners and did not execute real package managers.

## Contributor Checklist

- [x] Linked issue #24 with a non-closing reference because issue #24 is intentionally split across multiple PR slices.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
