### PR TITLE
feat(deps): support Homebrew cask dependencies

### DIFF
--- a/dots.yaml
+++ b/dots.yaml
@@ -199,7 +199,7 @@ entries:
         command: zed
         brew: zed
       - name: CascadiaCode Nerd Font
-        brew: font-cascadia-code-nf
+        brew_cask: font-cascadia-code-nf
         font_match: "CascadiaCodeNF*"
   - source: configs/zed/keymap.json
     target: ~/.config/zed/keymap.json

--- a/internal/cli/deps.go
+++ b/internal/cli/deps.go
@@ -90,10 +90,11 @@ func newDepsPlanCommand() *cobra.Command {
 				return err
 			}
 
+			home, _ := os.UserHomeDir()
 			report, err := deps.Plan(*m, deps.Options{
 				Profile: profile,
 				OS:      runtime.GOOS,
-			}, lookupCommand, resolvedTier)
+			}, lookupCommand, fontInstalled(runtime.GOOS, home), resolvedTier)
 			if err != nil {
 				return err
 			}
@@ -140,7 +141,8 @@ func newDepsInstallCommand() *cobra.Command {
 				OS:      runtime.GOOS,
 			}
 
-			report, err := deps.InstallDryRun(*m, options, lookupCommand, resolvedTier)
+			home, _ := os.UserHomeDir()
+			report, err := deps.InstallDryRun(*m, options, lookupCommand, fontInstalled(runtime.GOOS, home), resolvedTier)
 			if err != nil {
 				return err
 			}
@@ -183,7 +185,8 @@ func newDepsInstallCommand() *cobra.Command {
 }
 
 func runDepsInstall(cmd *cobra.Command, m manifest.Manifest, options deps.Options, tier deps.Tier) error {
-	report, err := deps.Install(m, options, lookupCommand, tier, depsExecRunner{
+	home, _ := os.UserHomeDir()
+	report, err := deps.Install(m, options, lookupCommand, fontInstalled(runtime.GOOS, home), tier, depsExecRunner{
 		ctx:    cmd.Context(),
 		stdin:  cmd.InOrStdin(),
 		stdout: cmd.OutOrStdout(),

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -110,7 +110,7 @@ func runProvisioners(cmd *cobra.Command, m manifest.Manifest, profile, home stri
 		stdout: cmd.OutOrStdout(),
 		stderr: cmd.ErrOrStderr(),
 	}
-	report, err := provision.Apply(m, provision.Options{Profile: profile, OS: runtime.GOOS}, lookupCommand, runner)
+	report, err := provision.Apply(m, provision.Options{Profile: profile, OS: runtime.GOOS}, lookupCommand, fontInstalled(runtime.GOOS, home), runner)
 	renderProvisionReport(cmd.OutOrStdout(), report)
 	return err
 }

--- a/internal/deps/deps.go
+++ b/internal/deps/deps.go
@@ -51,19 +51,28 @@ func Check(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup) 
 
 	report := CheckReport{Profile: opts.Profile}
 	for _, dep := range selected {
-		var result Result
-		if dep.IsFont() {
-			// A font has no executable on PATH; detect it as an installed asset
-			// by scanning the workstation font directories for a matching file.
-			match := strings.TrimSpace(dep.FontMatch)
-			result = Result{Name: dep.Name, Command: match, Present: fontLook(match)}
-		} else {
-			probe := dep.Probe()
-			result = Result{Name: dep.Name, Command: probe, Present: look(probe)}
-		}
+		result := checkResult(dep, look, fontLook)
 		report.Results = append(report.Results, result)
 	}
 	return report, nil
+}
+
+func dependencyPresent(dep manifest.Dependency, look Lookup, fontLook FontLookup) bool {
+	if dep.IsFont() {
+		return fontLook(strings.TrimSpace(dep.FontMatch))
+	}
+	return look(dep.Probe())
+}
+
+func checkResult(dep manifest.Dependency, look Lookup, fontLook FontLookup) Result {
+	if dep.IsFont() {
+		// A font has no executable on PATH; detect it as an installed asset
+		// by scanning the workstation font directories for a matching file.
+		match := strings.TrimSpace(dep.FontMatch)
+		return Result{Name: dep.Name, Command: match, Present: fontLook(match)}
+	}
+	probe := dep.Probe()
+	return Result{Name: dep.Name, Command: probe, Present: look(probe)}
 }
 
 // selectDependencies gathers the Dependencies of every Managed Entry and

--- a/internal/deps/install.go
+++ b/internal/deps/install.go
@@ -68,8 +68,8 @@ type InstallReport struct {
 
 // InstallDryRun computes the install preview for missing Dependencies without
 // executing package managers.
-func InstallDryRun(m manifest.Manifest, opts Options, look Lookup, tier Tier) (InstallDryRunReport, error) {
-	plan, err := Plan(m, opts, look, tier)
+func InstallDryRun(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup, tier Tier) (InstallDryRunReport, error) {
+	plan, err := Plan(m, opts, look, fontLook, tier)
 	if err != nil {
 		return InstallDryRunReport{}, err
 	}
@@ -94,8 +94,8 @@ func InstallDryRun(m manifest.Manifest, opts Options, look Lookup, tier Tier) (I
 
 // Install executes missing executable install actions and re-probes each
 // dependency after a successful package-manager command.
-func Install(m manifest.Manifest, opts Options, look Lookup, tier Tier, runner Runner) (InstallReport, error) {
-	plan, err := Plan(m, opts, look, tier)
+func Install(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup, tier Tier, runner Runner) (InstallReport, error) {
+	plan, err := Plan(m, opts, look, fontLook, tier)
 	if err != nil {
 		return InstallReport{}, err
 	}
@@ -123,7 +123,7 @@ func Install(m manifest.Manifest, opts Options, look Lookup, tier Tier, runner R
 			})
 			return report, fmt.Errorf("install %q: %w", action.Dependency, err)
 		}
-		if !look(action.Probe) {
+		if !actionPresent(action, look, fontLook) {
 			unresolved = true
 			report.Items = append(report.Items, InstallItem{
 				Dependency: action.Dependency,
@@ -146,6 +146,13 @@ func Install(m manifest.Manifest, opts Options, look Lookup, tier Tier, runner R
 		return report, errors.New("unresolved dependencies remain after install")
 	}
 	return report, nil
+}
+
+func actionPresent(action InstallAction, look Lookup, fontLook FontLookup) bool {
+	if action.FontMatch != "" {
+		return fontLook(action.FontMatch)
+	}
+	return look(action.Probe)
 }
 
 func installArgsWithConfirmation(action InstallAction, tier Tier) []string {

--- a/internal/deps/install_test.go
+++ b/internal/deps/install_test.go
@@ -18,7 +18,7 @@ func TestInstallYesExecutesInstallableActionsThroughRunner(t *testing.T) {
 		},
 	}
 
-	report, err := deps.Install(planManifest(), deps.Options{Profile: "default", OS: "darwin"}, look, deps.TierHomebrew, runner)
+	report, err := deps.Install(planManifest(), deps.Options{Profile: "default", OS: "darwin"}, look, fontLookupSet(), deps.TierHomebrew, runner)
 	if err != nil {
 		t.Fatalf("Install() error = %v", err)
 	}
@@ -57,7 +57,7 @@ func TestInstallYesUsesPackageManagerConfirmationArgs(t *testing.T) {
 
 			if _, err := deps.Install(planManifest(), deps.Options{Profile: "default", OS: "darwin"}, func(command string) bool {
 				return present[command]
-			}, tt.tier, runner); err != nil {
+			}, fontLookupSet(), tt.tier, runner); err != nil {
 				t.Fatalf("Install() error = %v", err)
 			}
 
@@ -88,7 +88,7 @@ func TestInstallYesExecutesMissingInstallableActionsInPlanOrder(t *testing.T) {
 
 	if _, err := deps.Install(installSelectionManifest(), deps.Options{Profile: "default", OS: "darwin"}, func(command string) bool {
 		return present[command]
-	}, deps.TierHomebrew, runner); err != nil {
+	}, fontLookupSet(), deps.TierHomebrew, runner); err != nil {
 		t.Fatalf("Install() error = %v", err)
 	}
 
@@ -105,7 +105,7 @@ func TestInstallYesExecutesMissingInstallableActionsInPlanOrder(t *testing.T) {
 func TestInstallYesDoesNotRunManualActionsAndReportsUnresolved(t *testing.T) {
 	runner := &recordingRunner{}
 
-	report, err := deps.Install(manualOnlyManifest(), deps.Options{Profile: "default", OS: "linux"}, lookupSet(), deps.TierGeneric, runner)
+	report, err := deps.Install(manualOnlyManifest(), deps.Options{Profile: "default", OS: "linux"}, lookupSet(), fontLookupSet(), deps.TierGeneric, runner)
 	if err == nil {
 		t.Fatalf("Install() error = nil, want unresolved manual dependency error")
 	}
@@ -125,7 +125,7 @@ func TestInstallYesReprobesAfterSuccessAndErrorsWhenStillMissing(t *testing.T) {
 		return command == "tmux"
 	}
 
-	report, err := deps.Install(planManifest(), deps.Options{Profile: "default", OS: "darwin"}, look, deps.TierHomebrew, runner)
+	report, err := deps.Install(planManifest(), deps.Options{Profile: "default", OS: "darwin"}, look, fontLookupSet(), deps.TierHomebrew, runner)
 	if err == nil {
 		t.Fatalf("Install() error = nil, want unresolved dependency error")
 	}
@@ -144,7 +144,7 @@ func TestInstallYesStopsOnFirstRunnerFailure(t *testing.T) {
 	runnerErr := errors.New("package manager failed")
 	runner := &recordingRunner{err: runnerErr}
 
-	report, err := deps.Install(installSelectionManifest(), deps.Options{Profile: "default", OS: "darwin"}, lookupSet("tmux", "nvim"), deps.TierHomebrew, runner)
+	report, err := deps.Install(installSelectionManifest(), deps.Options{Profile: "default", OS: "darwin"}, lookupSet("tmux", "nvim"), fontLookupSet(), deps.TierHomebrew, runner)
 	if !errors.Is(err, runnerErr) {
 		t.Fatalf("Install() error = %v, want runner error", err)
 	}
@@ -159,7 +159,7 @@ func TestInstallYesStopsOnFirstRunnerFailure(t *testing.T) {
 func TestInstallYesSkipsAlreadyPresentDependenciesBeforeExecution(t *testing.T) {
 	runner := &recordingRunner{}
 
-	report, err := deps.Install(planManifest(), deps.Options{Profile: "default", OS: "darwin"}, lookupSet("tmux", "starship"), deps.TierHomebrew, runner)
+	report, err := deps.Install(planManifest(), deps.Options{Profile: "default", OS: "darwin"}, lookupSet("tmux", "starship"), fontLookupSet(), deps.TierHomebrew, runner)
 	if err != nil {
 		t.Fatalf("Install() error = %v", err)
 	}
@@ -177,7 +177,7 @@ func TestInstallYesAllowsProgressWithManualAndInstallableDependencies(t *testing
 
 	report, err := deps.Install(mixedManualAndInstallableManifest(), deps.Options{Profile: "default", OS: "darwin"}, func(command string) bool {
 		return present[command]
-	}, deps.TierHomebrew, runner)
+	}, fontLookupSet(), deps.TierHomebrew, runner)
 	if err == nil {
 		t.Fatalf("Install() error = nil, want unresolved manual dependency error")
 	}
@@ -244,8 +244,45 @@ func (r *recordingRunner) Run(executable string, args []string) error {
 	return nil
 }
 
+func TestInstallYesExecutesHomebrewCaskActionsThroughRunner(t *testing.T) {
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"desktop"}}},
+		Entries: []manifest.Entry{
+			{
+				Source: "configs/zed/settings.json", Target: "~/.config/zed/settings.json", Strategy: "symlink", Tags: []string{"desktop"},
+				Dependencies: []manifest.Dependency{
+					{Name: "CascadiaCode Nerd Font", BrewCask: "font-cascadia-code-nf", FontMatch: "CascadiaCodeNF*"},
+				},
+			},
+		},
+	}
+	fontPresent := false
+	runner := &recordingRunner{afterRun: func() { fontPresent = true }}
+
+	report, err := deps.Install(m, deps.Options{Profile: "default", OS: "darwin"}, lookupSet(), func(match string) bool {
+		return fontPresent && match == "CascadiaCodeNF*"
+	}, deps.TierHomebrew, runner)
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+
+	if len(runner.calls) != 1 {
+		t.Fatalf("runner calls len = %d, want 1 (%#v)", len(runner.calls), runner.calls)
+	}
+	if runner.calls[0].executable != "brew" {
+		t.Fatalf("runner executable = %q, want brew", runner.calls[0].executable)
+	}
+	if !reflect.DeepEqual(runner.calls[0].args, []string{"install", "--cask", "font-cascadia-code-nf"}) {
+		t.Fatalf("runner args = %#v, want brew install --cask font-cascadia-code-nf", runner.calls[0].args)
+	}
+	if len(report.Items) != 1 || report.Items[0].Status != deps.InstallStatusInstalled {
+		t.Fatalf("report items = %#v, want one installed item", report.Items)
+	}
+}
+
 func TestInstallDryRunReportsInstallableActions(t *testing.T) {
-	report, err := deps.InstallDryRun(planManifest(), deps.Options{Profile: "default", OS: "darwin"}, lookupSet("tmux"), deps.TierHomebrew)
+	report, err := deps.InstallDryRun(planManifest(), deps.Options{Profile: "default", OS: "darwin"}, lookupSet("tmux"), fontLookupSet(), deps.TierHomebrew)
 	if err != nil {
 		t.Fatalf("InstallDryRun() error = %v", err)
 	}
@@ -279,7 +316,7 @@ func TestInstallDryRunReportsInstallableActions(t *testing.T) {
 }
 
 func TestInstallDryRunReportsManualActionsAsManual(t *testing.T) {
-	report, err := deps.InstallDryRun(manualOnlyManifest(), deps.Options{Profile: "default", OS: "linux"}, lookupSet(), deps.TierGeneric)
+	report, err := deps.InstallDryRun(manualOnlyManifest(), deps.Options{Profile: "default", OS: "linux"}, lookupSet(), fontLookupSet(), deps.TierGeneric)
 	if err != nil {
 		t.Fatalf("InstallDryRun() error = %v", err)
 	}
@@ -313,7 +350,7 @@ func manualOnlyManifest() manifest.Manifest {
 }
 
 func TestInstallDryRunUsesPlanSelectionOrderAndSkipsPresentDependencies(t *testing.T) {
-	report, err := deps.InstallDryRun(installSelectionManifest(), deps.Options{Profile: "default", OS: "darwin"}, lookupSet("tmux", "nvim"), deps.TierHomebrew)
+	report, err := deps.InstallDryRun(installSelectionManifest(), deps.Options{Profile: "default", OS: "darwin"}, lookupSet("tmux", "nvim"), fontLookupSet(), deps.TierHomebrew)
 	if err != nil {
 		t.Fatalf("InstallDryRun() error = %v", err)
 	}
@@ -368,7 +405,7 @@ func TestInstallDryRunIncludesSelectedProvisionerDependencies(t *testing.T) {
 		},
 	}
 
-	report, err := deps.InstallDryRun(m, deps.Options{Profile: "default", OS: "darwin"}, lookupSet("engram"), deps.TierHomebrew)
+	report, err := deps.InstallDryRun(m, deps.Options{Profile: "default", OS: "darwin"}, lookupSet("engram"), fontLookupSet(), deps.TierHomebrew)
 	if err != nil {
 		t.Fatalf("InstallDryRun() error = %v", err)
 	}

--- a/internal/deps/plan.go
+++ b/internal/deps/plan.go
@@ -14,6 +14,7 @@ import (
 type InstallAction struct {
 	Dependency string
 	Probe      string
+	FontMatch  string
 	Package    string
 	Executable string
 	Args       []string
@@ -42,7 +43,7 @@ type PlanReport struct {
 
 // Plan computes advisory installation guidance for the Dependencies that the
 // Profile needs but the workstation is missing, tailored to the active Tier.
-func Plan(m manifest.Manifest, opts Options, look Lookup, tier Tier) (PlanReport, error) {
+func Plan(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup, tier Tier) (PlanReport, error) {
 	selected, err := selectDependencies(m, opts)
 	if err != nil {
 		return PlanReport{}, err
@@ -50,7 +51,7 @@ func Plan(m manifest.Manifest, opts Options, look Lookup, tier Tier) (PlanReport
 
 	report := PlanReport{Profile: opts.Profile, Tier: tier}
 	for _, dep := range selected {
-		if look(dep.Probe()) {
+		if dependencyPresent(dep, look, fontLook) {
 			continue
 		}
 		action := actionFor(dep, tier)
@@ -65,11 +66,12 @@ func Plan(m manifest.Manifest, opts Options, look Lookup, tier Tier) (PlanReport
 func actionFor(dep manifest.Dependency, tier Tier) InstallAction {
 	pkg, executable, args := tierPackage(dep, tier)
 	if pkg == "" {
-		return InstallAction{Dependency: dep.Name, Probe: dep.Probe(), Manual: manualNote(dep, tier)}
+		return InstallAction{Dependency: dep.Name, Probe: dep.Probe(), FontMatch: strings.TrimSpace(dep.FontMatch), Manual: manualNote(dep, tier)}
 	}
 	return InstallAction{
 		Dependency: dep.Name,
 		Probe:      dep.Probe(),
+		FontMatch:  strings.TrimSpace(dep.FontMatch),
 		Package:    pkg,
 		Executable: executable,
 		Args:       append(args, pkg),
@@ -95,19 +97,30 @@ func (a InstallAction) commandHint() string {
 func tierPackage(dep manifest.Dependency, tier Tier) (pkg, executable string, args []string) {
 	switch tier {
 	case TierHomebrew:
-		return dep.Brew, "brew", []string{"install"}
+		if pkg := strings.TrimSpace(dep.BrewCask); pkg != "" {
+			return pkg, "brew", []string{"install", "--cask"}
+		}
+		return strings.TrimSpace(dep.Brew), "brew", []string{"install"}
 	case TierDebian:
-		return dep.Apt, "sudo", []string{"apt-get", "install"}
+		return strings.TrimSpace(dep.Apt), "sudo", []string{"apt-get", "install"}
 	case TierFedora:
-		return dep.Dnf, "sudo", []string{"dnf", "install"}
+		return strings.TrimSpace(dep.Dnf), "sudo", []string{"dnf", "install"}
 	case TierArch:
-		return dep.Pacman, "sudo", []string{"pacman", "-S"}
+		return strings.TrimSpace(dep.Pacman), "sudo", []string{"pacman", "-S"}
 	default:
 		return "", "", nil
 	}
 }
 
 func manualNote(dep manifest.Dependency, tier Tier) string {
+	if dep.IsFont() && tier != TierHomebrew {
+		name := strings.TrimSpace(dep.Name)
+		match := strings.TrimSpace(dep.FontMatch)
+		if cask := strings.TrimSpace(dep.BrewCask); cask != "" {
+			return fmt.Sprintf("obtain the font files for %q manually on Linux using Homebrew cask token %q as the package/source clue; copy .ttf/.otf files into ~/.local/share/fonts; run fc-cache -f ~/.local/share/fonts; rerun dots deps check; dots will detect files matching font_match %q", name, cask, match)
+		}
+		return fmt.Sprintf("obtain the font files for %q manually on Linux; copy .ttf/.otf files into ~/.local/share/fonts; run fc-cache -f ~/.local/share/fonts; rerun dots deps check; dots will detect files matching font_match %q", name, match)
+	}
 	if tier == TierGeneric {
 		return fmt.Sprintf("install %q with your distribution's package manager", dep.Name)
 	}

--- a/internal/deps/plan_test.go
+++ b/internal/deps/plan_test.go
@@ -2,6 +2,7 @@ package deps_test
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/yersonargotev/dots/internal/deps"
@@ -39,7 +40,7 @@ func TestPlanProducesStructuredInstallActionsForMappedPackages(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			report, err := deps.Plan(planManifest(), deps.Options{Profile: "default", OS: "darwin"}, lookupSet("tmux"), tt.tier)
+			report, err := deps.Plan(planManifest(), deps.Options{Profile: "default", OS: "darwin"}, lookupSet("tmux"), fontLookupSet(), tt.tier)
 			if err != nil {
 				t.Fatalf("Plan() error = %v", err)
 			}
@@ -67,6 +68,94 @@ func TestPlanProducesStructuredInstallActionsForMappedPackages(t *testing.T) {
 	}
 }
 
+func TestPlanProducesHomebrewCaskActionsForMappedPackages(t *testing.T) {
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"desktop"}}},
+		Entries: []manifest.Entry{
+			{
+				Source: "configs/zed/settings.json", Target: "~/.config/zed/settings.json", Strategy: "symlink", Tags: []string{"desktop"},
+				Dependencies: []manifest.Dependency{
+					{Name: "CascadiaCode Nerd Font", BrewCask: "  font-cascadia-code-nf  ", FontMatch: "CascadiaCodeNF*"},
+				},
+			},
+		},
+	}
+
+	var commandProbes []string
+	report, err := deps.Plan(m, deps.Options{Profile: "default", OS: "darwin"}, func(command string) bool {
+		commandProbes = append(commandProbes, command)
+		return false
+	}, fontLookupSet(), deps.TierHomebrew)
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+
+	if len(commandProbes) != 0 {
+		t.Fatalf("command probes = %#v, want none for font dependency", commandProbes)
+	}
+	if len(report.Actions) != 1 {
+		t.Fatalf("Actions len = %d, want 1 (%#v)", len(report.Actions), report.Actions)
+	}
+	action := report.Actions[0]
+	if action.Package != "font-cascadia-code-nf" {
+		t.Fatalf("Package = %q, want font-cascadia-code-nf", action.Package)
+	}
+	if action.Executable != "brew" {
+		t.Fatalf("Executable = %q, want brew", action.Executable)
+	}
+	if !reflect.DeepEqual(action.Args, []string{"install", "--cask", "font-cascadia-code-nf"}) {
+		t.Fatalf("Args = %#v, want brew install --cask font-cascadia-code-nf", action.Args)
+	}
+	if report.Items[0].Command != "brew install --cask font-cascadia-code-nf" {
+		t.Fatalf("Command = %q, want brew install --cask font-cascadia-code-nf", report.Items[0].Command)
+	}
+}
+
+func TestPlanKeepsCaskOnlyFontsManualOutsideHomebrew(t *testing.T) {
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"desktop"}}},
+		Entries: []manifest.Entry{
+			{
+				Source: "configs/zed/settings.json", Target: "~/.config/zed/settings.json", Strategy: "symlink", Tags: []string{"desktop"},
+				Dependencies: []manifest.Dependency{
+					{Name: "CascadiaCode Nerd Font", BrewCask: "font-cascadia-code-nf", FontMatch: "CascadiaCodeNF*"},
+				},
+			},
+		},
+	}
+
+	report, err := deps.Plan(m, deps.Options{Profile: "default", OS: "linux"}, lookupSet(), fontLookupSet(), deps.TierDebian)
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+
+	if len(report.Actions) != 1 {
+		t.Fatalf("Actions len = %d, want 1 (%#v)", len(report.Actions), report.Actions)
+	}
+	action := report.Actions[0]
+	if action.Executable != "" || len(action.Args) != 0 || action.Package != "" {
+		t.Fatalf("linux cask-only font action = %#v, want manual advisory action", action)
+	}
+	if action.Manual == "" {
+		t.Fatalf("Manual empty, want advisory-only guidance")
+	}
+	wantSteps := []string{
+		`obtain the font files for "CascadiaCode Nerd Font"`,
+		`Homebrew cask token "font-cascadia-code-nf"`,
+		`copy .ttf/.otf files into ~/.local/share/fonts`,
+		`run fc-cache -f ~/.local/share/fonts`,
+		`rerun dots deps check`,
+		`font_match "CascadiaCodeNF*"`,
+	}
+	for _, want := range wantSteps {
+		if !strings.Contains(action.Manual, want) {
+			t.Fatalf("Manual = %q, want advisory step containing %q", action.Manual, want)
+		}
+	}
+}
+
 func TestPlanProducesTierGuidanceForMissingDependencies(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -82,7 +171,7 @@ func TestPlanProducesTierGuidanceForMissingDependencies(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// tmux is present, starship missing: only starship should be planned.
-			report, err := deps.Plan(planManifest(), deps.Options{Profile: "default", OS: "darwin"}, lookupSet("tmux"), tt.tier)
+			report, err := deps.Plan(planManifest(), deps.Options{Profile: "default", OS: "darwin"}, lookupSet("tmux"), fontLookupSet(), tt.tier)
 			if err != nil {
 				t.Fatalf("Plan() error = %v", err)
 			}
@@ -124,7 +213,7 @@ func TestPlanFallsBackToManualGuidance(t *testing.T) {
 	}
 
 	t.Run("generic tier is always manual", func(t *testing.T) {
-		report, err := deps.Plan(m, deps.Options{Profile: "default", OS: "linux"}, lookupSet(), deps.TierGeneric)
+		report, err := deps.Plan(m, deps.Options{Profile: "default", OS: "linux"}, lookupSet(), fontLookupSet(), deps.TierGeneric)
 		if err != nil {
 			t.Fatalf("Plan() error = %v", err)
 		}
@@ -142,7 +231,7 @@ func TestPlanFallsBackToManualGuidance(t *testing.T) {
 	})
 
 	t.Run("missing package field falls back to manual", func(t *testing.T) {
-		report, err := deps.Plan(m, deps.Options{Profile: "default", OS: "linux"}, lookupSet(), deps.TierDebian)
+		report, err := deps.Plan(m, deps.Options{Profile: "default", OS: "linux"}, lookupSet(), fontLookupSet(), deps.TierDebian)
 		if err != nil {
 			t.Fatalf("Plan() error = %v", err)
 		}
@@ -184,7 +273,7 @@ func TestPlanProducesManualInstallActions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			report, err := deps.Plan(m, deps.Options{Profile: "default", OS: "linux"}, lookupSet(), tt.tier)
+			report, err := deps.Plan(m, deps.Options{Profile: "default", OS: "linux"}, lookupSet(), fontLookupSet(), tt.tier)
 			if err != nil {
 				t.Fatalf("Plan() error = %v", err)
 			}
@@ -234,7 +323,7 @@ func TestPlanActionsUseManifestOrderAndSkipPresentDependencies(t *testing.T) {
 		},
 	}
 
-	report, err := deps.Plan(m, deps.Options{Profile: "default", OS: "darwin"}, lookupSet("tmux", "nvim"), deps.TierHomebrew)
+	report, err := deps.Plan(m, deps.Options{Profile: "default", OS: "darwin"}, lookupSet("tmux", "nvim"), fontLookupSet(), deps.TierHomebrew)
 	if err != nil {
 		t.Fatalf("Plan() error = %v", err)
 	}
@@ -253,7 +342,7 @@ func TestPlanActionsUseManifestOrderAndSkipPresentDependencies(t *testing.T) {
 }
 
 func TestPlanIsEmptyWhenAllDependenciesPresent(t *testing.T) {
-	report, err := deps.Plan(planManifest(), deps.Options{Profile: "default", OS: "darwin"}, lookupSet("tmux", "starship"), deps.TierHomebrew)
+	report, err := deps.Plan(planManifest(), deps.Options{Profile: "default", OS: "darwin"}, lookupSet("tmux", "starship"), fontLookupSet(), deps.TierHomebrew)
 	if err != nil {
 		t.Fatalf("Plan() error = %v", err)
 	}
@@ -281,7 +370,7 @@ func TestPlanIncludesSelectedProvisionerDependencies(t *testing.T) {
 		},
 	}
 
-	report, err := deps.Plan(m, deps.Options{Profile: "default", OS: "darwin"}, lookupSet("engram"), deps.TierHomebrew)
+	report, err := deps.Plan(m, deps.Options{Profile: "default", OS: "darwin"}, lookupSet("engram"), fontLookupSet(), deps.TierHomebrew)
 	if err != nil {
 		t.Fatalf("Plan() error = %v", err)
 	}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -94,7 +94,7 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options, look deps.Loo
 	}
 	report.Configuration = statusReport
 
-	provReport, err := provision.Check(m, provision.Options{Profile: opts.Profile, OS: opts.OS}, look)
+	provReport, err := provision.Check(m, provision.Options{Profile: opts.Profile, OS: opts.OS}, look, fontLook)
 	if err != nil {
 		return Report{}, err
 	}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -62,9 +62,13 @@ type Dependency struct {
 	Name    string `yaml:"name"`
 	Command string `yaml:"command,omitempty"`
 	Brew    string `yaml:"brew,omitempty"`
-	Apt     string `yaml:"apt,omitempty"`
-	Dnf     string `yaml:"dnf,omitempty"`
-	Pacman  string `yaml:"pacman,omitempty"`
+	// BrewCask declares a Homebrew cask package. It renders as
+	// `brew install --cask <token>` and is separate from Brew so casks are not
+	// hidden behind Homebrew's implicit formula/cask resolution.
+	BrewCask string `yaml:"brew_cask,omitempty"`
+	Apt      string `yaml:"apt,omitempty"`
+	Dnf      string `yaml:"dnf,omitempty"`
+	Pacman   string `yaml:"pacman,omitempty"`
 	// FontMatch, when set, switches detection from a PATH lookup to a scan of
 	// the workstation font directories for an installed file whose name matches
 	// this case-insensitive glob (e.g. "CascadiaCodeNF*"). A font has no
@@ -157,11 +161,8 @@ func (m Manifest) Validate() error {
 			}
 		}
 		for j, dep := range entry.Dependencies {
-			if strings.TrimSpace(dep.Name) == "" {
-				return fmt.Errorf("entries[%d].dependencies[%d].name is required", i, j)
-			}
-			if dep.Command != "" && strings.TrimSpace(dep.Command) == "" {
-				return fmt.Errorf("entries[%d].dependencies[%d].command must not be empty", i, j)
+			if err := validateDependency(dep, fmt.Sprintf("entries[%d].dependencies[%d]", i, j)); err != nil {
+				return err
 			}
 		}
 	}
@@ -200,15 +201,28 @@ func (m Manifest) Validate() error {
 			return fmt.Errorf("provisioners[%d].spec.skills[%d] must not be empty", i, j)
 		}
 		for j, dep := range prov.Dependencies {
-			if strings.TrimSpace(dep.Name) == "" {
-				return fmt.Errorf("provisioners[%d].dependencies[%d].name is required", i, j)
-			}
-			if dep.Command != "" && strings.TrimSpace(dep.Command) == "" {
-				return fmt.Errorf("provisioners[%d].dependencies[%d].command must not be empty", i, j)
+			if err := validateDependency(dep, fmt.Sprintf("provisioners[%d].dependencies[%d]", i, j)); err != nil {
+				return err
 			}
 		}
 	}
 
+	return nil
+}
+
+func validateDependency(dep Dependency, path string) error {
+	if strings.TrimSpace(dep.Name) == "" {
+		return fmt.Errorf("%s.name is required", path)
+	}
+	if dep.Command != "" && strings.TrimSpace(dep.Command) == "" {
+		return fmt.Errorf("%s.command must not be empty", path)
+	}
+	if dep.BrewCask != "" && strings.TrimSpace(dep.BrewCask) == "" {
+		return fmt.Errorf("%s.brew_cask must not be empty", path)
+	}
+	if strings.TrimSpace(dep.Brew) != "" && strings.TrimSpace(dep.BrewCask) != "" {
+		return fmt.Errorf("%s must not set both brew and brew_cask", path)
+	}
 	return nil
 }
 

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -69,6 +69,9 @@ entries:
       - name: ripgrep
         command: rg
         brew: ripgrep
+      - name: CascadiaCode Nerd Font
+        brew_cask: font-cascadia-code-nf
+        font_match: "CascadiaCodeNF*"
 `)
 	if err := os.WriteFile(path, content, 0o600); err != nil {
 		t.Fatalf("write manifest: %v", err)
@@ -80,14 +83,17 @@ entries:
 	}
 
 	deps := got.Entries[0].Dependencies
-	if len(deps) != 2 {
-		t.Fatalf("Dependencies len = %d, want 2", len(deps))
+	if len(deps) != 3 {
+		t.Fatalf("Dependencies len = %d, want 3", len(deps))
 	}
 	if deps[0].Name != "tmux" || deps[0].Brew != "tmux" || deps[0].Apt != "tmux" || deps[0].Dnf != "tmux" || deps[0].Pacman != "tmux" {
 		t.Fatalf("Dependencies[0] = %#v, want fully mapped tmux dependency", deps[0])
 	}
 	if deps[1].Name != "ripgrep" || deps[1].Command != "rg" || deps[1].Brew != "ripgrep" {
 		t.Fatalf("Dependencies[1] = %#v, want ripgrep with rg command", deps[1])
+	}
+	if deps[2].Name != "CascadiaCode Nerd Font" || deps[2].BrewCask != "font-cascadia-code-nf" || deps[2].FontMatch != "CascadiaCodeNF*" {
+		t.Fatalf("Dependencies[2] = %#v, want Homebrew cask font dependency", deps[2])
 	}
 }
 
@@ -399,6 +405,42 @@ entries:
 			want: `entries[0].dependencies[0].command must not be empty`,
 		},
 		{
+			name: "dependency with whitespace-only brew cask",
+			content: `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/fonts
+    target: ~/.local/share/fonts
+    strategy: copy
+    tags: [core]
+    dependencies:
+      - name: CascadiaCode Nerd Font
+        brew_cask: "  "
+        font_match: "CascadiaCodeNF*"
+`,
+			want: `entries[0].dependencies[0].brew_cask must not be empty`,
+		},
+		{
+			name: "dependency with ambiguous homebrew formula and cask",
+			content: `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/fonts
+    target: ~/.local/share/fonts
+    strategy: copy
+    tags: [core]
+    dependencies:
+      - name: CascadiaCode Nerd Font
+        brew: cascadia-code
+        brew_cask: font-cascadia-code-nf
+`,
+			want: `entries[0].dependencies[0] must not set both brew and brew_cask`,
+		},
+		{
 			name: "missing entry target",
 			content: `version: 1
 profiles:
@@ -560,6 +602,32 @@ provisioners:
       - brew: gentleman-programming/tap/gentle-ai
 `,
 			want: "provisioners[0].dependencies[0].name is required",
+		},
+		{
+			name: "dependency with whitespace-only brew cask",
+			provisioner: `  - tool: gentle-ai
+    tags: [core]
+    spec:
+      scope: global
+    dependencies:
+      - name: CascadiaCode Nerd Font
+        brew_cask: "  "
+        font_match: "CascadiaCodeNF*"
+`,
+			want: "provisioners[0].dependencies[0].brew_cask must not be empty",
+		},
+		{
+			name: "dependency with ambiguous homebrew formula and cask",
+			provisioner: `  - tool: gentle-ai
+    tags: [core]
+    spec:
+      scope: global
+    dependencies:
+      - name: CascadiaCode Nerd Font
+        brew: cascadia-code
+        brew_cask: font-cascadia-code-nf
+`,
+			want: "provisioners[0].dependencies[0] must not set both brew and brew_cask",
 		},
 	}
 

--- a/internal/provision/apply.go
+++ b/internal/provision/apply.go
@@ -2,6 +2,7 @@ package provision
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/yersonargotev/dots/internal/deps"
 	"github.com/yersonargotev/dots/internal/manifest"
@@ -45,7 +46,7 @@ type Report struct {
 // HOME threading for sandboxing is the concrete Runner's responsibility, not
 // this orchestration. Apply stops at the first failing Provisioner and returns
 // the partial Report alongside the error.
-func Apply(m manifest.Manifest, opts Options, look deps.Lookup, runner deps.Runner) (Report, error) {
+func Apply(m manifest.Manifest, opts Options, look deps.Lookup, fontLook deps.FontLookup, runner deps.Runner) (Report, error) {
 	selected, err := Select(m, opts)
 	if err != nil {
 		return Report{}, err
@@ -55,7 +56,7 @@ func Apply(m manifest.Manifest, opts Options, look deps.Lookup, runner deps.Runn
 	for _, prov := range selected {
 		executable, args := RenderCommand(prov)
 
-		if missing := missingDependencies(prov, look); len(missing) > 0 {
+		if missing := missingDependencies(prov, look, fontLook); len(missing) > 0 {
 			report.Items = append(report.Items, RunItem{
 				Tool:       prov.Tool,
 				Executable: executable,
@@ -88,9 +89,16 @@ func Apply(m manifest.Manifest, opts Options, look deps.Lookup, runner deps.Runn
 
 // missingDependencies returns the probes of the Provisioner's declared
 // dependencies that are absent on the workstation, in declared order.
-func missingDependencies(prov manifest.Provisioner, look deps.Lookup) []string {
+func missingDependencies(prov manifest.Provisioner, look deps.Lookup, fontLook deps.FontLookup) []string {
 	var missing []string
 	for _, dep := range prov.Dependencies {
+		if dep.IsFont() {
+			match := strings.TrimSpace(dep.FontMatch)
+			if !fontLook(match) {
+				missing = append(missing, match)
+			}
+			continue
+		}
 		probe := dep.Probe()
 		if !look(probe) {
 			missing = append(missing, probe)

--- a/internal/provision/apply_test.go
+++ b/internal/provision/apply_test.go
@@ -34,6 +34,14 @@ func lookupWith(present ...string) deps.Lookup {
 	return func(command string) bool { return set[command] }
 }
 
+func fontLookupWith(present ...string) deps.FontLookup {
+	set := make(map[string]bool, len(present))
+	for _, p := range present {
+		set[p] = true
+	}
+	return func(match string) bool { return set[match] }
+}
+
 func gentleAIProvisioner(agent string) manifest.Provisioner {
 	return manifest.Provisioner{
 		Tool: "gentle-ai",
@@ -51,7 +59,7 @@ func TestApplyRunsSelectedProvisionersInOrder(t *testing.T) {
 	runner := &fakeRunner{}
 	look := lookupWith("gentle-ai", "engram")
 
-	report, err := provision.Apply(m, provision.Options{Profile: "default", OS: "darwin"}, look, runner)
+	report, err := provision.Apply(m, provision.Options{Profile: "default", OS: "darwin"}, look, fontLookupWith(), runner)
 	if err != nil {
 		t.Fatalf("Apply() error = %v", err)
 	}
@@ -78,7 +86,7 @@ func TestApplyFailsWithoutRunningWhenDependencyMissing(t *testing.T) {
 	runner := &fakeRunner{}
 	look := lookupWith("gentle-ai") // engram missing
 
-	report, err := provision.Apply(m, provision.Options{Profile: "default", OS: "darwin"}, look, runner)
+	report, err := provision.Apply(m, provision.Options{Profile: "default", OS: "darwin"}, look, fontLookupWith(), runner)
 	if err == nil {
 		t.Fatal("Apply() error = nil, want missing-dependency error")
 	}
@@ -103,7 +111,7 @@ func TestApplyStopsAndReportsOnRunnerFailure(t *testing.T) {
 	runner := &fakeRunner{failOn: 1, failErr: runErr}
 	look := lookupWith("gentle-ai", "engram")
 
-	report, err := provision.Apply(m, provision.Options{Profile: "default", OS: "darwin"}, look, runner)
+	report, err := provision.Apply(m, provision.Options{Profile: "default", OS: "darwin"}, look, fontLookupWith(), runner)
 	if err == nil {
 		t.Fatal("Apply() error = nil, want runner failure error")
 	}
@@ -122,7 +130,7 @@ func TestApplyNoProvisionersIsNoOp(t *testing.T) {
 	m := manifestWithProvisioners()
 	runner := &fakeRunner{}
 
-	report, err := provision.Apply(m, provision.Options{Profile: "default", OS: "darwin"}, lookupWith(), runner)
+	report, err := provision.Apply(m, provision.Options{Profile: "default", OS: "darwin"}, lookupWith(), fontLookupWith(), runner)
 	if err != nil {
 		t.Fatalf("Apply() error = %v", err)
 	}
@@ -136,7 +144,35 @@ func TestApplyNoProvisionersIsNoOp(t *testing.T) {
 
 func TestApplyUnknownProfileIsError(t *testing.T) {
 	m := manifestWithProvisioners(gentleAIProvisioner("codex"))
-	if _, err := provision.Apply(m, provision.Options{Profile: "ghost", OS: "darwin"}, lookupWith(), &fakeRunner{}); err == nil {
+	if _, err := provision.Apply(m, provision.Options{Profile: "ghost", OS: "darwin"}, lookupWith(), fontLookupWith(), &fakeRunner{}); err == nil {
 		t.Fatal("Apply() error = nil, want unknown-profile error")
+	}
+}
+
+func TestApplyUsesFontLookupForProvisionerFontDependencies(t *testing.T) {
+	prov := gentleAIProvisioner("codex")
+	prov.Dependencies = append(prov.Dependencies, manifest.Dependency{
+		Name: "CascadiaCode Nerd Font", BrewCask: "font-cascadia-code-nf", FontMatch: "CascadiaCodeNF*",
+	})
+	m := manifestWithProvisioners(prov)
+	runner := &fakeRunner{}
+	var commandProbes []string
+
+	report, err := provision.Apply(m, provision.Options{Profile: "default", OS: "darwin"}, func(command string) bool {
+		commandProbes = append(commandProbes, command)
+		return command == "gentle-ai" || command == "engram"
+	}, fontLookupWith("CascadiaCodeNF*"), runner)
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	if !reflect.DeepEqual(commandProbes, []string{"gentle-ai", "engram"}) {
+		t.Fatalf("command probes = %#v, want only command dependencies", commandProbes)
+	}
+	if len(report.Items) != 1 || report.Items[0].Status != provision.RunStatusProvisioned {
+		t.Fatalf("report.Items = %#v, want provisioned item", report.Items)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("runner.calls = %#v, want one provisioner invocation", runner.calls)
 	}
 }

--- a/internal/provision/check.go
+++ b/internal/provision/check.go
@@ -27,7 +27,7 @@ type CheckReport struct {
 // Check reports each selected Provisioner's resolved command and dependency
 // readiness without invoking any tool. It is the read-only diagnostic surfaced
 // by dots doctor.
-func Check(m manifest.Manifest, opts Options, look deps.Lookup) (CheckReport, error) {
+func Check(m manifest.Manifest, opts Options, look deps.Lookup, fontLook deps.FontLookup) (CheckReport, error) {
 	selected, err := Select(m, opts)
 	if err != nil {
 		return CheckReport{}, err
@@ -40,7 +40,7 @@ func Check(m manifest.Manifest, opts Options, look deps.Lookup) (CheckReport, er
 			Tool:       prov.Tool,
 			Executable: executable,
 			Args:       args,
-			Missing:    missingDependencies(prov, look),
+			Missing:    missingDependencies(prov, look, fontLook),
 		})
 	}
 	return report, nil

--- a/internal/provision/check_test.go
+++ b/internal/provision/check_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/provision"
 )
 
@@ -11,7 +12,7 @@ func TestCheckReportsReadiness(t *testing.T) {
 	m := manifestWithProvisioners(gentleAIProvisioner("codex"))
 
 	t.Run("all dependencies present", func(t *testing.T) {
-		report, err := provision.Check(m, provision.Options{Profile: "default", OS: "darwin"}, lookupWith("gentle-ai", "engram"))
+		report, err := provision.Check(m, provision.Options{Profile: "default", OS: "darwin"}, lookupWith("gentle-ai", "engram"), fontLookupWith())
 		if err != nil {
 			t.Fatalf("Check() error = %v", err)
 		}
@@ -35,7 +36,7 @@ func TestCheckReportsReadiness(t *testing.T) {
 	})
 
 	t.Run("missing dependency is reported without executing", func(t *testing.T) {
-		report, err := provision.Check(m, provision.Options{Profile: "default", OS: "darwin"}, lookupWith("gentle-ai"))
+		report, err := provision.Check(m, provision.Options{Profile: "default", OS: "darwin"}, lookupWith("gentle-ai"), fontLookupWith())
 		if err != nil {
 			t.Fatalf("Check() error = %v", err)
 		}
@@ -45,8 +46,35 @@ func TestCheckReportsReadiness(t *testing.T) {
 	})
 
 	t.Run("unknown profile is an error", func(t *testing.T) {
-		if _, err := provision.Check(m, provision.Options{Profile: "ghost", OS: "darwin"}, lookupWith()); err == nil {
+		if _, err := provision.Check(m, provision.Options{Profile: "ghost", OS: "darwin"}, lookupWith(), fontLookupWith()); err == nil {
 			t.Fatal("Check() error = nil, want unknown-profile error")
 		}
 	})
+}
+
+func TestCheckUsesFontLookupForProvisionerFontDependencies(t *testing.T) {
+	prov := gentleAIProvisioner("codex")
+	prov.Dependencies = append(prov.Dependencies, manifest.Dependency{
+		Name: "CascadiaCode Nerd Font", BrewCask: "font-cascadia-code-nf", FontMatch: "CascadiaCodeNF*",
+	})
+	m := manifestWithProvisioners(prov)
+	var commandProbes []string
+
+	report, err := provision.Check(m, provision.Options{Profile: "default", OS: "darwin"}, func(command string) bool {
+		commandProbes = append(commandProbes, command)
+		return command == "gentle-ai" || command == "engram"
+	}, fontLookupWith("CascadiaCodeNF*"))
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+
+	if !reflect.DeepEqual(commandProbes, []string{"gentle-ai", "engram"}) {
+		t.Fatalf("command probes = %#v, want only command dependencies", commandProbes)
+	}
+	if len(report.Items) != 1 {
+		t.Fatalf("len(Check.Items) = %d, want 1", len(report.Items))
+	}
+	if len(report.Items[0].Missing) != 0 {
+		t.Fatalf("readiness Missing = %#v, want none when font is installed", report.Items[0].Missing)
+	}
 }


### PR DESCRIPTION
Closes #74

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds explicit `brew_cask` Dependency support and renders Homebrew casks as `brew install --cask <token>`.
- Reuses font-match detection for dependency plan/install/provisioner checks so provisioning stays verifiable and separate from detection.
- Keeps Linux font provisioning advisory-only with explicit manual guidance.

## Changes

| File | Change |
|------|--------|
| `internal/manifest/manifest.go` | Adds `brew_cask` to Dependency and validates ambiguous/blank cask declarations. |
| `internal/deps/*` | Plans and installs Homebrew cask actions; uses font lookup for font dependencies; adds Linux manual font guidance. |
| `internal/provision/*` | Makes provisioner dependency checks respect `font_match`. |
| `internal/cli/*`, `internal/doctor/doctor.go` | Threads font lookup through affected dependency/provision flows. |
| `dots.yaml` | Declares CascadiaCode Nerd Font via `brew_cask`. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp>`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>` and `--source-root "$PWD"` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
