### PR TITLE
feat(config): migrate portable Atuin configuration

### DIFF
--- a/configs/atuin/.gitignore
+++ b/configs/atuin/.gitignore
@@ -1,0 +1,29 @@
+# Keep Atuin history, sync/auth state, machine identity, and generated files out
+# of the repository. Atuin stores these in ~/.local/share/atuin/ (the data dir)
+# by default, but guard the config directory too in case ATUIN_CONFIG_DIR or a
+# custom data_dir points here.
+
+# Shell history database and write-ahead/shared-memory sidecars.
+history.db
+history.db-*
+
+# Sync record store and its sidecars.
+records.db
+records.db-*
+
+# Encryption key, auth session token, and machine identity.
+key
+session
+host_id
+
+# Generated runtime/update state.
+last_version_check_time
+latest_version
+atuin-receipt.json
+*.sock
+
+# Machine-local override file (when used) and transient artifacts.
+config.local.toml
+*.log
+*.bak
+*.tmp

--- a/configs/atuin/README.md
+++ b/configs/atuin/README.md
@@ -1,0 +1,126 @@
+# Atuin configuration
+
+`configs/atuin/config.toml` is the repository-managed Atuin configuration
+installed as `~/.config/atuin/config.toml` (symlink strategy, `core` tag,
+`darwin`+`linux`). The portable Catppuccin Mocha theme it references is installed
+alongside it as `~/.config/atuin/themes/catppuccin-mocha.toml`.
+
+The Source of Truth is this repository. The installed files are links to the
+tracked sources; shell history, sync/auth state, machine identity, generated
+files, and machine-local overrides stay outside version control.
+
+## Prerequisites
+
+- **`atuin`** — declared as an advisory dependency for the core profile.
+  `dots install` does not install packages. `dots deps plan` and the explicit
+  `dots deps install` workflow can report/use Homebrew guidance where available;
+  Linux package mappings are intentionally omitted until package names are
+  verified for each distro.
+
+The shell integration is **not** part of this slice. It is a guarded hook owned
+by Zsh in `configs/zsh/rc.d/post/40-tools.zsh`:
+
+```zsh
+[[ -r "${HOME}/.atuin/bin/env" ]] && source "${HOME}/.atuin/bin/env"
+command -v atuin >/dev/null 2>&1 && eval "$(atuin init zsh)"
+```
+
+The `command -v atuin` guard keeps the shell usable when Atuin is absent, so a
+fresh machine without Atuin still starts cleanly. This slice manages only the
+declarative config and theme — never the `init` hook.
+
+## Portability classification
+
+The live `~/.config/atuin/config.toml` was classified before adoption:
+
+| Category | Examples | Repository decision |
+| --- | --- | --- |
+| **Portable** | `enter_accept`, `filter_mode_shell_up_key_binding`, `[sync] records`, `[theme] name`, the custom `themes/catppuccin-mocha.toml` palette | Managed in `configs/atuin/config.toml` and `configs/atuin/themes/catppuccin-mocha.toml`. |
+| **Machine-specific** | `db_path`, `key_path`, `session_path`, `data_dir`, `sync_address`, `auto_sync`, `timezone`, daemon socket/port | Excluded from the shared file. Set per machine via `ATUIN_*` env vars in `~/.zshrc.local`. |
+| **Generated** | `history.db` (+ `-shm`/`-wal`), `records.db`, `last_version_check_time`, `latest_version`, `atuin-receipt.json`, daemon socket | Never committed. Live in `~/.local/share/atuin/`, which dots never manages. |
+| **Private** | encryption `key`, auth `session` token, `host_id`, sync server credentials | Excluded. Live in `~/.local/share/atuin/` and are created/managed by Atuin itself. |
+
+### Why history, sync tokens, and auth state are safe
+
+Atuin stores its sensitive and generated state in a separate **data directory**
+(`~/.local/share/atuin/`, or `$XDG_DATA_HOME/atuin`), not in the config
+directory:
+
+- **History database** — `~/.local/share/atuin/history.db`
+- **Encryption key** — `~/.local/share/atuin/key`
+- **Auth session token** — `~/.local/share/atuin/session`
+- **Sync records** — `~/.local/share/atuin/records.db`
+- **Machine identity** — `~/.local/share/atuin/host_id`
+
+`dots` only symlinks the two tracked config files into `~/.config/atuin/`; it
+never reads, writes, or links anything in the data directory. The
+`configs/atuin/.gitignore` additionally guards the config directory against any
+of these files being committed if a machine relocates them there via
+`ATUIN_CONFIG_DIR` or a custom `data_dir`.
+
+## Local machine overrides
+
+Atuin has no `include` or local-override file mechanism. Configuration is layered
+as: built-in defaults → `config.toml` → `ATUIN_*` environment variables (highest
+priority). Nested keys use a double-underscore separator.
+
+Set machine-specific values in `~/.zshrc.local` (not managed by dots):
+
+```sh
+# Examples — adjust per machine, never commit these.
+export ATUIN_SYNC_ADDRESS="https://api.atuin.sh"
+export ATUIN_TIMEZONE="local"
+export ATUIN_SEARCH__MODE="fuzzy"
+```
+
+Verify the effective, merged value of any setting with:
+
+```sh
+atuin config get <key> --resolved
+```
+
+If a setting turns out to be portable for every machine, review it and move it
+into `configs/atuin/config.toml` instead of leaving it in `~/.zshrc.local`.
+
+## Sandbox validation
+
+Validate Atuin config changes with temporary directories — never the real
+`$HOME`, `~/.config/atuin`, or `~/.local/share/atuin` (per `AGENTS.md`):
+
+```bash
+sandbox_root="$(mktemp -d)"
+sandbox_home="$sandbox_root/home"
+sandbox_state="$sandbox_root/state"
+sandbox_cache="$sandbox_root/cache"
+sandbox_gopath="$sandbox_root/gopath"
+sandbox_modcache="$sandbox_root/modcache"
+mkdir -p "$sandbox_home" "$sandbox_state" "$sandbox_cache" "$sandbox_gopath" "$sandbox_modcache"
+
+HOME="$sandbox_home" \
+GOCACHE="$sandbox_cache" \
+GOPATH="$sandbox_gopath" \
+GOMODCACHE="$sandbox_modcache" \
+XDG_CACHE_HOME="$sandbox_cache" \
+go run ./cmd/dots install \
+  --profile default \
+  --yes \
+  --home "$sandbox_home" \
+  --source-root "$PWD" \
+  --state-root "$sandbox_state"
+
+HOME="$sandbox_home" \
+GOCACHE="$sandbox_cache" \
+GOPATH="$sandbox_gopath" \
+GOMODCACHE="$sandbox_modcache" \
+XDG_CACHE_HOME="$sandbox_cache" \
+go run ./cmd/dots status \
+  --profile default \
+  --home "$sandbox_home" \
+  --source-root "$PWD" \
+  --state-root "$sandbox_state"
+```
+
+The expected result is that `~/.config/atuin/config.toml` and
+`~/.config/atuin/themes/catppuccin-mocha.toml` are installed/aligned inside
+`$sandbox_home` as symlinks to the repository sources. The maintainer's real home
+directory must not be touched.

--- a/configs/atuin/config.toml
+++ b/configs/atuin/config.toml
@@ -1,0 +1,27 @@
+# Atuin portable preferences managed by dots.
+#
+# Atuin has no native include mechanism. Settings are layered: built-in defaults,
+# then this file, then ATUIN_* environment variables (highest priority). Nested
+# keys use a double underscore, e.g. ATUIN_SEARCH__MODE. Machine-specific values
+# (db_path, key_path, session_path, data_dir, sync_address, timezone, daemon
+# socket) and any secrets belong in ~/.zshrc.local via ATUIN_* env vars, never in
+# this shared file.
+#
+# Shell history, encryption key, session/auth token, host id, and sync records
+# live in ~/.local/share/atuin/ (the data dir), which dots never manages.
+
+# Immediately run the highlighted command on Enter; press Tab to edit it first.
+enter_accept = true
+
+# Up-arrow scopes history to the current shell session instead of global history.
+filter_mode_shell_up_key_binding = "session"
+
+[sync]
+# Use record-based sync (v2). Enabling sync and the server/account itself are
+# machine concerns handled by `atuin login` plus ATUIN_* env vars, not this file.
+records = true
+
+[theme]
+# Portable Catppuccin Mocha theme shipped in ./themes/catppuccin-mocha.toml and
+# installed alongside this file as ~/.config/atuin/themes/catppuccin-mocha.toml.
+name = "catppuccin-mocha"

--- a/configs/atuin/themes/catppuccin-mocha.toml
+++ b/configs/atuin/themes/catppuccin-mocha.toml
@@ -1,0 +1,12 @@
+[theme]
+name = "catppuccin-mocha"
+
+[colors]
+AlertInfo = "#a6e3a1"
+AlertWarn = "#fab387"
+AlertError = "#f38ba8"
+Annotation = "#89b4fa"
+Base = "#cdd6f4"
+Guidance = "#9399b2"
+Important = "#f38ba8"
+Title = "#89b4fa"

--- a/dots.yaml
+++ b/dots.yaml
@@ -132,3 +132,27 @@ entries:
       - name: ghostty
         command: ghostty
         brew: ghostty
+  - source: configs/atuin/config.toml
+    target: ~/.config/atuin/config.toml
+    strategy: symlink
+    tags:
+      - core
+    os:
+      - darwin
+      - linux
+    dependencies:
+      - name: atuin
+        command: atuin
+        brew: atuin
+  - source: configs/atuin/themes/catppuccin-mocha.toml
+    target: ~/.config/atuin/themes/catppuccin-mocha.toml
+    strategy: symlink
+    tags:
+      - core
+    os:
+      - darwin
+      - linux
+    dependencies:
+      - name: atuin
+        command: atuin
+        brew: atuin

--- a/internal/cli/atuin_config_test.go
+++ b/internal/cli/atuin_config_test.go
@@ -1,0 +1,110 @@
+package cli_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/cli"
+)
+
+func TestAtuinDefaultProfileInstallsAndReportsAlignedInSandbox(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	install := cli.NewRootCommand()
+	var installOut bytes.Buffer
+	install.SetOut(&installOut)
+	install.SetErr(&installOut)
+	install.SetArgs([]string{
+		"install",
+		"--file", filepath.Join(repoRoot, "dots.yaml"),
+		"--profile", "default",
+		"--source-root", repoRoot,
+		"--home", home,
+		"--state-root", stateRoot,
+		"--yes",
+	})
+
+	if err := install.Execute(); err != nil {
+		t.Fatalf("dots install failed in sandbox: %v\noutput:\n%s", err, installOut.String())
+	}
+
+	managed := []struct {
+		target string
+		source string
+	}{
+		{
+			target: filepath.Join(home, ".config", "atuin", "config.toml"),
+			source: filepath.Join(repoRoot, "configs", "atuin", "config.toml"),
+		},
+		{
+			target: filepath.Join(home, ".config", "atuin", "themes", "catppuccin-mocha.toml"),
+			source: filepath.Join(repoRoot, "configs", "atuin", "themes", "catppuccin-mocha.toml"),
+		},
+	}
+
+	for _, entry := range managed {
+		info, err := os.Lstat(entry.target)
+		if err != nil {
+			t.Fatalf("atuin target %q missing after sandbox install: %v\ninstall output:\n%s", entry.target, err, installOut.String())
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			t.Fatalf("atuin target %q mode = %v, want symlink", entry.target, info.Mode())
+		}
+		gotSource, err := os.Readlink(entry.target)
+		if err != nil {
+			t.Fatalf("read atuin symlink %q: %v", entry.target, err)
+		}
+		if gotSource != entry.source {
+			t.Fatalf("atuin symlink %q = %q, want %q", entry.target, gotSource, entry.source)
+		}
+	}
+
+	// History/sync/auth state lives in the data dir, never the config dir, so a
+	// fresh install must not create ~/.local/share/atuin in the sandbox home.
+	dataDir := filepath.Join(home, ".local", "share", "atuin")
+	if _, err := os.Stat(dataDir); !os.IsNotExist(err) {
+		t.Fatalf("atuin data dir %q should not exist after install; stat err = %v", dataDir, err)
+	}
+
+	status := cli.NewRootCommand()
+	var statusOut bytes.Buffer
+	status.SetOut(&statusOut)
+	status.SetErr(&statusOut)
+	status.SetArgs([]string{
+		"status",
+		"--file", filepath.Join(repoRoot, "dots.yaml"),
+		"--profile", "default",
+		"--source-root", repoRoot,
+		"--home", home,
+		"--state-root", stateRoot,
+	})
+
+	if err := status.Execute(); err != nil {
+		t.Fatalf("dots status failed in sandbox: %v\noutput:\n%s", err, statusOut.String())
+	}
+
+	got := statusOut.String()
+	for _, want := range []string{
+		"configs/atuin/config.toml -> " + managed[0].target,
+		"configs/atuin/themes/catppuccin-mocha.toml -> " + managed[1].target,
+		"Summary:",
+		"0 conflict",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("status output missing %q\noutput:\n%s", want, got)
+		}
+	}
+
+	if !strings.Contains(installOut.String(), "configs/atuin/config.toml") {
+		t.Fatalf("install plan did not include the Atuin managed entry\noutput:\n%s", installOut.String())
+	}
+}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -938,7 +938,7 @@ func TestRepositoryGitConfigInstallsAndReportsAlignedInSandbox(t *testing.T) {
 		"configs/git/gitconfig -> " + gitconfigTarget,
 		"configs/zellij/config.kdl -> " + zellijConfigTarget,
 		"configs/zellij/layouts/default.kdl -> " + zellijLayoutTarget,
-		"Summary: 8 ok, 0 missing, 0 conflict, 0 skipped, 0 drifted, 0 unsupported",
+		"Summary: 10 ok, 0 missing, 0 conflict, 0 skipped, 0 drifted, 0 unsupported",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("status output missing %q\noutput:\n%s", want, got)

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -958,8 +958,8 @@ func TestRepositoryManifestPlansMVPConfigurationSetSafely(t *testing.T) {
 		t.Fatalf("Build() error = %v", err)
 	}
 
-	if len(p.Actions) != 8 {
-		t.Fatalf("len(Actions) = %d, want 8", len(p.Actions))
+	if len(p.Actions) != 10 {
+		t.Fatalf("len(Actions) = %d, want 10", len(p.Actions))
 	}
 	for _, action := range p.Actions {
 		if action.Status != plan.StatusCreate {


### PR DESCRIPTION
Closes #44

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Migrate portable Atuin configuration into `dots` as a `core`-tagged slice (parent #37).
- Manage `config.toml` plus the referenced Catppuccin Mocha theme as symlinks; keep shell integration as the existing guarded Zsh hook.
- Exclude shell history, sync records, encryption key, auth session, and machine identity — all of which live in Atuin's data dir, never the config dir.

## Changes

| File | Change |
|------|--------|
| `configs/atuin/config.toml` | Portable Atuin config (Source of Truth): `enter_accept`, `filter_mode_shell_up_key_binding=session`, `[sync] records`, `[theme] name`. |
| `configs/atuin/themes/catppuccin-mocha.toml` | Portable theme referenced by the config, installed alongside it. |
| `configs/atuin/.gitignore` | Guards the config dir against history.db, records.db, `key`, `session`, `host_id`, receipt, and generated state. |
| `configs/atuin/README.md` | Portability classification table, env-var override guidance (`ATUIN_*`), and sandbox validation steps. |
| `dots.yaml` | Two `core` symlink entries (`darwin`+`linux`) with an advisory `atuin` dependency. |
| `internal/cli/atuin_config_test.go` | Sandbox test: both symlinks aligned, status reports `0 conflict`, data dir not created. |
| `internal/cli/cli_test.go` | Update default-profile summary count `8 -> 10`. |
| `internal/manifest/manifest_test.go` | Update default-profile action count `8 -> 10`. |

## Reviewer notes

- **No shell-hook changes.** The `atuin init zsh` integration already exists in `configs/zsh/rc.d/post/40-tools.zsh`, guarded by `command -v atuin`. This slice manages only the declarative config + theme.
- **Why history/auth/sync are safe.** Atuin stores `history.db`, `records.db`, `key`, `session`, and `host_id` in the data dir (`~/.local/share/atuin/`), not the config dir. The symlink strategy never touches the data dir; the test asserts it is not created on a fresh install.
- **No config include mechanism.** Unlike Ghostty's `config-file = ?`, Atuin layers `defaults -> config.toml -> ATUIN_* env vars` (nested keys use `__`). Machine-specific overrides are documented for `~/.zshrc.local`, not a `config.local` file.
- Atuin is classified as `core` (shell tool), so it joins the `default` profile — hence the two count-assertion updates.

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed install + status with `--home`, `--source-root`, `--state-root` temp dirs

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
