### PR TITLE
feat(config): migrate portable eza defaults

### DIFF
--- a/configs/eza/README.md
+++ b/configs/eza/README.md
@@ -1,0 +1,99 @@
+# eza configuration
+
+eza is an **alias-only** slice (issue #45, epic #37). It has **no
+repository-managed config file** and **no `dots.yaml` entry** — the entire
+portable footprint is one guarded shell alias, and that alias is owned by the
+**Zsh slice**, not by eza.
+
+```zsh
+# configs/zsh/rc.d/post/50-aliases.zsh
+command -v eza >/dev/null 2>&1 && \
+  alias ls='eza -a --icons=always --color=always --grid --group-directories-first'
+```
+
+The `command -v eza` guard keeps the shell usable when eza is absent, so a fresh
+machine without eza still starts cleanly and `ls` falls back to the system
+binary. This slice manages only the **decision and its rationale** — there is no
+file for `dots` to install.
+
+## Why there is no managed config file
+
+eza is configured two ways, neither of which produces a portable file worth
+versioning here:
+
+1. **CLI flags** — all behavior in use (`-a`, `--icons`, `--color`, `--grid`,
+   `--group-directories-first`) is expressed inline in the alias above. The alias
+   already lives in the Zsh slice, so there is nothing else to manage.
+2. **`theme.yml`** — eza's only standalone config surface is a colors-only
+   `theme.yml`, discovered via `EZA_CONFIG_DIR` (default `~/.config/eza/`). The
+   Source of Truth machine **does not use one**: there is no `~/.config/eza/`
+   directory, no `theme.yml`, and no `EZA_*` environment variables. Colors come
+   from the inline `--color=always` flag plus the terminal palette.
+
+Introducing a `theme.yml` that no machine actually runs would be **inventing
+configuration**, which contradicts epic #37's principle of treating current
+machine configuration as *input evidence, not source code to copy verbatim*. If
+a custom eza theme is ever adopted on a real machine, that becomes its own
+migration slice with real evidence behind it.
+
+## Portability classification
+
+The live eza usage was classified before adoption:
+
+| Category | Examples | Repository decision |
+| --- | --- | --- |
+| **Portable** | the `ls` alias flag set (`-a --icons=always --color=always --grid --group-directories-first`) | Owned by the Zsh slice in `configs/zsh/rc.d/post/50-aliases.zsh`, guarded by `command -v eza`. |
+| **Machine-specific** | `EZA_CONFIG_DIR`, any per-host theme | None in use. Would belong in `~/.zshrc.local` (env var) if ever needed — never committed. |
+| **Generated / private** | — | eza is stateless: no history, cache, tokens, or machine identity. Nothing to exclude. |
+
+The alias set is intentionally **strict**: only the single `ls` alias that runs
+on the Source of Truth machine is migrated. `ll`, `lt`, tree views, and other
+common eza aliases are **not** added, because they are not in real use — adding
+them would be the same "copy verbatim / invent config" failure mode rejected for
+`theme.yml`.
+
+## Local machine overrides
+
+If a machine ever needs eza-specific configuration, layer it without touching the
+shared slice:
+
+- A custom theme: set `EZA_CONFIG_DIR` and drop a `theme.yml` there, exporting the
+  variable from `~/.zshrc.local` (never committed).
+- Extra aliases: add them to `~/.zshrc.local`.
+
+If a setting turns out to be portable for every machine, review it and promote it
+into the appropriate shared slice instead of leaving it local.
+
+## Sandbox validation
+
+Because this slice adds **no** managed file, validation is a **negative
+assertion**: prove that `dots` installs and reports alignment safely *without*
+creating any eza artifact, and that the real `$HOME` is untouched (per
+`AGENTS.md`). Use temporary directories plus explicit flags — never your real
+`$HOME` or `~/.config/eza`:
+
+```sh
+sandbox_root="$(mktemp -d)"
+sandbox_home="$sandbox_root/home"
+sandbox_state="$sandbox_root/state"
+mkdir -p "$sandbox_home" "$sandbox_state"
+
+go run ./cmd/dots install \
+  --profile default --yes \
+  --home "$sandbox_home" --source-root "$PWD" --state-root "$sandbox_state"
+
+go run ./cmd/dots status \
+  --profile default \
+  --home "$sandbox_home" --source-root "$PWD" --state-root "$sandbox_state"
+```
+
+Expected results:
+
+- `install` and `status` run clean and report existing managed entries as aligned.
+- **No** `~/.config/eza/` artifact is created inside `$sandbox_home` — there is no
+  eza entry in `dots.yaml` to install.
+- The maintainer's real home directory is never touched.
+
+The alias-guard behavior is owned by the Zsh slice: sourcing
+`configs/zsh/rc.d/post/50-aliases.zsh` defines `ls` only when eza is present and
+starts the shell without error when it is absent.

--- a/configs/zsh/rc.d/post/50-aliases.zsh
+++ b/configs/zsh/rc.d/post/50-aliases.zsh
@@ -1,6 +1,7 @@
 # Aliases. Guarded where they depend on an optional tool.
 
-# Prefer eza for `ls` when available.
+# Prefer eza for `ls` when available. eza is an alias-only slice with no managed
+# config file; see configs/eza/README.md for the rationale.
 if command -v eza >/dev/null 2>&1; then
   alias ls='eza -a --icons=always --color=always --grid --group-directories-first'
 fi


### PR DESCRIPTION
Closes #45

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Slice 8 of epic #37. Classifies eza usage and migrates it as an **alias-only** slice: the only real footprint is the guarded `ls` alias already owned by the Zsh slice.
- Adds a dedicated `configs/eza/README.md` documenting why there is no managed config file and no `theme.yml` (the user runs neither; adding one would invent config against the epic's "input evidence, not verbatim copy" principle).
- No behavior change and no new `dots.yaml` entry — eza installs nothing. This is the first epic-#37 slice that adds no managed file, so its validation is a negative assertion.

## Changes

| File | Change |
|------|--------|
| `configs/eza/README.md` | New. Documents the alias-only decision, the strict single-`ls` scope, the portability classification, local-override guidance, and sandbox validation (negative assertion). |
| `configs/zsh/rc.d/post/50-aliases.zsh` | Added a comment cross-referencing the eza README. The guarded `ls` alias is unchanged. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed `install`/`status` against a temp `--home`: 10 create / 10 ok, 0 conflict, 0 drifted. Confirmed **no** `~/.config/eza` artifact is created and `dots.yaml` has no eza entry.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #45`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.