### PR TITLE
feat(provision): extend the skipped-profile hint to file entries

### DIFF
--- a/docs/update.md
+++ b/docs/update.md
@@ -71,7 +71,13 @@ To keep that requirement discoverable, both `install` and `update` print a one-l
 Note: profile "default" skips 3 provisioner(s); run with --profile desktop to include them.
 ```
 
-The hint also appears in `--dry-run`, so you can see what a profile omits before committing to it. The fuller profile that already selects every provisioner prints no hint.
+File entries are profile-scoped the same way, and the `default` profile silently omits the `desktop`-tagged ones (the Ghostty and Zed configs, plus the OpenCode MCP overlay). To close the same discoverability gap, both commands print a parallel hint for skipped file entries:
+
+```
+Note: profile "default" skips 5 file entries; run with --profile desktop to include them.
+```
+
+Both hints also appear in `--dry-run`, so you can see what a profile omits before committing to it. The fuller profile that already selects every entry and provisioner prints no hint.
 
 ## References
 

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -58,6 +58,9 @@ func newInstallCommand() *cobra.Command {
 			}
 
 			renderPlan(cmd.OutOrStdout(), p)
+			if err := renderSkippedEntryHint(cmd.OutOrStdout(), *m, profile, runtime.GOOS); err != nil {
+				return err
+			}
 
 			provPlan, err := provision.Build(*m, provision.Options{Profile: profile, OS: runtime.GOOS})
 			if err != nil {

--- a/internal/cli/provision_hint_test.go
+++ b/internal/cli/provision_hint_test.go
@@ -47,6 +47,104 @@ provisioners:
       - name: codex
 `
 
+const skippedEntryHintManifest = `version: 1
+profiles:
+  default:
+    tags: [core]
+  desktop:
+    tags: [core, desktop]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+  - source: configs/ghostty/config.ghostty
+    target: ~/.config/ghostty/config
+    strategy: symlink
+    tags: [desktop]
+  - source: configs/zed/settings.json
+    target: ~/.config/zed/settings.json
+    strategy: symlink
+    tags: [desktop]
+`
+
+// TestInstallDryRunHintsSkippedDesktopEntries proves the default profile surfaces
+// a one-line nudge naming the fuller profile that would include the desktop-only
+// file entries it silently skips, in parallel with the provisioner hint.
+func TestInstallDryRunHintsSkippedDesktopEntries(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	writeCLISource(t, sourceRoot, "configs/zsh/zshrc", "managed\n")
+	writeCLISource(t, sourceRoot, "configs/ghostty/config.ghostty", "ghostty\n")
+	writeCLISource(t, sourceRoot, "configs/zed/settings.json", "{}\n")
+	manifestPath := writeCLIManifest(t, home, skippedEntryHintManifest)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"install", "--dry-run", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+
+	want := `Note: profile "default" skips 2 file entries; run with --profile desktop to include them.`
+	if !strings.Contains(out.String(), want) {
+		t.Fatalf("install --dry-run output missing skipped-entry hint %q\noutput:\n%s", want, out.String())
+	}
+}
+
+// TestInstallDesktopProfileShowsNoSkippedEntryHint proves the profile that
+// already selects every entry stays quiet — no spurious nudge.
+func TestInstallDesktopProfileShowsNoSkippedEntryHint(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	writeCLISource(t, sourceRoot, "configs/zsh/zshrc", "managed\n")
+	writeCLISource(t, sourceRoot, "configs/ghostty/config.ghostty", "ghostty\n")
+	writeCLISource(t, sourceRoot, "configs/zed/settings.json", "{}\n")
+	manifestPath := writeCLIManifest(t, home, skippedEntryHintManifest)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"install", "--dry-run", "--profile", "desktop", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+
+	if strings.Contains(out.String(), "skips") {
+		t.Fatalf("desktop profile should not show a skipped-entry hint\noutput:\n%s", out.String())
+	}
+}
+
+// TestUpdateDryRunHintsSkippedDesktopEntries proves the file-entry hint reaches
+// the update path too, not just install.
+func TestUpdateDryRunHintsSkippedDesktopEntries(t *testing.T) {
+	requireGitCLI(t)
+	home := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	_, sourceRoot := newInstalledRepo(t, map[string]string{
+		"configs/zsh/zshrc":              "managed\n",
+		"configs/ghostty/config.ghostty": "ghostty\n",
+		"configs/zed/settings.json":      "{}\n",
+		"dots.yaml":                      skippedEntryHintManifest,
+	})
+
+	out := runUpdate(t, "--dry-run", "--file", filepath.Join(sourceRoot, "dots.yaml"),
+		"--home", home, "--source-root", sourceRoot)
+
+	want := `Note: profile "default" skips 2 file entries; run with --profile desktop to include them.`
+	if !strings.Contains(out, want) {
+		t.Fatalf("update --dry-run output missing skipped-entry hint %q\noutput:\n%s", want, out)
+	}
+}
+
 // TestInstallDryRunHintsSkippedDesktopProvisioners proves the default profile
 // surfaces a one-line nudge naming the fuller profile that would include the
 // desktop-only provisioners it silently skips.

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/plan"
 )
 
@@ -41,4 +42,36 @@ func renderPlan(w io.Writer, p plan.Plan) {
 
 	fmt.Fprintf(w, "\nSummary: %d create, %d conflict, %d unchanged, %d missing-source\n",
 		counts.create, counts.conflict, counts.unchanged, counts.missingSource)
+}
+
+// renderSkippedEntryHint prints a one-line nudge when the active profile omits
+// file entries that another profile would select on this OS, so a default-profile
+// user discovers the fuller profile (e.g. the desktop-only Ghostty and Zed
+// configs) instead of silently missing them. It stays quiet when nothing is
+// skipped, keeping the fuller profile's output noise-free. The profile is already
+// validated upstream by plan.Build, so an error here only signals a programming
+// mistake and is surfaced rather than swallowed.
+//
+// It is the file-entry twin of renderSkippedProvisionerHint: same "Note: profile
+// %q skips N ...; run with --profile %s to include them." wording, and
+// SuggestedProfile is rendered with %s (an unquoted, copy-pasteable --profile
+// argument) while the descriptive active profile uses %q. The noun is pluralized
+// because "file entry"/"file entries" does not read well as "entry(s)". Together
+// the two hints close the profile-scope discoverability gap for both surfaces
+// (issue #87, following #85).
+func renderSkippedEntryHint(w io.Writer, m manifest.Manifest, profile, os string) error {
+	hint, ok, err := plan.SkippedEntries(m, plan.Options{Profile: profile, OS: os})
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	noun := "file entries"
+	if hint.Count == 1 {
+		noun = "file entry"
+	}
+	fmt.Fprintf(w, "\nNote: profile %q skips %d %s; run with --profile %s to include them.\n",
+		hint.Profile, hint.Count, noun, hint.SuggestedProfile)
+	return nil
 }

--- a/internal/cli/render_provision.go
+++ b/internal/cli/render_provision.go
@@ -37,11 +37,10 @@ func renderProvisionPlan(w io.Writer, p provision.Plan) {
 // profile is already validated upstream by plan.Build, so an error here only
 // signals a programming mistake and is surfaced rather than swallowed.
 //
-// Scope is deliberately provisioner-only: it targets the silent
-// agent-provisioning gap from issue #85 (chrome-devtools for Claude, Codex, and
-// the OpenCode overlay). File entries are profile-scoped the same way and are a
-// candidate for the same nudge, but that is a separate surface and is out of
-// scope here.
+// Scope is provisioner-only by design; renderSkippedEntryHint is its file-entry
+// twin. Keeping them as two functions over two surfaces (issue #85 covered the
+// agent-provisioning gap, issue #87 the file entries) lets each name exactly what
+// it omits and keeps this already-shipped message stable.
 //
 // SuggestedProfile is rendered with %s, not %q: it is a copy-pasteable shell
 // argument the user types as `--profile desktop`, so it is intentionally

--- a/internal/cli/render_test.go
+++ b/internal/cli/render_test.go
@@ -5,8 +5,59 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/plan"
 )
+
+func TestRenderSkippedEntryHint(t *testing.T) {
+	core := manifest.Entry{Source: "configs/zsh/zshrc", Target: "~/.zshrc", Strategy: "symlink", Tags: []string{"core"}}
+	desktop := func(source string) manifest.Entry {
+		return manifest.Entry{Source: source, Target: "~/" + source, Strategy: "symlink", Tags: []string{"desktop"}}
+	}
+	profiles := map[string]manifest.Profile{
+		"default": {Tags: []string{"core"}},
+		"desktop": {Tags: []string{"core", "desktop"}},
+	}
+
+	tests := []struct {
+		name    string
+		entries []manifest.Entry
+		profile string
+		want    string
+	}{
+		{
+			name:    "plural for more than one skipped entry",
+			entries: []manifest.Entry{core, desktop("configs/ghostty/config.ghostty"), desktop("configs/zed/settings.json")},
+			profile: "default",
+			want:    "\nNote: profile \"default\" skips 2 file entries; run with --profile desktop to include them.\n",
+		},
+		{
+			name:    "singular for exactly one skipped entry",
+			entries: []manifest.Entry{core, desktop("configs/ghostty/config.ghostty")},
+			profile: "default",
+			want:    "\nNote: profile \"default\" skips 1 file entry; run with --profile desktop to include them.\n",
+		},
+		{
+			name:    "quiet when the active profile selects everything",
+			entries: []manifest.Entry{core, desktop("configs/ghostty/config.ghostty")},
+			profile: "desktop",
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := manifest.Manifest{Version: 1, Profiles: profiles, Entries: tt.entries}
+			var out bytes.Buffer
+			if err := renderSkippedEntryHint(&out, m, tt.profile, "darwin"); err != nil {
+				t.Fatalf("renderSkippedEntryHint() error = %v", err)
+			}
+			if out.String() != tt.want {
+				t.Fatalf("renderSkippedEntryHint() = %q, want %q", out.String(), tt.want)
+			}
+		})
+	}
+}
 
 func TestDefaultSourceRoot(t *testing.T) {
 	home := filepath.Join("home", "user")

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -83,6 +83,9 @@ func newUpdateCommand() *cobra.Command {
 			}
 
 			renderPlan(out, p)
+			if err := renderSkippedEntryHint(out, *m, profile, runtime.GOOS); err != nil {
+				return err
+			}
 
 			provPlan, err := provision.Build(*m, provision.Options{Profile: profile, OS: runtime.GOOS})
 			if err != nil {

--- a/internal/deps/deps.go
+++ b/internal/deps/deps.go
@@ -100,45 +100,22 @@ func selectDependencies(m manifest.Manifest, opts Options) ([]manifest.Dependenc
 	}
 
 	for _, entry := range m.Entries {
-		if !sharesTag(entry.Tags, profile.Tags) {
+		if !manifest.SharesTag(entry.Tags, profile.Tags) {
 			continue
 		}
-		if !matchesOS(entry.OS, opts.OS) {
+		if !manifest.MatchesOS(entry.OS, opts.OS) {
 			continue
 		}
 		addDependencies(entry.Dependencies)
 	}
 	for _, prov := range m.Provisioners {
-		if !sharesTag(prov.Tags, profile.Tags) {
+		if !manifest.SharesTag(prov.Tags, profile.Tags) {
 			continue
 		}
-		if !matchesOS(prov.OS, opts.OS) {
+		if !manifest.MatchesOS(prov.OS, opts.OS) {
 			continue
 		}
 		addDependencies(prov.Dependencies)
 	}
 	return selected, nil
-}
-
-func sharesTag(entryTags, profileTags []string) bool {
-	for _, et := range entryTags {
-		for _, pt := range profileTags {
-			if et == pt {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func matchesOS(entryOS []string, current string) bool {
-	if len(entryOS) == 0 {
-		return true
-	}
-	for _, osName := range entryOS {
-		if osName == current {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -120,7 +120,7 @@ func ScanSecrets(m manifest.Manifest, opts Options) (SecretReport, error) {
 	var report SecretReport
 	seen := map[string]bool{}
 	for _, entry := range m.Entries {
-		if !sharesTag(entry.Tags, profile.Tags) || !matchesOS(entry.OS, opts.OS) || seen[entry.Source] {
+		if !manifest.SharesTag(entry.Tags, profile.Tags) || !manifest.MatchesOS(entry.OS, opts.OS) || seen[entry.Source] {
 			continue
 		}
 		seen[entry.Source] = true
@@ -217,29 +217,6 @@ func looksLikePlaceholder(text string) bool {
 	lower := strings.ToLower(text)
 	for _, marker := range []string{"example", "placeholder", "replace_me", "changeme", "your_", "dummy"} {
 		if strings.Contains(lower, marker) {
-			return true
-		}
-	}
-	return false
-}
-
-func sharesTag(entryTags, profileTags []string) bool {
-	for _, et := range entryTags {
-		for _, pt := range profileTags {
-			if et == pt {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func matchesOS(entryOS []string, current string) bool {
-	if len(entryOS) == 0 {
-		return true
-	}
-	for _, osName := range entryOS {
-		if strings.EqualFold(osName, current) {
 			return true
 		}
 	}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -350,6 +350,40 @@ func validateCodexSpec(s ProvisionerSpec, i int) error {
 	return nil
 }
 
+// SharesTag reports whether an item's tags intersect a profile's tags. It is
+// half the profile-scoping rule entries and provisioners share: an item belongs
+// to a profile when at least one of its tags matches one of the profile's tags.
+// Centralizing it here keeps plan, status, deps, doctor, and provision filtering
+// through one rule instead of each carrying its own copy.
+func SharesTag(itemTags, profileTags []string) bool {
+	for _, it := range itemTags {
+		for _, pt := range profileTags {
+			if it == pt {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// MatchesOS reports whether an item's OS filter admits the current OS. An empty
+// filter matches every OS. The comparison is case-insensitive so a manifest that
+// declared an OS in mixed case still matches runtime.GOOS, which is always
+// lowercase; validation already constrains OS values to lowercase darwin/linux,
+// so this is defensive rather than load-bearing. It is the other half of the
+// profile-scoping rule SharesTag begins.
+func MatchesOS(itemOS []string, currentOS string) bool {
+	if len(itemOS) == 0 {
+		return true
+	}
+	for _, osName := range itemOS {
+		if strings.EqualFold(osName, currentOS) {
+			return true
+		}
+	}
+	return false
+}
+
 func indexOfEmptyTag(tags []string) (int, bool) {
 	return indexOfEmptyString(tags)
 }

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -56,10 +56,10 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 
 	plan := Plan{Profile: opts.Profile}
 	for _, entry := range m.Entries {
-		if !sharesTag(entry.Tags, profile.Tags) {
+		if !manifest.SharesTag(entry.Tags, profile.Tags) {
 			continue
 		}
-		if !matchesOS(entry.OS, opts.OS) {
+		if !manifest.MatchesOS(entry.OS, opts.OS) {
 			continue
 		}
 
@@ -85,29 +85,6 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 	}
 
 	return plan, nil
-}
-
-func sharesTag(entryTags, profileTags []string) bool {
-	for _, et := range entryTags {
-		for _, pt := range profileTags {
-			if et == pt {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func matchesOS(entryOS []string, current string) bool {
-	if len(entryOS) == 0 {
-		return true
-	}
-	for _, osName := range entryOS {
-		if osName == current {
-			return true
-		}
-	}
-	return false
 }
 
 // ResolveTarget resolves a manifest target inside home. Targets are deliberately

--- a/internal/plan/skipped.go
+++ b/internal/plan/skipped.go
@@ -1,0 +1,39 @@
+package plan
+
+import (
+	"fmt"
+
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/profilesel"
+)
+
+// selectedEntryIndices returns the set of m.Entries positions a profile would
+// select on the given OS. Working in index space lets SkippedEntries reason about
+// entry identity across profiles (which entry, not just how many) without
+// depending on struct equality, and keeps Build and SkippedEntries filtering
+// through one tag/OS rule. It mirrors provision.selectedIndices for provisioners.
+func selectedEntryIndices(m manifest.Manifest, profileName, os string) (map[int]bool, error) {
+	profile, ok := m.Profiles[profileName]
+	if !ok {
+		return nil, fmt.Errorf("profile %q not found", profileName)
+	}
+
+	indices := make(map[int]bool)
+	for i, entry := range m.Entries {
+		if manifest.SharesTag(entry.Tags, profile.Tags) && manifest.MatchesOS(entry.OS, os) {
+			indices[i] = true
+		}
+	}
+	return indices, nil
+}
+
+// SkippedEntries reports whether the active profile omits file entries that
+// another profile would select on this OS, and which single profile best recovers
+// them. It is a thin adapter over profilesel.Skipped, injecting the entry index
+// selection; provision.SkippedProvisioners is its provisioner twin over the same
+// shared math. It is PURE: no I/O and safe in a dry-run.
+func SkippedEntries(m manifest.Manifest, opts Options) (profilesel.Hint, bool, error) {
+	return profilesel.Skipped(m.Profiles, opts.Profile, opts.OS, func(name, os string) (map[int]bool, error) {
+		return selectedEntryIndices(m, name, os)
+	})
+}

--- a/internal/plan/skipped_test.go
+++ b/internal/plan/skipped_test.go
@@ -1,0 +1,129 @@
+package plan_test
+
+import (
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/plan"
+)
+
+func coreEntry() manifest.Entry {
+	return manifest.Entry{Source: "configs/zsh/zshrc", Target: "~/.zshrc", Strategy: "symlink", Tags: []string{"core"}}
+}
+
+func desktopEntry(source string) manifest.Entry {
+	return manifest.Entry{Source: source, Target: "~/" + source, Strategy: "symlink", Tags: []string{"desktop"}, OS: []string{"darwin", "linux"}}
+}
+
+func nestedProfiles() map[string]manifest.Profile {
+	return map[string]manifest.Profile{
+		"default": {Tags: []string{"core"}},
+		"desktop": {Tags: []string{"core", "desktop"}},
+	}
+}
+
+func TestSkippedEntries(t *testing.T) {
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: nestedProfiles(),
+		Entries:  []manifest.Entry{coreEntry(), desktopEntry("configs/ghostty/config.ghostty"), desktopEntry("configs/zed/settings.json")},
+	}
+
+	tests := []struct {
+		name          string
+		opts          plan.Options
+		wantOK        bool
+		wantCount     int
+		wantSuggested string
+	}{
+		{
+			name:          "default profile reports the desktop-only entries it skips",
+			opts:          plan.Options{Profile: "default", OS: "darwin"},
+			wantOK:        true,
+			wantCount:     2,
+			wantSuggested: "desktop",
+		},
+		{
+			name:   "desktop profile selects everything so there is no hint",
+			opts:   plan.Options{Profile: "desktop", OS: "darwin"},
+			wantOK: false,
+		},
+		{
+			name:   "no hint when the skipped entries are excluded on this OS",
+			opts:   plan.Options{Profile: "default", OS: "windows"},
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hint, ok, err := plan.SkippedEntries(m, tt.opts)
+			if err != nil {
+				t.Fatalf("SkippedEntries() error = %v", err)
+			}
+			if ok != tt.wantOK {
+				t.Fatalf("SkippedEntries() ok = %v, want %v (hint=%+v)", ok, tt.wantOK, hint)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if hint.Profile != tt.opts.Profile {
+				t.Fatalf("hint.Profile = %q, want %q", hint.Profile, tt.opts.Profile)
+			}
+			if hint.Count != tt.wantCount {
+				t.Fatalf("hint.Count = %d, want %d", hint.Count, tt.wantCount)
+			}
+			if hint.SuggestedProfile != tt.wantSuggested {
+				t.Fatalf("hint.SuggestedProfile = %q, want %q", hint.SuggestedProfile, tt.wantSuggested)
+			}
+		})
+	}
+}
+
+// TestSkippedEntriesCountReflectsSuggestedCoverage proves Count is the suggested
+// profile's coverage of the skipped set, not the union of omissions across every
+// profile, so the "run --profile S to include them" message never promises more
+// than S delivers when no single profile is a superset.
+func TestSkippedEntriesCountReflectsSuggestedCoverage(t *testing.T) {
+	// Three non-nested profiles: neither "a" nor "b" is a superset of the two
+	// extras the default profile omits. The union of omissions is 2, but each
+	// other profile recovers only 1.
+	m := manifest.Manifest{
+		Version: 1,
+		Profiles: map[string]manifest.Profile{
+			"default": {Tags: []string{"core"}},
+			"a":       {Tags: []string{"core", "a"}},
+			"b":       {Tags: []string{"core", "b"}},
+		},
+		Entries: []manifest.Entry{
+			coreEntry(),
+			{Source: "configs/a", Target: "~/.a", Strategy: "symlink", Tags: []string{"a"}},
+			{Source: "configs/b", Target: "~/.b", Strategy: "symlink", Tags: []string{"b"}},
+		},
+	}
+
+	hint, ok, err := plan.SkippedEntries(m, plan.Options{Profile: "default", OS: "darwin"})
+	if err != nil {
+		t.Fatalf("SkippedEntries() error = %v", err)
+	}
+	if !ok {
+		t.Fatalf("SkippedEntries() ok = false, want true")
+	}
+	if hint.Count != 1 {
+		t.Fatalf("hint.Count = %d, want 1 (suggested profile's coverage, not the union of 2)", hint.Count)
+	}
+	if hint.SuggestedProfile != "a" {
+		t.Fatalf("hint.SuggestedProfile = %q, want %q (alphabetical tie-break on equal coverage)", hint.SuggestedProfile, "a")
+	}
+}
+
+func TestSkippedEntriesUnknownProfileErrors(t *testing.T) {
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: nestedProfiles(),
+		Entries:  []manifest.Entry{coreEntry()},
+	}
+	if _, _, err := plan.SkippedEntries(m, plan.Options{Profile: "ghost", OS: "darwin"}); err == nil {
+		t.Fatal("SkippedEntries() error = nil, want unknown-profile error")
+	}
+}

--- a/internal/profilesel/profilesel.go
+++ b/internal/profilesel/profilesel.go
@@ -1,0 +1,104 @@
+// Package profilesel computes profile-scope omission math shared by the file
+// entry and provisioner surfaces: given how each profile selects items, which
+// items the active profile silently skips and which single profile best recovers
+// them. It is pure (no I/O) and item-agnostic — callers inject a Selector that
+// knows how to select their own slice (entries, provisioners, ...).
+package profilesel
+
+import (
+	"sort"
+
+	"github.com/yersonargotev/dots/internal/manifest"
+)
+
+// Hint describes items the active profile omits that some other profile would
+// select on this OS, so a caller can nudge the user toward the fuller profile
+// instead of silently dropping them.
+type Hint struct {
+	// Profile is the active profile being installed.
+	Profile string
+	// Count is how many of the skipped items SuggestedProfile would recover. It
+	// is intentionally the suggested profile's coverage, not the union of
+	// omissions across every profile, so the "run --profile S to include them"
+	// nudge is always exact and never promises more than S delivers. In the
+	// nested-profile model dots uses (e.g. desktop ⊇ default) the most complete
+	// profile recovers everything, so Count equals the total the active profile
+	// omits.
+	Count int
+	// SuggestedProfile is the other profile that covers the most skipped items —
+	// the single most complete profile worth recommending.
+	SuggestedProfile string
+}
+
+// Selector returns the set of item positions (index space) a profile selects on
+// the given OS. Working in index space lets Skipped compare item identity across
+// profiles — which item, not just how many — without depending on item struct
+// equality. It returns an error for an unknown profile so Skipped surfaces the
+// same validation the caller's own selection uses.
+type Selector func(profileName, os string) (map[int]bool, error)
+
+// Skipped reports whether the active profile omits items that another profile
+// would select on this OS, and which single profile best recovers them. The
+// second return is false (with a zero hint) when nothing is skipped — either the
+// active profile already selects everything, or the OS filter excludes the extras
+// for every profile so switching profiles would not recover them. The reported
+// Count is the suggested profile's coverage of the skipped set, so the caller's
+// remediation message stays accurate even when no single profile is a superset of
+// every omission.
+func Skipped(profiles map[string]manifest.Profile, active, os string, sel Selector) (Hint, bool, error) {
+	activeSet, err := sel(active, os)
+	if err != nil {
+		return Hint{}, false, err
+	}
+
+	others := make([]string, 0, len(profiles))
+	for name := range profiles {
+		if name != active {
+			others = append(others, name)
+		}
+	}
+	// Sort so the suggested profile is deterministic on ties (first by name).
+	sort.Strings(others)
+
+	selections := make(map[string]map[int]bool, len(others))
+	skipped := make(map[int]bool)
+	for _, name := range others {
+		set, err := sel(name, os)
+		if err != nil {
+			return Hint{}, false, err
+		}
+		selections[name] = set
+		for i := range set {
+			if !activeSet[i] {
+				skipped[i] = true
+			}
+		}
+	}
+
+	if len(skipped) == 0 {
+		return Hint{}, false, nil
+	}
+
+	var (
+		suggested string
+		best      int
+	)
+	for _, name := range others {
+		covered := 0
+		for i := range selections[name] {
+			if skipped[i] {
+				covered++
+			}
+		}
+		if covered > best {
+			best = covered
+			suggested = name
+		}
+	}
+
+	// best is the suggested profile's coverage of the skipped set, and is >= 1
+	// whenever skipped is non-empty: every skipped index came from some other
+	// profile's selection, so that profile covers it. Reporting best (not
+	// len(skipped)) keeps "run --profile S to include them" exact.
+	return Hint{Profile: active, Count: best, SuggestedProfile: suggested}, true, nil
+}

--- a/internal/profilesel/profilesel_test.go
+++ b/internal/profilesel/profilesel_test.go
@@ -1,0 +1,101 @@
+package profilesel_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/profilesel"
+)
+
+// fakeSelector builds a Selector from a fixed profile -> selected-index set,
+// ignoring OS so the math is exercised independently of any real item slice.
+func fakeSelector(selections map[string]map[int]bool) profilesel.Selector {
+	return func(profileName, _ string) (map[int]bool, error) {
+		sel, ok := selections[profileName]
+		if !ok {
+			return nil, errors.New("unknown profile")
+		}
+		return sel, nil
+	}
+}
+
+func profileNames(names ...string) map[string]manifest.Profile {
+	m := make(map[string]manifest.Profile, len(names))
+	for _, name := range names {
+		m[name] = manifest.Profile{Tags: []string{name}}
+	}
+	return m
+}
+
+func TestSkipped(t *testing.T) {
+	tests := []struct {
+		name          string
+		profiles      map[string]manifest.Profile
+		selections    map[string]map[int]bool
+		active        string
+		wantOK        bool
+		wantCount     int
+		wantSuggested string
+	}{
+		{
+			name:          "nested profile recovers everything the active one skips",
+			profiles:      profileNames("default", "desktop"),
+			selections:    map[string]map[int]bool{"default": {0: true}, "desktop": {0: true, 1: true, 2: true}},
+			active:        "default",
+			wantOK:        true,
+			wantCount:     2,
+			wantSuggested: "desktop",
+		},
+		{
+			name:       "active profile already selects everything",
+			profiles:   profileNames("default", "desktop"),
+			selections: map[string]map[int]bool{"default": {0: true, 1: true}, "desktop": {0: true, 1: true}},
+			active:     "desktop",
+			wantOK:     false,
+		},
+		{
+			name:          "non-superset: Count is suggested coverage, not the union of omissions",
+			profiles:      profileNames("default", "a", "b"),
+			selections:    map[string]map[int]bool{"default": {0: true}, "a": {0: true, 1: true}, "b": {0: true, 2: true}},
+			active:        "default",
+			wantOK:        true,
+			wantCount:     1,   // union of skipped is {1,2}=2, but each other profile recovers only 1
+			wantSuggested: "a", // alphabetical tie-break on equal coverage
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hint, ok, err := profilesel.Skipped(tt.profiles, tt.active, "darwin", fakeSelector(tt.selections))
+			if err != nil {
+				t.Fatalf("Skipped() error = %v", err)
+			}
+			if ok != tt.wantOK {
+				t.Fatalf("Skipped() ok = %v, want %v (hint=%+v)", ok, tt.wantOK, hint)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if hint.Profile != tt.active {
+				t.Fatalf("hint.Profile = %q, want %q", hint.Profile, tt.active)
+			}
+			if hint.Count != tt.wantCount {
+				t.Fatalf("hint.Count = %d, want %d", hint.Count, tt.wantCount)
+			}
+			if hint.SuggestedProfile != tt.wantSuggested {
+				t.Fatalf("hint.SuggestedProfile = %q, want %q", hint.SuggestedProfile, tt.wantSuggested)
+			}
+		})
+	}
+}
+
+// TestSkippedPropagatesSelectorError proves an error from the active selection
+// (e.g. an unknown active profile) surfaces instead of being swallowed.
+func TestSkippedPropagatesSelectorError(t *testing.T) {
+	profiles := profileNames("default", "desktop")
+	sel := fakeSelector(map[string]map[int]bool{"default": {0: true}, "desktop": {0: true, 1: true}})
+	if _, _, err := profilesel.Skipped(profiles, "ghost", "darwin", sel); err == nil {
+		t.Fatal("Skipped() error = nil, want selector error for unknown active profile")
+	}
+}

--- a/internal/provision/plan.go
+++ b/internal/provision/plan.go
@@ -2,9 +2,9 @@ package provision
 
 import (
 	"fmt"
-	"sort"
 
 	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/profilesel"
 )
 
 // Options carries the resolved inputs needed to select and plan Provisioners.
@@ -61,97 +61,23 @@ func selectedIndices(m manifest.Manifest, profileName, os string) (map[int]bool,
 
 	indices := make(map[int]bool)
 	for i, prov := range m.Provisioners {
-		if sharesTag(prov.Tags, profile.Tags) && matchesOS(prov.OS, os) {
+		if manifest.SharesTag(prov.Tags, profile.Tags) && manifest.MatchesOS(prov.OS, os) {
 			indices[i] = true
 		}
 	}
 	return indices, nil
 }
 
-// SkippedHint describes provisioners the active profile omits that some other
-// profile would select on this OS, so the CLI can nudge the user toward the
-// fuller profile instead of silently dropping them.
-type SkippedHint struct {
-	// Profile is the active profile being installed.
-	Profile string
-	// Count is how many of the skipped provisioners SuggestedProfile would
-	// recover. It is intentionally the suggested profile's coverage, not the
-	// union of omissions across every profile, so the "run --profile S to
-	// include them" nudge is always exact and never promises more than S
-	// delivers. In the nested-profile model dots uses (e.g. desktop ⊇ default)
-	// the most complete profile recovers everything, so Count equals the total
-	// the active profile omits.
-	Count int
-	// SuggestedProfile is the other profile that covers the most skipped
-	// provisioners — the single most complete profile worth recommending.
-	SuggestedProfile string
-}
-
 // SkippedProvisioners reports whether the active profile omits provisioners that
-// another profile would select on this OS, and which single profile best
-// recovers them. The second return is false (with a zero hint) when nothing is
-// skipped — either the active profile already selects everything, or the OS
-// filter excludes the extras for every profile so switching profiles would not
-// recover them. The reported Count is the suggested profile's coverage of the
-// skipped set, so the caller's remediation message stays accurate even when no
-// single profile is a superset of every omission. It is PURE: no I/O, safe in a
-// dry-run, and mirrors the tag/OS scoping used by Select.
-func SkippedProvisioners(m manifest.Manifest, opts Options) (SkippedHint, bool, error) {
-	active, err := selectedIndices(m, opts.Profile, opts.OS)
-	if err != nil {
-		return SkippedHint{}, false, err
-	}
-
-	others := make([]string, 0, len(m.Profiles))
-	for name := range m.Profiles {
-		if name != opts.Profile {
-			others = append(others, name)
-		}
-	}
-	// Sort so the suggested profile is deterministic on ties (first by name).
-	sort.Strings(others)
-
-	selections := make(map[string]map[int]bool, len(others))
-	skipped := make(map[int]bool)
-	for _, name := range others {
-		sel, err := selectedIndices(m, name, opts.OS)
-		if err != nil {
-			return SkippedHint{}, false, err
-		}
-		selections[name] = sel
-		for i := range sel {
-			if !active[i] {
-				skipped[i] = true
-			}
-		}
-	}
-
-	if len(skipped) == 0 {
-		return SkippedHint{}, false, nil
-	}
-
-	var (
-		suggested string
-		best      int
-	)
-	for _, name := range others {
-		covered := 0
-		for i := range selections[name] {
-			if skipped[i] {
-				covered++
-			}
-		}
-		if covered > best {
-			best = covered
-			suggested = name
-		}
-	}
-
-	// best is the suggested profile's coverage of the skipped set, and is >= 1
-	// whenever skipped is non-empty: every skipped index came from some other
-	// profile's selection, so that profile covers it. Reporting best (not
-	// len(skipped)) keeps "run --profile S to include them" exact.
-	return SkippedHint{Profile: opts.Profile, Count: best, SuggestedProfile: suggested}, true, nil
+// another profile would select on this OS, and which single profile best recovers
+// them. It is a thin adapter over profilesel.Skipped, injecting the provisioner
+// index selection; plan.SkippedEntries is its file-entry twin over the same
+// shared math. It is PURE: no I/O, safe in a dry-run, and mirrors the tag/OS
+// scoping used by Select.
+func SkippedProvisioners(m manifest.Manifest, opts Options) (profilesel.Hint, bool, error) {
+	return profilesel.Skipped(m.Profiles, opts.Profile, opts.OS, func(name, os string) (map[int]bool, error) {
+		return selectedIndices(m, name, os)
+	})
 }
 
 // Build resolves every selected Provisioner into its exact command and the
@@ -205,29 +131,6 @@ func managedRoots(prov manifest.Provisioner) []string {
 func includes(values []string, want string) bool {
 	for _, value := range values {
 		if value == want {
-			return true
-		}
-	}
-	return false
-}
-
-func sharesTag(provTags, profileTags []string) bool {
-	for _, pt := range provTags {
-		for _, prt := range profileTags {
-			if pt == prt {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func matchesOS(provOS []string, current string) bool {
-	if len(provOS) == 0 {
-		return true
-	}
-	for _, osName := range provOS {
-		if osName == current {
 			return true
 		}
 	}

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -70,12 +70,12 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options) (Report, erro
 
 	report := Report{Profile: opts.Profile}
 	for _, entry := range m.Entries {
-		if !sharesTag(entry.Tags, profile.Tags) {
+		if !manifest.SharesTag(entry.Tags, profile.Tags) {
 			continue
 		}
 
 		evaluated := Entry{Source: entry.Source, Target: entry.Target, Strategy: entry.Strategy}
-		if !matchesOS(entry.OS, opts.OS) {
+		if !manifest.MatchesOS(entry.OS, opts.OS) {
 			evaluated.State = StateSkipped
 			report.Entries = append(report.Entries, evaluated)
 			continue
@@ -191,27 +191,4 @@ func sameContent(a, b string) (bool, error) {
 		return false, fmt.Errorf("read %s: %w", b, err)
 	}
 	return bytes.Equal(da, db), nil
-}
-
-func sharesTag(entryTags, profileTags []string) bool {
-	for _, et := range entryTags {
-		for _, pt := range profileTags {
-			if et == pt {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func matchesOS(entryOS []string, current string) bool {
-	if len(entryOS) == 0 {
-		return true
-	}
-	for _, osName := range entryOS {
-		if osName == current {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
Closes #87

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- `install`/`update` now print a parallel hint when the active profile skips file entries another profile would select, mirroring the shipped provisioner hint (#85/#86) so the desktop-tagged configs (Ghostty, Zed, OpenCode MCP overlay) are no longer silently omitted for `default`-profile users.
- The "which profile best recovers the skipped items" set-math is extracted into `internal/profilesel`, so `plan.SkippedEntries` and `provision.SkippedProvisioners` are thin adapters over one implementation instead of two lockstep copies.
- The duplicated tag/OS predicate is consolidated into `manifest.SharesTag`/`manifest.MatchesOS`, removing the five local copies across `plan`, `provision`, `deps`, `status`, and `doctor`.

## Changes

| File | Change |
|------|--------|
| `internal/profilesel/profilesel.go` | New package: `Hint` + `Skipped(profiles, active, os, Selector)` — the single source of truth for skipped-profile omission math. |
| `internal/manifest/manifest.go` | Add exported `SharesTag` / `MatchesOS` profile-scoping predicates. |
| `internal/plan/skipped.go` | New `plan.SkippedEntries` (adapter over `profilesel`) + `selectedEntryIndices`. |
| `internal/cli/render.go` | New `renderSkippedEntryHint` (proper `file entry`/`file entries` pluralization). |
| `internal/cli/install.go`, `internal/cli/update.go` | Wire the entry hint in next to the file plan. |
| `internal/cli/render_provision.go` | `provision.SkippedProvisioners` returns `profilesel.Hint`; updated doc comment (entry twin now exists). |
| `internal/provision/plan.go` | `SkippedProvisioners` reduced to a `profilesel` adapter; predicate delegated to `manifest`. |
| `internal/plan/plan.go`, `internal/deps/deps.go`, `internal/status/status.go`, `internal/doctor/doctor.go` | Use shared `manifest` predicate; remove local `sharesTag`/`matchesOS` copies. |
| `docs/update.md` | Document the file-entry hint alongside the provisioner hint. |
| `internal/{plan,profilesel,cli}/*_test.go` | Unit tests for the shared math, the plan adapter, the renderer (singular/plural/quiet), and install/update dry-run hints. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp>`

Smoke test on the real manifest (`install --dry-run --profile default`):
```
Note: profile "default" skips 5 file entries; run with --profile desktop to include them.
Note: profile "default" skips 3 provisioner(s); run with --profile desktop to include them.
```

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.