### PR TITLE
feat(config): add portable modular zsh/zimfw slice

### DIFF
--- a/configs/zsh/README.md
+++ b/configs/zsh/README.md
@@ -1,0 +1,76 @@
+# Zsh / Zim configuration
+
+Portable, modular Zsh foundation managed by `dots`. This is the first
+workstation configuration slice (issue #38, epic #37).
+
+## Managed targets
+
+`dots` symlinks exactly three files into your home directory:
+
+| Source                | Target       |
+| --------------------- | ------------ |
+| `configs/zsh/zshrc`   | `~/.zshrc`   |
+| `configs/zsh/zimrc`   | `~/.zimrc`   |
+| `configs/zsh/zshenv`  | `~/.zshenv`  |
+
+The `symlink` strategy is **required**: `~/.zshrc` resolves its own real
+location to find the modular files under `rc.d/`. A copied `~/.zshrc` would not
+be able to locate them.
+
+## Layout
+
+```
+configs/zsh/
+├── zshrc                  # entry point: pre-init → Zim → post-init → local
+├── zimrc                  # Zim module list
+├── zshenv                 # environment for all shells (editor, cargo, foundry)
+├── rc.d/
+│   ├── pre/               # sourced BEFORE Zim loads its modules
+│   │   ├── 00-history.zsh
+│   │   ├── 10-input.zsh
+│   │   └── 20-modules.zsh # module tuning read at load time
+│   └── post/              # sourced AFTER Zim initializes
+│       ├── 30-path.zsh    # portable PATH additions (guarded)
+│       ├── 40-tools.zsh   # zoxide/starship/atuin/fnm (guarded)
+│       ├── 50-aliases.zsh # eza-backed ls (guarded)
+│       └── 60-ai.zsh      # Claude/Engram knobs (no secrets)
+└── zshrc.local.example    # template for machine-specific values + secrets
+```
+
+Drop a new `*.zsh` file into `rc.d/pre/` or `rc.d/post/` to extend the config;
+the numeric prefix controls load order.
+
+## Local overrides and secrets
+
+Anything machine-specific or secret goes in `~/.zshrc.local`, which `dots` never
+manages. Start from the template:
+
+```sh
+cp configs/zsh/zshrc.local.example ~/.zshrc.local
+```
+
+This is where tokens (e.g. `ENGRAM_CLOUD_TOKEN`), per-machine `PATH` entries, and
+IDE shell integrations live.
+
+## Zim runtime
+
+Installing Zim itself is out of scope for this slice. If Zim is not present,
+the shell prints a non-destructive notice and runs without modules. To install
+Zim:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/zimfw/install/master/install.zsh | zsh
+```
+
+Then restart your shell. The following are intentionally **excluded** from the
+repository: `~/.zim/`, `.zcompdump*`, `.zsh_history`, `.zsh_sessions/`, and any
+generated or backup files.
+
+## Validation
+
+Validate against a temporary home — never your real `$HOME`:
+
+```sh
+dots install --home /tmp/dots-home --source-root "$PWD" --state-root /tmp/dots-state
+dots status  --home /tmp/dots-home --source-root "$PWD" --state-root /tmp/dots-state
+```

--- a/configs/zsh/rc.d/post/30-path.zsh
+++ b/configs/zsh/rc.d/post/30-path.zsh
@@ -4,13 +4,19 @@
 # login. Machine-specific paths belong in ~/.zshrc.local, not here.
 
 # pnpm. Honors an existing PNPM_HOME; otherwise defaults to the macOS location.
+# Different pnpm versions place global binaries directly in PNPM_HOME or under
+# PNPM_HOME/bin, so add whichever directories exist.
 : "${PNPM_HOME:=${HOME}/Library/pnpm}"
 if [[ -d "${PNPM_HOME}" ]]; then
   export PNPM_HOME
-  case ":${PATH}:" in
-    *":${PNPM_HOME}:"*) ;;
-    *) export PATH="${PNPM_HOME}:${PATH}" ;;
-  esac
+  for _pnpm_dir in "${PNPM_HOME}/bin" "${PNPM_HOME}"; do
+    [[ -d "${_pnpm_dir}" ]] || continue
+    case ":${PATH}:" in
+      *":${_pnpm_dir}:"*) ;;
+      *) export PATH="${_pnpm_dir}:${PATH}" ;;
+    esac
+  done
+  unset _pnpm_dir
 fi
 
 # bun.
@@ -20,6 +26,10 @@ if [[ -d "${BUN_INSTALL}" ]]; then
   export PATH="${BUN_INSTALL}/bin:${PATH}"
 fi
 [[ -s "${BUN_INSTALL}/_bun" ]] && source "${BUN_INSTALL}/_bun"
+
+# yarn global binaries. Use the static default location rather than
+# `$(yarn global bin)`, which spawns a Node process on every shell startup.
+[[ -d "${HOME}/.yarn/bin" ]] && export PATH="${HOME}/.yarn/bin:${PATH}"
 
 # Generic local-bin env shim (rustup, uv, and similar installers write here).
 [[ -r "${HOME}/.local/bin/env" ]] && source "${HOME}/.local/bin/env"

--- a/configs/zsh/rc.d/post/30-path.zsh
+++ b/configs/zsh/rc.d/post/30-path.zsh
@@ -1,0 +1,25 @@
+# Portable PATH additions.
+#
+# Each block is guarded so a tool that is absent on this machine never breaks
+# login. Machine-specific paths belong in ~/.zshrc.local, not here.
+
+# pnpm. Honors an existing PNPM_HOME; otherwise defaults to the macOS location.
+: "${PNPM_HOME:=${HOME}/Library/pnpm}"
+if [[ -d "${PNPM_HOME}" ]]; then
+  export PNPM_HOME
+  case ":${PATH}:" in
+    *":${PNPM_HOME}:"*) ;;
+    *) export PATH="${PNPM_HOME}:${PATH}" ;;
+  esac
+fi
+
+# bun.
+: "${BUN_INSTALL:=${HOME}/.bun}"
+if [[ -d "${BUN_INSTALL}" ]]; then
+  export BUN_INSTALL
+  export PATH="${BUN_INSTALL}/bin:${PATH}"
+fi
+[[ -s "${BUN_INSTALL}/_bun" ]] && source "${BUN_INSTALL}/_bun"
+
+# Generic local-bin env shim (rustup, uv, and similar installers write here).
+[[ -r "${HOME}/.local/bin/env" ]] && source "${HOME}/.local/bin/env"

--- a/configs/zsh/rc.d/post/40-tools.zsh
+++ b/configs/zsh/rc.d/post/40-tools.zsh
@@ -1,0 +1,12 @@
+# Interactive tool integrations.
+#
+# Each is guarded by command -v so the shell stays usable when a tool is not
+# installed on this machine.
+
+command -v starship >/dev/null 2>&1 && eval "$(starship init zsh)"
+command -v zoxide   >/dev/null 2>&1 && eval "$(zoxide init zsh)"
+command -v fnm      >/dev/null 2>&1 && eval "$(fnm env)"
+
+# atuin ships an env shim plus a shell init step.
+[[ -r "${HOME}/.atuin/bin/env" ]] && source "${HOME}/.atuin/bin/env"
+command -v atuin >/dev/null 2>&1 && eval "$(atuin init zsh)"

--- a/configs/zsh/rc.d/post/50-aliases.zsh
+++ b/configs/zsh/rc.d/post/50-aliases.zsh
@@ -1,0 +1,6 @@
+# Aliases. Guarded where they depend on an optional tool.
+
+# Prefer eza for `ls` when available.
+if command -v eza >/dev/null 2>&1; then
+  alias ls='eza -a --icons=always --color=always --grid --group-directories-first'
+fi

--- a/configs/zsh/rc.d/post/60-ai.zsh
+++ b/configs/zsh/rc.d/post/60-ai.zsh
@@ -1,0 +1,10 @@
+# AI / agent tooling hooks.
+#
+# Portable knobs only — never credentials. Tokens (e.g. ENGRAM_CLOUD_TOKEN)
+# belong in ~/.zshrc.local, which is not managed by dots.
+
+# Claude Code: disable flicker in fullscreen rendering.
+export CLAUDE_CODE_NO_FLICKER=1
+
+# Engram: opt into tool-search behavior.
+export ENABLE_TOOL_SEARCH=true

--- a/configs/zsh/rc.d/pre/00-history.zsh
+++ b/configs/zsh/rc.d/pre/00-history.zsh
@@ -1,0 +1,4 @@
+# History behavior.
+
+# Drop an older duplicate when an identical command is added to the history.
+setopt HIST_IGNORE_ALL_DUPS

--- a/configs/zsh/rc.d/pre/10-input.zsh
+++ b/configs/zsh/rc.d/pre/10-input.zsh
@@ -1,0 +1,7 @@
+# Input: keymap and word boundaries.
+
+# Use the emacs keymap for line editing.
+bindkey -e
+
+# Treat the path separator as a word boundary (e.g. for Ctrl-W deletion).
+WORDCHARS=${WORDCHARS//[\/]}

--- a/configs/zsh/rc.d/pre/20-modules.zsh
+++ b/configs/zsh/rc.d/pre/20-modules.zsh
@@ -1,0 +1,10 @@
+# Zim module tuning.
+#
+# These settings are read by modules at load time, so they MUST run before Zim
+# initializes (this file is part of the pre-init phase in ~/.zshrc).
+
+# zsh-autosuggestions: skip widget re-binding on every prompt for performance.
+ZSH_AUTOSUGGEST_MANUAL_REBIND=1
+
+# zsh-syntax-highlighting: enable only the highlighters we use.
+ZSH_HIGHLIGHT_HIGHLIGHTERS=(main brackets)

--- a/configs/zsh/zimrc
+++ b/configs/zsh/zimrc
@@ -1,0 +1,55 @@
+#
+# This is not sourced during shell startup and is only used to configure zimfw.
+#
+
+#
+# Modules
+#
+
+# Sets sane Zsh built-in environment options.
+zmodule environment
+# Provides handy git aliases and functions.
+zmodule git
+# Applies correct bindkeys for input events.
+zmodule input
+# Sets a custom terminal title.
+zmodule termtitle
+# Utility aliases and functions. Adds colour to ls, grep and less.
+zmodule utility
+
+# <-- Normally new modules should be added here. Check each module documentation
+# for any caveats.
+
+#
+# Prompt
+#
+
+# Exposes how long the last command took to run to prompts.
+zmodule duration-info
+# Exposes git repository status information to prompts.
+zmodule git-info
+# A heavily reduced, ASCII-only version of the Spaceship and Starship prompts.
+zmodule asciiship
+
+#
+# Completion
+#
+
+# Additional completion definitions for Zsh.
+zmodule zsh-users/zsh-completions --fpath src
+# Enables and configures smart and extensive tab completion, must be sourced
+# after all modules that add completion definitions.
+zmodule completion
+
+#
+# Modules that must be initialized last
+#
+
+# Fish-like syntax highlighting for Zsh, must be sourced after completion.
+zmodule zsh-users/zsh-syntax-highlighting
+# Fish-like history search for Zsh, must be sourced after
+# zsh-users/zsh-syntax-highlighting.
+zmodule zsh-users/zsh-history-substring-search
+# Fish-like autosuggestions for Zsh. Add the following to your ~/.zshrc to boost
+# performance: ZSH_AUTOSUGGEST_MANUAL_REBIND=1
+zmodule zsh-users/zsh-autosuggestions

--- a/configs/zsh/zshenv
+++ b/configs/zsh/zshenv
@@ -1,0 +1,11 @@
+# Environment for all Zsh invocations (login, interactive, and scripts).
+# Keep this minimal and portable: no secrets, no machine-specific paths.
+
+# Default editor.
+command -v nvim >/dev/null 2>&1 && export EDITOR=nvim
+
+# Rust / Cargo.
+[[ -r "${HOME}/.cargo/env" ]] && source "${HOME}/.cargo/env"
+
+# Foundry (Ethereum toolchain).
+[[ -d "${HOME}/.foundry/bin" ]] && export PATH="${PATH}:${HOME}/.foundry/bin"

--- a/configs/zsh/zshrc
+++ b/configs/zsh/zshrc
@@ -1,12 +1,42 @@
-# Repository-managed zsh configuration.
-# Keep this file safe to source on new machines.
+# Repository-managed Zsh entry point.
+# Portable, modular, and safe to source on a fresh machine.
+# Machine-specific values and secrets live in ~/.zshrc.local (not managed).
 
-# Starship is optional at runtime; initialize it only when available.
-if command -v starship >/dev/null 2>&1; then
-  eval "$(starship init zsh)"
+# Resolve this file's real directory even when sourced through a symlink, so the
+# modular config and the Zim runtime can be located relative to the repository.
+# This requires the symlink install strategy (see configs/zsh/README.md).
+ZSH_CONFIG_DIR="${${(%):-%x}:A:h}"
+
+# Pre-init modular config: must run before Zim loads its modules, because some
+# modules read these settings at load time.
+for _zrc in "${ZSH_CONFIG_DIR}"/rc.d/pre/*.zsh(N); do
+  source "${_zrc}"
+done
+unset _zrc
+
+# --- Zim Framework ---------------------------------------------------------
+# Installing or bootstrapping Zim is intentionally out of scope for this slice.
+# We only use Zim when it is already present; a missing runtime degrades to a
+# usable, module-less shell instead of breaking the session.
+ZIM_HOME="${ZDOTDIR:-${HOME}}/.zim"
+if [[ -e "${ZIM_HOME}/init.zsh" ]]; then
+  # Recompile init.zsh when ~/.zimrc is newer than the compiled init.
+  if [[ ! "${ZIM_HOME}/init.zsh" -nt "${ZIM_CONFIG_FILE:-${ZDOTDIR:-${HOME}}/.zimrc}" ]]; then
+    source "${ZIM_HOME}/zimfw.zsh" init -q
+  fi
+  source "${ZIM_HOME}/init.zsh"
+else
+  print -u2 "dots: Zim not found at ${ZIM_HOME}; continuing without modules."
+  print -u2 "dots: install it, then restart your shell — see configs/zsh/README.md."
 fi
 
-# Local Extension Point: ~/.zshrc.local is private and machine-specific.
-if [ -r "${HOME}/.zshrc.local" ]; then
-  . "${HOME}/.zshrc.local"
+# Post-init modular config: PATH, tool integrations, aliases, AI hooks.
+for _zrc in "${ZSH_CONFIG_DIR}"/rc.d/post/*.zsh(N); do
+  source "${_zrc}"
+done
+unset _zrc
+
+# Machine-specific overrides and secrets — never managed by dots.
+if [[ -r "${ZDOTDIR:-${HOME}}/.zshrc.local" ]]; then
+  source "${ZDOTDIR:-${HOME}}/.zshrc.local"
 fi

--- a/configs/zsh/zshrc.local.example
+++ b/configs/zsh/zshrc.local.example
@@ -1,0 +1,26 @@
+# Example machine-specific Zsh overrides.
+#
+# Copy this to ~/.zshrc.local and edit. The managed ~/.zshrc sources that file
+# last. ~/.zshrc.local is NEVER tracked by dots — put secrets and per-machine
+# paths here.
+
+# --- Secrets ---------------------------------------------------------------
+# export ENGRAM_CLOUD_TOKEN="your-token-here"
+
+# --- Machine-specific PATH -------------------------------------------------
+# export PATH="${HOME}/.antigravity/antigravity/bin:${PATH}"
+# export PATH="${HOME}/Documents/dev/yersonargotev/hippo/bin:${PATH}"
+# export PATH="${HOME}/.local/bin:${PATH}"
+
+# Pin a specific fnm-managed Node version on PATH:
+# export PATH="${HOME}/.local/share/fnm/node-versions/v24.12.0/installation/bin:${PATH}"
+
+# --- Tool shell integrations (machine-specific) ----------------------------
+# Kiro IDE shell integration:
+# [[ "${TERM_PROGRAM}" == "kiro" ]] && source "$(kiro --locate-shell-integration-path zsh)"
+
+# OpenSpec completions:
+# fpath=("${HOME}/.zsh/completions" ${fpath})
+
+# yarn global bin (spawns a subprocess at startup; opt in only if you need it):
+# command -v yarn >/dev/null 2>&1 && export PATH="$(yarn global bin):${PATH}"

--- a/configs/zsh/zshrc.local.example
+++ b/configs/zsh/zshrc.local.example
@@ -21,6 +21,3 @@
 
 # OpenSpec completions:
 # fpath=("${HOME}/.zsh/completions" ${fpath})
-
-# yarn global bin (spawns a subprocess at startup; opt in only if you need it):
-# command -v yarn >/dev/null 2>&1 && export PATH="$(yarn global bin):${PATH}"

--- a/dots.yaml
+++ b/dots.yaml
@@ -18,6 +18,34 @@ entries:
         apt: zsh
         dnf: zsh
         pacman: zsh
+  - source: configs/zsh/zimrc
+    target: ~/.zimrc
+    strategy: symlink
+    tags:
+      - core
+    os:
+      - darwin
+      - linux
+    dependencies:
+      - name: zsh
+        brew: zsh
+        apt: zsh
+        dnf: zsh
+        pacman: zsh
+  - source: configs/zsh/zshenv
+    target: ~/.zshenv
+    strategy: symlink
+    tags:
+      - core
+    os:
+      - darwin
+      - linux
+    dependencies:
+      - name: zsh
+        brew: zsh
+        apt: zsh
+        dnf: zsh
+        pacman: zsh
   - source: configs/git/gitconfig
     target: ~/.gitconfig
     strategy: symlink

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -442,8 +442,8 @@ func TestRepositoryManagedConfigsExposeLocalExtensionPoints(t *testing.T) {
 			name: "zsh has private local include",
 			path: "configs/zsh/zshrc",
 			contains: []string{
-				"Local Extension Point",
-				"${HOME}/.zshrc.local",
+				"Machine-specific overrides and secrets",
+				".zshrc.local",
 			},
 		},
 		{
@@ -493,8 +493,8 @@ func TestRepositoryManifestPlansMVPConfigurationSetSafely(t *testing.T) {
 		t.Fatalf("Build() error = %v", err)
 	}
 
-	if len(p.Actions) != 4 {
-		t.Fatalf("len(Actions) = %d, want 4", len(p.Actions))
+	if len(p.Actions) != 6 {
+		t.Fatalf("len(Actions) = %d, want 6", len(p.Actions))
 	}
 	for _, action := range p.Actions {
 		if action.Status != plan.StatusCreate {


### PR DESCRIPTION
Closes #38 (epic #37).

## What

Migrates the workstation Zsh/ZimFW configuration into `dots` as the first portable, modular workstation-config slice. Manages exactly three targets via symlink: `~/.zshrc`, `~/.zimrc`, `~/.zshenv`.

## Classification (before adoption)

The current machine config was classified before anything entered the repo:

- **Portable** → Zim bootstrap, history/input opts, module tuning, tool integrations (zoxide/starship/atuin/fnm/pnpm/bun), eza alias, editor, cargo, foundry — all guarded and `$HOME`-relative.
- **Secret** → `ENGRAM_CLOUD_TOKEN` kept out of the repo; placeholder lives in the local example.
- **Machine-specific** → antigravity/hippo/Pi/kiro/openspec/yarn-global moved to the local example.
- **Excluded** → `~/.zim/`, `.zcompdump*`, `.zsh_history`, `.zsh_sessions/`, backups.

## Layout

- `zshrc` resolves its own real dir (`${${(%):-%x}:A:h}`) and sources `rc.d/pre/*` → Zim → `rc.d/post/*` → `~/.zshrc.local`.
- Modularity is internal: only 3 files are symlinked. **Requires the symlink strategy.**
- Missing Zim → non-destructive notice + usable shell (bootstrapping Zim is out of scope).

## Manifest

Added `~/.zimrc` and `~/.zshenv` entries (4 → 6). Updated the two repo-contract tests that assert against the real `dots.yaml`/configs.

## Validation

- `dots install` / `dots status` against a temp home (`--home`/`--source-root`/`--state-root`): 6 create → 6 ok. Real `$HOME` untouched.
- Functional `zsh -c 'source $HOME/.zshrc'` in sandbox: symlink resolution, graceful no-Zim path, pre/post module loading, and local override sourced last — all confirmed.
- `go test ./...` green.
- Secret scan: real token absent from repo.

## Notes

- Fixed a latent bug from the source config: `set ENABLE_TOOL_SEARCH=true` → `export`.
- ⚠️ Reviewer/author action: the original `ENGRAM_CLOUD_TOKEN` was plaintext in `~/.zshrc`; rotate it and move it to `~/.zshrc.local`.