### PR TITLE
feat(config): provision claude code through gentle-ai

### DIFF
--- a/configs/claude/settings.json
+++ b/configs/claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "agentPushNotifEnabled": true,
+  "editorMode": "vim",
+  "env": {
+    "ENABLE_TOOL_SEARCH": "true"
+  },
+  "model": "opus",
+  "permissions": {
+    "allow": [
+      "mcp__codegraph__codegraph_search",
+      "mcp__codegraph__codegraph_context",
+      "mcp__codegraph__codegraph_callers",
+      "mcp__codegraph__codegraph_callees",
+      "mcp__codegraph__codegraph_impact",
+      "mcp__codegraph__codegraph_node",
+      "mcp__codegraph__codegraph_status"
+    ]
+  },
+  "statusLine": {
+    "command": "bash ~/.claude/statusline-command.sh",
+    "type": "command"
+  },
+  "theme": "dark-ansi"
+}

--- a/configs/claude/statusline-command.sh
+++ b/configs/claude/statusline-command.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Claude Code statusLine — plain text + Catppuccin Mocha palette
+
+input=$(cat)
+
+model=$(echo "$input" | jq -r '.model.display_name // ""')
+used_pct=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+total_tokens=$(echo "$input" | jq -r '.context_window.total_input_tokens // empty')
+five_h=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
+five_h_resets=$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // empty')
+seven_d=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
+seven_d_resets=$(echo "$input" | jq -r '.rate_limits.seven_day.resets_at // empty')
+vim_mode=$(echo "$input" | jq -r '.vim.mode // ""')
+perm_mode=$(echo "$input" | jq -r '.permission_mode // .permissionMode // ""')
+
+# Catppuccin Mocha palette
+blue='\033[38;2;137;180;250m'
+mauve='\033[38;2;203;166;247m'
+green='\033[38;2;166;227;161m'
+yellow='\033[38;2;249;226;175m'
+subtext='\033[38;2;166;173;200m'
+overlay='\033[38;2;108;112;134m'
+red='\033[38;2;243;139;168m'
+pink='\033[38;2;245;194;231m'
+reset='\033[0m'
+
+sep="${overlay} | ${reset}"
+
+# --- Build output ---
+
+# Model first
+if [ -n "$model" ]; then
+  printf "${subtext}%s${reset}" "$model"
+fi
+
+# Vim mode
+if [ -n "$vim_mode" ]; then
+  printf "$sep"
+  case "$vim_mode" in
+  NORMAL) printf "${red}N${reset}" ;;
+  INSERT) printf "${pink}I${reset}" ;;
+  VISUAL) printf "${mauve}V${reset}" ;;
+  REPLACE) printf "${yellow}R${reset}" ;;
+  *) printf "${subtext}%s${reset}" "$vim_mode" ;;
+  esac
+fi
+
+# Permission mode
+case "$perm_mode" in
+bypassPermissions)
+  printf "${sep}${pink}bypass${reset}"
+  ;;
+acceptEdits)
+  printf "${sep}${green}accept edits${reset}"
+  ;;
+plan)
+  printf "${sep}${yellow}plan${reset}"
+  ;;
+esac
+
+# Context used
+if [ -n "$used_pct" ]; then
+  ctx_pct=$(printf '%.1f' "$used_pct")
+  if [ -n "$total_tokens" ]; then
+    ctx_k=$(echo "$total_tokens" | awk '{printf "%.1fk", $1 / 1000}')
+    printf "${sep}${yellow}ctx: ${ctx_k} ${ctx_pct}%%${reset}"
+  else
+    printf "${sep}${yellow}ctx: ${ctx_pct}%%${reset}"
+  fi
+fi
+
+# 5-hour rate limit
+if [ -n "$five_h" ]; then
+  printf "$sep"
+  if [ -n "$five_h_resets" ]; then
+    now=$(date +%s)
+    diff_secs=$(( five_h_resets - now ))
+    [ "$diff_secs" -lt 0 ] && diff_secs=0
+    hours_left=$(( diff_secs / 3600 ))
+    minutes_left=$(( (diff_secs % 3600) / 60 ))
+    five_h_left=$(echo "$five_h" | awk '{printf "%.0f", 100 - $1}')
+    printf "${blue}${hours_left}h:${minutes_left}m ${five_h_left}%% left${reset} ${overlay}> %s${reset}" "$(date -r "$five_h_resets" +%H:%M 2>/dev/null || date -d "@$five_h_resets" +%H:%M 2>/dev/null)"
+  else
+    five_h_left=$(echo "$five_h" | awk '{printf "%.0f", 100 - $1}')
+    printf "${blue}5h ${five_h_left}%% left${reset}"
+  fi
+fi
+
+# 7-day rate limit
+if [ -n "$seven_d" ]; then
+  printf "$sep"
+  if [ -n "$seven_d_resets" ]; then
+    now=$(date +%s)
+    diff_secs=$(( seven_d_resets - now ))
+    [ "$diff_secs" -lt 0 ] && diff_secs=0
+    days_left=$(( (diff_secs + 86399) / 86400 ))
+    seven_d_left=$(echo "$seven_d" | awk '{printf "%.0f", 100 - $1}')
+    printf "${blue}${days_left}d ${seven_d_left}%% left${reset} ${overlay}> %s${reset}" "$(date -r "$seven_d_resets" +%d/%m 2>/dev/null || date -d "@$seven_d_resets" +%d/%m 2>/dev/null)"
+  else
+    seven_d_left=$(echo "$seven_d" | awk '{printf "%.0f", 100 - $1}')
+    printf "${blue}7d ${seven_d_left}%% left${reset}"
+  fi
+fi
+
+printf "\n"
+exit 0

--- a/dots.yaml
+++ b/dots.yaml
@@ -186,6 +186,22 @@ entries:
         apt: neovim
         dnf: neovim
         pacman: neovim
+  - source: configs/claude/settings.json
+    target: ~/.claude/settings.json
+    strategy: copy
+    tags:
+      - core
+    os:
+      - darwin
+      - linux
+  - source: configs/claude/statusline-command.sh
+    target: ~/.claude/statusline-command.sh
+    strategy: copy
+    tags:
+      - core
+    os:
+      - darwin
+      - linux
 provisioners:
   - tool: gentle-ai
     tags:
@@ -197,6 +213,7 @@ provisioners:
       sdd-mode: multi
       agents:
         - codex
+        - claude-code
     dependencies:
       - name: gentle-ai
         command: gentle-ai

--- a/internal/cli/claude_config_test.go
+++ b/internal/cli/claude_config_test.go
@@ -2,6 +2,7 @@ package cli_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,9 +14,10 @@ import (
 // TestClaudeDefaultProfileSeedsUserBaselineInSandbox proves that dots seeds the
 // user-owned Claude settings baseline and the portable statusLine script with a
 // copy strategy (regular files, not symlinks) before the gentle-ai provisioner
-// runs, and that the provisioner is rendered to install the claude-code agent.
-// The gentle-ai/engram tools are stubbed so the provisioner step exits cleanly
-// without merging its own keys, keeping the sandbox aligned.
+// runs, that the provisioner is invoked for the claude-code agent, and that the
+// provisioner never escapes the threaded sandbox HOME. The gentle-ai/engram
+// tools are stubbed so the provisioner step exits cleanly without merging its
+// own keys, keeping the sandbox aligned.
 func TestClaudeDefaultProfileSeedsUserBaselineInSandbox(t *testing.T) {
 	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
 	if err != nil {
@@ -23,8 +25,17 @@ func TestClaudeDefaultProfileSeedsUserBaselineInSandbox(t *testing.T) {
 	}
 	home := t.TempDir()
 	stateRoot := t.TempDir()
-	t.Setenv("HOME", t.TempDir())
-	stubGentleAIProvisionerTools(t)
+	// realHome is the inherited HOME that the sandboxed install must never touch.
+	realHome := t.TempDir()
+	t.Setenv("HOME", realHome)
+
+	// The gentle-ai stub records the argv it received (under the threaded HOME)
+	// so the test can assert the resolved provisioner command, not just the
+	// rendered plan. engram only needs to be present on PATH for the dep check.
+	stubDir := t.TempDir()
+	writeExecStub(t, filepath.Join(stubDir, "gentle-ai"), "#!/bin/sh\nprintf '%s' \"$*\" > \"$HOME/gentle-ai-args\"\n")
+	writeExecStub(t, filepath.Join(stubDir, "engram"), "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	install := cli.NewRootCommand()
 	var installOut bytes.Buffer
@@ -44,20 +55,17 @@ func TestClaudeDefaultProfileSeedsUserBaselineInSandbox(t *testing.T) {
 		t.Fatalf("dots install failed in sandbox: %v\noutput:\n%s", err, installOut.String())
 	}
 
+	settingsTarget := filepath.Join(home, ".claude", "settings.json")
+	scriptTarget := filepath.Join(home, ".claude", "statusline-command.sh")
+
 	// The settings baseline and statusLine script are copied (not symlinked) so
 	// gentle-ai can merge its own keys without writing back into the repo.
 	managed := []struct {
 		target string
 		source string
 	}{
-		{
-			target: filepath.Join(home, ".claude", "settings.json"),
-			source: filepath.Join(repoRoot, "configs", "claude", "settings.json"),
-		},
-		{
-			target: filepath.Join(home, ".claude", "statusline-command.sh"),
-			source: filepath.Join(repoRoot, "configs", "claude", "statusline-command.sh"),
-		},
+		{target: settingsTarget, source: filepath.Join(repoRoot, "configs", "claude", "settings.json")},
+		{target: scriptTarget, source: filepath.Join(repoRoot, "configs", "claude", "statusline-command.sh")},
 	}
 	for _, m := range managed {
 		info, err := os.Lstat(m.target)
@@ -80,18 +88,63 @@ func TestClaudeDefaultProfileSeedsUserBaselineInSandbox(t *testing.T) {
 		}
 	}
 
-	// The baseline must not version any gentle-ai-managed or runtime-state key.
-	settings, err := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+	// The statusLine script must stay executable so Claude Code can run it.
+	scriptInfo, err := os.Stat(scriptTarget)
+	if err != nil {
+		t.Fatalf("stat copied statusline script: %v", err)
+	}
+	if scriptInfo.Mode()&0o111 == 0 {
+		t.Fatalf("copied statusline script %q is not executable (mode %v)", scriptTarget, scriptInfo.Mode())
+	}
+
+	settings, err := os.ReadFile(settingsTarget)
 	if err != nil {
 		t.Fatalf("read seeded settings.json: %v", err)
 	}
+
+	// The baseline must version every user-owned key — guard against shipping an
+	// empty or gutted file that would still pass the forbidden-key checks below.
+	var parsed struct {
+		Model                 *string         `json:"model"`
+		Theme                 *string         `json:"theme"`
+		EditorMode            *string         `json:"editorMode"`
+		Env                   json.RawMessage `json:"env"`
+		AgentPushNotifEnabled *bool           `json:"agentPushNotifEnabled"`
+		StatusLine            json.RawMessage `json:"statusLine"`
+		Permissions           *struct {
+			Allow []string `json:"allow"`
+		} `json:"permissions"`
+	}
+	if err := json.Unmarshal(settings, &parsed); err != nil {
+		t.Fatalf("seeded settings.json is not valid JSON: %v\ncontent:\n%s", err, settings)
+	}
+	switch {
+	case parsed.Model == nil:
+		t.Fatalf("seeded settings.json missing user-owned key %q\ncontent:\n%s", "model", settings)
+	case parsed.Theme == nil:
+		t.Fatalf("seeded settings.json missing user-owned key %q\ncontent:\n%s", "theme", settings)
+	case parsed.EditorMode == nil:
+		t.Fatalf("seeded settings.json missing user-owned key %q\ncontent:\n%s", "editorMode", settings)
+	case len(parsed.Env) == 0:
+		t.Fatalf("seeded settings.json missing user-owned key %q\ncontent:\n%s", "env", settings)
+	case parsed.AgentPushNotifEnabled == nil:
+		t.Fatalf("seeded settings.json missing user-owned key %q\ncontent:\n%s", "agentPushNotifEnabled", settings)
+	case len(parsed.StatusLine) == 0:
+		t.Fatalf("seeded settings.json missing user-owned key %q\ncontent:\n%s", "statusLine", settings)
+	case parsed.Permissions == nil || len(parsed.Permissions.Allow) == 0:
+		t.Fatalf("seeded settings.json missing user-owned key %q\ncontent:\n%s", "permissions.allow", settings)
+	}
+
+	// The baseline must not version any gentle-ai-managed or runtime-state key.
+	// Keys are matched in their quoted JSON-token form to avoid substring
+	// collisions with allowed values (e.g. an MCP tool name containing "hooks").
 	for _, forbidden := range []string{
-		"permissions.deny", "\"deny\"", "hooks", "outputStyle",
-		"enabledPlugins", "extraKnownMarketplaces", "defaultMode",
-		"skipDangerousModePermissionPrompt",
+		"\"deny\"", "\"hooks\"", "\"outputStyle\"", "\"enabledPlugins\"",
+		"\"extraKnownMarketplaces\"", "\"defaultMode\"",
+		"\"skipDangerousModePermissionPrompt\"",
 	} {
 		if strings.Contains(string(settings), forbidden) {
-			t.Fatalf("seeded settings.json must not version %q\ncontent:\n%s", forbidden, settings)
+			t.Fatalf("seeded settings.json must not version %s\ncontent:\n%s", forbidden, settings)
 		}
 	}
 	// The statusLine command must be portable (no hardcoded absolute home path).
@@ -99,11 +152,24 @@ func TestClaudeDefaultProfileSeedsUserBaselineInSandbox(t *testing.T) {
 		t.Fatalf("seeded settings.json statusLine command is not normalized to ~\ncontent:\n%s", settings)
 	}
 
+	// The provisioner must have run, threaded to the sandbox HOME, with both
+	// agents resolved on its argv — not merely shown in the rendered plan.
+	gotArgs, err := os.ReadFile(filepath.Join(home, "gentle-ai-args"))
+	if err != nil {
+		t.Fatalf("provisioner did not run under the sandbox HOME %q: %v", home, err)
+	}
+	if !strings.Contains(string(gotArgs), "--agents codex,claude-code") {
+		t.Fatalf("provisioner argv = %q, want it to install agents codex,claude-code", gotArgs)
+	}
+	// And it must never have escaped into the inherited real HOME.
+	if _, err := os.Stat(filepath.Join(realHome, "gentle-ai-args")); err == nil {
+		t.Fatalf("provisioner wrote into the inherited HOME %q instead of the sandbox", realHome)
+	}
+
 	out := installOut.String()
 	for _, want := range []string{
 		"configs/claude/settings.json",
 		"configs/claude/statusline-command.sh",
-		// The single gentle-ai provisioner now installs both agents.
 		"codex,claude-code",
 	} {
 		if !strings.Contains(out, want) {

--- a/internal/cli/claude_config_test.go
+++ b/internal/cli/claude_config_test.go
@@ -1,0 +1,113 @@
+package cli_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/cli"
+)
+
+// TestClaudeDefaultProfileSeedsUserBaselineInSandbox proves that dots seeds the
+// user-owned Claude settings baseline and the portable statusLine script with a
+// copy strategy (regular files, not symlinks) before the gentle-ai provisioner
+// runs, and that the provisioner is rendered to install the claude-code agent.
+// The gentle-ai/engram tools are stubbed so the provisioner step exits cleanly
+// without merging its own keys, keeping the sandbox aligned.
+func TestClaudeDefaultProfileSeedsUserBaselineInSandbox(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	stubGentleAIProvisionerTools(t)
+
+	install := cli.NewRootCommand()
+	var installOut bytes.Buffer
+	install.SetOut(&installOut)
+	install.SetErr(&installOut)
+	install.SetArgs([]string{
+		"install",
+		"--file", filepath.Join(repoRoot, "dots.yaml"),
+		"--profile", "default",
+		"--source-root", repoRoot,
+		"--home", home,
+		"--state-root", stateRoot,
+		"--yes",
+	})
+
+	if err := install.Execute(); err != nil {
+		t.Fatalf("dots install failed in sandbox: %v\noutput:\n%s", err, installOut.String())
+	}
+
+	// The settings baseline and statusLine script are copied (not symlinked) so
+	// gentle-ai can merge its own keys without writing back into the repo.
+	managed := []struct {
+		target string
+		source string
+	}{
+		{
+			target: filepath.Join(home, ".claude", "settings.json"),
+			source: filepath.Join(repoRoot, "configs", "claude", "settings.json"),
+		},
+		{
+			target: filepath.Join(home, ".claude", "statusline-command.sh"),
+			source: filepath.Join(repoRoot, "configs", "claude", "statusline-command.sh"),
+		},
+	}
+	for _, m := range managed {
+		info, err := os.Lstat(m.target)
+		if err != nil {
+			t.Fatalf("claude target missing after sandbox install: %v\ninstall output:\n%s", err, installOut.String())
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			t.Fatalf("claude target %q is a symlink, want a regular copied file", m.target)
+		}
+		got, err := os.ReadFile(m.target)
+		if err != nil {
+			t.Fatalf("read copied claude target %q: %v", m.target, err)
+		}
+		want, err := os.ReadFile(m.source)
+		if err != nil {
+			t.Fatalf("read claude source %q: %v", m.source, err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("copied claude target %q content differs from source %q", m.target, m.source)
+		}
+	}
+
+	// The baseline must not version any gentle-ai-managed or runtime-state key.
+	settings, err := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatalf("read seeded settings.json: %v", err)
+	}
+	for _, forbidden := range []string{
+		"permissions.deny", "\"deny\"", "hooks", "outputStyle",
+		"enabledPlugins", "extraKnownMarketplaces", "defaultMode",
+		"skipDangerousModePermissionPrompt",
+	} {
+		if strings.Contains(string(settings), forbidden) {
+			t.Fatalf("seeded settings.json must not version %q\ncontent:\n%s", forbidden, settings)
+		}
+	}
+	// The statusLine command must be portable (no hardcoded absolute home path).
+	if !strings.Contains(string(settings), "bash ~/.claude/statusline-command.sh") {
+		t.Fatalf("seeded settings.json statusLine command is not normalized to ~\ncontent:\n%s", settings)
+	}
+
+	out := installOut.String()
+	for _, want := range []string{
+		"configs/claude/settings.json",
+		"configs/claude/statusline-command.sh",
+		// The single gentle-ai provisioner now installs both agents.
+		"codex,claude-code",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("install output missing %q\noutput:\n%s", want, out)
+		}
+	}
+}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -947,7 +947,7 @@ func TestRepositoryGitConfigInstallsAndReportsAlignedInSandbox(t *testing.T) {
 		"configs/zellij/config.kdl -> " + zellijConfigTarget,
 		"configs/zellij/layouts/default.kdl -> " + zellijLayoutTarget,
 		"configs/nvim -> " + nvimTarget,
-		"Summary: 12 ok, 0 missing, 0 conflict, 0 skipped, 0 drifted, 0 unsupported",
+		"Summary: 14 ok, 0 missing, 0 conflict, 0 skipped, 0 drifted, 0 unsupported",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("status output missing %q\noutput:\n%s", want, got)

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -1172,8 +1172,8 @@ func TestRepositoryManifestPlansMVPConfigurationSetSafely(t *testing.T) {
 		t.Fatalf("Build() error = %v", err)
 	}
 
-	if len(p.Actions) != 12 {
-		t.Fatalf("len(Actions) = %d, want 12", len(p.Actions))
+	if len(p.Actions) != 14 {
+		t.Fatalf("len(Actions) = %d, want 14", len(p.Actions))
 	}
 	for _, action := range p.Actions {
 		if action.Status != plan.StatusCreate {


### PR DESCRIPTION
## Summary

Implements #49 — provision Claude Code through the existing `gentle-ai` provisioner and version the user-only settings complement that `gentle-ai` preserves on merge.

## Changes

- **`dots.yaml`**: add `claude-code` to the `gentle-ai` provisioner `agents` list (now `[codex, claude-code]`, single entry → `--agents codex,claude-code`); add two `strategy: copy` entries (tags: core, os: darwin/linux) for `~/.claude/settings.json` and `~/.claude/statusline-command.sh`.
- **`configs/claude/settings.json`**: user-owned baseline only — `model`, `theme`, `editorMode`, `env`, `permissions.allow`, `agentPushNotifEnabled`, `statusLine`. `statusLine.command` normalized to a portable `~` path.
- **`configs/claude/statusline-command.sh`**: portable statusLine script.
- **`internal/cli/claude_config_test.go`**: sandbox test validating copy (not symlink), content match, forbidden-key guard, portable path, and that the provisioner renders `codex,claude-code`.

## Why copy, not symlink

The install pipeline applies file entries **before** running provisioners (`internal/cli/install.go`), so `dots` seeds the baseline first and `gentle-ai` merges its own keys (`hooks`, `outputStyle`, `permissions.deny`) on top. A symlink would let `gentle-ai` write its merged keys back into the versioned repo file; `copy`'s skip-on-conflict default gives safe seed-once semantics.

## Excluded on purpose

`permissions.deny`, `hooks`, `outputStyle` (gentle-ai-managed), `enabledPlugins`, `extraKnownMarketplaces` (runtime state), and `defaultMode` / `skipDangerousModePermissionPrompt` (would propagate a no-guardrails permission posture to every machine).

## Validation

- Full `go test ./...` green (updated entry-count assertions 12→14).
- Dry-run sandbox against a temporary `--home` confirms the two copy actions and `--agents codex,claude-code` without touching the real home.

Closes #49