### PR TITLE
feat(config): provision codex through gentle-ai

### DIFF
--- a/dots.yaml
+++ b/dots.yaml
@@ -186,3 +186,21 @@ entries:
         apt: neovim
         dnf: neovim
         pacman: neovim
+provisioners:
+  - tool: gentle-ai
+    tags:
+      - core
+    spec:
+      scope: global
+      channel: stable
+      persona: neutral
+      sdd-mode: multi
+      agents:
+        - codex
+    dependencies:
+      - name: gentle-ai
+        command: gentle-ai
+        brew: gentleman-programming/tap/gentle-ai
+      - name: engram
+        command: engram
+        brew: gentleman-programming/tap/engram

--- a/internal/cli/atuin_config_test.go
+++ b/internal/cli/atuin_config_test.go
@@ -18,6 +18,7 @@ func TestAtuinDefaultProfileInstallsAndReportsAlignedInSandbox(t *testing.T) {
 	home := t.TempDir()
 	stateRoot := t.TempDir()
 	t.Setenv("HOME", t.TempDir())
+	stubGentleAIProvisionerTools(t)
 
 	install := cli.NewRootCommand()
 	var installOut bytes.Buffer

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -875,6 +875,7 @@ func TestRepositoryGitConfigInstallsAndReportsAlignedInSandbox(t *testing.T) {
 	home := t.TempDir()
 	stateRoot := t.TempDir()
 	t.Setenv("HOME", t.TempDir())
+	stubGentleAIProvisionerTools(t)
 
 	sourceRoot, err := filepath.Abs(filepath.Clean(filepath.Join("..", "..")))
 	if err != nil {

--- a/internal/cli/ghostty_config_test.go
+++ b/internal/cli/ghostty_config_test.go
@@ -18,6 +18,7 @@ func TestGhosttyDesktopProfileInstallsAndReportsAlignedInSandbox(t *testing.T) {
 	home := t.TempDir()
 	stateRoot := t.TempDir()
 	t.Setenv("HOME", t.TempDir())
+	stubGentleAIProvisionerTools(t)
 
 	install := cli.NewRootCommand()
 	var installOut bytes.Buffer

--- a/internal/cli/provision_test_helpers_test.go
+++ b/internal/cli/provision_test_helpers_test.go
@@ -1,0 +1,16 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func stubGentleAIProvisionerTools(t *testing.T) {
+	t.Helper()
+
+	stubDir := t.TempDir()
+	writeExecStub(t, filepath.Join(stubDir, "gentle-ai"), "#!/bin/sh\nexit 0\n")
+	writeExecStub(t, filepath.Join(stubDir, "engram"), "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}

--- a/internal/deps/deps.go
+++ b/internal/deps/deps.go
@@ -1,7 +1,7 @@
 // Package deps computes Dependency findings for a Profile: which external tools
-// a workstation needs for its Managed Entries, whether they are present,
-// OS-aware advisory guidance for installing the missing ones, and explicitly
-// confirmed package-manager execution.
+// a workstation needs for its selected Managed Entries and Provisioners, whether
+// they are present, OS-aware advisory guidance for installing the missing ones,
+// and explicitly confirmed package-manager execution.
 package deps
 
 import (
@@ -36,8 +36,8 @@ type CheckReport struct {
 }
 
 // Check reports which Dependencies declared by the Profile's selected Managed
-// Entries are present on the workstation. Dependencies are deduplicated by name
-// in first-declared order.
+// Entries and Provisioners are present on the workstation. Dependencies are
+// deduplicated by name in first-declared order.
 func Check(m manifest.Manifest, opts Options, look Lookup) (CheckReport, error) {
 	selected, err := selectDependencies(m, opts)
 	if err != nil {
@@ -56,9 +56,9 @@ func Check(m manifest.Manifest, opts Options, look Lookup) (CheckReport, error) 
 	return report, nil
 }
 
-// selectDependencies gathers the Dependencies of every Managed Entry that
-// belongs to the Profile and passes the OS filter, deduplicated by name in
-// first-declared order.
+// selectDependencies gathers the Dependencies of every Managed Entry and
+// Provisioner that belongs to the Profile and passes the OS filter, deduplicated
+// by name in first-declared order.
 func selectDependencies(m manifest.Manifest, opts Options) ([]manifest.Dependency, error) {
 	profile, ok := m.Profiles[opts.Profile]
 	if !ok {
@@ -67,14 +67,8 @@ func selectDependencies(m manifest.Manifest, opts Options) ([]manifest.Dependenc
 
 	var selected []manifest.Dependency
 	seen := make(map[string]bool)
-	for _, entry := range m.Entries {
-		if !sharesTag(entry.Tags, profile.Tags) {
-			continue
-		}
-		if !matchesOS(entry.OS, opts.OS) {
-			continue
-		}
-		for _, dep := range entry.Dependencies {
+	addDependencies := func(deps []manifest.Dependency) {
+		for _, dep := range deps {
 			// Normalize the name so padded and unpadded declarations of the same
 			// dependency deduplicate and render consistently with Probe().
 			dep.Name = strings.TrimSpace(dep.Name)
@@ -84,6 +78,25 @@ func selectDependencies(m manifest.Manifest, opts Options) ([]manifest.Dependenc
 			seen[dep.Name] = true
 			selected = append(selected, dep)
 		}
+	}
+
+	for _, entry := range m.Entries {
+		if !sharesTag(entry.Tags, profile.Tags) {
+			continue
+		}
+		if !matchesOS(entry.OS, opts.OS) {
+			continue
+		}
+		addDependencies(entry.Dependencies)
+	}
+	for _, prov := range m.Provisioners {
+		if !sharesTag(prov.Tags, profile.Tags) {
+			continue
+		}
+		if !matchesOS(prov.OS, opts.OS) {
+			continue
+		}
+		addDependencies(prov.Dependencies)
 	}
 	return selected, nil
 }

--- a/internal/deps/deps_test.go
+++ b/internal/deps/deps_test.go
@@ -133,3 +133,108 @@ func TestCheckFailsOnUnknownProfile(t *testing.T) {
 		t.Fatal("Check() error = nil, want error for unknown profile")
 	}
 }
+
+func TestCheckIncludesSelectedProvisionerDependencies(t *testing.T) {
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}},
+		Entries: []manifest.Entry{
+			{
+				Source: "configs/zsh/zshrc", Target: "~/.zshrc", Strategy: "symlink", Tags: []string{"core"},
+				Dependencies: []manifest.Dependency{{Name: "zsh"}},
+			},
+		},
+		Provisioners: []manifest.Provisioner{
+			{
+				Tool: "gentle-ai",
+				Tags: []string{"core"},
+				Dependencies: []manifest.Dependency{
+					{Name: "gentle-ai", Brew: "gentleman-programming/tap/gentle-ai"},
+					{Name: "engram", Brew: "gentleman-programming/tap/engram"},
+				},
+			},
+		},
+	}
+
+	report, err := deps.Check(m, deps.Options{Profile: "default", OS: "darwin"}, lookupSet("zsh", "engram"))
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+
+	want := []deps.Result{
+		{Name: "zsh", Command: "zsh", Present: true},
+		{Name: "gentle-ai", Command: "gentle-ai", Present: false},
+		{Name: "engram", Command: "engram", Present: true},
+	}
+	if len(report.Results) != len(want) {
+		t.Fatalf("Results len = %d, want %d (%#v)", len(report.Results), len(want), report.Results)
+	}
+	for i := range want {
+		if report.Results[i] != want[i] {
+			t.Fatalf("Results[%d] = %#v, want %#v", i, report.Results[i], want[i])
+		}
+	}
+}
+
+func TestCheckFiltersProvisionerDependenciesByProfileAndOS(t *testing.T) {
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}},
+		Provisioners: []manifest.Provisioner{
+			{Tool: "gentle-ai", Tags: []string{"core"}, OS: []string{"darwin"}, Dependencies: []manifest.Dependency{{Name: "gentle-ai"}}},
+			{Tool: "opencode", Tags: []string{"work"}, Dependencies: []manifest.Dependency{{Name: "opencode"}}},
+			{Tool: "claude", Tags: []string{"core"}, OS: []string{"linux"}, Dependencies: []manifest.Dependency{{Name: "claude"}}},
+		},
+	}
+
+	report, err := deps.Check(m, deps.Options{Profile: "default", OS: "darwin"}, lookupSet())
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+
+	if len(report.Results) != 1 {
+		t.Fatalf("Results len = %d, want 1 (%#v)", len(report.Results), report.Results)
+	}
+	if report.Results[0].Name != "gentle-ai" {
+		t.Fatalf("Results[0].Name = %q, want gentle-ai", report.Results[0].Name)
+	}
+}
+
+func TestCheckDedupesProvisionerDependenciesWithEntries(t *testing.T) {
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}},
+		Entries: []manifest.Entry{
+			{
+				Source: "configs/a", Target: "~/.a", Strategy: "symlink", Tags: []string{"core"},
+				Dependencies: []manifest.Dependency{{Name: "gentle-ai", Brew: "gentleman-programming/tap/gentle-ai"}},
+			},
+		},
+		Provisioners: []manifest.Provisioner{
+			{
+				Tool:         "gentle-ai",
+				Tags:         []string{"core"},
+				Dependencies: []manifest.Dependency{{Name: " gentle-ai "}, {Name: "engram"}},
+			},
+		},
+	}
+
+	report, err := deps.Check(m, deps.Options{Profile: "default", OS: "darwin"}, lookupSet())
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+
+	got := make([]string, 0, len(report.Results))
+	for _, result := range report.Results {
+		got = append(got, result.Name)
+	}
+	want := []string{"gentle-ai", "engram"}
+	if len(got) != len(want) {
+		t.Fatalf("dependency names = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("dependency names = %v, want %v", got, want)
+		}
+	}
+}

--- a/internal/deps/install_test.go
+++ b/internal/deps/install_test.go
@@ -351,3 +351,35 @@ func installSelectionManifest() manifest.Manifest {
 		},
 	}
 }
+
+func TestInstallDryRunIncludesSelectedProvisionerDependencies(t *testing.T) {
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}},
+		Provisioners: []manifest.Provisioner{
+			{
+				Tool: "gentle-ai",
+				Tags: []string{"core"},
+				Dependencies: []manifest.Dependency{
+					{Name: "gentle-ai", Brew: "gentleman-programming/tap/gentle-ai"},
+					{Name: "engram", Brew: "gentleman-programming/tap/engram"},
+				},
+			},
+		},
+	}
+
+	report, err := deps.InstallDryRun(m, deps.Options{Profile: "default", OS: "darwin"}, lookupSet("engram"), deps.TierHomebrew)
+	if err != nil {
+		t.Fatalf("InstallDryRun() error = %v", err)
+	}
+	if len(report.Items) != 1 {
+		t.Fatalf("Items len = %d, want 1 (%#v)", len(report.Items), report.Items)
+	}
+	item := report.Items[0]
+	if item.Dependency != "gentle-ai" {
+		t.Fatalf("Items[0].Dependency = %q, want gentle-ai", item.Dependency)
+	}
+	if item.Package != "gentleman-programming/tap/gentle-ai" {
+		t.Fatalf("Items[0].Package = %q, want tap package", item.Package)
+	}
+}

--- a/internal/deps/plan_test.go
+++ b/internal/deps/plan_test.go
@@ -264,3 +264,35 @@ func TestPlanIsEmptyWhenAllDependenciesPresent(t *testing.T) {
 		t.Fatalf("Actions len = %d, want 0 when all present", len(report.Actions))
 	}
 }
+
+func TestPlanIncludesSelectedProvisionerDependencies(t *testing.T) {
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}},
+		Provisioners: []manifest.Provisioner{
+			{
+				Tool: "gentle-ai",
+				Tags: []string{"core"},
+				Dependencies: []manifest.Dependency{
+					{Name: "gentle-ai", Brew: "gentleman-programming/tap/gentle-ai"},
+					{Name: "engram", Brew: "gentleman-programming/tap/engram"},
+				},
+			},
+		},
+	}
+
+	report, err := deps.Plan(m, deps.Options{Profile: "default", OS: "darwin"}, lookupSet("engram"), deps.TierHomebrew)
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+	if len(report.Actions) != 1 {
+		t.Fatalf("Actions len = %d, want 1 (%#v)", len(report.Actions), report.Actions)
+	}
+	action := report.Actions[0]
+	if action.Dependency != "gentle-ai" {
+		t.Fatalf("Actions[0].Dependency = %q, want gentle-ai", action.Dependency)
+	}
+	if action.Package != "gentleman-programming/tap/gentle-ai" {
+		t.Fatalf("Actions[0].Package = %q, want tap package", action.Package)
+	}
+}


### PR DESCRIPTION
Closes #48

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds Codex as the first declarative `gentle-ai` provisioner consumer in `dots.yaml`.
- Declares `gentle-ai` and `engram` as Homebrew dependencies from `gentleman-programming/tap`.
- Includes selected provisioner dependencies in `dots deps check`, `dots deps plan`, and `dots deps install` with first-seen deduplication.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Adds the selected Codex `gentle-ai` provisioner and its dependencies. |
| `internal/deps/deps.go` | Selects dependencies from matching entries and provisioners. |
| `internal/deps/deps_test.go` | Covers check behavior for provisioner dependencies, OS/profile filtering, and deduplication. |
| `internal/deps/plan_test.go` | Covers planning selected provisioner dependencies. |
| `internal/deps/install_test.go` | Covers install dry-run preview for selected provisioner dependencies. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l internal/deps/deps.go internal/deps/deps_test.go internal/deps/install_test.go internal/deps/plan_test.go`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp>`
- [x] Sandboxed install dry-run: `go run ./cmd/dots install --dry-run --home <tmp> --source-root "$PWD" --state-root <tmp> --no-tui`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
