### PR TITLE
feat(config): migrate portable zellij config

### DIFF
--- a/configs/zellij/.gitignore
+++ b/configs/zellij/.gitignore
@@ -1,0 +1,11 @@
+# Generated Zellij runtime/plugin artifacts are intentionally excluded.
+# Portable config lives in config.kdl and layouts/*.kdl.
+plugins/
+cache/
+logs/
+sessions/
+*.wasm
+*.bak
+*.log
+plugexit
+plugin-manager

--- a/configs/zellij/README.md
+++ b/configs/zellij/README.md
@@ -1,0 +1,107 @@
+# Zellij configuration
+
+`configs/zellij/config.kdl` is the repository-managed Zellij configuration
+installed as `~/.config/zellij/config.kdl` (symlink strategy, `core` tag,
+`darwin`+`linux`). `configs/zellij/layouts/default.kdl` is installed as
+`~/.config/zellij/layouts/default.kdl` and selected by `default_layout "default"`.
+
+The Source of Truth is this repository. The installed files are links to these
+tracked sources; runtime state and downloaded plugins stay outside version
+control.
+
+## Prerequisites
+
+- **`zellij`** — declared as the entry dependency; `dots` reports it across
+  brew/apt/dnf/pacman but never installs it automatically.
+- **`nvim`** — used by `scrollback_editor "nvim"`. It is an editor preference,
+  not a managed Zellij dependency in this slice.
+- **`zjstatus`** — optional/manual prerequisite for the default layout status
+  bar. Place the plugin binary at `~/.config/zellij/plugins/zjstatus.wasm` on
+  machines that want this layout exactly. The `.wasm` binary is intentionally
+  not committed; it is a future vendoring candidate only if the repository gets
+  a deliberate plugin-binary policy.
+
+## Portability classification
+
+The live `~/.config/zellij` directory was classified before adoption:
+
+| Category | Examples | Repository decision |
+| --- | --- | --- |
+| **Portable** | locked-by-default mode, `Ctrl+g` command flow, pane/tab/resize/move/scroll keybindings, Alt navigation shortcuts, Catppuccin Mocha theme, rounded pane frames, mouse mode, scroll buffer size, Neovim scrollback editor, built-in plugin aliases, default layout selection, and the personal status bar layout | Managed in `configs/zellij/config.kdl` and `configs/zellij/layouts/default.kdl`. |
+| **Machine-specific** | absolute user paths, hostnames, machine IDs, per-host overrides | **Excluded.** Use a separate config file or config directory through real Zellij mechanisms when a host needs divergence. |
+| **Generated** | downloaded `.wasm` plugin binaries, `plugexit`, plugin-manager output, caches, logs, sessions, serialized runtime state, backup files such as `config.kdl.bak-*` | **Never committed.** Runtime files live under the user's Zellij data/config locations. |
+| **Private** | secrets, tokens, local-only paths, private command wiring | **Excluded.** Keep them outside the managed files. |
+
+## Behavior carried by the portable config
+
+- Zellij starts in `default_mode "locked"` so Neovim/LazyVim receives normal
+  bindings without terminal multiplexer interference.
+- `Ctrl+g` moves from locked mode into Zellij normal mode; `Ctrl+g`, `Esc`, or
+  completing most commands returns to locked mode.
+- The UI uses the built-in `catppuccin-mocha` theme, rounded pane frames,
+  `mouse_mode true`, and `scroll_buffer_size 10000`.
+- Scrollback opens in Neovim via `scrollback_editor "nvim"`.
+- The default layout includes a `zjstatus` status bar with the intentional
+  personal timezone preference `America/Bogota`. That timezone is portable
+  because it is an explicit preference, not host detection.
+
+## Local/private overrides
+
+Zellij does **not** have a native `config.local.kdl` include mechanism. Do not
+invent one: Zellij will not read it automatically.
+
+Use real Zellij mechanisms instead:
+
+```sh
+# Point at one private config file.
+ZELLIJ_CONFIG_FILE="$HOME/.config/zellij-private/config.kdl" zellij
+zellij --config "$HOME/.config/zellij-private/config.kdl"
+
+# Point at a private config directory containing config.kdl and layouts/.
+ZELLIJ_CONFIG_DIR="$HOME/.config/zellij-private" zellij
+zellij --config-dir "$HOME/.config/zellij-private"
+```
+
+Those private files are machine-local. They must not be committed to this
+repository unless they are reclassified as portable.
+
+## Sandbox validation
+
+Validate Zellij config changes with temporary directories — never the real
+`$HOME` or `~/.config/zellij` (per `AGENTS.md`):
+
+```bash
+sandbox_root="$(mktemp -d)"
+sandbox_home="$sandbox_root/home"
+sandbox_state="$sandbox_root/state"
+sandbox_cache="$sandbox_root/cache"
+sandbox_gopath="$sandbox_root/gopath"
+sandbox_modcache="$sandbox_root/modcache"
+mkdir -p "$sandbox_home" "$sandbox_state" "$sandbox_cache" "$sandbox_gopath" "$sandbox_modcache"
+
+HOME="$sandbox_home" \
+GOCACHE="$sandbox_cache" \
+GOPATH="$sandbox_gopath" \
+GOMODCACHE="$sandbox_modcache" \
+XDG_CACHE_HOME="$sandbox_cache" \
+go run ./cmd/dots install \
+  --yes \
+  --home "$sandbox_home" \
+  --source-root "$PWD" \
+  --state-root "$sandbox_state"
+
+HOME="$sandbox_home" \
+GOCACHE="$sandbox_cache" \
+GOPATH="$sandbox_gopath" \
+GOMODCACHE="$sandbox_modcache" \
+XDG_CACHE_HOME="$sandbox_cache" \
+go run ./cmd/dots status \
+  --home "$sandbox_home" \
+  --source-root "$PWD" \
+  --state-root "$sandbox_state"
+```
+
+The expected result is that both `~/.config/zellij/config.kdl` and
+`~/.config/zellij/layouts/default.kdl` are installed/aligned inside
+`$sandbox_home` as symlinks to repository sources. The maintainer's real home
+directory must not be touched.

--- a/configs/zellij/config.kdl
+++ b/configs/zellij/config.kdl
@@ -1,0 +1,290 @@
+// Zellij configuration - portable defaults for Neovim/LazyVim workflows.
+// Zellij starts locked so terminal applications receive normal keybindings.
+// Press Ctrl+g to enter the Zellij command flow, then Ctrl+g/Esc to lock again.
+
+keybinds clear-defaults=true {
+    locked {
+        bind "Ctrl g" { SwitchToMode "normal"; }
+    }
+
+    normal {
+        bind "Ctrl g" { SwitchToMode "locked"; }
+    }
+
+    pane {
+        bind "left" { MoveFocus "left"; }
+        bind "down" { MoveFocus "down"; }
+        bind "up" { MoveFocus "up"; }
+        bind "right" { MoveFocus "right"; }
+        bind "c" { SwitchToMode "renamepane"; PaneNameInput 0; }
+        bind "d" { NewPane "down"; SwitchToMode "locked"; }
+        bind "e" { TogglePaneEmbedOrFloating; SwitchToMode "locked"; }
+        bind "f" { ToggleFocusFullscreen; SwitchToMode "locked"; }
+        bind "h" { MoveFocus "left"; }
+        bind "j" { MoveFocus "down"; }
+        bind "k" { MoveFocus "up"; }
+        bind "l" { MoveFocus "right"; }
+        bind "n" { NewPane; SwitchToMode "locked"; }
+        bind "p" { SwitchToMode "normal"; }
+        bind "r" { NewPane "right"; SwitchToMode "locked"; }
+        bind "s" { NewPane "stacked"; SwitchToMode "locked"; }
+        bind "w" { ToggleFloatingPanes; SwitchToMode "locked"; }
+        bind "x" { CloseFocus; SwitchToMode "locked"; }
+        bind "z" { TogglePaneFrames; SwitchToMode "locked"; }
+        bind "i" { TogglePanePinned; SwitchToMode "locked"; }
+        bind "tab" { SwitchFocus; }
+    }
+
+    tab {
+        bind "left" { GoToPreviousTab; }
+        bind "down" { GoToNextTab; }
+        bind "up" { GoToPreviousTab; }
+        bind "right" { GoToNextTab; }
+        bind "1" { GoToTab 1; SwitchToMode "locked"; }
+        bind "2" { GoToTab 2; SwitchToMode "locked"; }
+        bind "3" { GoToTab 3; SwitchToMode "locked"; }
+        bind "4" { GoToTab 4; SwitchToMode "locked"; }
+        bind "5" { GoToTab 5; SwitchToMode "locked"; }
+        bind "6" { GoToTab 6; SwitchToMode "locked"; }
+        bind "7" { GoToTab 7; SwitchToMode "locked"; }
+        bind "8" { GoToTab 8; SwitchToMode "locked"; }
+        bind "9" { GoToTab 9; SwitchToMode "locked"; }
+        bind "[" { BreakPaneLeft; SwitchToMode "locked"; }
+        bind "]" { BreakPaneRight; SwitchToMode "locked"; }
+        bind "b" { BreakPane; SwitchToMode "locked"; }
+        bind "h" { GoToPreviousTab; }
+        bind "j" { GoToNextTab; }
+        bind "k" { GoToPreviousTab; }
+        bind "l" { GoToNextTab; }
+        bind "n" { NewTab; SwitchToMode "locked"; }
+        bind "r" { SwitchToMode "renametab"; TabNameInput 0; }
+        bind "s" { ToggleActiveSyncTab; SwitchToMode "locked"; }
+        bind "t" { SwitchToMode "normal"; }
+        bind "x" { CloseTab; SwitchToMode "locked"; }
+        bind "tab" { ToggleTab; }
+    }
+
+    resize {
+        bind "left" { Resize "Increase left"; }
+        bind "down" { Resize "Increase down"; }
+        bind "up" { Resize "Increase up"; }
+        bind "right" { Resize "Increase right"; }
+        bind "+" { Resize "Increase"; }
+        bind "-" { Resize "Decrease"; }
+        bind "=" { Resize "Increase"; }
+        bind "H" { Resize "Decrease left"; }
+        bind "J" { Resize "Decrease down"; }
+        bind "K" { Resize "Decrease up"; }
+        bind "L" { Resize "Decrease right"; }
+        bind "h" { Resize "Increase left"; }
+        bind "j" { Resize "Increase down"; }
+        bind "k" { Resize "Increase up"; }
+        bind "l" { Resize "Increase right"; }
+        bind "r" { SwitchToMode "normal"; }
+    }
+
+    move {
+        bind "left" { MovePane "left"; }
+        bind "down" { MovePane "down"; }
+        bind "up" { MovePane "up"; }
+        bind "right" { MovePane "right"; }
+        bind "h" { MovePane "left"; }
+        bind "j" { MovePane "down"; }
+        bind "k" { MovePane "up"; }
+        bind "l" { MovePane "right"; }
+        bind "m" { SwitchToMode "normal"; }
+        bind "n" { MovePane; }
+        bind "p" { MovePaneBackwards; }
+        bind "tab" { MovePane; }
+    }
+
+    scroll {
+        bind "e" { EditScrollback; SwitchToMode "locked"; }
+        bind "f" { SwitchToMode "entersearch"; SearchInput 0; }
+        bind "s" { SwitchToMode "normal"; }
+    }
+
+    search {
+        bind "c" { SearchToggleOption "CaseSensitivity"; }
+        bind "n" { Search "down"; }
+        bind "o" { SearchToggleOption "WholeWord"; }
+        bind "p" { Search "up"; }
+        bind "w" { SearchToggleOption "Wrap"; }
+    }
+
+    session {
+        bind "c" {
+            LaunchOrFocusPlugin "configuration" {
+                floating true
+                move_to_focused_tab true
+            }
+            SwitchToMode "locked"
+        }
+        bind "d" { Detach; }
+        bind "o" { SwitchToMode "normal"; }
+        bind "p" {
+            LaunchOrFocusPlugin "plugin-manager" {
+                floating true
+                move_to_focused_tab true
+            }
+            SwitchToMode "locked"
+        }
+        bind "w" {
+            LaunchOrFocusPlugin "session-manager" {
+                floating true
+                move_to_focused_tab true
+            }
+            SwitchToMode "locked"
+        }
+        bind "a" {
+            LaunchOrFocusPlugin "about" {
+                floating true
+                move_to_focused_tab true
+            }
+            SwitchToMode "locked"
+        }
+    }
+
+    // Shared Alt bindings stay available in locked mode because they do not
+    // collide with normal Vim/LazyVim bindings.
+    shared_among "normal" "locked" {
+        bind "Alt left" { MoveFocusOrTab "left"; }
+        bind "Alt down" { MoveFocus "down"; }
+        bind "Alt up" { MoveFocus "up"; }
+        bind "Alt right" { MoveFocusOrTab "right"; }
+        bind "Alt +" { Resize "Increase"; }
+        bind "Alt -" { Resize "Decrease"; }
+        bind "Alt =" { Resize "Increase"; }
+        bind "Alt [" { PreviousSwapLayout; }
+        bind "Alt ]" { NextSwapLayout; }
+        bind "Alt f" { ToggleFloatingPanes; }
+        bind "Alt h" { MoveFocusOrTab "left"; }
+        bind "Alt i" { MoveTab "Left"; }
+        bind "Alt j" { MoveFocus "down"; }
+        bind "Alt k" { MoveFocus "up"; }
+        bind "Alt l" { MoveFocusOrTab "right"; }
+        bind "Alt n" { NewPane; }
+        bind "Alt o" { MoveTab "Right"; }
+        bind "Alt p" { TogglePaneInGroup; }
+        bind "Alt Shift p" { ToggleGroupMarking; }
+        bind "Alt t" { NewTab; }
+        bind "Alt w" { CloseTab; }
+        bind "Alt 1" { GoToTab 1; }
+        bind "Alt 2" { GoToTab 2; }
+        bind "Alt 3" { GoToTab 3; }
+        bind "Alt 4" { GoToTab 4; }
+        bind "Alt 5" { GoToTab 5; }
+        bind "Alt 6" { GoToTab 6; }
+        bind "Alt 7" { GoToTab 7; }
+        bind "Alt 8" { GoToTab 8; }
+        bind "Alt 9" { GoToTab 9; }
+    }
+
+    shared_except "locked" "renametab" "renamepane" {
+        bind "Ctrl g" { SwitchToMode "locked"; }
+        bind "Ctrl q" { Quit; }
+    }
+
+    shared_except "locked" "entersearch" {
+        bind "enter" { SwitchToMode "locked"; }
+    }
+
+    shared_except "locked" "entersearch" "renametab" "renamepane" {
+        bind "esc" { SwitchToMode "locked"; }
+    }
+
+    shared_except "locked" "entersearch" "renametab" "renamepane" "move" {
+        bind "m" { SwitchToMode "move"; }
+    }
+
+    shared_except "locked" "entersearch" "search" "renametab" "renamepane" "session" {
+        bind "o" { SwitchToMode "session"; }
+    }
+
+    shared_except "locked" "tab" "entersearch" "renametab" "renamepane" {
+        bind "t" { SwitchToMode "tab"; }
+    }
+
+    shared_except "locked" "tab" "scroll" "entersearch" "renametab" "renamepane" {
+        bind "s" { SwitchToMode "scroll"; }
+    }
+
+    shared_among "normal" "resize" "tab" "scroll" "prompt" "tmux" {
+        bind "p" { SwitchToMode "pane"; }
+    }
+
+    shared_except "locked" "resize" "pane" "tab" "entersearch" "renametab" "renamepane" {
+        bind "r" { SwitchToMode "resize"; }
+    }
+
+    shared_among "scroll" "search" {
+        bind "PageDown" { PageScrollDown; }
+        bind "PageUp" { PageScrollUp; }
+        bind "left" { PageScrollUp; }
+        bind "down" { ScrollDown; }
+        bind "up" { ScrollUp; }
+        bind "right" { PageScrollDown; }
+        bind "Ctrl b" { PageScrollUp; }
+        bind "Ctrl c" { ScrollToBottom; SwitchToMode "locked"; }
+        bind "d" { HalfPageScrollDown; }
+        bind "Ctrl f" { PageScrollDown; }
+        bind "h" { PageScrollUp; }
+        bind "j" { ScrollDown; }
+        bind "k" { ScrollUp; }
+        bind "l" { PageScrollDown; }
+        bind "u" { HalfPageScrollUp; }
+    }
+
+    entersearch {
+        bind "Ctrl c" { SwitchToMode "scroll"; }
+        bind "esc" { SwitchToMode "scroll"; }
+        bind "enter" { SwitchToMode "search"; }
+    }
+
+    renametab {
+        bind "esc" { UndoRenameTab; SwitchToMode "tab"; }
+    }
+
+    shared_among "renametab" "renamepane" {
+        bind "Ctrl c" { SwitchToMode "locked"; }
+    }
+
+    renamepane {
+        bind "esc" { UndoRenamePane; SwitchToMode "pane"; }
+    }
+}
+
+// Built-in plugin aliases. Third-party plugins are intentionally not vendored
+// here; optional plugin binaries remain manual per-machine prerequisites.
+plugins {
+    tab-bar location="zellij:tab-bar"
+    status-bar location="zellij:status-bar"
+    strider location="zellij:strider"
+    compact-bar location="zellij:compact-bar"
+    session-manager location="zellij:session-manager"
+    welcome-screen location="zellij:session-manager" {
+        welcome_screen true
+    }
+    filepicker location="zellij:strider" {
+        cwd "/"
+    }
+    configuration location="zellij:configuration"
+    plugin-manager location="zellij:plugin-manager"
+    about location="zellij:about"
+}
+
+load_plugins {
+}
+
+theme "catppuccin-mocha"
+default_mode "locked"
+mouse_mode true
+scroll_buffer_size 10000
+default_layout "default"
+scrollback_editor "nvim"
+
+ui {
+    pane_frames {
+        rounded_corners true
+    }
+}

--- a/configs/zellij/layouts/default.kdl
+++ b/configs/zellij/layouts/default.kdl
@@ -1,0 +1,35 @@
+layout {
+    default_tab_template {
+        children
+        pane size=1 borderless=true {
+            // Personal portable status bar preference. The zjstatus plugin
+            // binary is a manual per-machine prerequisite and is not vendored
+            // by this repository.
+            plugin location="file:~/.config/zellij/plugins/zjstatus.wasm" {
+                format_left  "{mode} #[fg=#89B4FA,bold]{session}"
+                format_center "{tabs}"
+                format_right "{command_git_branch} {datetime}"
+                format_space ""
+
+                border_enabled "false"
+                hide_frame_for_single_pane "true"
+
+                mode_normal "#[bg=#89B4FA,fg=#181825,bold] NORMAL "
+                mode_tmux   "#[bg=#FAB387,fg=#181825,bold] TMUX "
+                mode_locked "#[bg=#F38BA8,fg=#181825,bold] LOCKED "
+
+                tab_normal            "#[fg=#6C7086] {name} "
+                tab_active            "#[fg=#A6E3A1,bold,italic] {name} "
+                tab_active_fullscreen "#[fg=#A6E3A1,bold,italic] {name} [F]"
+
+                datetime          "#[fg=#9399B2] {format} "
+                datetime_format   "%H:%M"
+                datetime_timezone "America/Bogota"
+
+                command_git_branch_command  "git rev-parse --abbrev-ref HEAD"
+                command_git_branch_format   "#[fg=#F5C2E7] {stdout} "
+                command_git_branch_interval "10"
+            }
+        }
+    }
+}

--- a/dots.yaml
+++ b/dots.yaml
@@ -88,3 +88,31 @@ entries:
         apt: tmux
         dnf: tmux
         pacman: tmux
+  - source: configs/zellij/config.kdl
+    target: ~/.config/zellij/config.kdl
+    strategy: symlink
+    tags:
+      - core
+    os:
+      - darwin
+      - linux
+    dependencies:
+      - name: zellij
+        brew: zellij
+        apt: zellij
+        dnf: zellij
+        pacman: zellij
+  - source: configs/zellij/layouts/default.kdl
+    target: ~/.config/zellij/layouts/default.kdl
+    strategy: symlink
+    tags:
+      - core
+    os:
+      - darwin
+      - linux
+    dependencies:
+      - name: zellij
+        brew: zellij
+        apt: zellij
+        dnf: zellij
+        pacman: zellij

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -904,6 +904,18 @@ func TestRepositoryGitConfigInstallsAndReportsAlignedInSandbox(t *testing.T) {
 	} else if want := filepath.Join(sourceRoot, "configs/git/gitconfig"); target != want {
 		t.Fatalf("sandbox gitconfig symlink = %q, want %q", target, want)
 	}
+	zellijConfigTarget := filepath.Join(home, ".config/zellij/config.kdl")
+	if target, err := os.Readlink(zellijConfigTarget); err != nil {
+		t.Fatalf("sandbox Zellij config target is not a symlink: %v", err)
+	} else if want := filepath.Join(sourceRoot, "configs/zellij/config.kdl"); target != want {
+		t.Fatalf("sandbox Zellij config symlink = %q, want %q", target, want)
+	}
+	zellijLayoutTarget := filepath.Join(home, ".config/zellij/layouts/default.kdl")
+	if target, err := os.Readlink(zellijLayoutTarget); err != nil {
+		t.Fatalf("sandbox Zellij default layout target is not a symlink: %v", err)
+	} else if want := filepath.Join(sourceRoot, "configs/zellij/layouts/default.kdl"); target != want {
+		t.Fatalf("sandbox Zellij default layout symlink = %q, want %q", target, want)
+	}
 
 	statusCmd := cli.NewRootCommand()
 	var statusOut bytes.Buffer
@@ -924,7 +936,9 @@ func TestRepositoryGitConfigInstallsAndReportsAlignedInSandbox(t *testing.T) {
 	for _, want := range []string{
 		"ok",
 		"configs/git/gitconfig -> " + gitconfigTarget,
-		"Summary: 6 ok, 0 missing, 0 conflict, 0 skipped, 0 drifted, 0 unsupported",
+		"configs/zellij/config.kdl -> " + zellijConfigTarget,
+		"configs/zellij/layouts/default.kdl -> " + zellijLayoutTarget,
+		"Summary: 8 ok, 0 missing, 0 conflict, 0 skipped, 0 drifted, 0 unsupported",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("status output missing %q\noutput:\n%s", want, got)

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -756,6 +756,186 @@ func TestRepositoryTmuxConfigClassifiesPortableConfigSafely(t *testing.T) {
 	}
 }
 
+func TestRepositoryZellijConfigClassifiesPortableConfigSafely(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", ".."))
+	manifestPath := filepath.Join(root, "dots.yaml")
+
+	got, err := manifest.LoadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("LoadFile(%q) error = %v", manifestPath, err)
+	}
+
+	entriesByTarget := map[string]manifest.Entry{}
+	for _, entry := range got.Entries {
+		entriesByTarget[entry.Target] = entry
+	}
+
+	tests := []struct {
+		name   string
+		target string
+		source string
+	}{
+		{
+			name:   "config",
+			target: "~/.config/zellij/config.kdl",
+			source: "configs/zellij/config.kdl",
+		},
+		{
+			name:   "default layout",
+			target: "~/.config/zellij/layouts/default.kdl",
+			source: "configs/zellij/layouts/default.kdl",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entry, ok := entriesByTarget[tt.target]
+			if !ok {
+				t.Fatalf("repository manifest missing Zellij entry for target %q", tt.target)
+			}
+			if entry.Source != tt.source {
+				t.Errorf("Source = %q, want %q", entry.Source, tt.source)
+			}
+			if entry.Strategy != "symlink" {
+				t.Errorf("Strategy = %q, want symlink", entry.Strategy)
+			}
+			if !hasString(entry.Tags, "core") {
+				t.Errorf("Tags = %#v, want core tag", entry.Tags)
+			}
+			if !sameStrings(entry.OS, []string{"darwin", "linux"}) {
+				t.Errorf("OS = %#v, want [darwin linux]", entry.OS)
+			}
+			if !hasDependency(entry.Dependencies, "zellij") {
+				t.Errorf("Dependencies = %#v, want zellij", entry.Dependencies)
+			}
+		})
+	}
+
+	configPath := filepath.Join(root, "configs/zellij/config.kdl")
+	configBytes, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", configPath, err)
+	}
+	config := string(configBytes)
+
+	if strings.TrimSpace(config) == "" {
+		t.Fatalf("managed Zellij config is empty")
+	}
+
+	for _, want := range []string{
+		`keybinds clear-defaults=true`,
+		`bind "Ctrl g" { SwitchToMode "normal"; }`,
+		`bind "Ctrl g" { SwitchToMode "locked"; }`,
+		`theme "catppuccin-mocha"`,
+		`default_mode "locked"`,
+		`mouse_mode true`,
+		`scroll_buffer_size 10000`,
+		`default_layout "default"`,
+		`scrollback_editor "nvim"`,
+		`plugins {`,
+		`session-manager location="zellij:session-manager"`,
+		`plugin-manager location="zellij:plugin-manager"`,
+		`pane_frames {`,
+		`rounded_corners true`,
+	} {
+		if !strings.Contains(config, want) {
+			t.Fatalf("managed Zellij config missing portable segment %q:\n%s", want, config)
+		}
+	}
+
+	layoutPath := filepath.Join(root, "configs/zellij/layouts/default.kdl")
+	layoutBytes, err := os.ReadFile(layoutPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", layoutPath, err)
+	}
+	layout := string(layoutBytes)
+	for _, want := range []string{
+		`layout {`,
+		`default_tab_template {`,
+		`plugin location="file:~/.config/zellij/plugins/zjstatus.wasm"`,
+		`datetime_timezone "America/Bogota"`,
+	} {
+		if !strings.Contains(layout, want) {
+			t.Fatalf("managed Zellij layout missing portable segment %q:\n%s", want, layout)
+		}
+	}
+
+	for name, content := range map[string]string{
+		"config": config,
+		"layout": layout,
+	} {
+		normalized := strings.ToLower(content)
+		for _, forbidden := range []string{
+			"/users/",
+			"/home/",
+			"argote",
+			"yerson",
+			"password",
+			"secret",
+			"token",
+			"api_key",
+			"hostname",
+		} {
+			if strings.Contains(normalized, forbidden) {
+				t.Fatalf("managed Zellij %s contains machine-specific/private concern %q:\n%s", name, forbidden, content)
+			}
+		}
+	}
+
+	zellijDir := filepath.Join(root, "configs/zellij")
+	if err := filepath.WalkDir(zellijDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case "plugins", "cache", "logs", "sessions":
+				t.Fatalf("repository ships generated Zellij runtime state under %s", path)
+			}
+			return nil
+		}
+		name := strings.ToLower(d.Name())
+		for _, forbiddenSuffix := range []string{".wasm", ".bak", ".log"} {
+			if strings.HasSuffix(name, forbiddenSuffix) {
+				t.Fatalf("repository ships generated Zellij runtime file %s", path)
+			}
+		}
+		for _, forbiddenName := range []string{"plugexit", "plugin-manager"} {
+			if name == forbiddenName {
+				t.Fatalf("repository ships generated Zellij runtime file %s", path)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("WalkDir(%q) error = %v", zellijDir, err)
+	}
+
+	docPath := filepath.Join(root, "configs/zellij/README.md")
+	docBytes, err := os.ReadFile(docPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", docPath, err)
+	}
+	doc := string(docBytes)
+	for _, want := range []string{
+		"Portable",
+		"Machine-specific",
+		"Generated",
+		"Private",
+		"ZELLIJ_CONFIG_FILE",
+		"ZELLIJ_CONFIG_DIR",
+		"zellij --config",
+		"zellij --config-dir",
+		"zjstatus",
+		"manual prerequisite",
+		"America/Bogota",
+		"Sandbox validation",
+	} {
+		if !strings.Contains(doc, want) {
+			t.Fatalf("Zellij config documentation missing %q:\n%s", want, doc)
+		}
+	}
+}
+
 func TestRepositoryManifestPlansMVPConfigurationSetSafely(t *testing.T) {
 	root, err := filepath.Abs(filepath.Clean(filepath.Join("..", "..")))
 	if err != nil {
@@ -778,8 +958,8 @@ func TestRepositoryManifestPlansMVPConfigurationSetSafely(t *testing.T) {
 		t.Fatalf("Build() error = %v", err)
 	}
 
-	if len(p.Actions) != 6 {
-		t.Fatalf("len(Actions) = %d, want 6", len(p.Actions))
+	if len(p.Actions) != 8 {
+		t.Fatalf("len(Actions) = %d, want 8", len(p.Actions))
 	}
 	for _, action := range p.Actions {
 		if action.Status != plan.StatusCreate {


### PR DESCRIPTION
Closes #42

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds portable Zellij configuration and default layout as managed dotfiles.
- Documents portability classification, local override mechanisms, manual plugin prerequisites, and runtime exclusions.
- Extends manifest and sandbox install/status tests for Zellij-managed entries.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Adds Zellij config and default layout entries with symlink strategy, `core` tag, darwin/linux filters, and advisory `zellij` dependency. |
| `configs/zellij/config.kdl` | Adds portable locked-by-default Zellij configuration for Neovim/LazyVim workflows. |
| `configs/zellij/layouts/default.kdl` | Adds portable default layout with manual `zjstatus` prerequisite and intentional `America/Bogota` timezone preference. |
| `configs/zellij/README.md` | Records classification, prerequisites, exclusions, local override guidance, and sandbox validation commands. |
| `configs/zellij/.gitignore` | Blocks generated Zellij runtime/plugin artifacts from accidental commits. |
| `internal/manifest/manifest_test.go` | Adds repository-level Zellij manifest, classification, and exclusion assertions. |
| `internal/cli/cli_test.go` | Verifies sandbox install/status alignment for both Zellij symlinks. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp>`
- [x] Sandboxed install/status validation with temporary `--home`, `--source-root "$PWD"`, and `--state-root <tmp>`
- [x] `zellij --config-dir "$PWD/configs/zellij" --data-dir <tmp>/zellij-data setup --check`
- [x] Fresh-context review completed with no blockers

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
