### PR TITLE
feat(config): migrate portable Tmux configuration

### DIFF
--- a/configs/tmux/README.md
+++ b/configs/tmux/README.md
@@ -1,0 +1,98 @@
+# Tmux configuration
+
+`configs/tmux/tmux.conf` is the repository-managed Tmux configuration installed
+as `~/.tmux.conf` (symlink strategy, `core` tag, `darwin`+`linux`). It carries
+the portable, auditable setup so a fresh machine gets a usable Tmux without the
+maintainer's machine state.
+
+## Prerequisites
+
+- **`tmux`** — declared as the entry dependency; `dots` reports it across
+  brew/apt/dnf/pacman but never installs it automatically.
+- **TPM (Tmux Plugin Manager)** — the config *declares* plugins via `@plugin`
+  lines and loads TPM only when `~/.tmux/plugins/tpm/tpm` exists, but it does
+  not install TPM. Clone it once per machine, then press `prefix + I` (here
+  `C-a I`) inside tmux to fetch the declared plugins:
+
+  ```sh
+  git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
+  ```
+
+- **A Nerd Font** — the Catppuccin status modules use Nerd Font glyphs. Install
+  and select a [Nerd Font](https://www.nerdfonts.com/) in your terminal for the
+  status line to render correctly. This is a documented expectation, not a
+  machine-specific path.
+
+## Portability classification
+
+The live `~/.tmux.conf` (a full Gentleman.Dots setup) was walked line by line
+before adoption and bucketed into four categories:
+
+| Category | Examples | Repository decision |
+| --- | --- | --- |
+| **Portable** | prefix remap `C-a`, vi copy-mode + clipboard binding, split/pane keymaps (`v`/`d`/`D`), window nav (`M-h`/`M-l`), pane resize (`M-H/J/K/L`), `mouse`, status position/lengths, base/pane index, terminal/key options (`default-terminal`, `terminal-features`, `extended-keys`, `escape-time`), the floating `scratch` popup, kill-other-sessions confirm, window-status formatting, the TPM `@plugin` declarations, the Catppuccin theme options + status modules, and guarded `run` lines that load TPM/Catppuccin when their runtime files exist | Managed in `configs/tmux/tmux.conf`. |
+| **Machine-specific** | `default-command`/`default-shell` hardcoding an absolute shell path (`/bin/zsh`); a status comment leaking `user@host` | **Excluded.** tmux inherits the login shell on its own; an absolute shell path is an installer concern. Put it in `~/.tmux.conf.local` if a host needs it. |
+| **Generated** | everything under `~/.tmux/plugins/...` (downloaded plugin contents, TPM bootstrap output) | **Never committed.** Plugin *declarations* are versioned; downloaded *contents* are runtime state. The `run` lines that load them are config and stay. |
+| **Private** | secrets, machine IDs, per-host overrides | **Excluded.** They live in the untracked `~/.tmux.conf.local`. |
+
+## Local / private extension point
+
+`~/.tmux.conf.local` is an optional, untracked file sourced **last** by a
+guarded `if-shell` at the end of `tmux.conf`:
+
+```tmux
+if-shell "test -f ~/.tmux.conf.local" "source-file ~/.tmux.conf.local"
+```
+
+Because it is sourced after the portable defaults, anything you put there wins.
+Use it for machine-specific tweaks that must never enter the repo — for example
+an absolute `default-shell`, per-host keymaps, or a private status module:
+
+```tmux
+# ~/.tmux.conf.local (untracked, per-machine)
+set -g default-shell "/opt/homebrew/bin/zsh"
+```
+
+The repository ships no `tmux.conf.local` and never tracks one; tmux silently
+skips the `source-file` when the file is absent, so a fresh machine works
+without it.
+
+## Sandbox validation
+
+Validate Tmux config changes with temporary directories — never the real
+`$HOME` or `~/.tmux.conf` (per `AGENTS.md`):
+
+```bash
+sandbox_root="$(mktemp -d)"
+sandbox_home="$sandbox_root/home"
+sandbox_state="$sandbox_root/state"
+sandbox_cache="$sandbox_root/cache"
+sandbox_gopath="$sandbox_root/gopath"
+sandbox_modcache="$sandbox_root/modcache"
+mkdir -p "$sandbox_home" "$sandbox_state" "$sandbox_cache" "$sandbox_gopath" "$sandbox_modcache"
+
+HOME="$sandbox_home" \
+GOCACHE="$sandbox_cache" \
+GOPATH="$sandbox_gopath" \
+GOMODCACHE="$sandbox_modcache" \
+XDG_CACHE_HOME="$sandbox_cache" \
+go run ./cmd/dots install \
+  --yes \
+  --home "$sandbox_home" \
+  --source-root "$PWD" \
+  --state-root "$sandbox_state"
+
+HOME="$sandbox_home" \
+GOCACHE="$sandbox_cache" \
+GOPATH="$sandbox_gopath" \
+GOMODCACHE="$sandbox_modcache" \
+XDG_CACHE_HOME="$sandbox_cache" \
+go run ./cmd/dots status \
+  --home "$sandbox_home" \
+  --source-root "$PWD" \
+  --state-root "$sandbox_state"
+```
+
+The expected result is that `~/.tmux.conf` is installed/aligned inside
+`$sandbox_home` as a symlink to the repository source. The maintainer's real
+home directory must not be touched.

--- a/configs/tmux/tmux.conf
+++ b/configs/tmux/tmux.conf
@@ -1,9 +1,132 @@
 # Repository-managed tmux configuration.
+#
+# Portable, auditable Tmux setup installed as ~/.tmux.conf (symlink strategy).
+# It carries universal options, keymaps, TPM plugin DECLARATIONS, and the
+# Catppuccin theme. It deliberately omits machine-specific state:
+#
+#   - No default-command/default-shell with an absolute shell path. That is an
+#     installer/machine concern; tmux inherits the login shell on its own.
+#   - No downloaded plugin contents under ~/.tmux/plugins/...; those are runtime
+#     state bootstrapped by TPM, never committed. The `run` lines that load TPM
+#     and Catppuccin from that generated directory ARE config and stay here.
+#   - No secrets, machine IDs, hostnames, usernames, or per-host overrides;
+#     those belong in the private, untracked ~/.tmux.conf.local (see the end).
+#
+# See configs/tmux/README.md for the full portability classification.
 
+# --- TPM plugin declarations (downloaded contents are generated, not tracked) ---
+set -g @plugin 'tmux-plugins/tpm'
+
+# Tested options for TMUX compatibility
+set -g @plugin 'tmux-plugins/tmux-sensible'
+
+# Clipboard management
+set -g @plugin 'tmux-plugins/tmux-yank'
+
+# Tmux Navigation
+set -g @plugin 'christoomey/vim-tmux-navigator'
+
+# Tmux Resurrect
+set -g @plugin 'tmux-plugins/tmux-resurrect'
+
+# Which Key
+set -g @plugin 'alexwforsythe/tmux-which-key'
+
+# CPU/RAM modules for Catppuccin status line
+set -g @plugin 'tmux-plugins/tmux-cpu'
+
+# Catppuccin theme
+set -g @plugin 'catppuccin/tmux#v2.3.0'
+set -g @catppuccin_flavor "mocha"
+set -g @catppuccin_window_status_style "rounded"
+set -g @catppuccin_status_background "default"
+set -g @catppuccin_status_connect_separator "yes"
+set -g @catppuccin_status_fill "icon"
+
+# Floating window
+bind-key -n M-g if-shell -F '#{==:#{session_name},scratch}' {
+  detach-client
+} {
+  # open in the same directory of the current pane
+  display-popup -d "#{pane_current_path}" -E -k "tmux new-session -A -s scratch"
+}
+
+# --- terminal & key handling ---
+set -g default-terminal "tmux-256color"
+set -as terminal-features ",*:RGB"
+set -as terminal-features ",*:usstyle"
+set -as terminal-features ",*:hyperlinks"
+
+set -s extended-keys on
+set -s extended-keys-format csi-u
+set -as terminal-features 'xterm*:extkeys'
+set -sg escape-time 10
+
+# Vim mode
+set -g mode-keys vi
+set -g set-clipboard on
+bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel
+
+# Keymaps
+unbind C-b
+set -g prefix C-a
+bind C-a send-prefix
+
+unbind %
+unbind '"'
+bind v split-window -h -c "#{pane_current_path}"
+bind d split-window -v -c "#{pane_current_path}"
+bind D detach-client
+
+
+# Window navigation
+bind-key -n M-h previous-window
+bind-key -n M-l next-window
+
+# Pane resize via Ghostty Cmd+Shift+h/j/k/l translated to Meta+Shift+h/j/k/l
+bind-key -n M-H resize-pane -L 10
+bind-key -n M-J resize-pane -D 10
+bind-key -n M-K resize-pane -U 10
+bind-key -n M-L resize-pane -R 10
+
+# Mouse support
 set -g mouse on
-set -g history-limit 10000
+
+# Status bar position
+set -g status-position top
+set -g status-right-length 100
+set -g status-left-length 100
+
+# Catppuccin status line
+# The theme must be loaded before expanding its status modules.
+if-shell '[ -f "$HOME/.tmux/plugins/tmux/catppuccin.tmux" ]' 'run "$HOME/.tmux/plugins/tmux/catppuccin.tmux"'
+set -g status-left ""
+# Show the active pane directory on the right instead of repeating the current
+# command/window name already visible in the window list.
+set -g status-right "#{E:@catppuccin_status_directory}"
+set -agF status-right "#{E:@catppuccin_status_cpu}"
+set -agF status-right "#{E:@catppuccin_status_ram}"
+set -ag status-right "#{E:@catppuccin_status_session}"
+set -ag status-right "#{E:@catppuccin_status_uptime}"
+
+# Kill all sessions except current
+bind K confirm-before -p "Kill all other sessions? (y/n)" "kill-session -a"
+
+# Index base
 set -g base-index 1
 setw -g pane-base-index 1
 
+# TPM init
+# TPM itself is runtime state, so load it only when the machine has it.
+if-shell '[ -f "$HOME/.tmux/plugins/tpm/tpm" ]' 'run "$HOME/.tmux/plugins/tpm/tpm"'
+
+# Use tmux window names instead of pane titles so the status bar does not show
+# the shell-provided "user@host: ~/path" title.
+set -g window-status-format "#[fg=#11111b,bg=#{@thm_overlay_2}]#[fg=#181825,reverse]#[none]#I #[fg=#cdd6f4,bg=#{@thm_surface_0}] #W#[fg=#181825,reverse]#[none]"
+set -g window-status-current-format "#[fg=#11111b,bg=#{@thm_mauve}]#[fg=#181825,reverse]#[none]#I #[fg=#cdd6f4,bg=#{@thm_surface_1}] #W#[fg=#181825,reverse]#[none]"
+
 # Local Extension Point: ~/.tmux.conf.local is private and machine-specific.
+# Machine-specific overrides and secrets (per-host keymaps, an absolute
+# default-shell, private status modules) belong here, not in this tracked file.
+# Sourced last so local tweaks win over the portable defaults above.
 if-shell "test -f ~/.tmux.conf.local" "source-file ~/.tmux.conf.local"

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -454,6 +454,14 @@ func TestRepositoryManagedConfigsExposeLocalExtensionPoints(t *testing.T) {
 				"path = ~/.gitconfig.local",
 			},
 		},
+		{
+			name: "tmux has private local include",
+			path: "configs/tmux/tmux.conf",
+			contains: []string{
+				"Machine-specific overrides and secrets",
+				"source-file ~/.tmux.conf.local",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -637,6 +645,113 @@ func TestRepositoryStarshipConfigClassifiesPortablePromptSafely(t *testing.T) {
 	} {
 		if _, err := os.Stat(filepath.Join(root, stray)); err == nil {
 			t.Fatalf("repository ships a broken Starship local-override file Starship cannot read: %s", stray)
+		}
+	}
+}
+
+func TestRepositoryTmuxConfigClassifiesPortableConfigSafely(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", ".."))
+
+	managedPath := filepath.Join(root, "configs/tmux/tmux.conf")
+	managedBytes, err := os.ReadFile(managedPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", managedPath, err)
+	}
+	managed := string(managedBytes)
+
+	if strings.TrimSpace(managed) == "" {
+		t.Fatalf("managed tmux config is empty")
+	}
+
+	for _, want := range []string{
+		"set -g @plugin 'tmux-plugins/tpm'",
+		"set -g @plugin 'catppuccin/tmux#v2.3.0'",
+		"set -g prefix C-a",
+		"set -g mode-keys vi",
+		"set -g status-position top",
+		"display-popup",
+		"source-file ~/.tmux.conf.local",
+	} {
+		if !strings.Contains(managed, want) {
+			t.Fatalf("managed tmux config missing portable segment %q:\n%s", want, managed)
+		}
+	}
+
+	// Guard against committing active machine-specific shell wiring or private
+	// values. Comments may explain why those concerns are excluded, so only
+	// non-comment configuration lines are checked for shell commands.
+	for _, line := range strings.Split(managed, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		for _, forbidden := range []string{
+			"default-command",
+			"default-shell",
+		} {
+			if strings.Contains(trimmed, forbidden) {
+				t.Fatalf("managed tmux config contains active machine-specific shell setting %q:\n%s", line, managed)
+			}
+		}
+	}
+
+	activeTmuxConfig := make([]string, 0)
+	for _, line := range strings.Split(managed, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		activeTmuxConfig = append(activeTmuxConfig, trimmed)
+	}
+	normalizedManaged := strings.ToLower(strings.Join(activeTmuxConfig, "\n"))
+	for _, forbidden := range []string{
+		"/users/",
+		"/bin/zsh",
+		"argote",
+		"yerson",
+		"password",
+		"secret",
+		"token",
+		"api_key",
+	} {
+		if strings.Contains(normalizedManaged, forbidden) {
+			t.Fatalf("managed tmux config contains machine-specific/private concern %q:\n%s", forbidden, managed)
+		}
+	}
+
+	tmuxDir := filepath.Join(root, "configs/tmux")
+	if err := filepath.WalkDir(tmuxDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		if d.Name() == "plugins" || d.Name() == ".tmux" {
+			t.Fatalf("repository ships generated tmux plugin state under %s", path)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("WalkDir(%q) error = %v", tmuxDir, err)
+	}
+
+	docPath := filepath.Join(root, "configs/tmux/README.md")
+	docBytes, err := os.ReadFile(docPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", docPath, err)
+	}
+	doc := string(docBytes)
+	for _, want := range []string{
+		"Portable",
+		"Machine-specific",
+		"Generated",
+		"Private",
+		"Tmux Plugin Manager",
+		"~/.tmux.conf.local",
+		"Sandbox validation",
+	} {
+		if !strings.Contains(doc, want) {
+			t.Fatalf("tmux config documentation missing %q:\n%s", want, doc)
 		}
 	}
 }


### PR DESCRIPTION
Closes #41

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Migrates the repository-managed Tmux config from a placeholder to the portable workstation setup.
- Documents the boundary between portable config, machine-specific overrides, private local config, and generated TPM plugin state.
- Adds repository tests that protect the Tmux portability classification and local extension point.

## Changes

| File | Change |
|------|--------|
| `configs/tmux/tmux.conf` | Adds portable Tmux options, keymaps, TPM plugin declarations, Catppuccin status configuration, guarded runtime plugin loading, and guarded `~/.tmux.conf.local` sourcing. |
| `configs/tmux/README.md` | Documents prerequisites, portability classification, local/private extension point, generated plugin-state exclusion, and sandbox validation. |
| `internal/manifest/manifest_test.go` | Adds tests for the Tmux local include, expected portable segments, exclusion of active machine-specific/private concerns, exclusion of generated plugin directories, and documentation coverage. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp>`
- [x] Sandboxed install/status validation with temporary `HOME`, `GOCACHE`, `GOPATH`, `GOMODCACHE`, `XDG_CACHE_HOME`, and `--state-root <tmp>`:
  - `configs/tmux/tmux.conf -> <tmp>/home/.tmux.conf`
  - install summary: `6 create, 0 conflict, 0 unchanged, 0 missing-source`
  - status summary: `6 ok, 0 missing, 0 conflict, 0 skipped, 0 drifted, 0 unsupported`
- [x] Tmux parse smoke test with temporary `HOME` and no TPM/Catppuccin runtime files.
- [x] `git diff --check -- configs/tmux/tmux.conf configs/tmux/README.md internal/manifest/manifest_test.go`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
