### PR TITLE
feat(config): migrate portable bat configuration

### DIFF
--- a/configs/bat/README.md
+++ b/configs/bat/README.md
@@ -1,0 +1,105 @@
+# bat configuration
+
+bat is a **single-file** slice (issue #46, epic #37). The entire portable
+footprint is one managed config file:
+
+```
+# configs/bat/config
+--theme="Catppuccin Mocha"
+```
+
+`dots` symlinks it to `~/.config/bat/config`. There is **no managed theme file**
+and **no managed cache** — the only thing this slice owns is the theme selection,
+and the theme it selects ships **inside bat itself**.
+
+## Why the theme is selected but not vendored
+
+`Catppuccin Mocha` is a **built-in bat theme** as of **bat 0.25**. On the
+Source-of-Truth machine (bat 0.26.1), `--theme="Catppuccin Mocha"` resolves to
+the built-in theme with no custom theme file present — verified against an empty
+config directory:
+
+```sh
+echo test | BAT_CONFIG_DIR="$(mktemp -d)" bat --theme="Catppuccin Mocha" -p -l txt
+# renders with Catppuccin Mocha colors, exit 0
+```
+
+So the config line is portable on its own: any machine with bat ≥ 0.25 renders it
+identically without shipping a single byte of theme data.
+
+## Why there is no managed theme file or cache
+
+The live machine still carries leftover state from before bat bundled
+Catppuccin. It is **intentionally excluded** from the repo:
+
+| Live artifact | Category | Repository decision |
+| --- | --- | --- |
+| `~/.config/bat/config` (`--theme="Catppuccin Mocha"`) | **Portable / source-of-truth** | Managed as `configs/bat/config`, symlinked via `dots.yaml`. |
+| `~/.config/bat/themes/Catppuccin Mocha.tmTheme` (~66 KB) | **Downloaded / redundant** | **Excluded.** The theme is built-in since bat 0.25, so the file is dead weight, not source-owned. Versioning it would be copying machine state verbatim — exactly what epic #37 rejects. |
+| `~/.cache/bat/` (`syntaxes.bin`, `themes.bin`, `metadata.yaml`) | **Generated** (`bat cache --build`) | **Excluded.** Regenerable, and only existed to register the redundant custom theme. With the built-in theme there is nothing to build. |
+| Shell alias (`cat`→`bat`), `BAT_THEME` / `MANPAGER` / `BAT_*` env | **Not in use** | Nothing to migrate. If ever adopted, they belong to the Zsh slice or a future slice — never invented here. |
+
+Contrast with the **atuin** slice, which *does* vendor `catppuccin-mocha.toml`:
+atuin's Catppuccin theme is **not** built-in, so the file is genuine
+source-of-truth there. bat is the opposite case — same palette, different
+ownership, because the evidence differs.
+
+## Version floor and fallback
+
+This slice relies on bat's **built-in** Catppuccin themes, available from
+**bat ≥ 0.25**. The `dots.yaml` entry declares a `bat` dependency
+(`brew` / `apt` / `dnf` / `pacman`), and the runtime `command: bat` guard keeps
+install/status safe when bat is absent.
+
+On an **older bat** (some distro packages still ship < 0.25, e.g. older Ubuntu
+LTS), the config degrades **gracefully**: bat parses `--theme="Catppuccin Mocha"`,
+finds no matching theme, and falls back to its default theme. The shell and
+`bat` stay usable — there is **no error and no broken startup**. The slice does
+not hard-pin a minimum version; a graceful fallback is preferred over install
+friction.
+
+## Local machine overrides
+
+Layer machine-specific bat settings without touching this slice:
+
+- A different theme on one host: set it in a local, uncommitted bat config, or
+  export `BAT_THEME` from `~/.zshrc.local`.
+- A genuinely custom theme: drop the `.tmTheme` into `~/.config/bat/themes/`,
+  run `bat cache --build`, and keep both out of the repo (the cache is generated;
+  the theme is host-local) unless it becomes portable for every machine — in
+  which case promote it into a dedicated slice with real evidence behind it.
+
+The redundant `~/.config/bat/themes/Catppuccin Mocha.tmTheme` already on the live
+machine can be removed manually at your convenience; this slice deliberately does
+**not** touch the real `$HOME`.
+
+## Sandbox validation
+
+Validate against temporary directories with explicit flags — never the real
+`$HOME` or `~/.config/bat` (per `AGENTS.md`):
+
+```sh
+sandbox_root="$(mktemp -d)"
+sandbox_home="$sandbox_root/home"
+sandbox_state="$sandbox_root/state"
+mkdir -p "$sandbox_home" "$sandbox_state"
+
+go run ./cmd/dots install \
+  --profile default --yes \
+  --home "$sandbox_home" --source-root "$PWD" --state-root "$sandbox_state"
+
+go run ./cmd/dots status \
+  --profile default \
+  --home "$sandbox_home" --source-root "$PWD" --state-root "$sandbox_state"
+```
+
+Expected results:
+
+- `install` and `status` run clean and report the bat entry as **aligned**.
+- `$sandbox_home/.config/bat/config` is a symlink into the repo and resolves the
+  **built-in** Catppuccin Mocha theme:
+  `echo test | BAT_CONFIG_DIR="$sandbox_home/.config/bat" bat -p -l txt` renders
+  with Catppuccin colors and exits 0.
+- **No** `~/.config/bat/themes/` and **no** `~/.cache/bat/` artifact is created
+  by `dots` — there is no such entry in `dots.yaml`.
+- The maintainer's real home directory is never touched.

--- a/configs/bat/config
+++ b/configs/bat/config
@@ -1,0 +1,1 @@
+--theme="Catppuccin Mocha"

--- a/dots.yaml
+++ b/dots.yaml
@@ -156,3 +156,18 @@ entries:
       - name: atuin
         command: atuin
         brew: atuin
+  - source: configs/bat/config
+    target: ~/.config/bat/config
+    strategy: symlink
+    tags:
+      - core
+    os:
+      - darwin
+      - linux
+    dependencies:
+      - name: bat
+        command: bat
+        brew: bat
+        apt: bat
+        dnf: bat
+        pacman: bat

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -938,7 +938,7 @@ func TestRepositoryGitConfigInstallsAndReportsAlignedInSandbox(t *testing.T) {
 		"configs/git/gitconfig -> " + gitconfigTarget,
 		"configs/zellij/config.kdl -> " + zellijConfigTarget,
 		"configs/zellij/layouts/default.kdl -> " + zellijLayoutTarget,
-		"Summary: 10 ok, 0 missing, 0 conflict, 0 skipped, 0 drifted, 0 unsupported",
+		"Summary: 11 ok, 0 missing, 0 conflict, 0 skipped, 0 drifted, 0 unsupported",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("status output missing %q\noutput:\n%s", want, got)

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -958,8 +958,8 @@ func TestRepositoryManifestPlansMVPConfigurationSetSafely(t *testing.T) {
 		t.Fatalf("Build() error = %v", err)
 	}
 
-	if len(p.Actions) != 10 {
-		t.Fatalf("len(Actions) = %d, want 10", len(p.Actions))
+	if len(p.Actions) != 11 {
+		t.Fatalf("len(Actions) = %d, want 11", len(p.Actions))
 	}
 	for _, action := range p.Actions {
 		if action.Status != plan.StatusCreate {


### PR DESCRIPTION
Closes #46

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Migrate the portable `bat` config as a single managed file (`configs/bat/config` → `~/.config/bat/config`), epic #37 slice 9.
- Rely on bat's **built-in** Catppuccin Mocha theme (built-in since bat 0.25); exclude the redundant custom `.tmTheme` and the generated cache.
- Document the classification, the bat ≥ 0.25 version floor, and the graceful fallback on older bat.

## Changes

| File | Change |
|------|--------|
| `configs/bat/config` | New managed config: single line `--theme="Catppuccin Mocha"`. |
| `configs/bat/README.md` | Portability classification, built-in-theme rationale, version floor + fallback, sandbox validation. Contrasts with the atuin slice (which vendors its theme because it is not built-in). |
| `dots.yaml` | New symlink entry after atuin: `~/.config/bat/config`, `tags: [core]`, `os: [darwin, linux]`, `bat` dependency (`command` guard + `brew`/`apt`/`dnf`/`pacman`). |
| `internal/manifest/manifest_test.go` | Bump expected managed actions 10 → 11. |
| `internal/cli/cli_test.go` | Bump sandbox status summary 10 → 11 ok. |

### Why the theme is not vendored

`Catppuccin Mocha` ships inside bat as of 0.25. Verified on bat 0.26.1 that `--theme="Catppuccin Mocha"` resolves against an empty config dir, so the live `~/.config/bat/themes/Catppuccin Mocha.tmTheme` (~66 KB) and `~/.cache/bat/*` are redundant downloaded/generated state — excluding them follows epic #37's "input evidence, not source to copy verbatim" principle.

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed install + status: `dots install`/`status` with `--home <tmp> --source-root "$PWD" --state-root <tmp>` → 11 create / 11 ok, 0 conflict, 0 drifted; symlinked config resolves the built-in theme; no `themes/` or `~/.cache/bat/` created by `dots`.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #46`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
