### PR TITLE
fix(deps): detect font Dependencies by installed-file presence

### DIFF
--- a/dots.yaml
+++ b/dots.yaml
@@ -198,8 +198,9 @@ entries:
       - name: zed
         command: zed
         brew: zed
-      - name: CaskaydiaCove Nerd Font
-        brew: font-caskaydia-cove-nerd-font
+      - name: CascadiaCode Nerd Font
+        brew: font-cascadia-code-nf
+        font_match: "CascadiaCodeNF*"
   - source: configs/zed/keymap.json
     target: ~/.config/zed/keymap.json
     strategy: symlink

--- a/internal/cli/deps.go
+++ b/internal/cli/deps.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -45,10 +46,11 @@ func newDepsCheckCommand() *cobra.Command {
 				return err
 			}
 
+			home, _ := os.UserHomeDir()
 			report, err := deps.Check(*m, deps.Options{
 				Profile: profile,
 				OS:      runtime.GOOS,
-			}, lookupCommand)
+			}, lookupCommand, fontInstalled(runtime.GOOS, home))
 			if err != nil {
 				return err
 			}
@@ -234,6 +236,41 @@ func (r depsExecRunner) Run(executable string, args []string) error {
 func lookupCommand(command string) bool {
 	_, err := exec.LookPath(command)
 	return err == nil
+}
+
+// fontDirectories returns the workstation directories that hold installed font
+// files for the given OS, rooting the per-user locations at home. A font
+// declared as a Dependency is detected by scanning these for a matching file.
+// When home is empty (e.g. $HOME unset) the per-user locations are omitted
+// rather than emitted as paths relative to the process working directory, so
+// detection degrades to the system directories instead of scanning the wrong
+// place. Font detection never aborts deps check, so a missing home is not fatal.
+func fontDirectories(goos, home string) []string {
+	if goos == "darwin" {
+		var dirs []string
+		if home != "" {
+			dirs = append(dirs, filepath.Join(home, "Library", "Fonts"))
+		}
+		return append(dirs, "/Library/Fonts", "/System/Library/Fonts")
+	}
+	// Linux and other fontconfig layouts.
+	var dirs []string
+	if home != "" {
+		dirs = append(dirs,
+			filepath.Join(home, ".local", "share", "fonts"),
+			filepath.Join(home, ".fonts"),
+		)
+	}
+	return append(dirs, "/usr/share/fonts", "/usr/local/share/fonts")
+}
+
+// fontInstalled is the production FontLookup: it scans the OS font directories
+// under home for an installed file matching the declared glob.
+func fontInstalled(goos, home string) deps.FontLookup {
+	dirs := fontDirectories(goos, home)
+	return func(match string) bool {
+		return deps.ScanFonts(dirs, match)
+	}
 }
 
 // resolveTier returns the Dependency Plan Tier, either from an explicit override

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -56,7 +56,7 @@ func newDoctorCommand() *cobra.Command {
 				OS:         runtime.GOOS,
 				SourceRoot: paths.SourceRoot,
 				Home:       paths.Home,
-			}, lookupCommand)
+			}, lookupCommand, fontInstalled(runtime.GOOS, paths.Home))
 			if err != nil {
 				return err
 			}

--- a/internal/cli/font_internal_test.go
+++ b/internal/cli/font_internal_test.go
@@ -1,0 +1,28 @@
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestFontDirectoriesOmitsPerUserDirsWhenHomeEmpty(t *testing.T) {
+	for _, goos := range []string{"darwin", "linux"} {
+		t.Run(goos, func(t *testing.T) {
+			for _, dir := range fontDirectories(goos, "") {
+				// A missing home must never yield a path relative to the process
+				// working directory; only absolute system directories remain.
+				if !filepath.IsAbs(dir) {
+					t.Fatalf("fontDirectories(%q, \"\") returned non-absolute %q", goos, dir)
+				}
+			}
+		})
+	}
+}
+
+func TestFontDirectoriesRootsPerUserDirsAtHome(t *testing.T) {
+	home := "/tmp/home"
+	got := fontDirectories("darwin", home)
+	if len(got) == 0 || got[0] != filepath.Join(home, "Library", "Fonts") {
+		t.Fatalf("fontDirectories(darwin, home)[0] = %q, want per-user Fonts dir first", got[0])
+	}
+}

--- a/internal/deps/deps.go
+++ b/internal/deps/deps.go
@@ -16,6 +16,11 @@ import (
 // in tests.
 type Lookup func(command string) bool
 
+// FontLookup reports whether a font matching the declared glob is installed on
+// the workstation. It is the injectable boundary around font-directory scanning,
+// parallel to Lookup, so font dependency checks stay deterministic in tests.
+type FontLookup func(match string) bool
+
 // Options carries the resolved inputs needed to select Dependencies.
 type Options struct {
 	Profile string
@@ -38,7 +43,7 @@ type CheckReport struct {
 // Check reports which Dependencies declared by the Profile's selected Managed
 // Entries and Provisioners are present on the workstation. Dependencies are
 // deduplicated by name in first-declared order.
-func Check(m manifest.Manifest, opts Options, look Lookup) (CheckReport, error) {
+func Check(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup) (CheckReport, error) {
 	selected, err := selectDependencies(m, opts)
 	if err != nil {
 		return CheckReport{}, err
@@ -46,12 +51,17 @@ func Check(m manifest.Manifest, opts Options, look Lookup) (CheckReport, error) 
 
 	report := CheckReport{Profile: opts.Profile}
 	for _, dep := range selected {
-		probe := dep.Probe()
-		report.Results = append(report.Results, Result{
-			Name:    dep.Name,
-			Command: probe,
-			Present: look(probe),
-		})
+		var result Result
+		if dep.IsFont() {
+			// A font has no executable on PATH; detect it as an installed asset
+			// by scanning the workstation font directories for a matching file.
+			match := strings.TrimSpace(dep.FontMatch)
+			result = Result{Name: dep.Name, Command: match, Present: fontLook(match)}
+		} else {
+			probe := dep.Probe()
+			result = Result{Name: dep.Name, Command: probe, Present: look(probe)}
+		}
+		report.Results = append(report.Results, result)
 	}
 	return report, nil
 }

--- a/internal/deps/deps_test.go
+++ b/internal/deps/deps_test.go
@@ -15,6 +15,48 @@ func lookupSet(present ...string) deps.Lookup {
 	return func(command string) bool { return set[command] }
 }
 
+func fontLookupSet(present ...string) deps.FontLookup {
+	set := make(map[string]bool, len(present))
+	for _, p := range present {
+		set[p] = true
+	}
+	return func(match string) bool { return set[match] }
+}
+
+func TestCheckDetectsFontDependencyByScanNotPath(t *testing.T) {
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"desktop"}}},
+		Entries: []manifest.Entry{
+			{
+				Source: "configs/zed/settings.json", Target: "~/.config/zed/settings.json", Strategy: "symlink", Tags: []string{"desktop"},
+				Dependencies: []manifest.Dependency{
+					{Name: "zed", Command: "zed"},
+					{Name: "CascadiaCode NF", FontMatch: "CascadiaCodeNF*", Brew: "font-cascadia-code-nf"},
+				},
+			},
+		},
+	}
+
+	// The font is installed on disk (font scan hits) but has no executable on
+	// PATH; the command tool is the inverse. Detection must use the right probe
+	// for each.
+	report, err := deps.Check(m, deps.Options{Profile: "default", OS: "darwin"},
+		lookupSet("zed"), fontLookupSet("CascadiaCodeNF*"))
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+	if len(report.Results) != 2 {
+		t.Fatalf("Results len = %d, want 2 (%#v)", len(report.Results), report.Results)
+	}
+	if !report.Results[1].Present {
+		t.Fatalf("Results[1] = %#v, want font present via scan", report.Results[1])
+	}
+	if report.Results[1].Name != "CascadiaCode NF" {
+		t.Fatalf("Results[1].Name = %q, want CascadiaCode NF", report.Results[1].Name)
+	}
+}
+
 func TestCheckReportsPresentAndMissingForProfile(t *testing.T) {
 	m := manifest.Manifest{
 		Version:  1,
@@ -30,7 +72,7 @@ func TestCheckReportsPresentAndMissingForProfile(t *testing.T) {
 		},
 	}
 
-	report, err := deps.Check(m, deps.Options{Profile: "default", OS: "darwin"}, lookupSet("tmux"))
+	report, err := deps.Check(m, deps.Options{Profile: "default", OS: "darwin"}, lookupSet("tmux"), fontLookupSet())
 	if err != nil {
 		t.Fatalf("Check() error = %v", err)
 	}
@@ -76,7 +118,7 @@ func TestCheckDedupesAndSkipsEntriesFilteredOutByOS(t *testing.T) {
 		},
 	}
 
-	report, err := deps.Check(m, deps.Options{Profile: "default", OS: "darwin"}, lookupSet("zsh"))
+	report, err := deps.Check(m, deps.Options{Profile: "default", OS: "darwin"}, lookupSet("zsh"), fontLookupSet())
 	if err != nil {
 		t.Fatalf("Check() error = %v", err)
 	}
@@ -110,7 +152,7 @@ func TestCheckTrimsAndDedupesPaddedNames(t *testing.T) {
 		},
 	}
 
-	report, err := deps.Check(m, deps.Options{Profile: "default", OS: "darwin"}, lookupSet())
+	report, err := deps.Check(m, deps.Options{Profile: "default", OS: "darwin"}, lookupSet(), fontLookupSet())
 	if err != nil {
 		t.Fatalf("Check() error = %v", err)
 	}
@@ -129,7 +171,7 @@ func TestCheckFailsOnUnknownProfile(t *testing.T) {
 		Entries:  []manifest.Entry{{Source: "s", Target: "~/.t", Strategy: "symlink", Tags: []string{"core"}}},
 	}
 
-	if _, err := deps.Check(m, deps.Options{Profile: "missing", OS: "darwin"}, lookupSet()); err == nil {
+	if _, err := deps.Check(m, deps.Options{Profile: "missing", OS: "darwin"}, lookupSet(), fontLookupSet()); err == nil {
 		t.Fatal("Check() error = nil, want error for unknown profile")
 	}
 }
@@ -156,7 +198,7 @@ func TestCheckIncludesSelectedProvisionerDependencies(t *testing.T) {
 		},
 	}
 
-	report, err := deps.Check(m, deps.Options{Profile: "default", OS: "darwin"}, lookupSet("zsh", "engram"))
+	report, err := deps.Check(m, deps.Options{Profile: "default", OS: "darwin"}, lookupSet("zsh", "engram"), fontLookupSet())
 	if err != nil {
 		t.Fatalf("Check() error = %v", err)
 	}
@@ -187,7 +229,7 @@ func TestCheckFiltersProvisionerDependenciesByProfileAndOS(t *testing.T) {
 		},
 	}
 
-	report, err := deps.Check(m, deps.Options{Profile: "default", OS: "darwin"}, lookupSet())
+	report, err := deps.Check(m, deps.Options{Profile: "default", OS: "darwin"}, lookupSet(), fontLookupSet())
 	if err != nil {
 		t.Fatalf("Check() error = %v", err)
 	}
@@ -219,7 +261,7 @@ func TestCheckDedupesProvisionerDependenciesWithEntries(t *testing.T) {
 		},
 	}
 
-	report, err := deps.Check(m, deps.Options{Profile: "default", OS: "darwin"}, lookupSet())
+	report, err := deps.Check(m, deps.Options{Profile: "default", OS: "darwin"}, lookupSet(), fontLookupSet())
 	if err != nil {
 		t.Fatalf("Check() error = %v", err)
 	}

--- a/internal/deps/font.go
+++ b/internal/deps/font.go
@@ -1,0 +1,44 @@
+package deps
+
+import (
+	"io/fs"
+	"path/filepath"
+	"strings"
+)
+
+// ScanFonts reports whether any installed font file under the given root
+// directories matches the declared glob. The match is case-insensitive against
+// the file name and the scan is recursive. A missing directory or a permission
+// error on a root is treated as "not found here" rather than an error, so a
+// Dependency check never aborts on an unreadable font directory.
+func ScanFonts(roots []string, match string) bool {
+	pattern := strings.ToLower(strings.TrimSpace(match))
+	if pattern == "" {
+		return false
+	}
+
+	for _, root := range roots {
+		found := false
+		_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				// Unreadable directory or entry: skip it, keep scanning.
+				if d != nil && d.IsDir() {
+					return fs.SkipDir
+				}
+				return nil
+			}
+			if d.IsDir() {
+				return nil
+			}
+			if ok, _ := filepath.Match(pattern, strings.ToLower(d.Name())); ok {
+				found = true
+				return fs.SkipAll
+			}
+			return nil
+		})
+		if found {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/deps/font_test.go
+++ b/internal/deps/font_test.go
@@ -1,0 +1,63 @@
+package deps_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/deps"
+)
+
+func TestScanFontsMatchesRecursivelyCaseInsensitive(t *testing.T) {
+	root := t.TempDir()
+	nested := filepath.Join(root, "CascadiaCode")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	// Installed font file lives in a nested directory and its casing differs
+	// from the declared glob; detection must still find it.
+	fontFile := filepath.Join(nested, "cascadiacodenf-regular.ttf")
+	if err := os.WriteFile(fontFile, []byte("font"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	if !deps.ScanFonts([]string{root}, "CascadiaCodeNF*") {
+		t.Fatalf("ScanFonts() = false, want true for installed matching font")
+	}
+}
+
+func TestScanFontsToleratesUnreadableSubdir(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+	root := t.TempDir()
+	// A matching font lives at the top level; a sibling subdirectory is
+	// unreadable. The permission error on the subtree must not abort the scan.
+	if err := os.WriteFile(filepath.Join(root, "CascadiaCodeNF-Bold.ttf"), []byte("font"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	locked := filepath.Join(root, "locked")
+	if err := os.MkdirAll(locked, 0o000); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+
+	if !deps.ScanFonts([]string{root}, "CascadiaCodeNF*") {
+		t.Fatalf("ScanFonts() = false, want true despite an unreadable subdirectory")
+	}
+}
+
+func TestScanFontsToleratesMissingRootAndNoMatch(t *testing.T) {
+	root := t.TempDir()
+	other := filepath.Join(root, "Arial.ttf")
+	if err := os.WriteFile(other, []byte("font"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	missing := filepath.Join(root, "does-not-exist")
+
+	// A missing font directory must not abort the scan; with no matching file
+	// anywhere, detection reports absence.
+	if deps.ScanFonts([]string{missing, root}, "CascadiaCodeNF*") {
+		t.Fatalf("ScanFonts() = true, want false when no font matches")
+	}
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -70,14 +70,14 @@ var secretPatterns = []secretPattern{
 }
 
 // Build runs all doctor diagnostics without mutating the filesystem.
-func Build(m manifest.Manifest, meta state.Metadata, opts Options, look deps.Lookup) (Report, error) {
+func Build(m manifest.Manifest, meta state.Metadata, opts Options, look deps.Lookup, fontLook deps.FontLookup) (Report, error) {
 	report := Report{
 		Profile:  opts.Profile,
 		OS:       opts.OS,
 		Platform: Platform{Supported: supportedOS(opts.OS), OS: opts.OS},
 	}
 
-	depReport, err := deps.Check(m, deps.Options{Profile: opts.Profile, OS: opts.OS}, look)
+	depReport, err := deps.Check(m, deps.Options{Profile: opts.Profile, OS: opts.OS}, look, fontLook)
 	if err != nil {
 		return Report{}, err
 	}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -143,7 +143,7 @@ func TestBuildDiagnosticSections(t *testing.T) {
 			m := singleEntryManifest("configs/app/config")
 			m.Entries[0].Dependencies = tt.deps
 
-			report, err := doctor.Build(m, state.Metadata{}, doctor.Options{Profile: "default", OS: tt.goos, SourceRoot: sourceRoot, Home: home}, lookupSet(tt.present...))
+			report, err := doctor.Build(m, state.Metadata{}, doctor.Options{Profile: "default", OS: tt.goos, SourceRoot: sourceRoot, Home: home}, lookupSet(tt.present...), fontLookupSet())
 			if err != nil {
 				t.Fatalf("Build() error = %v", err)
 			}
@@ -183,7 +183,7 @@ func TestBuildReportsProvisionerReadiness(t *testing.T) {
 	// without ever being executed.
 	report, err := doctor.Build(m, state.Metadata{}, doctor.Options{
 		Profile: "default", OS: "darwin", SourceRoot: sourceRoot, Home: home,
-	}, lookupSet("gentle-ai"))
+	}, lookupSet("gentle-ai"), fontLookupSet())
 	if err != nil {
 		t.Fatalf("Build() error = %v", err)
 	}
@@ -230,6 +230,14 @@ func lookupSet(present ...string) func(string) bool {
 		set[command] = true
 	}
 	return func(command string) bool { return set[command] }
+}
+
+func fontLookupSet(present ...string) func(string) bool {
+	set := make(map[string]bool, len(present))
+	for _, match := range present {
+		set[match] = true
+	}
+	return func(match string) bool { return set[match] }
 }
 
 func writeFile(t *testing.T, root, rel, content string) {

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -65,6 +65,17 @@ type Dependency struct {
 	Apt     string `yaml:"apt,omitempty"`
 	Dnf     string `yaml:"dnf,omitempty"`
 	Pacman  string `yaml:"pacman,omitempty"`
+	// FontMatch, when set, switches detection from a PATH lookup to a scan of
+	// the workstation font directories for an installed file whose name matches
+	// this case-insensitive glob (e.g. "CascadiaCodeNF*"). A font has no
+	// executable on the path, so it must be probed as an installed asset.
+	FontMatch string `yaml:"font_match,omitempty"`
+}
+
+// IsFont reports whether the Dependency is detected as an installed font asset
+// rather than an executable on PATH. It is true exactly when FontMatch is set.
+func (d Dependency) IsFont() bool {
+	return strings.TrimSpace(d.FontMatch) != ""
 }
 
 // Probe is the command name used to detect a Dependency's presence in PATH. It

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -184,6 +184,26 @@ func TestDependencyProbeTrimsWhitespace(t *testing.T) {
 	}
 }
 
+func TestDependencyIsFont(t *testing.T) {
+	tests := []struct {
+		name string
+		dep  manifest.Dependency
+		want bool
+	}{
+		{name: "command dependency is not a font", dep: manifest.Dependency{Name: "tmux"}, want: false},
+		{name: "font_match marks a font dependency", dep: manifest.Dependency{Name: "CascadiaCode NF", FontMatch: "CascadiaCodeNF*"}, want: true},
+		{name: "blank font_match is not a font", dep: manifest.Dependency{Name: "tmux", FontMatch: "  "}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.dep.IsFont(); got != tt.want {
+				t.Fatalf("IsFont() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestLoadFileRejectsUnknownFields(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "dots.yaml")


### PR DESCRIPTION
Closes #73

## Summary

- Fixes a detection bug: a declared Nerd Font Dependency was probed only as an executable on PATH, so it always reported missing and never converged.
- Adds an optional `font_match` field to the Dependency model; when set, presence is detected by scanning the workstation font directories for a matching installed file instead of a PATH lookup.
- Implements detection per ADR 0002 — provisioning the font stays out of scope.

## Changes

| File | Change |
|------|--------|
| `internal/manifest/manifest.go` | Add `FontMatch` field (`font_match`) and `IsFont()` to `Dependency`. |
| `internal/deps/font.go` | New `ScanFonts(roots, match)`: recursive, case-insensitive glob match on file name; missing dir / permission error tolerated (never aborts). |
| `internal/deps/deps.go` | New injectable `FontLookup`; `Check` branches to the font scan when `dep.IsFont()`. |
| `internal/cli/deps.go` | Production wiring: `fontDirectories(goos, home)` (macOS + Linux/fontconfig) and `fontInstalled`; empty home degrades to system dirs only. |
| `internal/cli/doctor.go`, `internal/doctor/doctor.go` | Thread the `FontLookup` through `doctor.Build`, honoring `--home`. |
| `dots.yaml` | Migrate font to `font-cascadia-code-nf` with `font_match: "CascadiaCodeNF*"`. |

## Test Plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass
- [x] `gofmt -l .` clean
- [x] Unit tests: recursive/case-insensitive match, missing root, unreadable subdir, `IsFont`, `Check` font branch, `fontDirectories` empty-home guard
- [x] Manual smoke test: sandbox `HOME` without the `.ttf` reports `missing`, with it reports `present`

## Notes

- Built test-first (strict TDD) and passed a fresh-context adversarial review. The review's MAJOR finding (relative font paths when `$HOME` is unset) is fixed by degrading to system directories rather than aborting, consistent with ADR 0002's "never abort deps check".
- Known accepted gap: no full CLI-level integration test for `font_match`; each layer is unit-tested and the end-to-end path was smoke-tested manually.
