### PR TITLE
feat(cli): expose installed dots version

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ brew "yersonargotev/tap/dots", trusted: true
 Verify the binary is available:
 
 ```bash
-dots --help
+dots --version
 ```
 
 ## Quickstart
@@ -89,6 +89,7 @@ dots backups list
 When the plan looks right, run the install for real:
 
 ```bash
+dots --version
 dots install
 ```
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -55,7 +55,7 @@ Install the latest tap formula with a fully-qualified formula name:
 
 ```bash
 brew install yersonargotev/tap/dots
-dots --help
+dots --version
 dots install
 ```
 
@@ -77,7 +77,7 @@ For Brewfile-managed machines, prefer formula-level trust:
 brew "yersonargotev/tap/dots", trusted: true
 ```
 
-The formula selects the correct Release Artifact for macOS/Linux and amd64/arm64, marks each raw executable URL with `using: :nounzip`, verifies the published SHA-256 checksum from the generated formula, installs the downloaded binary as `dots`, and runs `dots --help` in `brew test`.
+The formula selects the correct Release Artifact for macOS/Linux and amd64/arm64, marks each raw executable URL with `using: :nounzip`, verifies the published SHA-256 checksum from the generated formula, installs the downloaded binary as `dots`, and runs `dots --version` in `brew test`.
 
 The release workflow proves tap write access before it mutates the public GitHub Release, but it does not publish the tap update until the release assets exist:
 
@@ -101,9 +101,10 @@ Install the latest published v0.x release with the checksum-verified Bootstrappe
 curl -fsSL https://raw.githubusercontent.com/yersonargotev/dots/main/scripts/install.sh | bash
 ```
 
-The Bootstrapper downloads `checksums.txt` and the matching platform artifact from the latest GitHub Release by default, verifies the SHA-256 checksum, installs the executable as `~/.local/bin/dots`, and then delegates setup to:
+The Bootstrapper downloads `checksums.txt` and the matching platform artifact from the latest GitHub Release by default, verifies the SHA-256 checksum, installs the executable as `~/.local/bin/dots`, and then uses that tested binary for setup. Before any real-home install, verify the installed binary version:
 
 ```bash
+~/.local/bin/dots --version
 ~/.local/bin/dots install
 ```
 
@@ -132,6 +133,7 @@ DOTS_VERSION=v0.5.1 DOTS_SOURCE_ROOT="$PWD" bash scripts/install.sh
 - [ ] All four platform artifacts are attached to the GitHub Release.
 - [ ] `checksums.txt` contains one SHA-256 entry for each artifact.
 - [ ] The Bootstrapper maps its detected `goos/goarch` to the matching artifact name.
+- [ ] `dots --version` and `dots version` both report the release tag.
 - [ ] `Formula/dots.rb` in `yersonargotev/homebrew-tap` points at the same tag and checksums.
 - [ ] A Tap Trust install path has been checked with `HOMEBREW_REQUIRE_TAP_TRUST=1` using the fully-qualified formula or formula-level trust.
 - [ ] `HOMEBREW_TAP_TOKEN` is configured before relying on automatic tap updates.

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -28,6 +28,38 @@ func TestRootHelpIdentifiesDotsCLI(t *testing.T) {
 	}
 }
 
+func TestRootVersionFlagReportsDevelopmentVersion(t *testing.T) {
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--version"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if got, want := strings.TrimSpace(out.String()), "dots dev"; got != want {
+		t.Fatalf("version output = %q, want %q", got, want)
+	}
+}
+
+func TestVersionCommandReportsDevelopmentVersion(t *testing.T) {
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"version"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if got, want := strings.TrimSpace(out.String()), "dots dev"; got != want {
+		t.Fatalf("version output = %q, want %q", got, want)
+	}
+}
+
 func TestPlanCommandRendersPreviewForResolvedEnvironment(t *testing.T) {
 	home := t.TempDir()
 	sourceRoot := t.TempDir()

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -5,15 +5,19 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/version"
 )
 
 func NewRootCommand() *cobra.Command {
 	root := &cobra.Command{
-		Use:   "dots",
-		Short: "Dotfiles CLI",
-		Long:  "dots is the Dotfiles CLI for managing repository-owned workstation configuration.",
+		Use:     "dots",
+		Short:   "Dotfiles CLI",
+		Long:    "dots is the Dotfiles CLI for managing repository-owned workstation configuration.",
+		Version: version.Value,
 	}
+	root.SetVersionTemplate("dots {{.Version}}\n")
 
+	root.AddCommand(newVersionCommand())
 	root.AddCommand(newManifestCommand())
 	root.AddCommand(newPlanCommand())
 	root.AddCommand(newInstallCommand())
@@ -23,6 +27,18 @@ func NewRootCommand() *cobra.Command {
 	root.AddCommand(newDepsCommand())
 	root.AddCommand(newDoctorCommand())
 	return root
+}
+
+func newVersionCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print the dots version",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Fprintf(cmd.OutOrStdout(), "dots %s\n", version.Value)
+			return nil
+		},
+	}
 }
 
 func newManifestCommand() *cobra.Command {

--- a/internal/release/release_automation_test.go
+++ b/internal/release/release_automation_test.go
@@ -214,6 +214,14 @@ func TestBuildReleaseArtifactsValidatesReleaseVersionLikeWorkflow(t *testing.T) 
 				if _, err := os.Stat(logPath); err != nil {
 					t.Fatalf("expected accepted version %s to reach go build: %v", version, err)
 				}
+				log, err := os.ReadFile(logPath)
+				if err != nil {
+					t.Fatalf("read go build log: %v", err)
+				}
+				wantLdflag := "-X github.com/yersonargotev/dots/internal/version.Value=" + version
+				if !strings.Contains(string(log), wantLdflag) {
+					t.Fatalf("release build should inject version with ldflags %q\nlog:\n%s", wantLdflag, log)
+				}
 			})
 		}
 	})
@@ -291,7 +299,7 @@ func TestGenerateHomebrewFormulaUsesChecksummedReleaseArtifacts(t *testing.T) {
 		`url "https://github.com/yersonargotev/dots/releases/download/v0.99.0/dots_v0.99.0_linux_arm64", using: :nounzip`,
 		`sha256 "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"`,
 		`bin.install downloaded_binary => "dots"`,
-		`system "#{bin}/dots", "--help"`,
+		`system "#{bin}/dots", "--version"`,
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("formula should contain %q\nformula:\n%s", want, text)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,8 @@
+package version
+
+// Value is the semantic version reported by the CLI.
+//
+// Release builds override this with:
+//
+//	go build -ldflags "-X github.com/yersonargotev/dots/internal/version.Value=v0.x.y"
+var Value = "dev"

--- a/scripts/build-release-artifacts.sh
+++ b/scripts/build-release-artifacts.sh
@@ -66,7 +66,7 @@ for platform in "${platforms[@]}"; do
   artifact="dots_${version}_${goos}_${goarch}"
   echo "building ${artifact}"
   CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" \
-    go build -trimpath -ldflags="-s -w" -o "$out_dir/$artifact" ./cmd/dots
+    go build -trimpath -ldflags="-s -w -X github.com/yersonargotev/dots/internal/version.Value=${version}" -o "$out_dir/$artifact" ./cmd/dots
   artifacts+=("$artifact")
 done
 

--- a/scripts/generate-homebrew-formula.sh
+++ b/scripts/generate-homebrew-formula.sh
@@ -221,7 +221,7 @@ class Dots < Formula
   end
 
   test do
-    system "#{bin}/dots", "--help"
+    system "#{bin}/dots", "--version"
   end
 end
 FORMULA


### PR DESCRIPTION
Closes #78

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds `dots --version` and `dots version` so installed binaries can report their version before setup.
- Keeps development builds explicit as `dots dev` while release builds inject the release tag.
- Updates release/Homebrew docs and formula validation to use version verification.

## Changes

| File | Change |
|------|--------|
| `internal/version/version.go` | Adds the injectable CLI version value, defaulting to `dev`. |
| `internal/cli/root.go` | Wires Cobra `--version` output and adds the `version` command. |
| `internal/cli/cli_test.go` | Covers root flag and command behavior through the CLI public interface. |
| `internal/release/release_automation_test.go` | Verifies release ldflags injection and Homebrew formula version checks. |
| `scripts/build-release-artifacts.sh` | Injects the validated release tag into built binaries. |
| `scripts/generate-homebrew-formula.sh` | Changes generated `brew test` to run `dots --version`. |
| `README.md`, `docs/release.md` | Documents version verification before install/release validation. |

## Test Plan

- [x] `shellcheck scripts/build-release-artifacts.sh scripts/generate-homebrew-formula.sh`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] `go build -o ./dots ./cmd/dots && ./dots --version && ./dots version`
- [x] Release artifact smoke test: `scripts/build-release-artifacts.sh --version v0.99.1 --out-dir <tmp>` plus generated binary `--version` and `version`
- [x] Sandboxed plan only when dotfiles behavior changes: N/A — this PR changes CLI version reporting and release validation only.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
