### PR TITLE
feat(provision): run provisioners on update and surface skipped ones

### DIFF
--- a/docs/update.md
+++ b/docs/update.md
@@ -9,6 +9,7 @@
 3. **Fast-forwards only.** `update` fetches the upstream and advances the branch with `git merge --ff-only`. If the branch has diverged from its upstream, it cannot be fast-forwarded; `update` reports the divergence and asks you to resolve it manually with Git. It never performs an automatic merge or rebase.
 4. **Recomputes the Install Plan.** After the fast-forward, the manifest is loaded from the updated repository (so a manifest change pulled from upstream is honored) and a fresh Install Plan is computed against the current workstation state, surfacing any new Conflicts or Drift.
 5. **Applies safely.** The post-update install resolves conflicts exactly like `dots install`: interactive TUI by default, text prompts with `--no-tui`, or the conservative skip default with `--yes`. Any `replace` still creates a [Backup Set](../CONTEXT.md) before touching an existing target.
+6. **Runs provisioners.** After the file plan is applied, `update` runs the same provisioners `install` would for the active profile, so provisioner-managed agent configuration (gentle-ai regen, Claude plugins, Codex MCP server) stays aligned with the Source of Truth. Provisioners run only when the file apply was not canceled; a `--dry-run` renders the Provisioners plan section without executing anything. If conflict resolution is canceled, the whole run aborts before any provisioner can mutate tool-managed config.
 
 ## Versioning model
 
@@ -59,6 +60,18 @@ Installed Repository can fast-forward a1b2c3d -> e4f5a6b:
 ```
 
 Because no fast-forward is applied in a dry run, the rendered plan reflects the **current** Source of Truth, not the post-update state. Run `update` without `--dry-run` to apply the fast-forward and compute the plan against the updated repository.
+
+## Profiles and provisioners
+
+Provisioners are scoped by profile tags, exactly like file entries. The `default` profile selects only `core`-tagged provisioners (gentle-ai); the chrome-devtools integration for Claude, Codex, and the OpenCode overlay is tagged `desktop` and is only provisioned under `--profile desktop`. This is design-intent — chrome-devtools drives a real browser and does not belong in headless or server installs.
+
+To keep that requirement discoverable, both `install` and `update` print a one-line hint when the active profile skips provisioners another profile would select on this OS:
+
+```
+Note: profile "default" skips 3 provisioner(s); run with --profile desktop to include them.
+```
+
+The hint also appears in `--dry-run`, so you can see what a profile omits before committing to it. The fuller profile that already selects every provisioner prints no hint.
 
 ## References
 

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -64,6 +64,9 @@ func newInstallCommand() *cobra.Command {
 				return err
 			}
 			renderProvisionPlan(cmd.OutOrStdout(), provPlan)
+			if err := renderSkippedProvisionerHint(cmd.OutOrStdout(), *m, profile, runtime.GOOS); err != nil {
+				return err
+			}
 
 			if dryRun {
 				return nil

--- a/internal/cli/provision_hint_test.go
+++ b/internal/cli/provision_hint_test.go
@@ -1,0 +1,119 @@
+package cli_test
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/cli"
+)
+
+const skippedHintManifest = `version: 1
+profiles:
+  default:
+    tags: [core]
+  desktop:
+    tags: [core, desktop]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+provisioners:
+  - tool: gentle-ai
+    tags: [core]
+    spec:
+      scope: global
+      persona: neutral
+      agents: [codex]
+    dependencies:
+      - name: gentle-ai
+      - name: engram
+  - tool: claude
+    tags: [desktop]
+    os: [darwin, linux]
+    spec:
+      marketplace: ChromeDevTools/chrome-devtools-mcp
+    dependencies:
+      - name: claude
+  - tool: codex
+    tags: [desktop]
+    os: [darwin, linux]
+    spec:
+      mcp: chrome-devtools
+      command: [npx, -y, chrome-devtools-mcp@latest]
+    dependencies:
+      - name: codex
+`
+
+// TestInstallDryRunHintsSkippedDesktopProvisioners proves the default profile
+// surfaces a one-line nudge naming the fuller profile that would include the
+// desktop-only provisioners it silently skips.
+func TestInstallDryRunHintsSkippedDesktopProvisioners(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	writeCLISource(t, sourceRoot, "configs/zsh/zshrc", "managed\n")
+	manifestPath := writeCLIManifest(t, home, skippedHintManifest)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"install", "--dry-run", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+
+	want := `Note: profile "default" skips 2 provisioner(s); run with --profile desktop to include them.`
+	if !strings.Contains(out.String(), want) {
+		t.Fatalf("install --dry-run output missing skipped-provisioner hint %q\noutput:\n%s", want, out.String())
+	}
+}
+
+// TestInstallDesktopProfileShowsNoSkippedHint proves the profile that already
+// selects every provisioner stays quiet — no spurious nudge.
+func TestInstallDesktopProfileShowsNoSkippedHint(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	writeCLISource(t, sourceRoot, "configs/zsh/zshrc", "managed\n")
+	manifestPath := writeCLIManifest(t, home, skippedHintManifest)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"install", "--dry-run", "--profile", "desktop", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+
+	if strings.Contains(out.String(), "skips") {
+		t.Fatalf("desktop profile should not show a skipped-provisioner hint\noutput:\n%s", out.String())
+	}
+}
+
+// TestUpdateDryRunHintsSkippedDesktopProvisioners proves the discoverability
+// hint reaches the update path too, not just install.
+func TestUpdateDryRunHintsSkippedDesktopProvisioners(t *testing.T) {
+	requireGitCLI(t)
+	home := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	_, sourceRoot := newInstalledRepo(t, map[string]string{
+		"configs/zsh/zshrc": "managed\n",
+		"dots.yaml":         skippedHintManifest,
+	})
+
+	out := runUpdate(t, "--dry-run", "--file", filepath.Join(sourceRoot, "dots.yaml"),
+		"--home", home, "--source-root", sourceRoot)
+
+	want := `Note: profile "default" skips 2 provisioner(s); run with --profile desktop to include them.`
+	if !strings.Contains(out, want) {
+		t.Fatalf("update --dry-run output missing skipped-provisioner hint %q\noutput:\n%s", want, out)
+	}
+}

--- a/internal/cli/render_provision.go
+++ b/internal/cli/render_provision.go
@@ -36,6 +36,16 @@ func renderProvisionPlan(w io.Writer, p provision.Plan) {
 // when nothing is skipped, keeping the fuller profile's output noise-free. The
 // profile is already validated upstream by plan.Build, so an error here only
 // signals a programming mistake and is surfaced rather than swallowed.
+//
+// Scope is deliberately provisioner-only: it targets the silent
+// agent-provisioning gap from issue #85 (chrome-devtools for Claude, Codex, and
+// the OpenCode overlay). File entries are profile-scoped the same way and are a
+// candidate for the same nudge, but that is a separate surface and is out of
+// scope here.
+//
+// SuggestedProfile is rendered with %s, not %q: it is a copy-pasteable shell
+// argument the user types as `--profile desktop`, so it is intentionally
+// unquoted while the descriptive active profile uses %q.
 func renderSkippedProvisionerHint(w io.Writer, m manifest.Manifest, profile, os string) error {
 	hint, ok, err := provision.SkippedProvisioners(m, provision.Options{Profile: profile, OS: os})
 	if err != nil {

--- a/internal/cli/render_provision.go
+++ b/internal/cli/render_provision.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/provision"
 )
 
@@ -26,6 +27,26 @@ func renderProvisionPlan(w io.Writer, p provision.Plan) {
 		}
 	}
 	fmt.Fprintf(w, "\nSummary: %d provisioner(s)\n", len(p.Steps))
+}
+
+// renderSkippedProvisionerHint prints a one-line nudge when the active profile
+// omits provisioners that another profile would select on this OS, so a
+// default-profile user discovers the fuller profile (e.g. the desktop-only
+// chrome-devtools integration) instead of silently missing it. It stays quiet
+// when nothing is skipped, keeping the fuller profile's output noise-free. The
+// profile is already validated upstream by plan.Build, so an error here only
+// signals a programming mistake and is surfaced rather than swallowed.
+func renderSkippedProvisionerHint(w io.Writer, m manifest.Manifest, profile, os string) error {
+	hint, ok, err := provision.SkippedProvisioners(m, provision.Options{Profile: profile, OS: os})
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	fmt.Fprintf(w, "\nNote: profile %q skips %d provisioner(s); run with --profile %s to include them.\n",
+		hint.Profile, hint.Count, hint.SuggestedProfile)
+	return nil
 }
 
 // renderProvisionReport writes the actual execution outcomes for provisioners.

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -11,6 +11,7 @@ import (
 	"github.com/yersonargotev/dots/internal/gitrepo"
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/plan"
+	"github.com/yersonargotev/dots/internal/provision"
 )
 
 func newUpdateCommand() *cobra.Command {
@@ -29,10 +30,11 @@ func newUpdateCommand() *cobra.Command {
 		Use:   "update",
 		Short: "Update the Installed Repository and re-run the safe install flow",
 		Long: "update fast-forwards the Installed Repository (default ~/.local/share/dots) to its " +
-			"upstream, then recomputes the Install Plan so managed configuration stays aligned with " +
-			"the Source of Truth. It refuses to touch a repository with local changes and only ever " +
-			"applies a clean fast-forward, never a merge or rebase. Conflicts during the post-update " +
-			"install are resolved exactly like dots install, creating a Backup Set before any replacement.",
+			"upstream, then recomputes the Install Plan and re-runs the selected provisioners so managed " +
+			"configuration stays aligned with the Source of Truth. It refuses to touch a repository with " +
+			"local changes and only ever applies a clean fast-forward, never a merge or rebase. Conflicts " +
+			"during the post-update install are resolved exactly like dots install, creating a Backup Set " +
+			"before any replacement.",
 		// Domain failures (dirty repo, divergence, conflicts) are user-facing
 		// conditions, not command misuse, so do not dump the usage block.
 		SilenceUsage: true,
@@ -81,12 +83,32 @@ func newUpdateCommand() *cobra.Command {
 			}
 
 			renderPlan(out, p)
+
+			provPlan, err := provision.Build(*m, provision.Options{Profile: profile, OS: runtime.GOOS})
+			if err != nil {
+				return err
+			}
+			renderProvisionPlan(out, provPlan)
+			if err := renderSkippedProvisionerHint(out, *m, profile, runtime.GOOS); err != nil {
+				return err
+			}
+
 			if dryRun {
 				return nil
 			}
 
-			_, err = resolveAndApply(cmd, p, paths, yes, noTUI)
-			return err
+			applied, err := resolveAndApply(cmd, p, paths, yes, noTUI)
+			if err != nil {
+				return err
+			}
+			if !applied {
+				return nil
+			}
+
+			// Mirror install: managed agent configuration stays aligned with the
+			// Source of Truth only if the same provisioners install runs are
+			// re-applied after an update, not just the file plan.
+			return runProvisioners(cmd, *m, profile, paths.Home)
 		},
 	}
 

--- a/internal/cli/update_provision_test.go
+++ b/internal/cli/update_provision_test.go
@@ -1,0 +1,146 @@
+package cli_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/cli"
+)
+
+const updateProvisionerManifest = `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/git/gitconfig
+    target: ~/.gitconfig
+    strategy: copy
+    tags: [core]
+provisioners:
+  - tool: gentle-ai
+    tags: [core]
+    spec:
+      scope: global
+      persona: neutral
+      agents: [codex]
+    dependencies:
+      - name: gentle-ai
+      - name: engram
+`
+
+// TestUpdateDryRunRendersProvisionerPlan proves a dry-run update renders the
+// Provisioners plan section for parity with install, without executing the tool.
+func TestUpdateDryRunRendersProvisionerPlan(t *testing.T) {
+	requireGitCLI(t)
+	home := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	_, sourceRoot := newInstalledRepo(t, map[string]string{
+		"configs/git/gitconfig": "managed\n",
+		"dots.yaml":             updateProvisionerManifest,
+	})
+
+	out := runUpdate(t, "--dry-run", "--file", filepath.Join(sourceRoot, "dots.yaml"),
+		"--home", home, "--source-root", sourceRoot)
+
+	for _, want := range []string{
+		`Provisioners for profile "default"`,
+		"gentle-ai install --scope global --persona neutral --agents codex",
+		"Summary: 1 provisioner(s)",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("update --dry-run output missing %q\noutput:\n%s", want, out)
+		}
+	}
+	if _, err := os.Lstat(filepath.Join(home, ".gitconfig")); !os.IsNotExist(err) {
+		t.Fatalf("dry-run installed a target; lstat err = %v", err)
+	}
+}
+
+// TestUpdateExecutesProvisionersAfterApply proves a real update runs the selected
+// provisioners after the file-plan apply (mirroring install), with HOME threaded
+// to the sandbox, and reports the results.
+func TestUpdateExecutesProvisionersAfterApply(t *testing.T) {
+	requireGitCLI(t)
+	sandboxHome := t.TempDir()
+	stateRoot := t.TempDir()
+	fakeRealHome := t.TempDir()
+	t.Setenv("HOME", fakeRealHome)
+
+	stubDir := t.TempDir()
+	writeExecStub(t, filepath.Join(stubDir, "gentle-ai"), "#!/bin/sh\nprintf 'ok' > \"$HOME/gentle-ai-ran\"\n")
+	writeExecStub(t, filepath.Join(stubDir, "engram"), "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	_, sourceRoot := newInstalledRepo(t, map[string]string{
+		"configs/git/gitconfig": "managed\n",
+		"dots.yaml":             updateProvisionerManifest,
+	})
+
+	out := runUpdate(t, "--yes", "--file", filepath.Join(sourceRoot, "dots.yaml"),
+		"--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot)
+
+	if _, err := os.Stat(filepath.Join(sandboxHome, "gentle-ai-ran")); err != nil {
+		t.Fatalf("update did not run the provisioner under the sandbox HOME %q: %v\noutput:\n%s", sandboxHome, err, out)
+	}
+	if _, err := os.Stat(filepath.Join(fakeRealHome, "gentle-ai-ran")); err == nil {
+		t.Fatalf("update ran the provisioner under the inherited HOME %q instead of the sandbox", fakeRealHome)
+	}
+	if !strings.Contains(out, `Provisioner results for profile "default"`) {
+		t.Fatalf("update output missing provisioner results report\noutput:\n%s", out)
+	}
+}
+
+// TestUpdateCanceledConflictDoesNotRunProvisioners proves canceling conflict
+// resolution during a post-update install aborts before any provisioner runs —
+// the same applied-gating install enforces.
+func TestUpdateCanceledConflictDoesNotRunProvisioners(t *testing.T) {
+	requireGitCLI(t)
+	sandboxHome := t.TempDir()
+	stateRoot := t.TempDir()
+	fakeRealHome := t.TempDir()
+	t.Setenv("HOME", fakeRealHome)
+
+	stubDir := t.TempDir()
+	writeExecStub(t, filepath.Join(stubDir, "gentle-ai"), "#!/bin/sh\nprintf 'ran' > \"$HOME/gentle-ai-ran\"\n")
+	writeExecStub(t, filepath.Join(stubDir, "engram"), "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	_, sourceRoot := newInstalledRepo(t, map[string]string{
+		"configs/git/gitconfig": "managed\n",
+		"dots.yaml":             updateProvisionerManifest,
+	})
+	// A divergent local target forces a conflict the user then cancels.
+	target := filepath.Join(sandboxHome, ".gitconfig")
+	if err := os.WriteFile(target, []byte("local\n"), 0o600); err != nil {
+		t.Fatalf("write local target: %v", err)
+	}
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetIn(strings.NewReader("q"))
+	cmd.SetArgs([]string{"update", "--file", filepath.Join(sourceRoot, "dots.yaml"),
+		"--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("update Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(got) != "local\n" {
+		t.Fatalf("canceled update changed conflict target to %q", got)
+	}
+	if _, err := os.Stat(filepath.Join(sandboxHome, "gentle-ai-ran")); !os.IsNotExist(err) {
+		t.Fatalf("canceled update ran the provisioner in sandbox HOME; stat err = %v", err)
+	}
+	if !strings.Contains(out.String(), "Conflict resolution canceled; no changes applied.") {
+		t.Fatalf("cancel output missing abort message\noutput:\n%s", out.String())
+	}
+}

--- a/internal/provision/plan.go
+++ b/internal/provision/plan.go
@@ -2,6 +2,7 @@ package provision
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/yersonargotev/dots/internal/manifest"
 )
@@ -33,22 +34,112 @@ type Plan struct {
 // intersect the Profile's tags) and pass the OS filter, preserving manifest
 // order. It mirrors the Entry selection used by deps, plan, and status.
 func Select(m manifest.Manifest, opts Options) ([]manifest.Provisioner, error) {
-	profile, ok := m.Profiles[opts.Profile]
-	if !ok {
-		return nil, fmt.Errorf("profile %q not found", opts.Profile)
+	indices, err := selectedIndices(m, opts.Profile, opts.OS)
+	if err != nil {
+		return nil, err
 	}
 
 	var selected []manifest.Provisioner
-	for _, prov := range m.Provisioners {
-		if !sharesTag(prov.Tags, profile.Tags) {
-			continue
+	for i, prov := range m.Provisioners {
+		if indices[i] {
+			selected = append(selected, prov)
 		}
-		if !matchesOS(prov.OS, opts.OS) {
-			continue
-		}
-		selected = append(selected, prov)
 	}
 	return selected, nil
+}
+
+// selectedIndices returns the set of m.Provisioners positions a profile would
+// select on the given OS. Working in index space lets callers reason about
+// provisioner identity across profiles (which provisioner, not just how many)
+// without depending on struct equality, and keeps Select and SkippedProvisioners
+// filtering through one tag/OS rule.
+func selectedIndices(m manifest.Manifest, profileName, os string) (map[int]bool, error) {
+	profile, ok := m.Profiles[profileName]
+	if !ok {
+		return nil, fmt.Errorf("profile %q not found", profileName)
+	}
+
+	indices := make(map[int]bool)
+	for i, prov := range m.Provisioners {
+		if sharesTag(prov.Tags, profile.Tags) && matchesOS(prov.OS, os) {
+			indices[i] = true
+		}
+	}
+	return indices, nil
+}
+
+// SkippedHint describes provisioners the active profile omits that some other
+// profile would select on this OS, so the CLI can nudge the user toward the
+// fuller profile instead of silently dropping them.
+type SkippedHint struct {
+	// Profile is the active profile being installed.
+	Profile string
+	// Count is how many provisioners the active profile skips that at least one
+	// other profile would include.
+	Count int
+	// SuggestedProfile is the other profile that covers the most skipped
+	// provisioners — the one worth recommending to recover them.
+	SuggestedProfile string
+}
+
+// SkippedProvisioners reports whether the active profile omits provisioners that
+// another profile would select on this OS. The second return is false (with a
+// zero hint) when nothing is skipped — either the active profile already selects
+// everything, or the OS filter excludes the extras for every profile so
+// switching profiles would not recover them. It is PURE: no I/O, safe in a
+// dry-run, and mirrors the tag/OS scoping used by Select.
+func SkippedProvisioners(m manifest.Manifest, opts Options) (SkippedHint, bool, error) {
+	active, err := selectedIndices(m, opts.Profile, opts.OS)
+	if err != nil {
+		return SkippedHint{}, false, err
+	}
+
+	others := make([]string, 0, len(m.Profiles))
+	for name := range m.Profiles {
+		if name != opts.Profile {
+			others = append(others, name)
+		}
+	}
+	// Sort so the suggested profile is deterministic on ties (first by name).
+	sort.Strings(others)
+
+	selections := make(map[string]map[int]bool, len(others))
+	skipped := make(map[int]bool)
+	for _, name := range others {
+		sel, err := selectedIndices(m, name, opts.OS)
+		if err != nil {
+			return SkippedHint{}, false, err
+		}
+		selections[name] = sel
+		for i := range sel {
+			if !active[i] {
+				skipped[i] = true
+			}
+		}
+	}
+
+	if len(skipped) == 0 {
+		return SkippedHint{}, false, nil
+	}
+
+	var (
+		suggested string
+		best      int
+	)
+	for _, name := range others {
+		covered := 0
+		for i := range selections[name] {
+			if skipped[i] {
+				covered++
+			}
+		}
+		if covered > best {
+			best = covered
+			suggested = name
+		}
+	}
+
+	return SkippedHint{Profile: opts.Profile, Count: len(skipped), SuggestedProfile: suggested}, true, nil
 }
 
 // Build resolves every selected Provisioner into its exact command and the

--- a/internal/provision/plan.go
+++ b/internal/provision/plan.go
@@ -74,19 +74,27 @@ func selectedIndices(m manifest.Manifest, profileName, os string) (map[int]bool,
 type SkippedHint struct {
 	// Profile is the active profile being installed.
 	Profile string
-	// Count is how many provisioners the active profile skips that at least one
-	// other profile would include.
+	// Count is how many of the skipped provisioners SuggestedProfile would
+	// recover. It is intentionally the suggested profile's coverage, not the
+	// union of omissions across every profile, so the "run --profile S to
+	// include them" nudge is always exact and never promises more than S
+	// delivers. In the nested-profile model dots uses (e.g. desktop ⊇ default)
+	// the most complete profile recovers everything, so Count equals the total
+	// the active profile omits.
 	Count int
 	// SuggestedProfile is the other profile that covers the most skipped
-	// provisioners — the one worth recommending to recover them.
+	// provisioners — the single most complete profile worth recommending.
 	SuggestedProfile string
 }
 
 // SkippedProvisioners reports whether the active profile omits provisioners that
-// another profile would select on this OS. The second return is false (with a
-// zero hint) when nothing is skipped — either the active profile already selects
-// everything, or the OS filter excludes the extras for every profile so
-// switching profiles would not recover them. It is PURE: no I/O, safe in a
+// another profile would select on this OS, and which single profile best
+// recovers them. The second return is false (with a zero hint) when nothing is
+// skipped — either the active profile already selects everything, or the OS
+// filter excludes the extras for every profile so switching profiles would not
+// recover them. The reported Count is the suggested profile's coverage of the
+// skipped set, so the caller's remediation message stays accurate even when no
+// single profile is a superset of every omission. It is PURE: no I/O, safe in a
 // dry-run, and mirrors the tag/OS scoping used by Select.
 func SkippedProvisioners(m manifest.Manifest, opts Options) (SkippedHint, bool, error) {
 	active, err := selectedIndices(m, opts.Profile, opts.OS)
@@ -139,7 +147,11 @@ func SkippedProvisioners(m manifest.Manifest, opts Options) (SkippedHint, bool, 
 		}
 	}
 
-	return SkippedHint{Profile: opts.Profile, Count: len(skipped), SuggestedProfile: suggested}, true, nil
+	// best is the suggested profile's coverage of the skipped set, and is >= 1
+	// whenever skipped is non-empty: every skipped index came from some other
+	// profile's selection, so that profile covers it. Reporting best (not
+	// len(skipped)) keeps "run --profile S to include them" exact.
+	return SkippedHint{Profile: opts.Profile, Count: best, SuggestedProfile: suggested}, true, nil
 }
 
 // Build resolves every selected Provisioner into its exact command and the

--- a/internal/provision/skipped_test.go
+++ b/internal/provision/skipped_test.go
@@ -1,0 +1,86 @@
+package provision_test
+
+import (
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/provision"
+)
+
+func TestSkippedProvisioners(t *testing.T) {
+	coreProv := manifest.Provisioner{
+		Tool: "gentle-ai", Tags: []string{"core"},
+		Spec: manifest.ProvisionerSpec{Scope: "global"},
+	}
+	desktopMarketplace := manifest.Provisioner{
+		Tool: "claude", Tags: []string{"desktop"}, OS: []string{"darwin", "linux"},
+		Spec: manifest.ProvisionerSpec{Marketplace: "ChromeDevTools/chrome-devtools-mcp"},
+	}
+	desktopPlugin := manifest.Provisioner{
+		Tool: "claude", Tags: []string{"desktop"}, OS: []string{"darwin", "linux"},
+		Spec: manifest.ProvisionerSpec{Plugin: "chrome-devtools-mcp", From: "chrome-devtools-plugins"},
+	}
+
+	tests := []struct {
+		name          string
+		m             manifest.Manifest
+		opts          provision.Options
+		wantOK        bool
+		wantCount     int
+		wantSuggested string
+	}{
+		{
+			name:          "default profile reports the desktop-only provisioners it skips",
+			m:             manifestWithProvisioners(coreProv, desktopMarketplace, desktopPlugin),
+			opts:          provision.Options{Profile: "default", OS: "darwin"},
+			wantOK:        true,
+			wantCount:     2,
+			wantSuggested: "desktop",
+		},
+		{
+			name:   "desktop profile selects everything so there is no hint",
+			m:      manifestWithProvisioners(coreProv, desktopMarketplace, desktopPlugin),
+			opts:   provision.Options{Profile: "desktop", OS: "darwin"},
+			wantOK: false,
+		},
+		{
+			name:   "no hint when the skipped provisioners are excluded on this OS",
+			m:      manifestWithProvisioners(coreProv, desktopMarketplace, desktopPlugin),
+			opts:   provision.Options{Profile: "default", OS: "windows"},
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hint, ok, err := provision.SkippedProvisioners(tt.m, tt.opts)
+			if err != nil {
+				t.Fatalf("SkippedProvisioners() error = %v", err)
+			}
+			if ok != tt.wantOK {
+				t.Fatalf("SkippedProvisioners() ok = %v, want %v (hint=%+v)", ok, tt.wantOK, hint)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if hint.Profile != tt.opts.Profile {
+				t.Fatalf("hint.Profile = %q, want %q", hint.Profile, tt.opts.Profile)
+			}
+			if hint.Count != tt.wantCount {
+				t.Fatalf("hint.Count = %d, want %d", hint.Count, tt.wantCount)
+			}
+			if hint.SuggestedProfile != tt.wantSuggested {
+				t.Fatalf("hint.SuggestedProfile = %q, want %q", hint.SuggestedProfile, tt.wantSuggested)
+			}
+		})
+	}
+}
+
+func TestSkippedProvisionersUnknownProfileErrors(t *testing.T) {
+	m := manifestWithProvisioners(manifest.Provisioner{
+		Tool: "gentle-ai", Tags: []string{"core"}, Spec: manifest.ProvisionerSpec{Scope: "global"},
+	})
+	if _, _, err := provision.SkippedProvisioners(m, provision.Options{Profile: "ghost", OS: "darwin"}); err == nil {
+		t.Fatal("SkippedProvisioners() error = nil, want unknown-profile error")
+	}
+}

--- a/internal/provision/skipped_test.go
+++ b/internal/provision/skipped_test.go
@@ -76,6 +76,54 @@ func TestSkippedProvisioners(t *testing.T) {
 	}
 }
 
+// TestSkippedProvisionersCountReflectsSuggestedCoverage proves Count is the
+// suggested profile's coverage of the skipped set, not the union of omissions
+// across every profile, so the "run --profile S to include them" message never
+// promises more than S delivers when no single profile is a superset.
+func TestSkippedProvisionersCountReflectsSuggestedCoverage(t *testing.T) {
+	coreProv := manifest.Provisioner{
+		Tool: "gentle-ai", Tags: []string{"core"},
+		Spec: manifest.ProvisionerSpec{Scope: "global"},
+	}
+	onlyAProv := manifest.Provisioner{
+		Tool: "claude", Tags: []string{"a"},
+		Spec: manifest.ProvisionerSpec{Marketplace: "owner/repo"},
+	}
+	onlyBProv := manifest.Provisioner{
+		Tool: "codex", Tags: []string{"b"},
+		Spec: manifest.ProvisionerSpec{MCP: "srv", Command: []string{"npx"}},
+	}
+	// Three non-nested profiles: neither "a" nor "b" is a superset of the two
+	// extras the default profile omits. The union of omissions is 2, but each
+	// other profile recovers only 1.
+	m := manifest.Manifest{
+		Version: 1,
+		Profiles: map[string]manifest.Profile{
+			"default": {Tags: []string{"core"}},
+			"a":       {Tags: []string{"core", "a"}},
+			"b":       {Tags: []string{"core", "b"}},
+		},
+		Entries: []manifest.Entry{{
+			Source: "configs/zsh/zshrc", Target: "~/.zshrc", Strategy: "symlink", Tags: []string{"core"},
+		}},
+		Provisioners: []manifest.Provisioner{coreProv, onlyAProv, onlyBProv},
+	}
+
+	hint, ok, err := provision.SkippedProvisioners(m, provision.Options{Profile: "default", OS: "darwin"})
+	if err != nil {
+		t.Fatalf("SkippedProvisioners() error = %v", err)
+	}
+	if !ok {
+		t.Fatalf("SkippedProvisioners() ok = false, want true")
+	}
+	if hint.Count != 1 {
+		t.Fatalf("hint.Count = %d, want 1 (suggested profile's coverage, not the union of 2)", hint.Count)
+	}
+	if hint.SuggestedProfile != "a" {
+		t.Fatalf("hint.SuggestedProfile = %q, want %q (alphabetical tie-break on equal coverage)", hint.SuggestedProfile, "a")
+	}
+}
+
 func TestSkippedProvisionersUnknownProfileErrors(t *testing.T) {
 	m := manifestWithProvisioners(manifest.Provisioner{
 		Tool: "gentle-ai", Tags: []string{"core"}, Spec: manifest.ProvisionerSpec{Scope: "global"},


### PR DESCRIPTION
## Summary

Fixes two related provisioner gaps discovered while validating PR #83 on a real machine. Both touch the same provisioning flow, so they ship together.

### Fix #84 — `dots update` never ran provisioners
`update` applied only the file plan and returned, so provisioner-managed agent config (gentle-ai regen, Claude plugins, Codex MCP server) drifted from the Source of Truth after every update — even though the command promises alignment. `update` now:
- renders the **Provisioners** plan section (including `--dry-run`), for parity with `install`;
- runs the selected provisioners after the file apply, mirroring `install`;
- honors the `applied` bool (previously discarded as `_`), so a canceled conflict resolution aborts before any provisioner mutates tool-managed config.

### Feat #85 — desktop-only provisioners were silently skipped
The `default` profile selects only `core`-tagged provisioners, so the chrome-devtools integration (Claude plugin, Codex MCP, OpenCode overlay — all `desktop`) was skipped with no diagnostic. `install` and `update` now print a one-line hint when the active profile skips provisioners another profile would select on this OS:

```
Note: profile "default" skips 3 provisioner(s); run with --profile desktop to include them.
```

The hint also shows in `--dry-run`; the fuller profile that already selects everything stays quiet. Logic lives in the pure `provision.SkippedProvisioners`; `Select` now shares its tag/OS filtering via `selectedIndices`.

## Verification
- `go build ./...`, `go vet ./...`, `go test ./...` all green.
- New tests: provisioner execution + plan render + cancel-gating on `update`; the discoverability hint on `install`/`update` (positive and negative); the pure `SkippedProvisioners` selector.
- Manual sandbox dry-run against the real `dots.yaml`: `default` shows the 3-provisioner hint and suggests `desktop`; `--profile desktop` shows 4 provisioners and no hint — matching the issue examples.

Closes #84
Closes #85