### PR TITLE
feat(cli): improve deps profile flag ergonomics

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1281,6 +1281,69 @@ entries:
 	}
 }
 
+func TestDepsCommandProfileFlagIsDiscoverableFromParent(t *testing.T) {
+	for _, args := range [][]string{
+		{"deps", "--profile", "desktop"},
+		{"deps", "-p", "desktop"},
+	} {
+		t.Run(strings.Join(args[:2], " "), func(t *testing.T) {
+			cmd := cli.NewRootCommand()
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs(args)
+
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+			}
+
+			got := out.String()
+			for _, want := range []string{"check", "plan", "install", "--profile"} {
+				if !strings.Contains(got, want) {
+					t.Fatalf("deps help missing %q\noutput:\n%s", want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestDepsCheckCommandInheritsParentProfileFlag(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+
+	manifestPath := writeCLIManifest(t, home, `version: 1
+profiles:
+  default:
+    tags: [core]
+  desktop:
+    tags: [desktop]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [desktop]
+    dependencies:
+      - name: desktop-only-tool
+`)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"deps", "--profile", "desktop", "check", "--file", manifestPath})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+
+	got := out.String()
+	for _, want := range []string{`Dependencies for profile "desktop"`, "missing  desktop-only-tool"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("deps check output missing %q\noutput:\n%s", want, got)
+		}
+	}
+}
+
 func writeFakeExecutable(t *testing.T, dir, name string) {
 	t.Helper()
 	path := filepath.Join(dir, name)

--- a/internal/cli/deps.go
+++ b/internal/cli/deps.go
@@ -17,22 +17,22 @@ import (
 )
 
 func newDepsCommand() *cobra.Command {
+	var profile string
+
 	cmd := &cobra.Command{
 		Use:   "deps",
 		Short: "Inspect external tool Dependencies declared by managed entries",
 		Long:  "deps reports which external Dependencies a profile needs, offers OS-aware installation guidance, and can execute missing install actions with explicit confirmation.",
 	}
-	cmd.AddCommand(newDepsCheckCommand())
-	cmd.AddCommand(newDepsPlanCommand())
-	cmd.AddCommand(newDepsInstallCommand())
+	cmd.PersistentFlags().StringVarP(&profile, "profile", "p", "default", "profile to inspect")
+	cmd.AddCommand(newDepsCheckCommand(&profile))
+	cmd.AddCommand(newDepsPlanCommand(&profile))
+	cmd.AddCommand(newDepsInstallCommand(&profile))
 	return cmd
 }
 
-func newDepsCheckCommand() *cobra.Command {
-	var (
-		file    string
-		profile string
-	)
+func newDepsCheckCommand(profile *string) *cobra.Command {
+	var file string
 
 	cmd := &cobra.Command{
 		Use:   "check",
@@ -48,7 +48,7 @@ func newDepsCheckCommand() *cobra.Command {
 
 			home, _ := os.UserHomeDir()
 			report, err := deps.Check(*m, deps.Options{
-				Profile: profile,
+				Profile: *profile,
 				OS:      runtime.GOOS,
 			}, lookupCommand, fontInstalled(runtime.GOOS, home))
 			if err != nil {
@@ -61,15 +61,13 @@ func newDepsCheckCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&file, "file", "f", "dots.yaml", "manifest file to inspect")
-	cmd.Flags().StringVarP(&profile, "profile", "p", "default", "profile to inspect")
 	return cmd
 }
 
-func newDepsPlanCommand() *cobra.Command {
+func newDepsPlanCommand(profile *string) *cobra.Command {
 	var (
-		file    string
-		profile string
-		tier    string
+		file string
+		tier string
 	)
 
 	cmd := &cobra.Command{
@@ -92,7 +90,7 @@ func newDepsPlanCommand() *cobra.Command {
 
 			home, _ := os.UserHomeDir()
 			report, err := deps.Plan(*m, deps.Options{
-				Profile: profile,
+				Profile: *profile,
 				OS:      runtime.GOOS,
 			}, lookupCommand, fontInstalled(runtime.GOOS, home), resolvedTier)
 			if err != nil {
@@ -105,18 +103,16 @@ func newDepsPlanCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&file, "file", "f", "dots.yaml", "manifest file to inspect")
-	cmd.Flags().StringVarP(&profile, "profile", "p", "default", "profile to inspect")
 	cmd.Flags().StringVar(&tier, "tier", "", "override the dependency plan tier (homebrew, debian, fedora, arch, generic); default: auto-detect from the host")
 	return cmd
 }
 
-func newDepsInstallCommand() *cobra.Command {
+func newDepsInstallCommand(profile *string) *cobra.Command {
 	var (
-		file    string
-		profile string
-		tier    string
-		dryRun  bool
-		yes     bool
+		file   string
+		tier   string
+		dryRun bool
+		yes    bool
 	)
 
 	cmd := &cobra.Command{
@@ -137,7 +133,7 @@ func newDepsInstallCommand() *cobra.Command {
 			}
 
 			options := deps.Options{
-				Profile: profile,
+				Profile: *profile,
 				OS:      runtime.GOOS,
 			}
 
@@ -177,7 +173,6 @@ func newDepsInstallCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&file, "file", "f", "dots.yaml", "manifest file to inspect")
-	cmd.Flags().StringVarP(&profile, "profile", "p", "default", "profile to inspect")
 	cmd.Flags().StringVar(&tier, "tier", "", "override the dependency install tier (homebrew, debian, fedora, arch, generic); default: auto-detect from the host")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview dependency install actions without executing package managers")
 	cmd.Flags().BoolVar(&yes, "yes", false, "execute dependency install actions without interactive confirmation")


### PR DESCRIPTION
Closes #93

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds `--profile/-p` as a persistent flag on the `deps` parent command.
- Keeps `deps check`, `deps plan`, and `deps install` using the inherited profile value.
- Adds CLI tests for parent-level profile discoverability and inherited profile behavior.

## Changes

| File | Change |
|------|--------|
| `internal/cli/deps.go` | Moves dependency profile selection to a parent persistent Cobra flag shared by subcommands. |
| `internal/cli/cli_test.go` | Covers `dots deps --profile/-p` parent help and inherited `deps check` profile selection. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: not applicable; this PR changes dependency CLI flag ergonomics only.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
