### PR TITLE
fix(doctor): scan directory sources

### DIFF
--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -145,6 +146,43 @@ func ScanSecrets(m manifest.Manifest, opts Options) (SecretReport, error) {
 }
 
 func scanSource(source, path string) ([]SecretFinding, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("stat secret scan source %s: %w", path, err)
+	}
+	if info.IsDir() {
+		var findings []SecretFinding
+		err := filepath.WalkDir(path, func(childPath string, entry os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if entry.IsDir() {
+				return nil
+			}
+			rel, err := filepath.Rel(path, childPath)
+			if err != nil {
+				return err
+			}
+			childSource := filepath.ToSlash(filepath.Join(source, rel))
+			childFindings, err := scanFile(childSource, childPath)
+			if err != nil {
+				return err
+			}
+			findings = append(findings, childFindings...)
+			return nil
+		})
+		if err != nil {
+			return nil, fmt.Errorf("scan source directory %s: %w", path, err)
+		}
+		return findings, nil
+	}
+	return scanFile(source, path)
+}
+
+func scanFile(source, path string) ([]SecretFinding, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -90,6 +90,27 @@ func TestScanSecretsIgnoresPlaceholdersAndUnselectedSources(t *testing.T) {
 	}
 }
 
+func TestScanSecretsScansDirectorySources(t *testing.T) {
+	sourceRoot := t.TempDir()
+	writeFile(t, sourceRoot, "configs/nvim/init.lua", "vim.g.mapleader = ' '\n")
+	writeFile(t, sourceRoot, "configs/nvim/lua/plugin.lua", "token = realtoken123\n")
+
+	report, err := doctor.ScanSecrets(singleEntryManifest("configs/nvim"), doctor.Options{
+		Profile: "default", OS: "linux", SourceRoot: sourceRoot,
+	})
+	if err != nil {
+		t.Fatalf("ScanSecrets() error = %v", err)
+	}
+
+	if len(report.Findings) != 1 {
+		t.Fatalf("Findings len = %d, want 1 (%#v)", len(report.Findings), report.Findings)
+	}
+	finding := report.Findings[0]
+	if finding.Source != "configs/nvim/lua/plugin.lua" || finding.Line != 1 || finding.Pattern != "credential-assignment" {
+		t.Fatalf("finding = %#v, want credential-assignment at configs/nvim/lua/plugin.lua:1", finding)
+	}
+}
+
 func TestBuildDiagnosticSections(t *testing.T) {
 	tests := []struct {
 		name            string


### PR DESCRIPTION
Closes #70

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Fixes `dots doctor` failing when a selected manifest source is a directory.
- Recursively scans directory sources during the secret scan guardrail.
- Adds regression coverage for nested files under directory sources.

## Changes

| File | Change |
|------|--------|
| `internal/doctor/doctor.go` | Detects directory sources and walks child files before scanning. |
| `internal/doctor/doctor_test.go` | Adds regression coverage for a `configs/nvim`-style directory source. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp>`
- [x] Sandboxed doctor validation: `go run ./cmd/dots doctor --file dots.yaml --profile default --source-root "$PWD" --home <tmp> --state-root <tmp>`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
