### PR TITLE
feat(config): migrate portable Starship configuration

### DIFF
--- a/configs/starship/README.md
+++ b/configs/starship/README.md
@@ -1,0 +1,95 @@
+# Starship prompt configuration
+
+`configs/starship/starship.toml` is the repository-managed Starship prompt
+installed as `~/.config/starship.toml` (symlink strategy, `core` tag,
+`darwin`+`linux`). It intentionally contains only portable defaults that are safe
+to share across machines.
+
+Shell integration stays out of this file. The prompt is loaded by a single
+guarded hook in the Zsh slice (`configs/zsh/rc.d/post/40-tools.zsh`):
+
+```sh
+command -v starship >/dev/null 2>&1 && eval "$(starship init zsh)"
+```
+
+No prompt configuration lives in shell rc files — all of it is owned by this
+Starship config.
+
+## Prerequisite: a Nerd Font
+
+The prompt uses Nerd Font glyphs for module icons, directory substitutions, and
+the `character`/vim-mode symbols. A [Nerd Font](https://www.nerdfonts.com/) must
+be installed and selected in your terminal for the prompt to render correctly.
+This is a documented expectation, not a machine-specific path — the config makes
+no assumption about which font or where it lives.
+
+## Portability classification
+
+The live workstation config was walked segment by segment before adoption. Every
+segment was bucketed as portable, machine-specific, or private:
+
+| Category | Examples | Repository decision |
+| --- | --- | --- |
+| Portable | `palette` + `[palettes.catppuccin_mocha]`, `format`, language/runtime modules (`nodejs`, `rust`, `golang`, `php`, `bun`, `java`, `c`, `zig`, `python`), `[character]` + vim symbols, `[fill]`, `[cmd_duration]`, `[time]`, `[directory]` substitutions, `add_newline`, `command_timeout` | Managed in `configs/starship/starship.toml`. |
+| Machine-specific | absolute paths, hostnames, per-host module wiring, `[custom]` modules calling local-only binaries | None found in the live config. Nothing to gate. |
+| Private | usernames, secrets, tokens, `env_var` modules surfacing private values | None found in the live config. The `[username]` module renders Starship's own `$user` variable at runtime — no name is committed. |
+
+The live config contained no machine-specific or private segments, so the fully
+portable config is adopted as the single source of truth with nothing excluded.
+
+## Personal overrides — Starship has no native include
+
+Unlike Git (`[include]`) or Zsh (sourcing a `.local` file), **Starship has no
+native include or local-override mechanism**. Starship reads exactly one config
+file (`$STARSHIP_CONFIG`, default `~/.config/starship.toml`); there is no
+supported way to layer a `starship.local.toml` on top of it. Inventing one would
+be silently ignored.
+
+So personal or machine-specific tweaks are made by editing your own copy
+directly, or by forking this repository. Because `dots` installs the config as a
+**symlink**, editing `~/.config/starship.toml` edits the tracked file in place —
+keep personal changes on a branch or fork rather than committing them to the
+shared source. If a future need for private prompt segments appears (for example
+a `[custom]` module calling a local-only script), the honest options are to fork
+the config or point `$STARSHIP_CONFIG` at a separate machine-local file; this
+repository does not ship a broken override file that Starship cannot read.
+
+## Sandbox validation
+
+Validate Starship config changes with temporary directories, never the real
+`$HOME`:
+
+```bash
+sandbox_root="$(mktemp -d)"
+sandbox_home="$sandbox_root/home"
+sandbox_state="$sandbox_root/state"
+sandbox_cache="$sandbox_root/cache"
+sandbox_gopath="$sandbox_root/gopath"
+sandbox_modcache="$sandbox_root/modcache"
+mkdir -p "$sandbox_home" "$sandbox_state" "$sandbox_cache" "$sandbox_gopath" "$sandbox_modcache"
+
+HOME="$sandbox_home" \
+GOCACHE="$sandbox_cache" \
+GOPATH="$sandbox_gopath" \
+GOMODCACHE="$sandbox_modcache" \
+XDG_CACHE_HOME="$sandbox_cache" \
+go run ./cmd/dots install \
+  --yes \
+  --home "$sandbox_home" \
+  --source-root "$PWD" \
+  --state-root "$sandbox_state"
+
+HOME="$sandbox_home" \
+GOCACHE="$sandbox_cache" \
+GOPATH="$sandbox_gopath" \
+GOMODCACHE="$sandbox_modcache" \
+XDG_CACHE_HOME="$sandbox_cache" \
+go run ./cmd/dots status \
+  --home "$sandbox_home" \
+  --source-root "$PWD" \
+  --state-root "$sandbox_state"
+```
+
+The expected result is that `~/.config/starship.toml` is installed/aligned inside
+`$sandbox_home` as a symlink to the repository source. The maintainer's real home
+directory must not be touched.

--- a/configs/starship/starship.toml
+++ b/configs/starship/starship.toml
@@ -1,7 +1,157 @@
 # Repository-managed Starship prompt configuration.
+#
+# This file is fully portable: it assumes only a Nerd Font and contains no
+# machine-specific paths, hostnames, or private values. Personal tweaks are made
+# by editing your own copy — Starship has no native include mechanism.
+# See configs/starship/README.md for the portability classification.
 
-add_newline = false
+format = """\
+($directory)\
+$os\
+$git_branch\
+$fill\
+$nodejs\
+$rust\
+$golang\
+$php\
+$bun\
+$java\
+$c\
+$conda\
+$zig\
+$cmd_duration\
+$time\
+\n$character\
+"""
+
+add_newline = true
+command_timeout = 3600000
+palette = "catppuccin_mocha"
+
+[fill]
+symbol = ' '
+
+[palettes.catppuccin_mocha]
+rosewater = "#f5e0dc"
+flamingo = "#f2cdcd"
+pink = "#f5c2e7"
+mauve = "#cba6f7"
+red = "#f38ba8"
+maroon = "#eba0ac"
+peach = "#fab387"
+yellow = "#f9e2af"
+green = "#a6e3a1"
+teal = "#94e2d5"
+sky = "#89dceb"
+sapphire = "#74c7ec"
+blue = "#89b4fa"
+lavender = "#b4befe"
+text = "#cdd6f4"
+subtext1 = "#bac2de"
+subtext0 = "#a6adc8"
+overlay2 = "#9399b2"
+overlay1 = "#7f849c"
+overlay0 = "#6c7086"
+surface2 = "#585b70"
+surface1 = "#45475a"
+surface0 = "#313244"
+base = "#1e1e2e"
+mantle = "#181825"
+crust = "#11111b"
 
 [character]
-success_symbol = "[❯](bold green)"
-error_symbol = "[❯](bold red)"
+success_symbol = "[ ](fg:green)"
+error_symbol = "[ ](fg:red)"
+vimcmd_symbol = "[N](bold red)"
+vimcmd_replace_one_symbol = "[R](bold peach)"
+vimcmd_visual_symbol = "[V](bold mauve)"
+
+[username]
+style_user = 'bold blue'
+style_root = 'bold red'
+format = '[ $user](fg:$style) '
+disabled = false
+show_always = true
+
+[directory]
+format = "[$path](bold $style)[$read_only]($read_only_style) "
+truncation_length = 2
+style = "fg:blue"
+read_only_style = "fg:blue"
+before_repo_root_style = "fg:blue"
+truncation_symbol = "…/"
+truncate_to_repo = true
+read_only = "  "
+
+[directory.substitutions]
+"Documents" = "󰈙"
+"Downloads" = "󰥥"
+"Music" = "󰈣"
+"Pictures" = ""
+
+[cmd_duration]
+format = " took [ $duration]($style) "
+style = "bold fg:yellow"
+min_time = 500
+
+[git_branch]
+format = "-> [$symbol$branch]($style) "
+style = "bold fg:mauve"
+symbol = " "
+
+[git_status]
+format = '[$all_status$ahead_behind ]($style)'
+style = "fg:text bg:pink"
+
+[docker_context]
+disabled = true
+symbol = " "
+
+[python]
+disabled = false
+format = "[$symbol$pyenv_prefix($version)( $virtualenv)](fg:peach)"
+symbol = " "
+version_format = "$raw"
+
+[java]
+format = '[[ $symbol ($version) ](fg:red)]($style)'
+version_format = "$raw"
+symbol = " "
+disabled = false
+
+[c]
+format = '[[ $symbol ($version) ](fg:blue)]($style)'
+symbol = " "
+version_format = "$raw"
+disabled = false
+
+[zig]
+format = '[[ $symbol ($version) ](fg:peach)]($style)'
+version_format = "$raw"
+disabled = false
+
+[bun]
+version_format = "$raw"
+format = '[[ $symbol ($version) ](fg:text)]($style)'
+disabled = false
+
+[nodejs]
+symbol = ""
+format = '[[ $symbol ($version) ](fg:green)]($style)'
+
+[rust]
+symbol = ""
+format = '[[ $symbol ($version) ](fg:red)]($style)'
+
+[golang]
+symbol = ""
+format = '[[ $symbol ($version) ](fg:teal)]($style)'
+
+[php]
+symbol = ""
+format = '[[ $symbol ($version) ](fg:peach)]($style)'
+
+[time]
+disabled = false
+time_format = "%R"
+format = '[[   $time ](fg:subtext0)]($style)'

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -559,6 +559,88 @@ func TestRepositoryGitConfigClassifiesPortableAndLocalConcerns(t *testing.T) {
 	}
 }
 
+func TestRepositoryStarshipConfigClassifiesPortablePromptSafely(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", ".."))
+
+	managedPath := filepath.Join(root, "configs/starship/starship.toml")
+	managedBytes, err := os.ReadFile(managedPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", managedPath, err)
+	}
+	managed := string(managedBytes)
+
+	if strings.TrimSpace(managed) == "" {
+		t.Fatalf("managed starship config is empty")
+	}
+
+	for _, want := range []string{
+		`palette = "catppuccin_mocha"`,
+		"[palettes.catppuccin_mocha]",
+		"format = ",
+		"[character]",
+		"[cmd_duration]",
+		"[time]",
+	} {
+		if !strings.Contains(managed, want) {
+			t.Fatalf("managed starship config missing portable prompt segment %q:\n%s", want, managed)
+		}
+	}
+
+	// Guard against committing machine-specific paths or private values. The
+	// [username] module renders Starship's own $user variable at runtime, so a
+	// literal username must never appear in the tracked file.
+	normalizedManaged := strings.ToLower(managed)
+	for _, forbidden := range []string{
+		"/users/",
+		"/home/",
+		"argote",
+		"yerson",
+		"[custom",
+		"env_var",
+		"password",
+		"secret",
+		"token",
+		"api_key",
+		"localhost",
+	} {
+		if strings.Contains(normalizedManaged, forbidden) {
+			t.Fatalf("managed starship config contains machine-specific/private concern %q:\n%s", forbidden, managed)
+		}
+	}
+
+	docPath := filepath.Join(root, "configs/starship/README.md")
+	docBytes, err := os.ReadFile(docPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", docPath, err)
+	}
+	doc := string(docBytes)
+	for _, want := range []string{
+		"Portable",
+		"Machine-specific",
+		"Private",
+		"Nerd Font",
+		// Starship has no native include; the README must say so honestly
+		// instead of documenting a broken local-override file.
+		"no native include",
+	} {
+		if !strings.Contains(doc, want) {
+			t.Fatalf("starship config documentation missing %q:\n%s", want, doc)
+		}
+	}
+
+	// Starship has no include mechanism, so the repository must NOT ship a
+	// local-override file that Starship would silently ignore.
+	for _, stray := range []string{
+		"configs/starship/starship.local.toml",
+		"configs/starship/starship.local.example",
+		"configs/starship/starship.toml.local",
+	} {
+		if _, err := os.Stat(filepath.Join(root, stray)); err == nil {
+			t.Fatalf("repository ships a broken Starship local-override file Starship cannot read: %s", stray)
+		}
+	}
+}
+
 func TestRepositoryManifestPlansMVPConfigurationSetSafely(t *testing.T) {
 	root, err := filepath.Abs(filepath.Clean(filepath.Join("..", "..")))
 	if err != nil {


### PR DESCRIPTION
## Summary

Migrates the maintainer's real portable Starship prompt into `dots`, replacing the 7-line MVP placeholder. Follows the pattern set by the Git migration (#39). Closes #40.

## What changed

- **`configs/starship/starship.toml`** — adopts the live prompt: Catppuccin Mocha palette, `format` string, ~12 language/runtime modules, `character` + vim-mode symbols, `fill`, `cmd_duration`, `time`, `directory` substitutions, `add_newline`, `command_timeout`. Faithful reproduction — no "fixes" to prompt behavior.
- **`configs/starship/README.md`** (new) — portability classification table, Nerd Font prerequisite, and the honest override story.
- **`internal/manifest/manifest_test.go`** — adds `TestRepositoryStarshipConfigClassifiesPortablePromptSafely`.

## Classification

The live config was walked segment by segment. Every segment is **portable** — no machine-specific paths, hostnames, usernames, or private values. The `[username]` module renders Starship's runtime `$user` variable, so no name is committed. Nothing needed gating.

## Starship has no native include

Unlike Git's `[include]` (used in #39) or Zsh sourcing a `.local` file, **Starship has no native include or local-override mechanism**. This PR does **not** invent a broken `starship.local.toml` that Starship would silently ignore. The README documents that personal tweaks are made by editing your own copy/fork or pointing `$STARSHIP_CONFIG` elsewhere. A test asserts no stray `starship.local.*` file ships.

## Zsh integration unchanged

The prompt is still loaded by the single guarded hook in `configs/zsh/rc.d/post/40-tools.zsh` — no prompt logic moved into shell rc files.

## Verification

- `go test ./...`, `go vet`, `gofmt` — all pass.
- Sandbox install/status with redirected `HOME`: symlink created to the repo source, `status` reports `ok` (aligned), real `$HOME` untouched.

## Acceptance criteria

- [x] Config classified before adoption
- [x] Prompt is Starship-owned, not embedded in `.zshrc`
- [x] Machine-specific/private content excluded (none existed)
- [x] Zsh integration remains a minimal conditional hook
- [x] Sandbox validation proves install + alignment without leaking host data
- [x] Tests assert the Starship entry is planned and resolves to `~/.config/starship.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)