### PR TITLE
feat(config): provision OpenCode through gentle-ai

### DIFF
--- a/dots.yaml
+++ b/dots.yaml
@@ -214,6 +214,7 @@ provisioners:
       agents:
         - codex
         - claude-code
+        - opencode
     dependencies:
       - name: gentle-ai
         command: gentle-ai

--- a/internal/cli/claude_config_test.go
+++ b/internal/cli/claude_config_test.go
@@ -33,7 +33,7 @@ func TestClaudeDefaultProfileSeedsUserBaselineInSandbox(t *testing.T) {
 	// so the test can assert the resolved provisioner command, not just the
 	// rendered plan. engram only needs to be present on PATH for the dep check.
 	stubDir := t.TempDir()
-	writeExecStub(t, filepath.Join(stubDir, "gentle-ai"), "#!/bin/sh\nprintf '%s' \"$*\" > \"$HOME/gentle-ai-args\"\n")
+	writeExecStub(t, filepath.Join(stubDir, "gentle-ai"), "#!/bin/sh\nprintf '%s' \"$*\" > \"$HOME/gentle-ai-args\"\ncase \" $* \" in\n  *\" --agents codex,claude-code,opencode \"*)\n    mkdir -p \"$HOME/.config/opencode\"\n    printf '{\"generated\":true}' > \"$HOME/.config/opencode/opencode.json\"\n    ;;\nesac\n")
 	writeExecStub(t, filepath.Join(stubDir, "engram"), "#!/bin/sh\nexit 0\n")
 	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
@@ -151,26 +151,35 @@ func TestClaudeDefaultProfileSeedsUserBaselineInSandbox(t *testing.T) {
 	if !strings.Contains(string(settings), "bash ~/.claude/statusline-command.sh") {
 		t.Fatalf("seeded settings.json statusLine command is not normalized to ~\ncontent:\n%s", settings)
 	}
+	if _, err := os.Stat(filepath.Join(repoRoot, "configs", "opencode")); !os.IsNotExist(err) {
+		t.Fatalf("repo must not version rendered OpenCode config under configs/opencode: %v", err)
+	}
 
-	// The provisioner must have run, threaded to the sandbox HOME, with both
+	// The provisioner must have run, threaded to the sandbox HOME, with all
 	// agents resolved on its argv — not merely shown in the rendered plan.
 	gotArgs, err := os.ReadFile(filepath.Join(home, "gentle-ai-args"))
 	if err != nil {
 		t.Fatalf("provisioner did not run under the sandbox HOME %q: %v", home, err)
 	}
-	if !strings.Contains(string(gotArgs), "--agents codex,claude-code") {
-		t.Fatalf("provisioner argv = %q, want it to install agents codex,claude-code", gotArgs)
+	if !strings.Contains(string(gotArgs), "--agents codex,claude-code,opencode") {
+		t.Fatalf("provisioner argv = %q, want it to install agents codex,claude-code,opencode", gotArgs)
 	}
 	// And it must never have escaped into the inherited real HOME.
 	if _, err := os.Stat(filepath.Join(realHome, "gentle-ai-args")); err == nil {
 		t.Fatalf("provisioner wrote into the inherited HOME %q instead of the sandbox", realHome)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".config", "opencode", "opencode.json")); err != nil {
+		t.Fatalf("OpenCode generated config did not land under the sandbox HOME %q: %v", home, err)
+	}
+	if _, err := os.Stat(filepath.Join(realHome, ".config", "opencode", "opencode.json")); err == nil {
+		t.Fatalf("OpenCode generated config escaped into the inherited HOME %q", realHome)
 	}
 
 	out := installOut.String()
 	for _, want := range []string{
 		"configs/claude/settings.json",
 		"configs/claude/statusline-command.sh",
-		"codex,claude-code",
+		"codex,claude-code,opencode",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("install output missing %q\noutput:\n%s", want, out)

--- a/internal/provision/plan.go
+++ b/internal/provision/plan.go
@@ -84,6 +84,9 @@ func managedRoots(prov manifest.Provisioner) []string {
 		if includes(prov.Spec.Agents, "codex") {
 			roots = append(roots, "~/.codex")
 		}
+		if includes(prov.Spec.Agents, "opencode") {
+			roots = append(roots, "~/.config/opencode")
+		}
 		return append(roots, "~/.gentle-ai")
 	default:
 		return nil

--- a/internal/provision/plan_test.go
+++ b/internal/provision/plan_test.go
@@ -97,7 +97,7 @@ func TestSelect(t *testing.T) {
 func TestPlanResolvesSelectedProvisioners(t *testing.T) {
 	prov := manifest.Provisioner{
 		Tool: "gentle-ai", Tags: []string{"core"},
-		Spec: manifest.ProvisionerSpec{Scope: "global", Agents: []string{"codex"}},
+		Spec: manifest.ProvisionerSpec{Scope: "global", Agents: []string{"codex", "opencode"}},
 	}
 	m := manifestWithProvisioners(prov)
 
@@ -116,12 +116,12 @@ func TestPlanResolvesSelectedProvisioners(t *testing.T) {
 	if step.Tool != "gentle-ai" || step.Executable != "gentle-ai" {
 		t.Fatalf("Step tool/executable = %q/%q, want gentle-ai", step.Tool, step.Executable)
 	}
-	wantArgs := []string{"install", "--scope", "global", "--agents", "codex"}
+	wantArgs := []string{"install", "--scope", "global", "--agents", "codex,opencode"}
 	if !reflect.DeepEqual(step.Args, wantArgs) {
 		t.Fatalf("Step.Args = %#v, want %#v", step.Args, wantArgs)
 	}
-	if !reflect.DeepEqual(step.Targets, []string{"~/.claude", "~/.codex", "~/.gentle-ai"}) {
-		t.Fatalf("Step.Targets = %#v, want [~/.claude ~/.codex ~/.gentle-ai]", step.Targets)
+	if !reflect.DeepEqual(step.Targets, []string{"~/.claude", "~/.codex", "~/.config/opencode", "~/.gentle-ai"}) {
+		t.Fatalf("Step.Targets = %#v, want [~/.claude ~/.codex ~/.config/opencode ~/.gentle-ai]", step.Targets)
 	}
 }
 


### PR DESCRIPTION
Closes #50

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds OpenCode to the existing `gentle-ai` provisioner invocation.
- Reports `~/.config/opencode` in provisioner blast-radius output when OpenCode is selected.
- Keeps OpenCode rendered configuration out of versioned dotfiles and validates sandboxed HOME behavior.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Adds `opencode` to the declarative `gentle-ai` agents list. |
| `internal/provision/plan.go` | Includes `~/.config/opencode` as a managed root when `opencode` is selected. |
| `internal/provision/plan_test.go` | Verifies OpenCode argv rendering and managed-root reporting. |
| `internal/cli/claude_config_test.go` | Verifies sandboxed provisioner argv, no `configs/opencode`, and generated OpenCode config under temp HOME only. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp>`
- [x] Sandboxed dry-run/status validation with `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.
- [x] Fresh adversarial review: APPROVED.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
