### PR TITLE
feat(config): guide Zed conflict resolution

### DIFF
--- a/configs/zed/README.md
+++ b/configs/zed/README.md
@@ -57,6 +57,85 @@ The live `~/.config/zed/` directory was classified before adoption:
 | **Generated** | `conversations/`, `prompts/`, compiled `extensions/`, extension index/DB, caches, logs | Never committed (see `.gitignore`). |
 | **Private** | secrets, authenticated state (Copilot auth lives outside the authored files), private paths, machine IDs | Excluded. |
 
+
+## Resolving existing local Zed files
+
+If `dots status --profile desktop` reports the Zed targets as `conflict`, the
+profile is only partially managed: local files already exist where `dots` wants
+to install repository-owned symlinks. That is a safety stop, not a failure.
+Choose the resolution explicitly:
+
+| Choice | Effect | Tradeoff |
+| --- | --- | --- |
+| **Skip / keep local** | Leaves the existing `~/.config/zed/...` file untouched for this run. | Safest when you are unsure, but Zed remains outside the completed managed state. |
+| **Replace** | Creates a Backup Set, then replaces the local target with the repository-owned symlink. | Fastest path to repository ownership; review backups before deleting anything permanently. |
+| **Adopt** | For supported regular-file conflicts only: copies the existing local target into `configs/zed/...`, then installs the managed symlink. | Preserves your current local content, but it becomes shared Source of Truth and must be reviewed for machine-specific or private data. |
+| **Diff** | Shows target versus source before choosing skip, replace, or adopt. | Read-only preview; it does not resolve the conflict by itself. |
+
+Non-interactive `dots install --profile desktop --yes` and `dots update --yes`
+remain conservative: unresolved conflicts are skipped by default and local Zed
+files are not overwritten or adopted automatically.
+
+### Sandbox rehearsal
+
+Rehearse conflict handling with temporary roots first. Pass every root explicitly
+so no real Zed configuration is read or written:
+
+```bash
+sandbox_root="$(mktemp -d)"
+sandbox_home="$sandbox_root/home"
+sandbox_state="$sandbox_root/state"
+mkdir -p "$sandbox_home/.config/zed/themes" "$sandbox_state"
+printf '{"local": true}\n' > "$sandbox_home/.config/zed/settings.json"
+printf '[]\n' > "$sandbox_home/.config/zed/keymap.json"
+printf '{"theme": "local"}\n' > "$sandbox_home/.config/zed/themes/catppuccin-blue.json"
+
+go run ./cmd/dots install \
+  --profile desktop \
+  --home "$sandbox_home" \
+  --source-root "$PWD" \
+  --state-root "$sandbox_state"
+# or, without the TUI:
+go run ./cmd/dots install \
+  --profile desktop \
+  --no-tui \
+  --home "$sandbox_home" \
+  --source-root "$PWD" \
+  --state-root "$sandbox_state"
+```
+
+For each conflicting Zed target:
+
+- choose **diff** when you need to compare the local file with `configs/zed/...`;
+- choose **skip** when the local file should stay machine-owned for now;
+- choose **replace** when the repository version should win;
+- choose **adopt** only after checking the local file contains portable, safe
+  configuration worth committing to this repository;
+- choose **skip** or **replace** for unsupported cases such as directories or
+  existing symlink leaves.
+
+### Real migration
+
+Run against your real home only when you are ready to make the migration decision:
+
+```bash
+dots install --profile desktop
+# or, without the TUI:
+dots install --profile desktop --no-tui
+```
+
+Replacement backups are recorded as Backup Sets under the state root, defaulting
+to `~/.local/state/dots/backups/`. Inspect and restore them with:
+
+```bash
+dots backups list
+dots backups restore <set> --dry-run
+dots backups restore <set>
+```
+
+See [`docs/backups.md`](../../docs/backups.md) for restore behavior, safety
+backups, provenance checks, and sandbox restore flags.
+
 ## Sandbox validation
 
 Validate Zed config changes with temporary directories — never the real `$HOME`

--- a/internal/cli/conflict_guidance.go
+++ b/internal/cli/conflict_guidance.go
@@ -1,0 +1,20 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+)
+
+// renderConflictResolutionGuidance teaches the safe next action for unresolved
+// conflicts without changing the safety model: unattended install/update keeps
+// conflicts skipped, while interactive paths require an explicit choice.
+func renderConflictResolutionGuidance(w io.Writer) {
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Conflict guidance:")
+	fmt.Fprintln(w, "  Conflicts mean this profile is only partially managed until you choose a resolution.")
+	fmt.Fprintln(w, "  - skip keeps the local file untouched; dots leaves that target unmanaged for this run.")
+	fmt.Fprintln(w, "  - replace creates a Backup Set before installing the Source of Truth.")
+	fmt.Fprintln(w, "  - adopt is only for supported regular-file conflicts; it copies local file content into the Source of Truth after you choose it.")
+	fmt.Fprintln(w, "  - diff previews target versus source before you decide.")
+	fmt.Fprintln(w, "  Non-interactive install/update keeps conflicts skipped by default.")
+}

--- a/internal/cli/issue92_zed_conflict_test.go
+++ b/internal/cli/issue92_zed_conflict_test.go
@@ -1,0 +1,128 @@
+package cli_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/cli"
+)
+
+func TestStatusCommandReportsDesktopZedConflictsWithNextActionGuidance(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	writeCLISource(t, sourceRoot, "configs/zed/settings.json", "{\"managed\": true}\n")
+	writeCLISource(t, sourceRoot, "configs/zed/keymap.json", "[]\n")
+	writeCLISource(t, sourceRoot, "configs/zed/themes/catppuccin-blue.json", "{\"theme\": \"managed\"}\n")
+	for rel, content := range map[string]string{
+		".config/zed/settings.json":               "{\"local\": true}\n",
+		".config/zed/keymap.json":                 "[{\"local\": true}]\n",
+		".config/zed/themes/catppuccin-blue.json": "{\"theme\": \"local\"}\n",
+	} {
+		path := filepath.Join(home, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir target: %v", err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write target: %v", err)
+		}
+	}
+
+	manifestPath := writeCLIManifest(t, home, `version: 1
+profiles:
+  desktop:
+    tags: [desktop]
+entries:
+  - source: configs/zed/settings.json
+    target: ~/.config/zed/settings.json
+    strategy: symlink
+    tags: [desktop]
+  - source: configs/zed/keymap.json
+    target: ~/.config/zed/keymap.json
+    strategy: symlink
+    tags: [desktop]
+  - source: configs/zed/themes/catppuccin-blue.json
+    target: ~/.config/zed/themes/catppuccin-blue.json
+    strategy: symlink
+    tags: [desktop]
+`)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"status", "--profile", "desktop", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("status Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+
+	got := out.String()
+	for _, want := range []string{
+		"conflict     symlink   configs/zed/settings.json -> " + filepath.Join(home, ".config/zed/settings.json"),
+		"conflict     symlink   configs/zed/keymap.json -> " + filepath.Join(home, ".config/zed/keymap.json"),
+		"conflict     symlink   configs/zed/themes/catppuccin-blue.json -> " + filepath.Join(home, ".config/zed/themes/catppuccin-blue.json"),
+		"Summary: 0 ok, 0 missing, 3 conflict, 0 skipped, 0 drifted, 0 unsupported",
+		"Conflicts mean this profile is only partially managed until you choose a resolution.",
+		"skip keeps the local file untouched",
+		"replace creates a Backup Set before installing the Source of Truth",
+		"adopt is only for supported regular-file conflicts; it copies local file content into the Source of Truth after you choose it",
+		"Non-interactive install/update keeps conflicts skipped by default.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("status output missing %q\noutput:\n%s", want, got)
+		}
+	}
+}
+
+func TestInstallNoTUIOutputExplainsConflictResolutionTradeoffs(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	writeCLISource(t, sourceRoot, "configs/zed/settings.json", "{\"managed\": true}\n")
+	target := filepath.Join(home, ".config/zed/settings.json")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("{\"local\": true}\n"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	manifestPath := writeCLIManifest(t, home, `version: 1
+profiles:
+  desktop:
+    tags: [desktop]
+entries:
+  - source: configs/zed/settings.json
+    target: ~/.config/zed/settings.json
+    strategy: symlink
+    tags: [desktop]
+`)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetIn(strings.NewReader("s\n"))
+	cmd.SetArgs([]string{"install", "--no-tui", "--profile", "desktop", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("install Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+
+	got := out.String()
+	for _, want := range []string{
+		"Resolve conflict for " + target,
+		"skip keeps the local file untouched",
+		"replace creates a Backup Set before installing the Source of Truth",
+		"adopt is only for supported regular-file conflicts; it copies local file content into the Source of Truth after you choose it",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("install output missing %q\noutput:\n%s", want, got)
+		}
+	}
+}

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -42,6 +42,9 @@ func renderPlan(w io.Writer, p plan.Plan) {
 
 	fmt.Fprintf(w, "\nSummary: %d create, %d conflict, %d unchanged, %d missing-source\n",
 		counts.create, counts.conflict, counts.unchanged, counts.missingSource)
+	if counts.conflict > 0 {
+		renderConflictResolutionGuidance(w)
+	}
 }
 
 // renderSkippedEntryHint prints a one-line nudge when the active profile omits

--- a/internal/cli/render_status.go
+++ b/internal/cli/render_status.go
@@ -47,6 +47,9 @@ func renderStatus(w io.Writer, report status.Report) {
 
 	fmt.Fprintf(w, "\nSummary: %d ok, %d missing, %d conflict, %d skipped, %d drifted, %d unsupported\n",
 		counts.ok, counts.missing, counts.conflict, counts.skipped, counts.drifted, counts.unsupported)
+	if counts.conflict > 0 {
+		renderConflictResolutionGuidance(w)
+	}
 }
 
 // renderStatusProvisioners lists the provisioners declared for the profile as

--- a/internal/cli/testdata/plan_all_statuses.golden
+++ b/internal/cli/testdata/plan_all_statuses.golden
@@ -6,3 +6,11 @@ Plan for profile "work"
   missing-source  template  configs/nvim/init.lua -> /home/user/.config/nvim/init.lua
 
 Summary: 1 create, 1 conflict, 1 unchanged, 1 missing-source
+
+Conflict guidance:
+  Conflicts mean this profile is only partially managed until you choose a resolution.
+  - skip keeps the local file untouched; dots leaves that target unmanaged for this run.
+  - replace creates a Backup Set before installing the Source of Truth.
+  - adopt is only for supported regular-file conflicts; it copies local file content into the Source of Truth after you choose it.
+  - diff previews target versus source before you decide.
+  Non-interactive install/update keeps conflicts skipped by default.

--- a/internal/cli/testdata/status_all_states.golden
+++ b/internal/cli/testdata/status_all_states.golden
@@ -8,3 +8,11 @@ Status for profile "work"
   unsupported  template  configs/nvim/init.lua -> /home/user/.config/nvim/init.lua
 
 Summary: 1 ok, 1 missing, 1 conflict, 1 skipped, 1 drifted, 1 unsupported
+
+Conflict guidance:
+  Conflicts mean this profile is only partially managed until you choose a resolution.
+  - skip keeps the local file untouched; dots leaves that target unmanaged for this run.
+  - replace creates a Backup Set before installing the Source of Truth.
+  - adopt is only for supported regular-file conflicts; it copies local file content into the Source of Truth after you choose it.
+  - diff previews target versus source before you decide.
+  Non-interactive install/update keeps conflicts skipped by default.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -207,6 +207,8 @@ func (m Model) viewList() string {
 	}
 
 	b.WriteString("\n")
+	b.WriteString(m.styles.Help.Render("skip keeps the local file untouched · replace backs up then installs the Source of Truth · adopt copies supported regular-file local content into the Source of Truth"))
+	b.WriteString("\n")
 	b.WriteString(m.styles.Help.Render("j/k move · s skip · r replace · a adopt · d diff · enter apply · q cancel"))
 	b.WriteString("\n")
 	return b.String()

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -109,6 +110,20 @@ func TestArrowKeysAlsoNavigate(t *testing.T) {
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyUp})
 	if m.cursor != 0 {
 		t.Fatalf("cursor = %d after up, want 0", m.cursor)
+	}
+}
+
+func TestListViewExplainsDecisionTradeoffs(t *testing.T) {
+	m := New(sampleConflicts(), nil)
+	view := m.View()
+	for _, want := range []string{
+		"skip keeps the local file untouched",
+		"replace backs up then installs the Source of Truth",
+		"adopt copies supported regular-file local content into the Source of Truth",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("view missing %q\nview:\n%s", want, view)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #92

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds conflict guidance to plan/status output when managed entries conflict.
- Clarifies Zed migration paths for skip, replace, adopt, diff, backups, and restore.
- Covers desktop-profile Zed conflicts and TUI/no-TUI guidance with regression tests.

## Changes

| File | Change |
|------|--------|
| `configs/zed/README.md` | Documents safe Zed conflict migration, sandbox rehearsal, backup restore, and adopt limitations. |
| `internal/cli/conflict_guidance.go` | Centralizes human-readable conflict-resolution guidance. |
| `internal/cli/render.go` | Prints guidance when install/update plans contain conflicts. |
| `internal/cli/render_status.go` | Prints guidance when status reports conflicts. |
| `internal/cli/issue92_zed_conflict_test.go` | Adds regression coverage for sandboxed Zed conflict status and no-TUI guidance. |
| `internal/tui/model.go` | Shows concise conflict action tradeoffs in the TUI. |
| `internal/tui/model_test.go` | Verifies TUI guidance copy. |
| `internal/cli/testdata/*.golden` | Updates golden output for conflict guidance. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile desktop --source-root "$PWD" --home <tmp>`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
