### PR TITLE
feat(config): add portable Ghostty configuration

### DIFF
--- a/configs/ghostty/.gitignore
+++ b/configs/ghostty/.gitignore
@@ -1,0 +1,10 @@
+# Keep machine-local overrides and generated Ghostty state out of the repository.
+config.local.ghostty
+*.log
+*.bak
+*.tmp
+cache/
+logs/
+sessions/
+state/
+shaders/

--- a/configs/ghostty/README.md
+++ b/configs/ghostty/README.md
@@ -1,0 +1,111 @@
+# Ghostty configuration
+
+`configs/ghostty/config.ghostty` is the repository-managed Ghostty terminal
+configuration installed as `~/.config/ghostty/config.ghostty` (symlink strategy,
+`desktop` tag, `darwin`+`linux`). It uses Ghostty's current canonical filename.
+
+The Source of Truth is this repository. The installed file is a link to the
+tracked source; runtime state, generated files, and machine-local overrides stay
+outside version control.
+
+## Prerequisites
+
+- **`ghostty`** — declared as an advisory dependency for the desktop profile.
+  `dots install` does not install packages. `dots deps plan` and the explicit
+  `dots deps install` workflow can report/use Homebrew guidance where available;
+  Linux package mappings are intentionally omitted until package names are
+  verified for each distro.
+
+## Portability classification
+
+The live `~/.config/ghostty/config` file was classified before adoption:
+
+| Category | Examples | Repository decision |
+| --- | --- | --- |
+| **Portable** | Catppuccin Mocha palette, foreground/background/cursor/selection colors, split divider color, intentional keybindings for terminal workflow and Zellij/tmux forwarding | Managed in `configs/ghostty/config.ghostty`. |
+| **Machine-specific** | font family, font size, window dimensions, opacity/blur, window padding ergonomics, explicit shell/command paths, initial working directories, OS integrations, display/GPU/host-dependent behavior | Excluded from the shared file. Documented in `configs/ghostty/config.local.ghostty.example`. |
+| **Generated** | logs, caches, sessions, backups, temporary files, generated state, local shaders | Never committed. |
+| **Private** | secrets, authenticated state, private paths, hostnames, machine IDs | Excluded. |
+
+## Legacy config migration
+
+Ghostty still loads the legacy `~/.config/ghostty/config` file for compatibility.
+Because Ghostty loads both `config.ghostty` and legacy `config`, an existing
+legacy file can override the repository-managed Source of Truth after install.
+
+Before switching a real workstation to this slice, classify the legacy file, move
+portable settings into `configs/ghostty/config.ghostty`, move machine-specific
+settings into `~/.config/ghostty/config.local.ghostty`, then archive or remove
+the legacy `~/.config/ghostty/config` file. Do the same review for macOS
+Application Support Ghostty config files if they exist.
+
+Do not delete the legacy file blindly: it is user state until it has been
+classified. The sandbox validation below starts from an empty temporary home, so
+it proves safe installation and alignment, not cleanup of a real workstation's
+legacy file.
+
+## Local machine overrides
+
+Ghostty supports split configuration with `config-file`. The shared file uses an
+optional local include:
+
+```ghostty
+config-file = ?config.local.ghostty
+```
+
+The `?` prefix means a fresh install remains aligned even when the local file is
+absent. When a machine needs private settings, copy the versioned example from the
+repository into the Ghostty config directory manually:
+
+```sh
+mkdir -p ~/.config/ghostty
+cp ~/.local/share/dots/configs/ghostty/config.local.ghostty.example \
+  ~/.config/ghostty/config.local.ghostty
+```
+
+If you are working from a development checkout instead of the default installed
+repository, replace `~/.local/share/dots` with that checkout path. Then edit
+`~/.config/ghostty/config.local.ghostty` locally. Do not commit that file unless
+the setting has been reviewed and reclassified as portable.
+
+## Sandbox validation
+
+Validate Ghostty config changes with temporary directories — never the real
+`$HOME` or `~/.config/ghostty` (per `AGENTS.md`):
+
+```bash
+sandbox_root="$(mktemp -d)"
+sandbox_home="$sandbox_root/home"
+sandbox_state="$sandbox_root/state"
+sandbox_cache="$sandbox_root/cache"
+sandbox_gopath="$sandbox_root/gopath"
+sandbox_modcache="$sandbox_root/modcache"
+mkdir -p "$sandbox_home" "$sandbox_state" "$sandbox_cache" "$sandbox_gopath" "$sandbox_modcache"
+
+HOME="$sandbox_home" \
+GOCACHE="$sandbox_cache" \
+GOPATH="$sandbox_gopath" \
+GOMODCACHE="$sandbox_modcache" \
+XDG_CACHE_HOME="$sandbox_cache" \
+go run ./cmd/dots install \
+  --profile desktop \
+  --yes \
+  --home "$sandbox_home" \
+  --source-root "$PWD" \
+  --state-root "$sandbox_state"
+
+HOME="$sandbox_home" \
+GOCACHE="$sandbox_cache" \
+GOPATH="$sandbox_gopath" \
+GOMODCACHE="$sandbox_modcache" \
+XDG_CACHE_HOME="$sandbox_cache" \
+go run ./cmd/dots status \
+  --profile desktop \
+  --home "$sandbox_home" \
+  --source-root "$PWD" \
+  --state-root "$sandbox_state"
+```
+
+The expected result is that `~/.config/ghostty/config.ghostty` is
+installed/aligned inside `$sandbox_home` as a symlink to the repository source.
+The maintainer's real home directory must not be touched.

--- a/configs/ghostty/config.ghostty
+++ b/configs/ghostty/config.ghostty
@@ -1,0 +1,42 @@
+# Ghostty portable preferences managed by dots.
+#
+# Machine-specific settings such as font family/size, window dimensions,
+# opacity/blur, shell paths, working directories, and platform integrations live
+# in the optional local file below. Ghostty resolves this relative to this file
+# and ignores it when it does not exist.
+config-file = ?config.local.ghostty
+
+# Catppuccin Mocha palette and terminal colors.
+palette = 0=#45475a
+palette = 1=#f38ba8
+palette = 2=#a6e3a1
+palette = 3=#f9e2af
+palette = 4=#89b4fa
+palette = 5=#f5c2e7
+palette = 6=#94e2d5
+palette = 7=#a6adc8
+palette = 8=#585b70
+palette = 9=#f38ba8
+palette = 10=#a6e3a1
+palette = 11=#f9e2af
+palette = 12=#89b4fa
+palette = 13=#f5c2e7
+palette = 14=#94e2d5
+palette = 15=#bac2de
+background = 1e1e2e
+foreground = cdd6f4
+cursor-color = f5e0dc
+cursor-text = 11111b
+selection-background = 353749
+selection-foreground = cdd6f4
+split-divider-color = 313244
+
+# Portable keyboard behavior for the terminal workflow.
+keybind = alt+left=unbind
+keybind = alt+right=unbind
+keybind = super+shift+h=esc:H
+keybind = super+shift+j=esc:J
+keybind = super+shift+k=esc:K
+keybind = super+shift+l=esc:L
+keybind = cmd+k=clear_screen
+keybind = alt+s=write_screen_file:paste

--- a/configs/ghostty/config.local.ghostty.example
+++ b/configs/ghostty/config.local.ghostty.example
@@ -1,0 +1,29 @@
+# Copy to ~/.config/ghostty/config.local.ghostty for machine-specific Ghostty
+# settings. The shared config loads this file with:
+#
+#   config-file = ?config.local.ghostty
+#
+# Keep this file local unless a setting is explicitly reviewed as portable.
+
+# Fonts are machine-specific because installed font names and comfortable sizes
+# differ across hosts, displays, and operating systems.
+# font-family = "CaskaydiaCove Nerd Font Mono"
+# font-size = 20
+
+# Window and rendering ergonomics depend on monitor size, compositor/GPU, and
+# personal workspace layout.
+# background-opacity = 0.95
+# background-blur-radius = 20
+# unfocused-split-opacity = 0.85
+# window-padding-color = extend
+# window-step-resize = false
+# window-padding-balance = true
+# window-height = 100
+# window-width = 100
+
+# Platform or integration settings must be reviewed before promotion to the
+# shared Source of Truth.
+# macos-option-as-alt = left
+# gtk-tabs-location = hidden
+# command = /path/to/local/shell-or-multiplexer
+# working-directory = ~/projects

--- a/dots.yaml
+++ b/dots.yaml
@@ -3,6 +3,10 @@ profiles:
   default:
     tags:
       - core
+  desktop:
+    tags:
+      - core
+      - desktop
 entries:
   - source: configs/zsh/zshrc
     target: ~/.zshrc
@@ -116,3 +120,15 @@ entries:
         apt: zellij
         dnf: zellij
         pacman: zellij
+  - source: configs/ghostty/config.ghostty
+    target: ~/.config/ghostty/config.ghostty
+    strategy: symlink
+    tags:
+      - desktop
+    os:
+      - darwin
+      - linux
+    dependencies:
+      - name: ghostty
+        command: ghostty
+        brew: ghostty

--- a/internal/cli/ghostty_config_test.go
+++ b/internal/cli/ghostty_config_test.go
@@ -1,0 +1,93 @@
+package cli_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/cli"
+)
+
+func TestGhosttyDesktopProfileInstallsAndReportsAlignedInSandbox(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	install := cli.NewRootCommand()
+	var installOut bytes.Buffer
+	install.SetOut(&installOut)
+	install.SetErr(&installOut)
+	install.SetArgs([]string{
+		"install",
+		"--file", filepath.Join(repoRoot, "dots.yaml"),
+		"--profile", "desktop",
+		"--source-root", repoRoot,
+		"--home", home,
+		"--state-root", stateRoot,
+		"--yes",
+	})
+
+	if err := install.Execute(); err != nil {
+		t.Fatalf("dots install failed in sandbox: %v\noutput:\n%s", err, installOut.String())
+	}
+
+	target := filepath.Join(home, ".config", "ghostty", "config.ghostty")
+	info, err := os.Lstat(target)
+	if err != nil {
+		t.Fatalf("ghostty target missing after sandbox install: %v\ninstall output:\n%s", err, installOut.String())
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("ghostty target mode = %v, want symlink", info.Mode())
+	}
+	wantSource := filepath.Join(repoRoot, "configs", "ghostty", "config.ghostty")
+	gotSource, err := os.Readlink(target)
+	if err != nil {
+		t.Fatalf("read ghostty symlink: %v", err)
+	}
+	if gotSource != wantSource {
+		t.Fatalf("ghostty symlink = %q, want %q", gotSource, wantSource)
+	}
+
+	localExample := filepath.Join(repoRoot, "configs", "ghostty", "config.local.ghostty.example")
+	if _, err := os.Stat(localExample); err != nil {
+		t.Fatalf("local override example missing: %v", err)
+	}
+
+	status := cli.NewRootCommand()
+	var statusOut bytes.Buffer
+	status.SetOut(&statusOut)
+	status.SetErr(&statusOut)
+	status.SetArgs([]string{
+		"status",
+		"--file", filepath.Join(repoRoot, "dots.yaml"),
+		"--profile", "desktop",
+		"--source-root", repoRoot,
+		"--home", home,
+		"--state-root", stateRoot,
+	})
+
+	if err := status.Execute(); err != nil {
+		t.Fatalf("dots status failed in sandbox: %v\noutput:\n%s", err, statusOut.String())
+	}
+
+	got := statusOut.String()
+	for _, want := range []string{
+		"configs/ghostty/config.ghostty -> " + target,
+		"Summary:",
+		"0 conflict",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("status output missing %q\noutput:\n%s", want, got)
+		}
+	}
+
+	if !strings.Contains(installOut.String(), "configs/ghostty/config.ghostty") {
+		t.Fatalf("install plan did not include the Ghostty managed entry\noutput:\n%s", installOut.String())
+	}
+}


### PR DESCRIPTION
Closes #43

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds a portable Ghostty configuration slice using Ghostty's canonical `config.ghostty` filename.
- Introduces a `desktop` profile/tag path for workstation terminal configuration without putting Ghostty in universal `core` only.
- Documents portability boundaries, local overrides, legacy config migration, and sandbox validation.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Adds the `desktop` profile and Ghostty managed entry targeting `~/.config/ghostty/config.ghostty`. |
| `configs/ghostty/config.ghostty` | Adds portable Catppuccin Mocha terminal colors, workflow keybindings, and optional local include. |
| `configs/ghostty/config.local.ghostty.example` | Documents machine-specific settings that belong outside the shared Source of Truth. |
| `configs/ghostty/.gitignore` | Excludes local overrides and generated Ghostty runtime artifacts. |
| `configs/ghostty/README.md` | Documents classification, dependency behavior, legacy config migration, local overrides, and safe sandbox validation. |
| `internal/cli/ghostty_config_test.go` | Adds sandbox install/status coverage for the Ghostty desktop profile. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed install/status validation:
  - `go run ./cmd/dots install --profile desktop --yes --home <tmp> --source-root "$PWD" --state-root <tmp>`
  - `go run ./cmd/dots status --profile desktop --home <tmp> --source-root "$PWD" --state-root <tmp>`
- [x] Dependency guidance checks:
  - `go run ./cmd/dots deps plan --profile desktop --file dots.yaml --tier homebrew`
  - `go run ./cmd/dots deps plan --profile desktop --file dots.yaml --tier debian`
- [x] Fresh-context review completed before commit/push.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
