### PR TITLE
feat(codex): manage CodeGraph setup

### DIFF
--- a/dots.yaml
+++ b/dots.yaml
@@ -318,3 +318,20 @@ provisioners:
     dependencies:
       - name: codex
         command: codex
+  - tool: codex
+    tags:
+      - desktop
+    os:
+      - darwin
+      - linux
+    spec:
+      mcp: codegraph
+      command:
+        - codegraph
+        - serve
+        - --mcp
+    dependencies:
+      - name: codex
+        command: codex
+      - name: codegraph
+        command: codegraph

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/yersonargotev/dots/internal/codexconfig"
 	"github.com/yersonargotev/dots/internal/install"
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/plan"
@@ -118,7 +119,38 @@ func runProvisioners(cmd *cobra.Command, m manifest.Manifest, profile, home stri
 	}
 	report, err := provision.Apply(m, provision.Options{Profile: profile, OS: runtime.GOOS}, lookupCommand, fontInstalled(runtime.GOOS, home), runner)
 	renderProvisionReport(cmd.OutOrStdout(), report)
-	return err
+	if err != nil {
+		return err
+	}
+	selected, err := provision.Select(m, provision.Options{Profile: profile, OS: runtime.GOOS})
+	if err != nil {
+		return err
+	}
+	if !selectedProvisionersAffectCodex(selected) {
+		return nil
+	}
+	return codexconfig.EnsureCodeGraphMode(home)
+}
+
+func selectedProvisionersAffectCodex(selected []manifest.Provisioner) bool {
+	for _, prov := range selected {
+		if prov.Tool == "codex" {
+			return true
+		}
+		if prov.Tool == "gentle-ai" && provisionerAgentsInclude(prov, "codex") {
+			return true
+		}
+	}
+	return false
+}
+
+func provisionerAgentsInclude(prov manifest.Provisioner, want string) bool {
+	for _, agent := range prov.Spec.Agents {
+		if agent == want {
+			return true
+		}
+	}
+	return false
 }
 
 // resolveAndApply resolves the plan's conflicts (via the TUI, text prompts, or

--- a/internal/cli/install_provision_test.go
+++ b/internal/cli/install_provision_test.go
@@ -116,6 +116,157 @@ func TestInstallExecutesProvisionerAfterFilesWithHomeThreaded(t *testing.T) {
 	}
 }
 
+// TestInstallWritesCodexCodeGraphOverlayAfterProvisioners proves dots adds its
+// own Codex AGENTS.md instruction layer only after a successful provisioner run,
+// under the sandbox HOME threaded through --home.
+func TestInstallWritesCodexCodeGraphOverlayAfterProvisioners(t *testing.T) {
+	sandboxHome := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	fakeRealHome := t.TempDir()
+	t.Setenv("HOME", fakeRealHome)
+
+	stubDir := t.TempDir()
+	writeExecStub(t, filepath.Join(stubDir, "gentle-ai"), "#!/bin/sh\nexit 0\n")
+	writeExecStub(t, filepath.Join(stubDir, "engram"), "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	writeCLISource(t, sourceRoot, "configs/zsh/zshrc", "managed\n")
+	manifestPath := writeCLIManifest(t, sandboxHome, provisionerManifest)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"install", "--yes", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+
+	got, err := os.ReadFile(filepath.Join(sandboxHome, ".codex", "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("read sandbox Codex AGENTS.md: %v", err)
+	}
+	content := string(got)
+	for _, want := range []string{
+		"<!-- dots:codegraph-mode -->",
+		"CodeGraph Mode: enabled",
+		"If `.codegraph/` exists in the project, use CodeGraph first",
+		"<!-- /dots:codegraph-mode -->",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("Codex AGENTS.md missing %q\ncontent:\n%s", want, content)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(fakeRealHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatalf("install wrote Codex AGENTS.md in inherited HOME %q; stat err = %v", fakeRealHome, err)
+	}
+}
+
+// TestInstallDoesNotWriteCodexCodeGraphOverlayWithoutSelectedProvisioners proves
+// the post-provision Codex layer is scoped to selected Codex-related
+// provisioners. A successful install whose active profile selects no
+// provisioners must not create a sandbox Codex AGENTS.md.
+func TestInstallDoesNotWriteCodexCodeGraphOverlayWithoutSelectedProvisioners(t *testing.T) {
+	sandboxHome := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	fakeRealHome := t.TempDir()
+	t.Setenv("HOME", fakeRealHome)
+
+	writeCLISource(t, sourceRoot, "configs/zsh/zshrc", "managed\n")
+	manifestPath := writeCLIManifest(t, sandboxHome, `version: 1
+profiles:
+  default:
+    tags: [core]
+  desktop:
+    tags: [desktop]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+provisioners:
+  - tool: gentle-ai
+    tags: [desktop]
+    spec:
+      scope: global
+      agents: [codex]
+    dependencies:
+      - name: gentle-ai
+`)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"install", "--yes", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+
+	if _, err := os.Stat(filepath.Join(sandboxHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatalf("install without selected provisioners created sandbox Codex AGENTS.md; stat err = %v\noutput:\n%s", err, out.String())
+	}
+	if _, err := os.Stat(filepath.Join(fakeRealHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatalf("install wrote Codex AGENTS.md in inherited HOME %q; stat err = %v", fakeRealHome, err)
+	}
+}
+
+// TestInstallWritesCodexCodeGraphOverlayAfterCodexProvisioner proves a selected
+// Codex MCP provisioner also qualifies for the post-provision Codex layer, not
+// only the gentle-ai provisioner that installs Codex agents.
+func TestInstallWritesCodexCodeGraphOverlayAfterCodexProvisioner(t *testing.T) {
+	sandboxHome := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	fakeRealHome := t.TempDir()
+	t.Setenv("HOME", fakeRealHome)
+
+	stubDir := t.TempDir()
+	writeExecStub(t, filepath.Join(stubDir, "codex"), "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	writeCLISource(t, sourceRoot, "configs/zsh/zshrc", "managed\n")
+	manifestPath := writeCLIManifest(t, sandboxHome, `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+provisioners:
+  - tool: codex
+    tags: [core]
+    spec:
+      mcp: codegraph
+      command: [codegraph, serve, --mcp]
+    dependencies:
+      - name: codex
+`)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"install", "--yes", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+
+	if _, err := os.ReadFile(filepath.Join(sandboxHome, ".codex", "AGENTS.md")); err != nil {
+		t.Fatalf("read sandbox Codex AGENTS.md after codex provisioner: %v\noutput:\n%s", err, out.String())
+	}
+	if _, err := os.Stat(filepath.Join(fakeRealHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatalf("install wrote Codex AGENTS.md in inherited HOME %q; stat err = %v", fakeRealHome, err)
+	}
+}
+
 // TestInstallExecutesClaudeProvisionerHomeThreaded proves a claude provisioner
 // renders and runs the exact `claude plugin ...` invocations, in manifest order,
 // under the sandbox HOME and never the inherited one.
@@ -179,6 +330,9 @@ provisioners:
 	}
 	if _, err := os.Stat(filepath.Join(fakeRealHome, "claude-calls")); err == nil {
 		t.Fatalf("claude provisioner wrote into the inherited HOME %q instead of the sandbox", fakeRealHome)
+	}
+	if _, err := os.Stat(filepath.Join(sandboxHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatalf("claude-only provisioners created sandbox Codex AGENTS.md; stat err = %v", err)
 	}
 }
 

--- a/internal/cli/provision_test_helpers_test.go
+++ b/internal/cli/provision_test_helpers_test.go
@@ -18,5 +18,6 @@ func stubGentleAIProvisionerTools(t *testing.T) {
 	// network or the real agent config.
 	writeExecStub(t, filepath.Join(stubDir, "claude"), "#!/bin/sh\nexit 0\n")
 	writeExecStub(t, filepath.Join(stubDir, "codex"), "#!/bin/sh\nexit 0\n")
+	writeExecStub(t, filepath.Join(stubDir, "codegraph"), "#!/bin/sh\nexit 0\n")
 	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }

--- a/internal/cli/update_provision_test.go
+++ b/internal/cli/update_provision_test.go
@@ -94,6 +94,49 @@ func TestUpdateExecutesProvisionersAfterApply(t *testing.T) {
 	}
 }
 
+// TestUpdateWritesCodexCodeGraphOverlayAfterProvisioners proves update reaches
+// the same post-provision Codex AGENTS.md overlay hook as install, under the
+// sandbox HOME.
+func TestUpdateWritesCodexCodeGraphOverlayAfterProvisioners(t *testing.T) {
+	requireGitCLI(t)
+	sandboxHome := t.TempDir()
+	stateRoot := t.TempDir()
+	fakeRealHome := t.TempDir()
+	t.Setenv("HOME", fakeRealHome)
+
+	stubDir := t.TempDir()
+	writeExecStub(t, filepath.Join(stubDir, "gentle-ai"), "#!/bin/sh\nexit 0\n")
+	writeExecStub(t, filepath.Join(stubDir, "engram"), "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	_, sourceRoot := newInstalledRepo(t, map[string]string{
+		"configs/git/gitconfig": "managed\n",
+		"dots.yaml":             updateProvisionerManifest,
+	})
+
+	out := runUpdate(t, "--yes", "--file", filepath.Join(sourceRoot, "dots.yaml"),
+		"--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot)
+
+	got, err := os.ReadFile(filepath.Join(sandboxHome, ".codex", "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("read sandbox Codex AGENTS.md: %v\noutput:\n%s", err, out)
+	}
+	content := string(got)
+	for _, want := range []string{
+		"<!-- dots:codegraph-mode -->",
+		"CodeGraph Mode: enabled",
+		"If `.codegraph/` exists in the project, use CodeGraph first",
+		"<!-- /dots:codegraph-mode -->",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("Codex AGENTS.md missing %q\ncontent:\n%s", want, content)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(fakeRealHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatalf("update wrote Codex AGENTS.md in inherited HOME %q; stat err = %v", fakeRealHome, err)
+	}
+}
+
 // TestUpdateCanceledConflictDoesNotRunProvisioners proves canceling conflict
 // resolution during a post-update install aborts before any provisioner runs —
 // the same applied-gating install enforces.

--- a/internal/codexconfig/codegraph.go
+++ b/internal/codexconfig/codegraph.go
@@ -1,0 +1,59 @@
+// Package codexconfig manages dots-owned overlays inside Codex configuration
+// files without taking ownership of the whole file.
+package codexconfig
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/yersonargotev/dots/internal/textblock"
+)
+
+const (
+	codeGraphStart       = "<!-- dots:codegraph-mode -->"
+	codeGraphEnd         = "<!-- /dots:codegraph-mode -->"
+	legacyCodeGraphStart = "<!-- gentle-ai:codegraph-mode -->"
+	legacyCodeGraphEnd   = "<!-- /gentle-ai:codegraph-mode -->"
+)
+
+const codeGraphInstructions = "CodeGraph Mode: enabled\n\n" +
+	"If `.codegraph/` exists in the project, use CodeGraph first for architecture, trace, impact, and symbol-discovery questions instead of re-deriving the same answer with grep/read loops.\n\n" +
+	"Use CodeGraph by intent:\n\n" +
+	"- `codegraph_context`: map a feature or area first.\n" +
+	"- `codegraph_trace`: trace how one symbol reaches another.\n" +
+	"- `codegraph_explore`: inspect related symbols in one bounded call.\n" +
+	"- `codegraph_search`: find a symbol by name.\n" +
+	"- `codegraph_callers` / `codegraph_callees`: walk call flow.\n" +
+	"- `codegraph_impact`: check affected code before edits.\n" +
+	"- `codegraph_node`: inspect one symbol.\n" +
+	"- `codegraph_files`: inspect indexed file structure.\n" +
+	"- `codegraph_status`: verify index health.\n\n" +
+	"Treat CodeGraph-returned source as already read. Use raw file reads only to verify details CodeGraph did not cover.\n\n" +
+	"If `.codegraph/` is missing, ask before running `codegraph init -i`."
+
+// EnsureCodeGraphMode inserts or updates the dots-owned CodeGraph instruction
+// block in <home>/.codex/AGENTS.md. It migrates the old manual gentle-ai block
+// to dots markers while preserving non-managed content.
+func EnsureCodeGraphMode(home string) error {
+	path := filepath.Join(home, ".codex", "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+
+	mode := os.FileMode(0o600)
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	} else if info, statErr := os.Stat(path); statErr == nil {
+		mode = info.Mode().Perm()
+	}
+
+	updated, err := textblock.Upsert(string(content), textblock.Markers{Start: codeGraphStart, End: codeGraphEnd}, codeGraphInstructions, textblock.Markers{Start: legacyCodeGraphStart, End: legacyCodeGraphEnd})
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(updated), mode)
+}

--- a/internal/codexconfig/codegraph_test.go
+++ b/internal/codexconfig/codegraph_test.go
@@ -1,0 +1,124 @@
+package codexconfig
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEnsureCodeGraphModeCreatesAgentsFileWhenMissing(t *testing.T) {
+	home := t.TempDir()
+
+	if err := EnsureCodeGraphMode(home); err != nil {
+		t.Fatalf("EnsureCodeGraphMode() error = %v", err)
+	}
+
+	got := readCodexAgents(t, home)
+	assertCodeGraphBlock(t, got)
+}
+
+func TestEnsureCodeGraphModePreservesExistingContent(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".codex", "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir codex dir: %v", err)
+	}
+	before := "# Personal Codex Rules\n\nKeep this line.\n"
+	if err := os.WriteFile(path, []byte(before), 0o600); err != nil {
+		t.Fatalf("write existing AGENTS.md: %v", err)
+	}
+
+	if err := EnsureCodeGraphMode(home); err != nil {
+		t.Fatalf("EnsureCodeGraphMode() error = %v", err)
+	}
+
+	got := readCodexAgents(t, home)
+	if !strings.Contains(got, before) {
+		t.Fatalf("AGENTS.md did not preserve existing content %q\ncontent:\n%s", before, got)
+	}
+	assertCodeGraphBlock(t, got)
+}
+
+func TestEnsureCodeGraphModeUpdatesExistingDotsBlockIdempotently(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".codex", "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir codex dir: %v", err)
+	}
+	existing := "before\n\n" + codeGraphStart + "\nstale instructions\n" + codeGraphEnd + "\n\nafter\n"
+	if err := os.WriteFile(path, []byte(existing), 0o600); err != nil {
+		t.Fatalf("write existing AGENTS.md: %v", err)
+	}
+
+	for i := 0; i < 2; i++ {
+		if err := EnsureCodeGraphMode(home); err != nil {
+			t.Fatalf("EnsureCodeGraphMode() run %d error = %v", i+1, err)
+		}
+	}
+
+	got := readCodexAgents(t, home)
+	assertCodeGraphBlock(t, got)
+	if strings.Contains(got, "stale instructions") {
+		t.Fatalf("AGENTS.md kept stale managed block content\ncontent:\n%s", got)
+	}
+	if count := strings.Count(got, codeGraphStart); count != 1 {
+		t.Fatalf("dots start marker count = %d, want 1\ncontent:\n%s", count, got)
+	}
+	if !strings.Contains(got, "before") || !strings.Contains(got, "after") {
+		t.Fatalf("AGENTS.md did not preserve content around managed block\ncontent:\n%s", got)
+	}
+}
+
+func TestEnsureCodeGraphModeMigratesLegacyGentleAIBlock(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".codex", "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir codex dir: %v", err)
+	}
+	existing := "before\n\n" + legacyCodeGraphStart + "\nmanual codegraph instructions\n" + legacyCodeGraphEnd + "\n\nafter\n"
+	if err := os.WriteFile(path, []byte(existing), 0o600); err != nil {
+		t.Fatalf("write existing AGENTS.md: %v", err)
+	}
+
+	if err := EnsureCodeGraphMode(home); err != nil {
+		t.Fatalf("EnsureCodeGraphMode() error = %v", err)
+	}
+
+	got := readCodexAgents(t, home)
+	assertCodeGraphBlock(t, got)
+	for _, legacy := range []string{legacyCodeGraphStart, legacyCodeGraphEnd, "manual codegraph instructions"} {
+		if strings.Contains(got, legacy) {
+			t.Fatalf("AGENTS.md kept legacy content %q\ncontent:\n%s", legacy, got)
+		}
+	}
+	if !strings.Contains(got, "before") || !strings.Contains(got, "after") {
+		t.Fatalf("AGENTS.md did not preserve content around legacy block\ncontent:\n%s", got)
+	}
+}
+
+func readCodexAgents(t *testing.T, home string) string {
+	t.Helper()
+	got, err := os.ReadFile(filepath.Join(home, ".codex", "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("read Codex AGENTS.md: %v", err)
+	}
+	return string(got)
+}
+
+func assertCodeGraphBlock(t *testing.T, content string) {
+	t.Helper()
+	for _, want := range []string{
+		codeGraphStart,
+		"CodeGraph Mode: enabled",
+		"If `.codegraph/` exists in the project, use CodeGraph first",
+		"`codegraph_context`: map a feature or area first.",
+		"Treat CodeGraph-returned source as already read.",
+		"If `.codegraph/` is missing, ask before running `codegraph init -i`.",
+		codeGraphEnd,
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("AGENTS.md missing %q\ncontent:\n%s", want, content)
+		}
+	}
+}

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -322,6 +322,40 @@ func TestRepositoryManifestIncludesChromeDevToolsCodexProvisioner(t *testing.T) 
 	}
 }
 
+func TestRepositoryManifestIncludesCodeGraphCodexProvisioner(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", ".."))
+	manifestPath := filepath.Join(root, "dots.yaml")
+
+	got, err := manifest.LoadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("LoadFile(%q) error = %v", manifestPath, err)
+	}
+
+	var codex *manifest.Provisioner
+	for i := range got.Provisioners {
+		prov := &got.Provisioners[i]
+		if prov.Tool == "codex" && prov.Spec.MCP == "codegraph" {
+			codex = prov
+		}
+	}
+
+	if codex == nil {
+		t.Fatal("repository manifest missing codex MCP provisioner for codegraph")
+	}
+	if !hasString(codex.Tags, "desktop") {
+		t.Errorf("codegraph codex provisioner %#v missing desktop tag", codex.Spec)
+	}
+	if !sameStrings(codex.OS, []string{"darwin", "linux"}) {
+		t.Errorf("codegraph codex provisioner OS = %#v, want [darwin linux]", codex.OS)
+	}
+	if !sameStrings(codex.Spec.Command, []string{"codegraph", "serve", "--mcp"}) {
+		t.Errorf("codegraph codex command = %#v, want [codegraph serve --mcp]", codex.Spec.Command)
+	}
+	if !hasDependency(codex.Dependencies, "codegraph") {
+		t.Errorf("codegraph codex provisioner missing codegraph dependency: %#v", codex.Dependencies)
+	}
+}
+
 func TestRepositoryManifestIncludesChromeDevToolsPluginProvisioners(t *testing.T) {
 	root := filepath.Clean(filepath.Join("..", ".."))
 	manifestPath := filepath.Join(root, "dots.yaml")

--- a/internal/provision/plan_test.go
+++ b/internal/provision/plan_test.go
@@ -197,6 +197,34 @@ func TestPlanResolvesCodexProvisioner(t *testing.T) {
 	}
 }
 
+func TestPlanResolvesCodeGraphCodexProvisioner(t *testing.T) {
+	codex := manifest.Provisioner{
+		Tool: "codex", Tags: []string{"core"},
+		Spec: manifest.ProvisionerSpec{
+			MCP:     "codegraph",
+			Command: []string{"codegraph", "serve", "--mcp"},
+		},
+	}
+	m := manifestWithProvisioners(codex)
+
+	p, err := provision.Build(m, provision.Options{Profile: "default", OS: "darwin"})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if len(p.Steps) != 1 {
+		t.Fatalf("len(Plan.Steps) = %d, want 1", len(p.Steps))
+	}
+
+	step := p.Steps[0]
+	wantArgs := []string{"mcp", "add", "codegraph", "--", "codegraph", "serve", "--mcp"}
+	if !reflect.DeepEqual(step.Args, wantArgs) {
+		t.Fatalf("codegraph codex args = %#v, want %#v", step.Args, wantArgs)
+	}
+	if !reflect.DeepEqual(step.Targets, []string{"~/.codex"}) {
+		t.Fatalf("codegraph codex targets = %#v, want [~/.codex]", step.Targets)
+	}
+}
+
 func TestPlanEmptyWhenNoProvisionerSelected(t *testing.T) {
 	prov := manifest.Provisioner{
 		Tool: "gentle-ai", Tags: []string{"desktop"},

--- a/internal/textblock/textblock.go
+++ b/internal/textblock/textblock.go
@@ -1,0 +1,95 @@
+// Package textblock manages marker-delimited text blocks without doing any file
+// I/O. Callers own where the resulting content is read from or written to.
+package textblock
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Markers identify the start and end comments around a managed block.
+type Markers struct {
+	Start string
+	End   string
+}
+
+// Upsert replaces an existing marker-delimited block or appends a new one. Any
+// legacy marker pairs are migrated to primary; if multiple known blocks exist,
+// the first becomes the single managed block and the rest are removed.
+func Upsert(content string, primary Markers, block string, legacy ...Markers) (string, error) {
+	if primary.Start == "" || primary.End == "" {
+		return "", fmt.Errorf("primary markers are required")
+	}
+
+	managed := wrap(primary, strings.TrimSpace(block))
+	markers := append([]Markers{primary}, legacy...)
+	ranges, err := findRanges(content, markers)
+	if err != nil {
+		return "", err
+	}
+	if len(ranges) == 0 {
+		return appendBlock(content, managed), nil
+	}
+
+	sort.Slice(ranges, func(i, j int) bool { return ranges[i].start < ranges[j].start })
+	var b strings.Builder
+	cursor := 0
+	for i, r := range ranges {
+		if r.start < cursor {
+			continue
+		}
+		b.WriteString(content[cursor:r.start])
+		if i == 0 {
+			b.WriteString(managed)
+		}
+		cursor = r.end
+	}
+	b.WriteString(content[cursor:])
+	return b.String(), nil
+}
+
+type blockRange struct {
+	start int
+	end   int
+}
+
+func findRanges(content string, markers []Markers) ([]blockRange, error) {
+	var ranges []blockRange
+	for _, m := range markers {
+		if m.Start == "" || m.End == "" {
+			return nil, fmt.Errorf("markers are required")
+		}
+		searchFrom := 0
+		for {
+			start := strings.Index(content[searchFrom:], m.Start)
+			if start == -1 {
+				break
+			}
+			start += searchFrom
+			endSearchFrom := start + len(m.Start)
+			end := strings.Index(content[endSearchFrom:], m.End)
+			if end == -1 {
+				return nil, fmt.Errorf("marker %q is missing closing marker %q", m.Start, m.End)
+			}
+			end += endSearchFrom + len(m.End)
+			ranges = append(ranges, blockRange{start: start, end: end})
+			searchFrom = end
+		}
+	}
+	return ranges, nil
+}
+
+func wrap(markers Markers, block string) string {
+	return markers.Start + "\n" + block + "\n" + markers.End
+}
+
+func appendBlock(content, block string) string {
+	if strings.TrimSpace(content) == "" {
+		return block + "\n"
+	}
+	if !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+	return content + "\n" + block + "\n"
+}

--- a/internal/textblock/textblock_test.go
+++ b/internal/textblock/textblock_test.go
@@ -1,0 +1,58 @@
+package textblock
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUpsertInsertsUpdatesAndMigratesBlocks(t *testing.T) {
+	primary := Markers{Start: "<!-- dots:block -->", End: "<!-- /dots:block -->"}
+	legacy := Markers{Start: "<!-- old:block -->", End: "<!-- /old:block -->"}
+
+	tests := []struct {
+		name    string
+		content string
+		wantHas []string
+		wantNot []string
+	}{
+		{
+			name:    "inserts into existing content",
+			content: "before\n",
+			wantHas: []string{"before", primary.Start, "new body", primary.End},
+		},
+		{
+			name:    "updates primary block",
+			content: "before\n" + primary.Start + "\nstale\n" + primary.End + "\nafter\n",
+			wantHas: []string{"before", "new body", "after"},
+			wantNot: []string{"stale"},
+		},
+		{
+			name:    "migrates legacy block",
+			content: "before\n" + legacy.Start + "\nold body\n" + legacy.End + "\nafter\n",
+			wantHas: []string{"before", primary.Start, "new body", primary.End, "after"},
+			wantNot: []string{legacy.Start, legacy.End, "old body"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Upsert(tt.content, primary, "new body", legacy)
+			if err != nil {
+				t.Fatalf("Upsert() error = %v", err)
+			}
+			for _, want := range tt.wantHas {
+				if !strings.Contains(got, want) {
+					t.Fatalf("Upsert() missing %q\ncontent:\n%s", want, got)
+				}
+			}
+			for _, not := range tt.wantNot {
+				if strings.Contains(got, not) {
+					t.Fatalf("Upsert() kept %q\ncontent:\n%s", not, got)
+				}
+			}
+			if count := strings.Count(got, primary.Start); count != 1 {
+				t.Fatalf("primary start marker count = %d, want 1\ncontent:\n%s", count, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #95

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds CodeGraph as a Codex MCP provisioner using `codegraph serve --mcp`.
- Adds a dots-owned Codex `AGENTS.md` CodeGraph overlay with marker migration and idempotent updates.
- Gates overlay writes to selected Codex-affecting provisioners and keeps tests sandboxed away from the real home directory.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Adds the Codex CodeGraph MCP provisioner. |
| `internal/cli/install.go` | Applies the CodeGraph AGENTS.md overlay after successful selected Codex provisioners. |
| `internal/codexconfig/codegraph.go` | Manages the dots-owned CodeGraph instruction block in Codex AGENTS.md. |
| `internal/textblock/textblock.go` | Adds reusable marker-delimited block upsert and migration support. |
| `internal/cli/*_test.go` | Covers install/update overlay behavior and temp-home safety. |
| `internal/codexconfig/*_test.go` | Covers overlay creation, idempotence, and legacy marker migration. |
| `internal/textblock/*_test.go` | Covers marker block insertion, replacement, migration, and duplicate cleanup. |
| `internal/manifest/manifest_test.go` | Verifies the manifest includes the CodeGraph Codex provisioner. |
| `internal/provision/plan_test.go` | Verifies the rendered CodeGraph Codex MCP command. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp>`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #95`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
