### PR TITLE
feat(config): migrate portable Git configuration

### DIFF
--- a/configs/git/README.md
+++ b/configs/git/README.md
@@ -1,0 +1,78 @@
+# Git configuration
+
+`configs/git/gitconfig` is the repository-managed Git configuration installed as
+`~/.gitconfig`. It intentionally contains only portable defaults that are safe to
+share across machines.
+
+Machine-specific configuration belongs in `~/.gitconfig.local`, which is loaded
+through the managed `[include]` entry. Use `gitconfig.local.example` as a starting
+point for the local file; never commit the real local file.
+
+## Classification from current machine evidence
+
+The current global Git config was inspected by key name only, not by committing
+private values. The resulting boundary is:
+
+| Category | Examples | Repository decision |
+| --- | --- | --- |
+| Portable | `init.defaultBranch`, `pull.rebase`, `merge.conflictStyle=diff3` | Managed in `configs/git/gitconfig`. |
+| Local/private | `user.name`, `user.email`, signing keys, credential helpers | Kept in `~/.gitconfig.local`. |
+| Generated | credential stores, tool caches, Git runtime state | Not managed by `dots`. |
+| Machine-specific | work/client `includeIf` rules, absolute local paths, optional pager/tool wiring such as delta | Kept in `~/.gitconfig.local` unless a later issue manages that tool explicitly. |
+
+## Local extension point
+
+The managed config works when `~/.gitconfig.local` is absent. That is intentional:
+sandbox validation must not require private material.
+
+For a real workstation only, create the local file deliberately and never
+overwrite an existing one:
+
+```bash
+test -e ~/.gitconfig.local || install -m 600 configs/git/gitconfig.local.example ~/.gitconfig.local
+```
+
+Then edit `~/.gitconfig.local` with identity, signing, credentials, work-specific
+includes, and optional local tooling. If the file already exists, inspect it
+manually instead of replacing it; it may contain private identity, signing,
+credential, or work configuration.
+
+## Sandbox validation
+
+Validate Git config changes with temporary directories, never the real `$HOME`:
+
+```bash
+sandbox_root="$(mktemp -d)"
+sandbox_home="$sandbox_root/home"
+sandbox_state="$sandbox_root/state"
+sandbox_cache="$sandbox_root/cache"
+sandbox_gopath="$sandbox_root/gopath"
+sandbox_modcache="$sandbox_root/modcache"
+mkdir -p "$sandbox_home" "$sandbox_state" "$sandbox_cache" "$sandbox_gopath" "$sandbox_modcache"
+
+HOME="$sandbox_home" \
+GOCACHE="$sandbox_cache" \
+GOPATH="$sandbox_gopath" \
+GOMODCACHE="$sandbox_modcache" \
+XDG_CACHE_HOME="$sandbox_cache" \
+go run ./cmd/dots install \
+  --yes \
+  --home "$sandbox_home" \
+  --source-root "$PWD" \
+  --state-root "$sandbox_state"
+
+HOME="$sandbox_home" \
+GOCACHE="$sandbox_cache" \
+GOPATH="$sandbox_gopath" \
+GOMODCACHE="$sandbox_modcache" \
+XDG_CACHE_HOME="$sandbox_cache" \
+go run ./cmd/dots status \
+  --home "$sandbox_home" \
+  --source-root "$PWD" \
+  --state-root "$sandbox_state"
+```
+
+The expected result is that `~/.gitconfig` is installed/aligned inside
+`$sandbox_home`. Both the Dotfiles CLI target paths and the Go toolchain caches
+are redirected into `$sandbox_root`; the maintainer's real home directory must
+not be touched.

--- a/configs/git/gitconfig
+++ b/configs/git/gitconfig
@@ -7,5 +7,8 @@
 [pull]
 	rebase = false
 
+[merge]
+	conflictStyle = diff3
+
 [include]
 	path = ~/.gitconfig.local

--- a/configs/git/gitconfig.local.example
+++ b/configs/git/gitconfig.local.example
@@ -1,0 +1,29 @@
+# Copy this file to ~/.gitconfig.local and fill in machine-specific values.
+# Do not commit the real ~/.gitconfig.local file.
+
+[user]
+	name = Your Name
+	email = you@example.com
+	# signingKey = YOUR_SIGNING_KEY_ID
+
+[commit]
+	# gpgsign = true
+
+[credential]
+	# Prefer an OS-backed credential helper when available. Do not use the
+	# plaintext `store` helper for tokens or passwords.
+	# helper = osxkeychain
+	# helper = cache
+
+# Work- or client-specific overrides belong behind local includeIf rules.
+# Keep real organization names, paths, and credentials out of repository-managed config.
+[includeIf "gitdir:~/work/"]
+	path = ~/.gitconfig.work
+
+# Optional local tooling such as delta belongs here unless the repository also
+# manages that tool as a dependency.
+#[core]
+#	pager = delta
+#
+#[interactive]
+#	diffFilter = delta --color-only

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -871,6 +871,67 @@ entries:
 	}
 }
 
+func TestRepositoryGitConfigInstallsAndReportsAlignedInSandbox(t *testing.T) {
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	sourceRoot, err := filepath.Abs(filepath.Clean(filepath.Join("..", "..")))
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+	manifestPath := filepath.Join(sourceRoot, "dots.yaml")
+
+	install := cli.NewRootCommand()
+	var installOut bytes.Buffer
+	install.SetOut(&installOut)
+	install.SetErr(&installOut)
+	install.SetArgs([]string{
+		"install",
+		"--yes",
+		"--file", manifestPath,
+		"--home", home,
+		"--source-root", sourceRoot,
+		"--state-root", stateRoot,
+	})
+	if err := install.Execute(); err != nil {
+		t.Fatalf("install Execute() error = %v\noutput:\n%s", err, installOut.String())
+	}
+
+	gitconfigTarget := filepath.Join(home, ".gitconfig")
+	if target, err := os.Readlink(gitconfigTarget); err != nil {
+		t.Fatalf("sandbox gitconfig target is not a symlink: %v", err)
+	} else if want := filepath.Join(sourceRoot, "configs/git/gitconfig"); target != want {
+		t.Fatalf("sandbox gitconfig symlink = %q, want %q", target, want)
+	}
+
+	statusCmd := cli.NewRootCommand()
+	var statusOut bytes.Buffer
+	statusCmd.SetOut(&statusOut)
+	statusCmd.SetErr(&statusOut)
+	statusCmd.SetArgs([]string{
+		"status",
+		"--file", manifestPath,
+		"--home", home,
+		"--source-root", sourceRoot,
+		"--state-root", stateRoot,
+	})
+	if err := statusCmd.Execute(); err != nil {
+		t.Fatalf("status Execute() error = %v\noutput:\n%s", err, statusOut.String())
+	}
+
+	got := statusOut.String()
+	for _, want := range []string{
+		"ok",
+		"configs/git/gitconfig -> " + gitconfigTarget,
+		"Summary: 6 ok, 0 missing, 0 conflict, 0 skipped, 0 drifted, 0 unsupported",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("status output missing %q\noutput:\n%s", want, got)
+		}
+	}
+}
+
 func TestStatusCommandReportsConflictForForeignTarget(t *testing.T) {
 	home := t.TempDir()
 	sourceRoot := t.TempDir()

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -471,6 +471,94 @@ func TestRepositoryManagedConfigsExposeLocalExtensionPoints(t *testing.T) {
 	}
 }
 
+func TestRepositoryGitConfigClassifiesPortableAndLocalConcerns(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", ".."))
+
+	managedPath := filepath.Join(root, "configs/git/gitconfig")
+	managedBytes, err := os.ReadFile(managedPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", managedPath, err)
+	}
+	managed := string(managedBytes)
+
+	for _, want := range []string{
+		"defaultBranch = main",
+		"rebase = false",
+		"conflictStyle = diff3",
+		"path = ~/.gitconfig.local",
+	} {
+		if !strings.Contains(managed, want) {
+			t.Fatalf("managed gitconfig missing portable/local boundary %q:\n%s", want, managed)
+		}
+	}
+
+	normalizedManaged := strings.ToLower(managed)
+	for _, forbidden := range []string{
+		"[user]",
+		"signingkey",
+		"gpgsign",
+		"[credential]",
+		"credential.helper",
+		"[credential ",
+		"includeif \"gitdir:~/",
+		"includeif.gitdir:",
+		"/users/",
+		"/home/",
+		"~/documents/",
+	} {
+		if strings.Contains(normalizedManaged, forbidden) {
+			t.Fatalf("managed gitconfig contains local/private concern %q:\n%s", forbidden, managed)
+		}
+	}
+
+	docPath := filepath.Join(root, "configs/git/README.md")
+	docBytes, err := os.ReadFile(docPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", docPath, err)
+	}
+	doc := string(docBytes)
+	for _, want := range []string{
+		"Portable",
+		"Local/private",
+		"Generated",
+		"Machine-specific",
+		"gitconfig.local.example",
+	} {
+		if !strings.Contains(doc, want) {
+			t.Fatalf("git config documentation missing %q:\n%s", want, doc)
+		}
+	}
+
+	examplePath := filepath.Join(root, "configs/git/gitconfig.local.example")
+	exampleBytes, err := os.ReadFile(examplePath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", examplePath, err)
+	}
+	example := string(exampleBytes)
+	for _, want := range []string{
+		"[user]",
+		"name =",
+		"email =",
+		"signingKey =",
+		"[credential]",
+		"[includeIf \"gitdir:~/work/\"]",
+	} {
+		if !strings.Contains(example, want) {
+			t.Fatalf("gitconfig.local.example missing %q:\n%s", want, example)
+		}
+	}
+	for _, line := range strings.Split(example, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		normalized := strings.ToLower(strings.ReplaceAll(trimmed, " ", ""))
+		if strings.Contains(normalized, "helper=store") || strings.Contains(normalized, "credential.helper=store") {
+			t.Fatalf("gitconfig.local.example contains uncommented plaintext credential store guidance: %q", line)
+		}
+	}
+}
+
 func TestRepositoryManifestPlansMVPConfigurationSetSafely(t *testing.T) {
 	root, err := filepath.Abs(filepath.Clean(filepath.Join("..", "..")))
 	if err != nil {


### PR DESCRIPTION
Closes #39

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds a portable repository-managed Git config with `main` as default branch, non-rebase pulls, `diff3` conflict style, and a local include extension point.
- Documents the portable vs. local/private Git config boundary and safe sandbox validation flow.
- Adds regression coverage for repository Git config classification and sandboxed install/status alignment.

## Changes

| File | Change |
|------|--------|
| `configs/git/gitconfig` | Adds portable `merge.conflictStyle=diff3` while keeping local/private settings in `~/.gitconfig.local`. |
| `configs/git/README.md` | Documents managed vs. local Git configuration, non-destructive local setup, and sandbox validation with redirected Go caches. |
| `configs/git/gitconfig.local.example` | Provides a safe local/private example for identity, signing, credential helpers, includeIf rules, and optional local tooling. |
| `internal/manifest/manifest_test.go` | Verifies portable Git config boundaries and guards against private/local concerns or plaintext credential-store guidance. |
| `internal/cli/cli_test.go` | Verifies repository Git config install/status behavior in a sandbox with explicit home/source/state roots. |

## Test Plan

- [x] `go test ./... -count=1`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp>`

Additional validation:

- [x] `git diff --check`
- [x] Audited `configs/git` for uncommented `credential.helper=store` guidance and destructive `~/.gitconfig.local` overwrite commands.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
