### PR TITLE
feat(provision): add allowlisted provisioner primitive

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -13,6 +14,7 @@ import (
 	"github.com/yersonargotev/dots/internal/install"
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/plan"
+	"github.com/yersonargotev/dots/internal/provision"
 	"github.com/yersonargotev/dots/internal/tui"
 )
 
@@ -56,11 +58,26 @@ func newInstallCommand() *cobra.Command {
 			}
 
 			renderPlan(cmd.OutOrStdout(), p)
+
+			provPlan, err := provision.Build(*m, provision.Options{Profile: profile, OS: runtime.GOOS})
+			if err != nil {
+				return err
+			}
+			renderProvisionPlan(cmd.OutOrStdout(), provPlan)
+
 			if dryRun {
 				return nil
 			}
 
-			return resolveAndApply(cmd, p, paths, yes, noTUI)
+			applied, err := resolveAndApply(cmd, p, paths, yes, noTUI)
+			if err != nil {
+				return err
+			}
+			if !applied {
+				return nil
+			}
+
+			return runProvisioners(cmd, *m, profile, paths.Home)
 		},
 	}
 
@@ -75,11 +92,34 @@ func newInstallCommand() *cobra.Command {
 	return cmd
 }
 
+// runProvisioners executes the selected provisioners after dependency installs
+// and file entries, in the same install run. It threads HOME from the resolved
+// --home so a sandboxed install lands every tool-managed file under the
+// temporary home. Apply stops at the first failing provisioner and returns the
+// error, which the caller surfaces; the tool's own stdout/stderr are streamed
+// through so its progress is visible.
+func runProvisioners(cmd *cobra.Command, m manifest.Manifest, profile, home string) error {
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	runner := provisionExecRunner{
+		ctx:    ctx,
+		home:   home,
+		stdin:  cmd.InOrStdin(),
+		stdout: cmd.OutOrStdout(),
+		stderr: cmd.ErrOrStderr(),
+	}
+	report, err := provision.Apply(m, provision.Options{Profile: profile, OS: runtime.GOOS}, lookupCommand, runner)
+	renderProvisionReport(cmd.OutOrStdout(), report)
+	return err
+}
+
 // resolveAndApply resolves the plan's conflicts (via the TUI, text prompts, or
 // the conservative --yes default) and applies it with Backup Set protection. It
 // is shared by install and update so post-update installation reuses identical
 // Conflict Resolution and filesystem machinery instead of reimplementing it.
-func resolveAndApply(cmd *cobra.Command, p plan.Plan, paths resolvedPaths, yes, noTUI bool) error {
+func resolveAndApply(cmd *cobra.Command, p plan.Plan, paths resolvedPaths, yes, noTUI bool) (bool, error) {
 	var (
 		decisions map[string]install.ConflictDecision
 		err       error
@@ -90,20 +130,20 @@ func resolveAndApply(cmd *cobra.Command, p plan.Plan, paths resolvedPaths, yes, 
 	case noTUI:
 		decisions, err = promptConflictDecisions(cmd, p, paths.Home, paths.SourceRoot)
 		if err != nil {
-			return err
+			return false, err
 		}
 	default:
 		decisions, err = resolveConflictsTUI(cmd, p, paths.Home, paths.SourceRoot)
 		if errors.Is(err, tui.ErrCanceled) {
 			fmt.Fprintln(cmd.OutOrStdout(), "Conflict resolution canceled; no changes applied.")
-			return nil
+			return false, nil
 		}
 		if err != nil {
-			return err
+			return false, err
 		}
 	}
 
-	return install.Apply(p, install.Options{SourceRoot: paths.SourceRoot, Home: paths.Home, StateRoot: paths.StateRoot, ConflictDecisions: decisions})
+	return true, install.Apply(p, install.Options{SourceRoot: paths.SourceRoot, Home: paths.Home, StateRoot: paths.StateRoot, ConflictDecisions: decisions})
 }
 
 // resolveConflictsTUI launches the Bubble Tea conflict resolver for the plan's

--- a/internal/cli/install_provision_test.go
+++ b/internal/cli/install_provision_test.go
@@ -1,0 +1,186 @@
+package cli_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/cli"
+)
+
+const provisionerManifest = `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+provisioners:
+  - tool: gentle-ai
+    tags: [core]
+    spec:
+      scope: global
+      persona: neutral
+      agents: [codex]
+    dependencies:
+      - name: gentle-ai
+      - name: engram
+`
+
+func writeExecStub(t *testing.T, path, script string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write stub %s: %v", path, err)
+	}
+}
+
+// TestInstallDryRunRendersProvisionerWithoutInvoking proves --dry-run prints the
+// resolved provisioner command and the roots it affects, while creating no files
+// and never invoking the tool (gentle-ai is absent, so an invocation would
+// error; the run succeeds because dry-run returns before any execution).
+func TestInstallDryRunRendersProvisionerWithoutInvoking(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	writeCLISource(t, sourceRoot, "configs/zsh/zshrc", "managed\n")
+	manifestPath := writeCLIManifest(t, home, provisionerManifest)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"install", "--dry-run", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+
+	if _, err := os.Lstat(filepath.Join(home, ".zshrc")); !os.IsNotExist(err) {
+		t.Fatalf("dry-run created the file entry; lstat err = %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{
+		`Provisioners for profile "default"`,
+		"gentle-ai install --scope global --persona neutral --agents codex",
+		"affects: ~/.claude, ~/.codex, ~/.gentle-ai",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("dry-run output missing %q\noutput:\n%s", want, got)
+		}
+	}
+}
+
+// TestInstallExecutesProvisionerAfterFilesWithHomeThreaded proves a real install
+// runs the provisioner after file entries, via the Runner, with HOME threaded
+// from --home so the tool writes under the sandbox home and never the inherited
+// one.
+func TestInstallExecutesProvisionerAfterFilesWithHomeThreaded(t *testing.T) {
+	sandboxHome := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	fakeRealHome := t.TempDir()
+	t.Setenv("HOME", fakeRealHome)
+
+	stubDir := t.TempDir()
+	writeExecStub(t, filepath.Join(stubDir, "gentle-ai"), "#!/bin/sh\nprintf 'ok' > \"$HOME/gentle-ai-ran\"\n")
+	writeExecStub(t, filepath.Join(stubDir, "engram"), "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	writeCLISource(t, sourceRoot, "configs/zsh/zshrc", "managed\n")
+	manifestPath := writeCLIManifest(t, sandboxHome, provisionerManifest)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"install", "--yes", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+
+	// The file entry must be installed.
+	if _, err := os.Lstat(filepath.Join(sandboxHome, ".zshrc")); err != nil {
+		t.Fatalf("install did not create the file entry: %v", err)
+	}
+	// The provisioner must have run with HOME threaded to the sandbox.
+	if _, err := os.Stat(filepath.Join(sandboxHome, "gentle-ai-ran")); err != nil {
+		t.Fatalf("provisioner did not run under the sandbox HOME %q: %v", sandboxHome, err)
+	}
+	if _, err := os.Stat(filepath.Join(fakeRealHome, "gentle-ai-ran")); err == nil {
+		t.Fatalf("provisioner wrote into the inherited HOME %q instead of the sandbox", fakeRealHome)
+	}
+}
+
+// TestInstallTUICancelDoesNotRunProvisioners proves canceling conflict
+// resolution aborts the whole install before any provisioner can mutate
+// tool-managed config roots.
+func TestInstallTUICancelDoesNotRunProvisioners(t *testing.T) {
+	sandboxHome := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	fakeRealHome := t.TempDir()
+	t.Setenv("HOME", fakeRealHome)
+
+	stubDir := t.TempDir()
+	writeExecStub(t, filepath.Join(stubDir, "gentle-ai"), "#!/bin/sh\nprintf 'ran' > \"$HOME/gentle-ai-ran\"\n")
+	writeExecStub(t, filepath.Join(stubDir, "engram"), "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	writeCLISource(t, sourceRoot, "configs/git/gitconfig", "managed\n")
+	if err := os.WriteFile(filepath.Join(sandboxHome, ".gitconfig"), []byte("local\n"), 0o600); err != nil {
+		t.Fatalf("write local target: %v", err)
+	}
+	manifestPath := writeCLIManifest(t, sandboxHome, `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/git/gitconfig
+    target: ~/.gitconfig
+    strategy: copy
+    tags: [core]
+provisioners:
+  - tool: gentle-ai
+    tags: [core]
+    spec:
+      scope: global
+      persona: neutral
+      agents: [codex]
+    dependencies:
+      - name: gentle-ai
+      - name: engram
+`)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetIn(strings.NewReader("q"))
+	cmd.SetArgs([]string{"install", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+
+	got, err := os.ReadFile(filepath.Join(sandboxHome, ".gitconfig"))
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(got) != "local\n" {
+		t.Fatalf("canceled install changed conflict target to %q", got)
+	}
+	if _, err := os.Stat(filepath.Join(sandboxHome, "gentle-ai-ran")); !os.IsNotExist(err) {
+		t.Fatalf("canceled install ran provisioner in sandbox HOME; stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(fakeRealHome, "gentle-ai-ran")); !os.IsNotExist(err) {
+		t.Fatalf("canceled install ran provisioner in inherited HOME; stat err = %v", err)
+	}
+	if !strings.Contains(out.String(), "Conflict resolution canceled; no changes applied.") {
+		t.Fatalf("cancel output missing abort message\noutput:\n%s", out.String())
+	}
+}

--- a/internal/cli/provision_runner.go
+++ b/internal/cli/provision_runner.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// provisionExecRunner executes an allowlisted provisioner command with HOME
+// threaded from the install's --home value, so a sandboxed install lands every
+// tool-managed file under the temporary home and never the real one. It
+// implements deps.Runner, reusing that boundary for execution; HOME threading is
+// this concrete runner's responsibility, not the provision orchestration's.
+type provisionExecRunner struct {
+	ctx    context.Context
+	home   string
+	stdin  io.Reader
+	stdout io.Writer
+	stderr io.Writer
+	// baseEnv is the environment to thread HOME into. It is os.Environ() in
+	// production and is injectable so sandbox tests never touch the real HOME.
+	baseEnv []string
+}
+
+func (r provisionExecRunner) Run(executable string, args []string) error {
+	cmd := exec.CommandContext(r.ctx, executable, args...)
+	cmd.Stdin = r.stdin
+	cmd.Stdout = r.stdout
+	cmd.Stderr = r.stderr
+
+	base := r.baseEnv
+	if base == nil {
+		base = os.Environ()
+	}
+	cmd.Env = envWithHome(base, r.home)
+	return cmd.Run()
+}
+
+// envWithHome returns base with every HOME entry removed and a single HOME=home
+// appended. Dropping inherited HOME entries is required because a child's libc
+// getenv commonly returns the first match, so merely appending HOME would let an
+// inherited real HOME win over the sandbox value.
+func envWithHome(base []string, home string) []string {
+	out := make([]string, 0, len(base)+1)
+	for _, kv := range base {
+		if strings.HasPrefix(kv, "HOME=") {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return append(out, "HOME="+home)
+}

--- a/internal/cli/provision_runner_test.go
+++ b/internal/cli/provision_runner_test.go
@@ -1,0 +1,140 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/manifest"
+)
+
+func TestEnvWithHomeOverridesExistingHome(t *testing.T) {
+	base := []string{"PATH=/usr/bin", "HOME=/real/home", "EDITOR=nvim"}
+
+	got := envWithHome(base, "/sandbox/home")
+
+	// There must be exactly one HOME entry and it must be the sandbox value, so a
+	// libc getenv (which commonly returns the first match) cannot resolve the
+	// inherited real HOME.
+	var homeCount int
+	var homeValue string
+	for _, kv := range got {
+		if strings.HasPrefix(kv, "HOME=") {
+			homeCount++
+			homeValue = strings.TrimPrefix(kv, "HOME=")
+		}
+	}
+	if homeCount != 1 {
+		t.Fatalf("HOME entries = %d, want exactly 1 (got env %#v)", homeCount, got)
+	}
+	if homeValue != "/sandbox/home" {
+		t.Fatalf("HOME = %q, want /sandbox/home", homeValue)
+	}
+
+	// Unrelated variables must be preserved.
+	if !containsEnv(got, "PATH=/usr/bin") || !containsEnv(got, "EDITOR=nvim") {
+		t.Fatalf("env lost unrelated variables: %#v", got)
+	}
+}
+
+func TestProvisionExecRunnerThreadsHomeToSubprocess(t *testing.T) {
+	sandboxHome := t.TempDir()
+	fakeRealHome := t.TempDir()
+
+	// A stub standing in for gentle-ai: it writes a marker into whatever HOME the
+	// subprocess sees. A correctly threaded runner makes that the sandbox home.
+	stub := filepath.Join(t.TempDir(), "gentle-ai")
+	script := "#!/bin/sh\nprintf 'provisioned' > \"$HOME/marker\"\n"
+	if err := os.WriteFile(stub, []byte(script), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+
+	runner := provisionExecRunner{
+		ctx:    context.Background(),
+		home:   sandboxHome,
+		stdout: io.Discard,
+		stderr: io.Discard,
+		// Inject a base env carrying a DIFFERENT HOME so the test can never write to
+		// the real $HOME, and so the override path is exercised.
+		baseEnv: []string{"HOME=" + fakeRealHome, "PATH=" + os.Getenv("PATH")},
+	}
+
+	if err := runner.Run(stub, []string{"install", "--scope", "global"}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(sandboxHome, "marker")); err != nil {
+		t.Fatalf("expected marker in sandbox home %q: %v", sandboxHome, err)
+	}
+	if _, err := os.Stat(filepath.Join(fakeRealHome, "marker")); err == nil {
+		t.Fatalf("provisioner wrote into the inherited HOME %q instead of the sandbox", fakeRealHome)
+	}
+}
+
+func TestRunProvisionersRendersPartialReportOnFailure(t *testing.T) {
+	home := t.TempDir()
+	stubDir := t.TempDir()
+	countPath := filepath.Join(t.TempDir(), "gentle-ai-count")
+	t.Setenv("PROVISION_COUNT", countPath)
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	script := `#!/bin/sh
+if [ -f "$PROVISION_COUNT" ]; then
+  printf failed > "$HOME/second-attempt"
+  exit 7
+fi
+printf first > "$PROVISION_COUNT"
+printf ok > "$HOME/first-attempt"
+`
+	if err := os.WriteFile(filepath.Join(stubDir, "gentle-ai"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write gentle-ai stub: %v", err)
+	}
+
+	m := manifest.Manifest{
+		Version: 1,
+		Profiles: map[string]manifest.Profile{
+			"default": {Tags: []string{"core"}},
+		},
+		Entries: []manifest.Entry{
+			{Source: "configs/zsh/zshrc", Target: "~/.zshrc", Strategy: "symlink", Tags: []string{"core"}},
+		},
+		Provisioners: []manifest.Provisioner{
+			{Tool: "gentle-ai", Tags: []string{"core"}, Spec: manifest.ProvisionerSpec{Scope: "global", Agents: []string{"codex"}}},
+			{Tool: "gentle-ai", Tags: []string{"core"}, Spec: manifest.ProvisionerSpec{Scope: "global", Agents: []string{"claude"}}},
+		},
+	}
+
+	cmd := NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	err := runProvisioners(cmd, m, "default", home)
+	if err == nil {
+		t.Fatal("runProvisioners() error = nil, want second provisioner failure")
+	}
+
+	got := out.String()
+	for _, want := range []string{
+		`Provisioner results for profile "default"`,
+		"gentle-ai install --scope global --agents codex — provisioned",
+		"gentle-ai install --scope global --agents claude — failed",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("partial report missing %q\noutput:\n%s", want, got)
+		}
+	}
+}
+
+func containsEnv(env []string, want string) bool {
+	for _, kv := range env {
+		if kv == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/render_doctor.go
+++ b/internal/cli/render_doctor.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 
+	"strings"
+
 	"github.com/yersonargotev/dots/internal/doctor"
 	"github.com/yersonargotev/dots/internal/status"
 )
@@ -19,7 +21,39 @@ func renderDoctor(w io.Writer, report doctor.Report) {
 
 	renderDoctorDependencies(w, report)
 	renderDoctorConfiguration(w, report)
+	renderDoctorProvisioners(w, report)
 	renderDoctorSecrets(w, report)
+}
+
+// renderDoctorProvisioners reports the readiness of each declared provisioner:
+// whether its dependencies are present so it could run. It never executes the
+// tool. A provisioner is "not ready" when any declared dependency is missing.
+func renderDoctorProvisioners(w io.Writer, report doctor.Report) {
+	items := report.Provisioners.Items
+	if len(items) == 0 {
+		fmt.Fprintln(w, "Provisioners: ok (no provisioners declared)")
+		return
+	}
+
+	var notReady int
+	for _, item := range items {
+		if len(item.Missing) > 0 {
+			notReady++
+		}
+	}
+	if notReady == 0 {
+		fmt.Fprintf(w, "Provisioners: ok (%d ready, 0 not ready)\n", len(items))
+		return
+	}
+
+	fmt.Fprintf(w, "Provisioners: warn (%d not ready)\n", notReady)
+	for _, item := range items {
+		if len(item.Missing) == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "  not ready: %s %s (missing: %s)\n",
+			item.Executable, strings.Join(item.Args, " "), strings.Join(item.Missing, ", "))
+	}
 }
 
 func renderDoctorDependencies(w io.Writer, report doctor.Report) {

--- a/internal/cli/render_doctor_golden_test.go
+++ b/internal/cli/render_doctor_golden_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/yersonargotev/dots/internal/deps"
 	"github.com/yersonargotev/dots/internal/doctor"
+	"github.com/yersonargotev/dots/internal/provision"
 	"github.com/yersonargotev/dots/internal/status"
 )
 
@@ -44,6 +45,25 @@ func TestRenderDoctorGolden(t *testing.T) {
 				SecretScan:    doctor.SecretReport{},
 			},
 			golden: "doctor_clean.golden",
+		},
+		{
+			name: "provisioner not ready",
+			report: doctor.Report{
+				Profile:       "default",
+				Platform:      doctor.Platform{Supported: true, OS: "darwin"},
+				Dependencies:  deps.CheckReport{Profile: "default"},
+				Configuration: status.Report{Profile: "default"},
+				Provisioners: provision.CheckReport{Profile: "default", Items: []provision.Readiness{
+					{
+						Tool:       "gentle-ai",
+						Executable: "gentle-ai",
+						Args:       []string{"install", "--scope", "global", "--agents", "codex"},
+						Missing:    []string{"engram"},
+					},
+				}},
+				SecretScan: doctor.SecretReport{},
+			},
+			golden: "doctor_provisioner_not_ready.golden",
 		},
 	}
 

--- a/internal/cli/render_provision.go
+++ b/internal/cli/render_provision.go
@@ -1,0 +1,47 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/yersonargotev/dots/internal/provision"
+)
+
+// renderProvisionPlan writes a deterministic preview of the Provisioner steps an
+// install would run: the exact resolved command and the roots each tool affects.
+// It renders nothing when no Provisioner is selected so manifests without a
+// provisioners section stay quiet. The output is stable for golden testing and
+// is what `dots install --dry-run` shows without invoking any tool.
+func renderProvisionPlan(w io.Writer, p provision.Plan) {
+	if len(p.Steps) == 0 {
+		return
+	}
+
+	fmt.Fprintf(w, "\nProvisioners for profile %q\n\n", p.Profile)
+	for _, step := range p.Steps {
+		fmt.Fprintf(w, "  %s %s\n", step.Executable, strings.Join(step.Args, " "))
+		if len(step.Targets) > 0 {
+			fmt.Fprintf(w, "    affects: %s\n", strings.Join(step.Targets, ", "))
+		}
+	}
+	fmt.Fprintf(w, "\nSummary: %d provisioner(s)\n", len(p.Steps))
+}
+
+// renderProvisionReport writes the actual execution outcomes for provisioners.
+// It is deliberately emitted even when Apply returns an error so users can see
+// which provisioners completed before the failing step stopped the run.
+func renderProvisionReport(w io.Writer, r provision.Report) {
+	if len(r.Items) == 0 {
+		return
+	}
+
+	fmt.Fprintf(w, "\nProvisioner results for profile %q\n\n", r.Profile)
+	for _, item := range r.Items {
+		fmt.Fprintf(w, "  %s %s — %s", item.Executable, strings.Join(item.Args, " "), item.Status)
+		if len(item.Missing) > 0 {
+			fmt.Fprintf(w, " (missing: %s)", strings.Join(item.Missing, ", "))
+		}
+		fmt.Fprintln(w)
+	}
+}

--- a/internal/cli/render_provision_golden_test.go
+++ b/internal/cli/render_provision_golden_test.go
@@ -1,0 +1,65 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/provision"
+)
+
+func TestRenderProvisionPlanGolden(t *testing.T) {
+	tests := []struct {
+		name   string
+		plan   provision.Plan
+		golden string
+	}{
+		{
+			name: "single provisioner",
+			plan: provision.Plan{
+				Profile: "default",
+				Steps: []provision.Step{
+					{
+						Tool:       "gentle-ai",
+						Executable: "gentle-ai",
+						Args:       []string{"install", "--scope", "global", "--persona", "neutral", "--agents", "codex"},
+						Targets:    []string{"~/.claude", "~/.codex", "~/.gentle-ai"},
+					},
+				},
+			},
+			golden: "provision_single.golden",
+		},
+		{
+			name:   "no provisioners renders nothing",
+			plan:   provision.Plan{Profile: "default"},
+			golden: "provision_empty.golden",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			renderProvisionPlan(&out, tt.plan)
+
+			goldenPath := filepath.Join("testdata", tt.golden)
+			if *update {
+				if err := os.MkdirAll("testdata", 0o755); err != nil {
+					t.Fatalf("mkdir testdata: %v", err)
+				}
+				if err := os.WriteFile(goldenPath, out.Bytes(), 0o600); err != nil {
+					t.Fatalf("write golden: %v", err)
+				}
+				return
+			}
+
+			want, err := os.ReadFile(goldenPath)
+			if err != nil {
+				t.Fatalf("read golden (run with -update to create): %v", err)
+			}
+			if got := out.Bytes(); !bytes.Equal(got, want) {
+				t.Fatalf("golden mismatch for %s\n got:\n%s\nwant:\n%s", tt.golden, got, want)
+			}
+		})
+	}
+}

--- a/internal/cli/render_status.go
+++ b/internal/cli/render_status.go
@@ -3,7 +3,9 @@ package cli
 import (
 	"fmt"
 	"io"
+	"strings"
 
+	"github.com/yersonargotev/dots/internal/provision"
 	"github.com/yersonargotev/dots/internal/status"
 )
 
@@ -45,4 +47,22 @@ func renderStatus(w io.Writer, report status.Report) {
 
 	fmt.Fprintf(w, "\nSummary: %d ok, %d missing, %d conflict, %d skipped, %d drifted, %d unsupported\n",
 		counts.ok, counts.missing, counts.conflict, counts.skipped, counts.drifted, counts.unsupported)
+}
+
+// renderStatusProvisioners lists the provisioners declared for the profile as
+// read-only, informational context. It deliberately makes no alignment claim:
+// whether a provisioner has actually been applied is verified by the tool
+// itself, not by dots. It renders nothing when no provisioner is declared.
+func renderStatusProvisioners(w io.Writer, p provision.Plan) {
+	if len(p.Steps) == 0 {
+		return
+	}
+
+	fmt.Fprintf(w, "\nDeclared provisioners for profile %q\n\n", p.Profile)
+	for _, step := range p.Steps {
+		fmt.Fprintf(w, "  %s %s\n", step.Executable, strings.Join(step.Args, " "))
+		if len(step.Targets) > 0 {
+			fmt.Fprintf(w, "    affects: %s\n", strings.Join(step.Targets, ", "))
+		}
+	}
 }

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/plan"
+	"github.com/yersonargotev/dots/internal/provision"
 	"github.com/yersonargotev/dots/internal/state"
 	"github.com/yersonargotev/dots/internal/status"
 )
@@ -62,6 +63,12 @@ func newStatusCommand() *cobra.Command {
 			}
 
 			renderStatus(cmd.OutOrStdout(), report)
+
+			provPlan, err := provision.Build(*m, provision.Options{Profile: profile, OS: runtime.GOOS})
+			if err != nil {
+				return err
+			}
+			renderStatusProvisioners(cmd.OutOrStdout(), provPlan)
 			return nil
 		},
 	}

--- a/internal/cli/status_provision_test.go
+++ b/internal/cli/status_provision_test.go
@@ -1,0 +1,43 @@
+package cli_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/cli"
+)
+
+// TestStatusListsDeclaredProvisioners proves status surfaces the provisioners
+// declared for the profile as informational, read-only context: it shows the
+// resolved command and affected roots without claiming an alignment state and
+// without executing anything.
+func TestStatusListsDeclaredProvisioners(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	writeCLISource(t, sourceRoot, "configs/zsh/zshrc", "managed\n")
+	manifestPath := writeCLIManifest(t, home, provisionerManifest)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"status", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+
+	got := out.String()
+	for _, want := range []string{
+		`Declared provisioners for profile "default"`,
+		"gentle-ai install --scope global --persona neutral --agents codex",
+		"affects: ~/.claude, ~/.codex, ~/.gentle-ai",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("status output missing %q\noutput:\n%s", want, got)
+		}
+	}
+}

--- a/internal/cli/testdata/doctor_concerns.golden
+++ b/internal/cli/testdata/doctor_concerns.golden
@@ -5,6 +5,7 @@ Dependencies: warn (1 missing)
   missing dependency: starship
 Configuration: warn (1 concerns)
   missing: configs/zsh/zshrc -> /home/user/.zshrc
+Provisioners: ok (no provisioners declared)
 Secret Scan: warn (1 findings)
   configs/git/config:3 credential-assignment
 Guardrail: Secret Scan catches obvious credential and private-key patterns only; it is not proof this repository is safe.

--- a/internal/cli/testdata/doctor_provisioner_not_ready.golden
+++ b/internal/cli/testdata/doctor_provisioner_not_ready.golden
@@ -1,8 +1,9 @@
-Doctor for profile "minimal"
+Doctor for profile "default"
 
 Platform: ok (darwin)
 Dependencies: ok (no dependencies declared)
-Configuration: ok (1 ok, 0 concerns)
-Provisioners: ok (no provisioners declared)
+Configuration: ok (0 ok, 0 concerns)
+Provisioners: warn (1 not ready)
+  not ready: gentle-ai install --scope global --agents codex (missing: engram)
 Secret Scan: ok (0 findings)
 Guardrail: Secret Scan catches obvious credential and private-key patterns only; it is not proof this repository is safe.

--- a/internal/cli/testdata/provision_single.golden
+++ b/internal/cli/testdata/provision_single.golden
@@ -1,0 +1,7 @@
+
+Provisioners for profile "default"
+
+  gentle-ai install --scope global --persona neutral --agents codex
+    affects: ~/.claude, ~/.codex, ~/.gentle-ai
+
+Summary: 1 provisioner(s)

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -85,7 +85,8 @@ func newUpdateCommand() *cobra.Command {
 				return nil
 			}
 
-			return resolveAndApply(cmd, p, paths, yes, noTUI)
+			_, err = resolveAndApply(cmd, p, paths, yes, noTUI)
+			return err
 		},
 	}
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -14,6 +14,7 @@ import (
 	"github.com/yersonargotev/dots/internal/deps"
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/plan"
+	"github.com/yersonargotev/dots/internal/provision"
 	"github.com/yersonargotev/dots/internal/state"
 	"github.com/yersonargotev/dots/internal/status"
 )
@@ -33,6 +34,7 @@ type Report struct {
 	Platform      Platform
 	Dependencies  deps.CheckReport
 	Configuration status.Report
+	Provisioners  provision.CheckReport
 	SecretScan    SecretReport
 }
 
@@ -90,6 +92,12 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options, look deps.Loo
 		return Report{}, err
 	}
 	report.Configuration = statusReport
+
+	provReport, err := provision.Check(m, provision.Options{Profile: opts.Profile, OS: opts.OS}, look)
+	if err != nil {
+		return Report{}, err
+	}
+	report.Provisioners = provReport
 
 	secretReport, err := ScanSecrets(m, opts)
 	if err != nil {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -142,6 +142,59 @@ func TestBuildDiagnosticSections(t *testing.T) {
 	}
 }
 
+func TestBuildReportsProvisionerReadiness(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	writeFile(t, sourceRoot, "configs/app/config", "safe = true\n")
+
+	m := singleEntryManifest("configs/app/config")
+	m.Provisioners = []manifest.Provisioner{{
+		Tool: "gentle-ai",
+		Tags: []string{"core"},
+		Spec: manifest.ProvisionerSpec{Scope: "global", Agents: []string{"codex"}},
+		Dependencies: []manifest.Dependency{
+			{Name: "gentle-ai"},
+			{Name: "engram"},
+		},
+	}}
+
+	// gentle-ai present, engram missing: the provisioner is surfaced as not ready
+	// without ever being executed.
+	report, err := doctor.Build(m, state.Metadata{}, doctor.Options{
+		Profile: "default", OS: "darwin", SourceRoot: sourceRoot, Home: home,
+	}, lookupSet("gentle-ai"))
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	if len(report.Provisioners.Items) != 1 {
+		t.Fatalf("len(Provisioners.Items) = %d, want 1", len(report.Provisioners.Items))
+	}
+	item := report.Provisioners.Items[0]
+	if item.Tool != "gentle-ai" {
+		t.Fatalf("provisioner tool = %q, want gentle-ai", item.Tool)
+	}
+	wantArgs := []string{"install", "--scope", "global", "--agents", "codex"}
+	if !equalStrings(item.Args, wantArgs) {
+		t.Fatalf("provisioner args = %#v, want %#v", item.Args, wantArgs)
+	}
+	if !equalStrings(item.Missing, []string{"engram"}) {
+		t.Fatalf("provisioner missing = %#v, want [engram]", item.Missing)
+	}
+}
+
+func equalStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func singleEntryManifest(source string) manifest.Manifest {
 	return manifest.Manifest{
 		Version:  1,

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -11,9 +11,10 @@ import (
 )
 
 type Manifest struct {
-	Version  int                `yaml:"version"`
-	Profiles map[string]Profile `yaml:"profiles"`
-	Entries  []Entry            `yaml:"entries"`
+	Version      int                `yaml:"version"`
+	Profiles     map[string]Profile `yaml:"profiles"`
+	Entries      []Entry            `yaml:"entries"`
+	Provisioners []Provisioner      `yaml:"provisioners,omitempty"`
 }
 
 type Profile struct {
@@ -27,6 +28,30 @@ type Entry struct {
 	Tags         []string     `yaml:"tags"`
 	OS           []string     `yaml:"os,omitempty"`
 	Dependencies []Dependency `yaml:"dependencies,omitempty"`
+}
+
+// Provisioner declares an allowlisted external agent-configuration tool that
+// dots drives declaratively after dependency installs and file entries. dots
+// versions the invocation (tool + flag spec), never the rendered content the
+// tool regenerates. Tags and OS reuse the same Profile scoping as Entries.
+type Provisioner struct {
+	Tool         string          `yaml:"tool"`
+	Tags         []string        `yaml:"tags"`
+	OS           []string        `yaml:"os,omitempty"`
+	Spec         ProvisionerSpec `yaml:"spec"`
+	Dependencies []Dependency    `yaml:"dependencies,omitempty"`
+}
+
+// ProvisionerSpec maps 1:1 to the allowlisted tool's install flags. dots owns
+// these declarative values; the tool owns how they render into agent config.
+type ProvisionerSpec struct {
+	Scope      string   `yaml:"scope,omitempty"`
+	Channel    string   `yaml:"channel,omitempty"`
+	Persona    string   `yaml:"persona,omitempty"`
+	SDDMode    string   `yaml:"sdd-mode,omitempty"`
+	Agents     []string `yaml:"agents,omitempty"`
+	Components []string `yaml:"components,omitempty"`
+	Skills     []string `yaml:"skills,omitempty"`
 }
 
 // Dependency is an external tool a Managed Entry needs to work correctly. dots
@@ -130,16 +155,85 @@ func (m Manifest) Validate() error {
 		}
 	}
 
+	for i, prov := range m.Provisioners {
+		if strings.TrimSpace(prov.Tool) == "" {
+			return fmt.Errorf("provisioners[%d].tool is required", i)
+		}
+		if !allowedProvisionerTool(prov.Tool) {
+			return fmt.Errorf("provisioners[%d].tool must be gentle-ai", i)
+		}
+		if len(prov.Tags) == 0 {
+			return fmt.Errorf("provisioners[%d].tags is required", i)
+		}
+		if j, ok := indexOfEmptyTag(prov.Tags); ok {
+			return fmt.Errorf("provisioners[%d].tags[%d] must not be empty", i, j)
+		}
+		for j, osName := range prov.OS {
+			if !allowedOS(osName) {
+				return fmt.Errorf("provisioners[%d].os[%d] must be one of darwin, linux", i, j)
+			}
+		}
+		if prov.Spec.IsEmpty() {
+			return fmt.Errorf("provisioners[%d].spec is required", i)
+		}
+		if persona := strings.TrimSpace(prov.Spec.Persona); persona != "" && !allowedPersona(persona) {
+			return fmt.Errorf("provisioners[%d].spec.persona must be one of gentleman, neutral", i)
+		}
+		if j, ok := indexOfEmptyString(prov.Spec.Agents); ok {
+			return fmt.Errorf("provisioners[%d].spec.agents[%d] must not be empty", i, j)
+		}
+		if j, ok := indexOfEmptyString(prov.Spec.Components); ok {
+			return fmt.Errorf("provisioners[%d].spec.components[%d] must not be empty", i, j)
+		}
+		if j, ok := indexOfEmptyString(prov.Spec.Skills); ok {
+			return fmt.Errorf("provisioners[%d].spec.skills[%d] must not be empty", i, j)
+		}
+		for j, dep := range prov.Dependencies {
+			if strings.TrimSpace(dep.Name) == "" {
+				return fmt.Errorf("provisioners[%d].dependencies[%d].name is required", i, j)
+			}
+			if dep.Command != "" && strings.TrimSpace(dep.Command) == "" {
+				return fmt.Errorf("provisioners[%d].dependencies[%d].command must not be empty", i, j)
+			}
+		}
+	}
+
 	return nil
 }
 
+// IsEmpty reports whether the spec declares no flags at all. A provisioner with
+// an empty spec would render a bare `gentle-ai install` with nothing to do, so
+// validation rejects it.
+func (s ProvisionerSpec) IsEmpty() bool {
+	return strings.TrimSpace(s.Scope) == "" &&
+		strings.TrimSpace(s.Channel) == "" &&
+		strings.TrimSpace(s.Persona) == "" &&
+		strings.TrimSpace(s.SDDMode) == "" &&
+		!hasNonEmptyString(s.Agents) &&
+		!hasNonEmptyString(s.Components) &&
+		!hasNonEmptyString(s.Skills)
+}
+
 func indexOfEmptyTag(tags []string) (int, bool) {
-	for i, tag := range tags {
-		if strings.TrimSpace(tag) == "" {
+	return indexOfEmptyString(tags)
+}
+
+func indexOfEmptyString(values []string) (int, bool) {
+	for i, value := range values {
+		if strings.TrimSpace(value) == "" {
 			return i, true
 		}
 	}
 	return -1, false
+}
+
+func hasNonEmptyString(values []string) bool {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func allowedStrategy(strategy string) bool {
@@ -154,6 +248,23 @@ func allowedStrategy(strategy string) bool {
 func allowedOS(osName string) bool {
 	switch osName {
 	case "darwin", "linux":
+		return true
+	default:
+		return false
+	}
+}
+
+// allowedProvisionerTool enforces the provisioner allowlist. dots is never a
+// generic command runner: only gentle-ai is an accepted provisioner tool in v1.
+func allowedProvisionerTool(tool string) bool {
+	return strings.TrimSpace(tool) == "gentle-ai"
+}
+
+// allowedPersona enforces the persona values gentle-ai ships as flag-driven
+// presets. Any other value is rejected before dots renders the install command.
+func allowedPersona(persona string) bool {
+	switch persona {
+	case "gentleman", "neutral":
 		return true
 	default:
 		return false

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -91,6 +91,78 @@ entries:
 	}
 }
 
+func TestLoadFileParsesProvisioners(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dots.yaml")
+	content := []byte(`version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+provisioners:
+  - tool: gentle-ai
+    tags: [core]
+    os: [darwin, linux]
+    spec:
+      scope: global
+      channel: stable
+      persona: neutral
+      sdd-mode: strict
+      agents: [codex]
+      components: [engram]
+      skills: [tdd]
+    dependencies:
+      - name: gentle-ai
+        brew: gentleman-programming/tap/gentle-ai
+      - name: engram
+        brew: gentleman-programming/tap/engram
+`)
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	got, err := manifest.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+
+	if len(got.Provisioners) != 1 {
+		t.Fatalf("Provisioners len = %d, want 1", len(got.Provisioners))
+	}
+	prov := got.Provisioners[0]
+	if prov.Tool != "gentle-ai" {
+		t.Fatalf("Provisioner.Tool = %q, want gentle-ai", prov.Tool)
+	}
+	if !sameStrings(prov.Tags, []string{"core"}) {
+		t.Fatalf("Provisioner.Tags = %#v, want [core]", prov.Tags)
+	}
+	if !sameStrings(prov.OS, []string{"darwin", "linux"}) {
+		t.Fatalf("Provisioner.OS = %#v, want [darwin linux]", prov.OS)
+	}
+	if prov.Spec.Scope != "global" || prov.Spec.Channel != "stable" || prov.Spec.Persona != "neutral" || prov.Spec.SDDMode != "strict" {
+		t.Fatalf("Provisioner.Spec scalar flags = %#v, want global/stable/neutral/strict", prov.Spec)
+	}
+	if !sameStrings(prov.Spec.Agents, []string{"codex"}) {
+		t.Fatalf("Provisioner.Spec.Agents = %#v, want [codex]", prov.Spec.Agents)
+	}
+	if !sameStrings(prov.Spec.Components, []string{"engram"}) {
+		t.Fatalf("Provisioner.Spec.Components = %#v, want [engram]", prov.Spec.Components)
+	}
+	if !sameStrings(prov.Spec.Skills, []string{"tdd"}) {
+		t.Fatalf("Provisioner.Spec.Skills = %#v, want [tdd]", prov.Spec.Skills)
+	}
+	if len(prov.Dependencies) != 2 {
+		t.Fatalf("Provisioner.Dependencies len = %d, want 2", len(prov.Dependencies))
+	}
+	if prov.Dependencies[0].Name != "gentle-ai" || prov.Dependencies[0].Brew != "gentleman-programming/tap/gentle-ai" {
+		t.Fatalf("Provisioner.Dependencies[0] = %#v, want gentle-ai brew dependency", prov.Dependencies[0])
+	}
+}
+
 func TestDependencyProbeTrimsWhitespace(t *testing.T) {
 	tests := []struct {
 		name string
@@ -326,6 +398,156 @@ entries:
 			dir := t.TempDir()
 			path := filepath.Join(dir, "dots.yaml")
 			if err := os.WriteFile(path, []byte(tt.content), 0o600); err != nil {
+				t.Fatalf("write manifest: %v", err)
+			}
+
+			_, err := manifest.LoadFile(path)
+			if err == nil {
+				t.Fatal("LoadFile() error = nil, want validation error")
+			}
+			if err.Error() != tt.want {
+				t.Fatalf("LoadFile() error = %q, want %q", err.Error(), tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadFileRejectsInvalidProvisioners(t *testing.T) {
+	const base = `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+provisioners:
+`
+
+	tests := []struct {
+		name        string
+		provisioner string
+		want        string
+	}{
+		{
+			name: "missing tool",
+			provisioner: `  - tags: [core]
+    spec:
+      scope: global
+`,
+			want: "provisioners[0].tool is required",
+		},
+		{
+			name: "tool not allowlisted",
+			provisioner: `  - tool: bash
+    tags: [core]
+    spec:
+      scope: global
+`,
+			want: "provisioners[0].tool must be gentle-ai",
+		},
+		{
+			name: "missing spec",
+			provisioner: `  - tool: gentle-ai
+    tags: [core]
+`,
+			want: "provisioners[0].spec is required",
+		},
+		{
+			name: "missing tags",
+			provisioner: `  - tool: gentle-ai
+    tags: []
+    spec:
+      scope: global
+`,
+			want: "provisioners[0].tags is required",
+		},
+		{
+			name: "empty tag value",
+			provisioner: `  - tool: gentle-ai
+    tags: ["", core]
+    spec:
+      scope: global
+`,
+			want: "provisioners[0].tags[0] must not be empty",
+		},
+		{
+			name: "unsupported os filter",
+			provisioner: `  - tool: gentle-ai
+    tags: [core]
+    os: [windows]
+    spec:
+      scope: global
+`,
+			want: "provisioners[0].os[0] must be one of darwin, linux",
+		},
+		{
+			name: "unsupported persona",
+			provisioner: `  - tool: gentle-ai
+    tags: [core]
+    spec:
+      persona: senior-architect
+`,
+			want: "provisioners[0].spec.persona must be one of gentleman, neutral",
+		},
+		{
+			name: "whitespace-only agents list is missing spec",
+			provisioner: `  - tool: gentle-ai
+    tags: [core]
+    spec:
+      agents: ["  "]
+`,
+			want: "provisioners[0].spec is required",
+		},
+		{
+			name: "empty agent value",
+			provisioner: `  - tool: gentle-ai
+    tags: [core]
+    spec:
+      scope: global
+      agents: ["  "]
+`,
+			want: "provisioners[0].spec.agents[0] must not be empty",
+		},
+		{
+			name: "empty component value",
+			provisioner: `  - tool: gentle-ai
+    tags: [core]
+    spec:
+      scope: global
+      components: ["  "]
+`,
+			want: "provisioners[0].spec.components[0] must not be empty",
+		},
+		{
+			name: "empty skill value",
+			provisioner: `  - tool: gentle-ai
+    tags: [core]
+    spec:
+      scope: global
+      skills: ["  "]
+`,
+			want: "provisioners[0].spec.skills[0] must not be empty",
+		},
+		{
+			name: "dependency without name",
+			provisioner: `  - tool: gentle-ai
+    tags: [core]
+    spec:
+      scope: global
+    dependencies:
+      - brew: gentleman-programming/tap/gentle-ai
+`,
+			want: "provisioners[0].dependencies[0].name is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "dots.yaml")
+			if err := os.WriteFile(path, []byte(base+tt.provisioner), 0o600); err != nil {
 				t.Fatalf("write manifest: %v", err)
 			}
 

--- a/internal/provision/apply.go
+++ b/internal/provision/apply.go
@@ -1,0 +1,100 @@
+package provision
+
+import (
+	"fmt"
+
+	"github.com/yersonargotev/dots/internal/deps"
+	"github.com/yersonargotev/dots/internal/manifest"
+)
+
+// RunStatus describes the outcome of attempting one Provisioner.
+type RunStatus string
+
+const (
+	// RunStatusProvisioned means the tool ran to completion successfully.
+	RunStatusProvisioned RunStatus = "provisioned"
+	// RunStatusMissingDeps means one or more declared dependencies were absent,
+	// so the tool was deliberately not invoked.
+	RunStatusMissingDeps RunStatus = "missing-dependencies"
+	// RunStatusFailed means the tool was invoked but exited with an error.
+	RunStatusFailed RunStatus = "failed"
+)
+
+// RunItem is the outcome of one attempted Provisioner.
+type RunItem struct {
+	Tool       string
+	Executable string
+	Args       []string
+	Status     RunStatus
+	// Missing holds the probes of absent dependencies when Status is
+	// RunStatusMissingDeps.
+	Missing []string
+}
+
+// Report records the outcome of an Apply run. A Report is always returned, even
+// on failure, so the caller can show exactly how far provisioning got and never
+// leaves the run half-applied without an account of it.
+type Report struct {
+	Profile string
+	Items   []RunItem
+}
+
+// Apply runs every selected Provisioner in manifest order via the deps Runner
+// boundary. Each Provisioner's declared dependencies are probed first; if any
+// are absent the tool is not invoked and the run stops with a clear failure.
+// HOME threading for sandboxing is the concrete Runner's responsibility, not
+// this orchestration. Apply stops at the first failing Provisioner and returns
+// the partial Report alongside the error.
+func Apply(m manifest.Manifest, opts Options, look deps.Lookup, runner deps.Runner) (Report, error) {
+	selected, err := Select(m, opts)
+	if err != nil {
+		return Report{}, err
+	}
+
+	report := Report{Profile: opts.Profile}
+	for _, prov := range selected {
+		executable, args := RenderCommand(prov)
+
+		if missing := missingDependencies(prov, look); len(missing) > 0 {
+			report.Items = append(report.Items, RunItem{
+				Tool:       prov.Tool,
+				Executable: executable,
+				Args:       args,
+				Status:     RunStatusMissingDeps,
+				Missing:    missing,
+			})
+			return report, fmt.Errorf("provisioner %q is missing dependencies: %v", prov.Tool, missing)
+		}
+
+		if err := runner.Run(executable, args); err != nil {
+			report.Items = append(report.Items, RunItem{
+				Tool:       prov.Tool,
+				Executable: executable,
+				Args:       args,
+				Status:     RunStatusFailed,
+			})
+			return report, fmt.Errorf("provisioner %q failed: %w", prov.Tool, err)
+		}
+
+		report.Items = append(report.Items, RunItem{
+			Tool:       prov.Tool,
+			Executable: executable,
+			Args:       args,
+			Status:     RunStatusProvisioned,
+		})
+	}
+	return report, nil
+}
+
+// missingDependencies returns the probes of the Provisioner's declared
+// dependencies that are absent on the workstation, in declared order.
+func missingDependencies(prov manifest.Provisioner, look deps.Lookup) []string {
+	var missing []string
+	for _, dep := range prov.Dependencies {
+		probe := dep.Probe()
+		if !look(probe) {
+			missing = append(missing, probe)
+		}
+	}
+	return missing
+}

--- a/internal/provision/apply_test.go
+++ b/internal/provision/apply_test.go
@@ -1,0 +1,142 @@
+package provision_test
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/deps"
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/provision"
+)
+
+// fakeRunner records every Run invocation and can be configured to fail on a
+// specific 1-based call index so tests can assert the run stops after a failure.
+type fakeRunner struct {
+	calls   [][]string
+	failOn  int
+	failErr error
+}
+
+func (r *fakeRunner) Run(executable string, args []string) error {
+	r.calls = append(r.calls, append([]string{executable}, args...))
+	if r.failOn != 0 && len(r.calls) == r.failOn {
+		return r.failErr
+	}
+	return nil
+}
+
+func lookupWith(present ...string) deps.Lookup {
+	set := make(map[string]bool, len(present))
+	for _, p := range present {
+		set[p] = true
+	}
+	return func(command string) bool { return set[command] }
+}
+
+func gentleAIProvisioner(agent string) manifest.Provisioner {
+	return manifest.Provisioner{
+		Tool: "gentle-ai",
+		Tags: []string{"core"},
+		Spec: manifest.ProvisionerSpec{Scope: "global", Agents: []string{agent}},
+		Dependencies: []manifest.Dependency{
+			{Name: "gentle-ai"},
+			{Name: "engram"},
+		},
+	}
+}
+
+func TestApplyRunsSelectedProvisionersInOrder(t *testing.T) {
+	m := manifestWithProvisioners(gentleAIProvisioner("codex"), gentleAIProvisioner("claude"))
+	runner := &fakeRunner{}
+	look := lookupWith("gentle-ai", "engram")
+
+	report, err := provision.Apply(m, provision.Options{Profile: "default", OS: "darwin"}, look, runner)
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	wantCalls := [][]string{
+		{"gentle-ai", "install", "--scope", "global", "--agents", "codex"},
+		{"gentle-ai", "install", "--scope", "global", "--agents", "claude"},
+	}
+	if !reflect.DeepEqual(runner.calls, wantCalls) {
+		t.Fatalf("runner.calls = %#v, want %#v", runner.calls, wantCalls)
+	}
+	if len(report.Items) != 2 {
+		t.Fatalf("len(report.Items) = %d, want 2", len(report.Items))
+	}
+	for i, item := range report.Items {
+		if item.Status != provision.RunStatusProvisioned {
+			t.Fatalf("report.Items[%d].Status = %q, want provisioned", i, item.Status)
+		}
+	}
+}
+
+func TestApplyFailsWithoutRunningWhenDependencyMissing(t *testing.T) {
+	m := manifestWithProvisioners(gentleAIProvisioner("codex"))
+	runner := &fakeRunner{}
+	look := lookupWith("gentle-ai") // engram missing
+
+	report, err := provision.Apply(m, provision.Options{Profile: "default", OS: "darwin"}, look, runner)
+	if err == nil {
+		t.Fatal("Apply() error = nil, want missing-dependency error")
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runner.calls = %#v, want no invocation when a dependency is missing", runner.calls)
+	}
+	if len(report.Items) != 1 {
+		t.Fatalf("len(report.Items) = %d, want 1", len(report.Items))
+	}
+	item := report.Items[0]
+	if item.Status != provision.RunStatusMissingDeps {
+		t.Fatalf("report.Items[0].Status = %q, want missing-dependencies", item.Status)
+	}
+	if !reflect.DeepEqual(item.Missing, []string{"engram"}) {
+		t.Fatalf("report.Items[0].Missing = %#v, want [engram]", item.Missing)
+	}
+}
+
+func TestApplyStopsAndReportsOnRunnerFailure(t *testing.T) {
+	m := manifestWithProvisioners(gentleAIProvisioner("codex"), gentleAIProvisioner("claude"))
+	runErr := errors.New("gentle-ai exploded")
+	runner := &fakeRunner{failOn: 1, failErr: runErr}
+	look := lookupWith("gentle-ai", "engram")
+
+	report, err := provision.Apply(m, provision.Options{Profile: "default", OS: "darwin"}, look, runner)
+	if err == nil {
+		t.Fatal("Apply() error = nil, want runner failure error")
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("runner.calls count = %d, want 1 (run must stop after the failure)", len(runner.calls))
+	}
+	if len(report.Items) != 1 {
+		t.Fatalf("len(report.Items) = %d, want 1", len(report.Items))
+	}
+	if report.Items[0].Status != provision.RunStatusFailed {
+		t.Fatalf("report.Items[0].Status = %q, want failed", report.Items[0].Status)
+	}
+}
+
+func TestApplyNoProvisionersIsNoOp(t *testing.T) {
+	m := manifestWithProvisioners()
+	runner := &fakeRunner{}
+
+	report, err := provision.Apply(m, provision.Options{Profile: "default", OS: "darwin"}, lookupWith(), runner)
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runner.calls = %#v, want none", runner.calls)
+	}
+	if len(report.Items) != 0 {
+		t.Fatalf("len(report.Items) = %d, want 0", len(report.Items))
+	}
+}
+
+func TestApplyUnknownProfileIsError(t *testing.T) {
+	m := manifestWithProvisioners(gentleAIProvisioner("codex"))
+	if _, err := provision.Apply(m, provision.Options{Profile: "ghost", OS: "darwin"}, lookupWith(), &fakeRunner{}); err == nil {
+		t.Fatal("Apply() error = nil, want unknown-profile error")
+	}
+}

--- a/internal/provision/check.go
+++ b/internal/provision/check.go
@@ -1,0 +1,47 @@
+package provision
+
+import (
+	"github.com/yersonargotev/dots/internal/deps"
+	"github.com/yersonargotev/dots/internal/manifest"
+)
+
+// Readiness is the read-only diagnostic for one selected Provisioner: its exact
+// resolved command and which declared dependencies are absent. It never runs the
+// tool.
+type Readiness struct {
+	Tool       string
+	Executable string
+	Args       []string
+	// Missing holds the probes of absent dependencies, in declared order. An
+	// empty Missing means the Provisioner is ready to run.
+	Missing []string
+}
+
+// CheckReport is the readiness report for a Profile's selected Provisioners, in
+// manifest order. It mirrors deps.CheckReport for Managed Entry dependencies.
+type CheckReport struct {
+	Profile string
+	Items   []Readiness
+}
+
+// Check reports each selected Provisioner's resolved command and dependency
+// readiness without invoking any tool. It is the read-only diagnostic surfaced
+// by dots doctor.
+func Check(m manifest.Manifest, opts Options, look deps.Lookup) (CheckReport, error) {
+	selected, err := Select(m, opts)
+	if err != nil {
+		return CheckReport{}, err
+	}
+
+	report := CheckReport{Profile: opts.Profile}
+	for _, prov := range selected {
+		executable, args := RenderCommand(prov)
+		report.Items = append(report.Items, Readiness{
+			Tool:       prov.Tool,
+			Executable: executable,
+			Args:       args,
+			Missing:    missingDependencies(prov, look),
+		})
+	}
+	return report, nil
+}

--- a/internal/provision/check_test.go
+++ b/internal/provision/check_test.go
@@ -1,0 +1,52 @@
+package provision_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/provision"
+)
+
+func TestCheckReportsReadiness(t *testing.T) {
+	m := manifestWithProvisioners(gentleAIProvisioner("codex"))
+
+	t.Run("all dependencies present", func(t *testing.T) {
+		report, err := provision.Check(m, provision.Options{Profile: "default", OS: "darwin"}, lookupWith("gentle-ai", "engram"))
+		if err != nil {
+			t.Fatalf("Check() error = %v", err)
+		}
+		if report.Profile != "default" {
+			t.Fatalf("Check.Profile = %q, want default", report.Profile)
+		}
+		if len(report.Items) != 1 {
+			t.Fatalf("len(Check.Items) = %d, want 1", len(report.Items))
+		}
+		item := report.Items[0]
+		if item.Tool != "gentle-ai" || item.Executable != "gentle-ai" {
+			t.Fatalf("readiness tool/executable = %q/%q, want gentle-ai", item.Tool, item.Executable)
+		}
+		wantArgs := []string{"install", "--scope", "global", "--agents", "codex"}
+		if !reflect.DeepEqual(item.Args, wantArgs) {
+			t.Fatalf("readiness Args = %#v, want %#v", item.Args, wantArgs)
+		}
+		if len(item.Missing) != 0 {
+			t.Fatalf("readiness Missing = %#v, want none", item.Missing)
+		}
+	})
+
+	t.Run("missing dependency is reported without executing", func(t *testing.T) {
+		report, err := provision.Check(m, provision.Options{Profile: "default", OS: "darwin"}, lookupWith("gentle-ai"))
+		if err != nil {
+			t.Fatalf("Check() error = %v", err)
+		}
+		if !reflect.DeepEqual(report.Items[0].Missing, []string{"engram"}) {
+			t.Fatalf("readiness Missing = %#v, want [engram]", report.Items[0].Missing)
+		}
+	})
+
+	t.Run("unknown profile is an error", func(t *testing.T) {
+		if _, err := provision.Check(m, provision.Options{Profile: "ghost", OS: "darwin"}, lookupWith()); err == nil {
+			t.Fatal("Check() error = nil, want unknown-profile error")
+		}
+	})
+}

--- a/internal/provision/plan.go
+++ b/internal/provision/plan.go
@@ -1,0 +1,123 @@
+package provision
+
+import (
+	"fmt"
+
+	"github.com/yersonargotev/dots/internal/manifest"
+)
+
+// Options carries the resolved inputs needed to select and plan Provisioners.
+type Options struct {
+	Profile string
+	OS      string
+}
+
+// Step is a single planned Provisioner invocation: the exact resolved command
+// plus the HOME-relative roots the tool will affect, shown so the user can judge
+// the blast radius before confirming.
+type Step struct {
+	Tool       string
+	Executable string
+	Args       []string
+	Targets    []string
+}
+
+// Plan is the preview of Provisioner steps the installer would run for a
+// Profile, in manifest order.
+type Plan struct {
+	Profile string
+	Steps   []Step
+}
+
+// Select gathers the Provisioners that belong to the Profile (their tags
+// intersect the Profile's tags) and pass the OS filter, preserving manifest
+// order. It mirrors the Entry selection used by deps, plan, and status.
+func Select(m manifest.Manifest, opts Options) ([]manifest.Provisioner, error) {
+	profile, ok := m.Profiles[opts.Profile]
+	if !ok {
+		return nil, fmt.Errorf("profile %q not found", opts.Profile)
+	}
+
+	var selected []manifest.Provisioner
+	for _, prov := range m.Provisioners {
+		if !sharesTag(prov.Tags, profile.Tags) {
+			continue
+		}
+		if !matchesOS(prov.OS, opts.OS) {
+			continue
+		}
+		selected = append(selected, prov)
+	}
+	return selected, nil
+}
+
+// Build resolves every selected Provisioner into its exact command and the
+// roots it affects. It performs no I/O and never invokes the tool, so it is safe
+// to render in a dry-run. It mirrors plan.Build for Managed Entries.
+func Build(m manifest.Manifest, opts Options) (Plan, error) {
+	selected, err := Select(m, opts)
+	if err != nil {
+		return Plan{}, err
+	}
+
+	plan := Plan{Profile: opts.Profile}
+	for _, prov := range selected {
+		executable, args := RenderCommand(prov)
+		plan.Steps = append(plan.Steps, Step{
+			Tool:       prov.Tool,
+			Executable: executable,
+			Args:       args,
+			Targets:    managedRoots(prov),
+		})
+	}
+	return plan, nil
+}
+
+// managedRoots returns the well-known HOME-relative roots an allowlisted tool
+// manages, used as the advisory blast radius in the plan. gentle-ai owns its own
+// state under ~/.gentle-ai, the Claude agent layer under ~/.claude, and selected
+// agent-specific configuration roots.
+func managedRoots(prov manifest.Provisioner) []string {
+	switch prov.Tool {
+	case "gentle-ai":
+		roots := []string{"~/.claude"}
+		if includes(prov.Spec.Agents, "codex") {
+			roots = append(roots, "~/.codex")
+		}
+		return append(roots, "~/.gentle-ai")
+	default:
+		return nil
+	}
+}
+
+func includes(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func sharesTag(provTags, profileTags []string) bool {
+	for _, pt := range provTags {
+		for _, prt := range profileTags {
+			if pt == prt {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func matchesOS(provOS []string, current string) bool {
+	if len(provOS) == 0 {
+		return true
+	}
+	for _, osName := range provOS {
+		if osName == current {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/provision/plan_test.go
+++ b/internal/provision/plan_test.go
@@ -1,0 +1,145 @@
+package provision_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/provision"
+)
+
+func manifestWithProvisioners(provs ...manifest.Provisioner) manifest.Manifest {
+	return manifest.Manifest{
+		Version: 1,
+		Profiles: map[string]manifest.Profile{
+			"default": {Tags: []string{"core"}},
+			"desktop": {Tags: []string{"core", "desktop"}},
+		},
+		Entries: []manifest.Entry{{
+			Source: "configs/zsh/zshrc", Target: "~/.zshrc", Strategy: "symlink", Tags: []string{"core"},
+		}},
+		Provisioners: provs,
+	}
+}
+
+func TestSelect(t *testing.T) {
+	coreProv := manifest.Provisioner{
+		Tool: "gentle-ai", Tags: []string{"core"},
+		Spec: manifest.ProvisionerSpec{Scope: "global"},
+	}
+	desktopProv := manifest.Provisioner{
+		Tool: "gentle-ai", Tags: []string{"desktop"},
+		Spec: manifest.ProvisionerSpec{Scope: "global", Agents: []string{"codex"}},
+	}
+	linuxOnlyProv := manifest.Provisioner{
+		Tool: "gentle-ai", Tags: []string{"core"}, OS: []string{"linux"},
+		Spec: manifest.ProvisionerSpec{Persona: "neutral"},
+	}
+
+	tests := []struct {
+		name    string
+		m       manifest.Manifest
+		opts    provision.Options
+		want    []manifest.Provisioner
+		wantErr bool
+	}{
+		{
+			name: "selects provisioner sharing a profile tag",
+			m:    manifestWithProvisioners(coreProv, desktopProv),
+			opts: provision.Options{Profile: "default", OS: "darwin"},
+			want: []manifest.Provisioner{coreProv},
+		},
+		{
+			name: "desktop profile selects both shared tags in manifest order",
+			m:    manifestWithProvisioners(coreProv, desktopProv),
+			opts: provision.Options{Profile: "desktop", OS: "darwin"},
+			want: []manifest.Provisioner{coreProv, desktopProv},
+		},
+		{
+			name: "skips provisioner excluded by OS filter",
+			m:    manifestWithProvisioners(linuxOnlyProv),
+			opts: provision.Options{Profile: "default", OS: "darwin"},
+			want: nil,
+		},
+		{
+			name: "includes provisioner with OS filter when it matches",
+			m:    manifestWithProvisioners(linuxOnlyProv),
+			opts: provision.Options{Profile: "default", OS: "linux"},
+			want: []manifest.Provisioner{linuxOnlyProv},
+		},
+		{
+			name:    "unknown profile is an error",
+			m:       manifestWithProvisioners(coreProv),
+			opts:    provision.Options{Profile: "ghost", OS: "darwin"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := provision.Select(tt.m, tt.opts)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Select() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Select() error = %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("Select() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPlanResolvesSelectedProvisioners(t *testing.T) {
+	prov := manifest.Provisioner{
+		Tool: "gentle-ai", Tags: []string{"core"},
+		Spec: manifest.ProvisionerSpec{Scope: "global", Agents: []string{"codex"}},
+	}
+	m := manifestWithProvisioners(prov)
+
+	p, err := provision.Build(m, provision.Options{Profile: "default", OS: "darwin"})
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+
+	if p.Profile != "default" {
+		t.Fatalf("Plan.Profile = %q, want default", p.Profile)
+	}
+	if len(p.Steps) != 1 {
+		t.Fatalf("len(Plan.Steps) = %d, want 1", len(p.Steps))
+	}
+	step := p.Steps[0]
+	if step.Tool != "gentle-ai" || step.Executable != "gentle-ai" {
+		t.Fatalf("Step tool/executable = %q/%q, want gentle-ai", step.Tool, step.Executable)
+	}
+	wantArgs := []string{"install", "--scope", "global", "--agents", "codex"}
+	if !reflect.DeepEqual(step.Args, wantArgs) {
+		t.Fatalf("Step.Args = %#v, want %#v", step.Args, wantArgs)
+	}
+	if !reflect.DeepEqual(step.Targets, []string{"~/.claude", "~/.codex", "~/.gentle-ai"}) {
+		t.Fatalf("Step.Targets = %#v, want [~/.claude ~/.codex ~/.gentle-ai]", step.Targets)
+	}
+}
+
+func TestPlanEmptyWhenNoProvisionerSelected(t *testing.T) {
+	prov := manifest.Provisioner{
+		Tool: "gentle-ai", Tags: []string{"desktop"},
+		Spec: manifest.ProvisionerSpec{Scope: "global"},
+	}
+	m := manifestWithProvisioners(prov)
+
+	p, err := provision.Build(m, provision.Options{Profile: "default", OS: "darwin"})
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+	if p.Profile != "default" {
+		t.Fatalf("Plan.Profile = %q, want default", p.Profile)
+	}
+	if len(p.Steps) != 0 {
+		t.Fatalf("len(Plan.Steps) = %d, want 0", len(p.Steps))
+	}
+}

--- a/internal/provision/provision.go
+++ b/internal/provision/provision.go
@@ -1,0 +1,56 @@
+// Package provision drives allowlisted external agent-configuration tools
+// (initially gentle-ai) declared in the Install Manifest. dots versions the
+// declarative invocation — the tool plus its flag spec — and renders it into an
+// exact, resolved command. It never versions the intellectual layer the tool
+// regenerates (skills, agents, personas, CLAUDE.md).
+package provision
+
+import (
+	"strings"
+
+	"github.com/yersonargotev/dots/internal/manifest"
+)
+
+// RenderCommand resolves a Provisioner into the exact executable and argv that
+// would run it. It is PURE: it performs no I/O and never invokes the tool, so it
+// is safe to render in a dry-run. Flags are emitted in a deterministic order;
+// unset scalar flags and empty list flags are omitted, and list values are
+// comma-joined. The tool name is the binary name (gentle-ai), enforced by the
+// manifest allowlist before this function is reached.
+func RenderCommand(p manifest.Provisioner) (executable string, args []string) {
+	args = []string{"install"}
+	args = appendScalarFlag(args, "--scope", p.Spec.Scope)
+	args = appendScalarFlag(args, "--channel", p.Spec.Channel)
+	args = appendScalarFlag(args, "--persona", p.Spec.Persona)
+	args = appendScalarFlag(args, "--sdd-mode", p.Spec.SDDMode)
+	args = appendListFlag(args, "--agents", p.Spec.Agents)
+	args = appendListFlag(args, "--components", p.Spec.Components)
+	args = appendListFlag(args, "--skills", p.Spec.Skills)
+	return p.Tool, args
+}
+
+func appendScalarFlag(args []string, flag, value string) []string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return args
+	}
+	return append(args, flag, value)
+}
+
+func appendListFlag(args []string, flag string, values []string) []string {
+	joined := joinNonEmpty(values)
+	if joined == "" {
+		return args
+	}
+	return append(args, flag, joined)
+}
+
+func joinNonEmpty(values []string) string {
+	cleaned := make([]string, 0, len(values))
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			cleaned = append(cleaned, trimmed)
+		}
+	}
+	return strings.Join(cleaned, ",")
+}

--- a/internal/provision/provision_test.go
+++ b/internal/provision/provision_test.go
@@ -1,0 +1,91 @@
+package provision_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/provision"
+)
+
+func TestRenderCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		prov     manifest.Provisioner
+		wantExec string
+		wantArgs []string
+	}{
+		{
+			name: "full spec renders every flag in deterministic order",
+			prov: manifest.Provisioner{
+				Tool: "gentle-ai",
+				Spec: manifest.ProvisionerSpec{
+					Scope:      "global",
+					Channel:    "stable",
+					Persona:    "neutral",
+					SDDMode:    "strict",
+					Agents:     []string{"codex", "claude"},
+					Components: []string{"engram", "sdd"},
+					Skills:     []string{"tdd", "go-testing"},
+				},
+			},
+			wantExec: "gentle-ai",
+			wantArgs: []string{
+				"install",
+				"--scope", "global",
+				"--channel", "stable",
+				"--persona", "neutral",
+				"--sdd-mode", "strict",
+				"--agents", "codex,claude",
+				"--components", "engram,sdd",
+				"--skills", "tdd,go-testing",
+			},
+		},
+		{
+			name: "partial spec omits unset flags",
+			prov: manifest.Provisioner{
+				Tool: "gentle-ai",
+				Spec: manifest.ProvisionerSpec{
+					Scope:  "global",
+					Agents: []string{"codex"},
+				},
+			},
+			wantExec: "gentle-ai",
+			wantArgs: []string{"install", "--scope", "global", "--agents", "codex"},
+		},
+		{
+			name: "persona only",
+			prov: manifest.Provisioner{
+				Tool: "gentle-ai",
+				Spec: manifest.ProvisionerSpec{Persona: "gentleman"},
+			},
+			wantExec: "gentle-ai",
+			wantArgs: []string{"install", "--persona", "gentleman"},
+		},
+		{
+			name: "whitespace scalars and list entries are trimmed and dropped",
+			prov: manifest.Provisioner{
+				Tool: "gentle-ai",
+				Spec: manifest.ProvisionerSpec{
+					Scope:   "  global  ",
+					Channel: "   ",
+					Agents:  []string{" codex ", "", "  ", "claude"},
+				},
+			},
+			wantExec: "gentle-ai",
+			wantArgs: []string{"install", "--scope", "global", "--agents", "codex,claude"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotExec, gotArgs := provision.RenderCommand(tt.prov)
+			if gotExec != tt.wantExec {
+				t.Fatalf("RenderCommand() executable = %q, want %q", gotExec, tt.wantExec)
+			}
+			if !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+				t.Fatalf("RenderCommand() args = %#v, want %#v", gotArgs, tt.wantArgs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #65

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds an allowlisted `provisioners` manifest primitive for running `gentle-ai install` after dotfile installation.
- Renders deterministic provisioner previews/results, including blast-radius roots and partial failure reports.
- Wires provisioner readiness into doctor/status surfaces and covers cancel/dry-run/sandbox-safe execution paths.

## Changes

| File | Change |
|------|--------|
| `internal/manifest/manifest.go` | Adds provisioner schema validation, including empty/whitespace list rejection. |
| `internal/provision/*` | Adds pure command rendering, selection/planning, dependency checks, and apply/report behavior. |
| `internal/cli/install.go` | Runs provisioners after install, skips them on TUI cancel, and supports dry-run previews. |
| `internal/cli/provision_runner.go` | Executes provisioners with sandboxable HOME/env threading. |
| `internal/cli/render_provision.go` | Renders provisioner plan and partial execution report output. |
| `internal/doctor/*` | Reports provisioner readiness without executing external tools. |
| `internal/cli/status.go` | Lists declared provisioners for the selected profile. |
| `internal/**/*_test.go` and `internal/cli/testdata/*` | Adds TDD coverage and deterministic golden output for the new primitive. |

## Review Workload

- [x] `size:exception` accepted by maintainer for a single PR.
- Review budget: 29 files, ~1837 changed lines.
- Rationale: #65 is a cohesive vertical primitive; splitting now would separate schema, planner, runner, and safety tests that need to be reviewed together.

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go build ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp>`
- [x] Sandboxed install dry-run only: `go run ./cmd/dots install --dry-run --file dots.yaml --profile default --source-root "$PWD" --home <tmp> --state-root <tmp>`
- [x] Judgment Day Round 2: both judges returned CLEAN after fixes.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed, or documented validation in this PR.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
