### PR TITLE
feat(doctor): detect broken Git toolchain

### DIFF
--- a/internal/cli/deps.go
+++ b/internal/cli/deps.go
@@ -236,6 +236,12 @@ func lookupCommand(command string) bool {
 	return err == nil
 }
 
+func commandOutput(command string, args ...string) (string, error) {
+	cmd := exec.Command(command, args...)
+	output, err := cmd.CombinedOutput()
+	return string(output), err
+}
+
 // fontDirectories returns the workstation directories that hold installed font
 // files for the given OS, rooting the per-user locations at home. A font
 // declared as a Dependency is detected by scanning these for a matching file.

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -56,6 +56,7 @@ func newDoctorCommand() *cobra.Command {
 				OS:         runtime.GOOS,
 				SourceRoot: paths.SourceRoot,
 				Home:       paths.Home,
+				ToolRunner: commandOutput,
 			}, lookupCommand, fontInstalled(runtime.GOOS, paths.Home))
 			if err != nil {
 				return err

--- a/internal/cli/render_doctor.go
+++ b/internal/cli/render_doctor.go
@@ -63,20 +63,37 @@ func renderDoctorDependencies(w io.Writer, report doctor.Report) {
 	}
 
 	var missing int
+	var warnings int
 	for _, result := range report.Dependencies.Results {
 		if !result.Present {
 			missing++
 		}
+		if result.Warning != "" {
+			warnings++
+		}
 	}
-	if missing == 0 {
+	if missing == 0 && warnings == 0 {
 		fmt.Fprintf(w, "Dependencies: ok (%d present, 0 missing)\n", len(report.Dependencies.Results))
 		return
 	}
 
-	fmt.Fprintf(w, "Dependencies: warn (%d missing)\n", missing)
+	if warnings == 0 {
+		fmt.Fprintf(w, "Dependencies: warn (%d missing)\n", missing)
+	} else {
+		fmt.Fprintf(w, "Dependencies: warn (%d missing, %d warnings)\n", missing, warnings)
+	}
 	for _, result := range report.Dependencies.Results {
 		if !result.Present {
 			fmt.Fprintf(w, "  missing dependency: %s\n", result.Name)
+		}
+		if result.Warning != "" {
+			fmt.Fprintf(w, "  warning: %s: %s\n", result.Name, result.Warning)
+			if result.ProbeDetail != "" {
+				fmt.Fprintf(w, "    detail: %s\n", result.ProbeDetail)
+			}
+			if result.Hint != "" {
+				fmt.Fprintf(w, "    hint: %s\n", result.Hint)
+			}
 		}
 	}
 }

--- a/internal/cli/render_doctor_golden_test.go
+++ b/internal/cli/render_doctor_golden_test.go
@@ -65,6 +65,26 @@ func TestRenderDoctorGolden(t *testing.T) {
 			},
 			golden: "doctor_provisioner_not_ready.golden",
 		},
+		{
+			name: "git toolchain warning",
+			report: doctor.Report{
+				Profile:  "default",
+				Platform: doctor.Platform{Supported: true, OS: "darwin"},
+				Dependencies: deps.CheckReport{Profile: "default", Results: []deps.Result{
+					{
+						Name:        "git",
+						Command:     "git",
+						Present:     true,
+						Warning:     "git resolved on PATH but `git --version` failed",
+						ProbeDetail: "xcrun: error: invalid active developer path (/Library/Developer/CommandLineTools), missing xcrun",
+						Hint:        "Repair Xcode Command Line Tools with `xcode-select --install` or reinstall them, then rerun `dots doctor`.",
+					},
+				}},
+				Configuration: status.Report{Profile: "default"},
+				SecretScan:    doctor.SecretReport{},
+			},
+			golden: "doctor_git_toolchain_warning.golden",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/cli/testdata/doctor_git_toolchain_warning.golden
+++ b/internal/cli/testdata/doctor_git_toolchain_warning.golden
@@ -1,0 +1,11 @@
+Doctor for profile "default"
+
+Platform: ok (darwin)
+Dependencies: warn (0 missing, 1 warnings)
+  warning: git: git resolved on PATH but `git --version` failed
+    detail: xcrun: error: invalid active developer path (/Library/Developer/CommandLineTools), missing xcrun
+    hint: Repair Xcode Command Line Tools with `xcode-select --install` or reinstall them, then rerun `dots doctor`.
+Configuration: ok (0 ok, 0 concerns)
+Provisioners: ok (no provisioners declared)
+Secret Scan: ok (0 findings)
+Guardrail: Secret Scan catches obvious credential and private-key patterns only; it is not proof this repository is safe.

--- a/internal/deps/deps.go
+++ b/internal/deps/deps.go
@@ -21,6 +21,9 @@ type Lookup func(command string) bool
 // parallel to Lookup, so font dependency checks stay deterministic in tests.
 type FontLookup func(match string) bool
 
+// CommandRunner executes a read-only tool probe and returns its combined output.
+type CommandRunner func(command string, args ...string) (string, error)
+
 // Options carries the resolved inputs needed to select Dependencies.
 type Options struct {
 	Profile string
@@ -29,9 +32,12 @@ type Options struct {
 
 // Result is the presence finding for a single declared Dependency.
 type Result struct {
-	Name    string
-	Command string
-	Present bool
+	Name        string
+	Command     string
+	Present     bool
+	Warning     string
+	ProbeDetail string
+	Hint        string
 }
 
 // CheckReport is the Dependency presence report for a Profile.
@@ -44,6 +50,12 @@ type CheckReport struct {
 // Entries and Provisioners are present on the workstation. Dependencies are
 // deduplicated by name in first-declared order.
 func Check(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup) (CheckReport, error) {
+	return CheckWithToolProbes(m, opts, look, fontLook, nil)
+}
+
+// CheckWithToolProbes reports Dependency presence and, for selected tools whose
+// PATH presence is not enough, runs read-only executable probes.
+func CheckWithToolProbes(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup, run CommandRunner) (CheckReport, error) {
 	selected, err := selectDependencies(m, opts)
 	if err != nil {
 		return CheckReport{}, err
@@ -52,6 +64,7 @@ func Check(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup) 
 	report := CheckReport{Profile: opts.Profile}
 	for _, dep := range selected {
 		result := checkResult(dep, look, fontLook)
+		probeToolchain(&result, opts, run)
 		report.Results = append(report.Results, result)
 	}
 	return report, nil
@@ -73,6 +86,37 @@ func checkResult(dep manifest.Dependency, look Lookup, fontLook FontLookup) Resu
 	}
 	probe := dep.Probe()
 	return Result{Name: dep.Name, Command: probe, Present: look(probe)}
+}
+
+const maxProbeDetailLen = 240
+
+func probeToolchain(result *Result, opts Options, run CommandRunner) {
+	if run == nil || !result.Present || result.Command != "git" {
+		return
+	}
+
+	output, err := run("git", "--version")
+	if err == nil {
+		return
+	}
+
+	result.Warning = "git resolved on PATH but `git --version` failed"
+	result.ProbeDetail = probeDetail(output, err)
+	if opts.OS == "darwin" && strings.Contains(output, "xcrun: error: invalid active developer path") {
+		result.Hint = "Repair Xcode Command Line Tools with `xcode-select --install` or reinstall them, then rerun `dots doctor`."
+	}
+}
+
+func probeDetail(output string, err error) string {
+	source := output
+	if strings.TrimSpace(source) == "" && err != nil {
+		source = err.Error()
+	}
+	detail := strings.Join(strings.Fields(source), " ")
+	if len(detail) <= maxProbeDetailLen {
+		return detail
+	}
+	return detail[:maxProbeDetailLen-len("...")] + "..."
 }
 
 // selectDependencies gathers the Dependencies of every Managed Entry and

--- a/internal/deps/deps_test.go
+++ b/internal/deps/deps_test.go
@@ -1,6 +1,8 @@
 package deps_test
 
 import (
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/yersonargotev/dots/internal/deps"
@@ -88,6 +90,113 @@ func TestCheckReportsPresentAndMissingForProfile(t *testing.T) {
 	}
 	if report.Results[1] != (deps.Result{Name: "starship", Command: "starship", Present: false}) {
 		t.Fatalf("Results[1] = %#v, want missing starship", report.Results[1])
+	}
+}
+
+func TestCheckWithToolProbesReportsGitToolchainWarnings(t *testing.T) {
+	errProbe := errors.New("exit status 1")
+	xcrunOutput := "xcrun: error: invalid active developer path (/Library/Developer/CommandLineTools), missing xcrun"
+
+	tests := []struct {
+		name          string
+		goos          string
+		present       []string
+		output        string
+		runErr        error
+		wantPresent   bool
+		wantWarning   bool
+		wantHint      bool
+		wantDetail    string
+		wantProbeRuns int
+	}{
+		{name: "git probe succeeds", goos: "darwin", present: []string{"git"}, wantPresent: true, wantProbeRuns: 1},
+		{name: "git missing skips probe", goos: "darwin", present: nil, wantPresent: false},
+		{name: "git probe fails", goos: "darwin", present: []string{"git"}, runErr: errProbe, wantPresent: true, wantWarning: true, wantDetail: "exit status 1", wantProbeRuns: 1},
+		{name: "darwin xcrun failure includes repair hint", goos: "darwin", present: []string{"git"}, output: xcrunOutput, runErr: errProbe, wantPresent: true, wantWarning: true, wantHint: true, wantDetail: xcrunOutput, wantProbeRuns: 1},
+		{name: "linux xcrun-looking failure keeps generic warning", goos: "linux", present: []string{"git"}, output: xcrunOutput, runErr: errProbe, wantPresent: true, wantWarning: true, wantDetail: xcrunOutput, wantProbeRuns: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := manifest.Manifest{
+				Version:  1,
+				Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}},
+				Entries: []manifest.Entry{{
+					Source: "configs/git/config", Target: "~/.gitconfig", Strategy: "copy", Tags: []string{"core"},
+					Dependencies: []manifest.Dependency{{Name: "git"}},
+				}},
+			}
+
+			var probeRuns int
+			report, err := deps.CheckWithToolProbes(m, deps.Options{Profile: "default", OS: tt.goos}, lookupSet(tt.present...), fontLookupSet(),
+				func(command string, args ...string) (string, error) {
+					probeRuns++
+					if command != "git" {
+						t.Fatalf("probe command = %q, want git", command)
+					}
+					if len(args) != 1 || args[0] != "--version" {
+						t.Fatalf("probe args = %#v, want [--version]", args)
+					}
+					return tt.output, tt.runErr
+				})
+			if err != nil {
+				t.Fatalf("CheckWithToolProbes() error = %v", err)
+			}
+
+			if probeRuns != tt.wantProbeRuns {
+				t.Fatalf("probe runs = %d, want %d", probeRuns, tt.wantProbeRuns)
+			}
+			if len(report.Results) != 1 {
+				t.Fatalf("Results len = %d, want 1 (%#v)", len(report.Results), report.Results)
+			}
+			result := report.Results[0]
+			if result.Present != tt.wantPresent {
+				t.Fatalf("Present = %v, want %v (%#v)", result.Present, tt.wantPresent, result)
+			}
+			if (result.Warning != "") != tt.wantWarning {
+				t.Fatalf("Warning = %q, want warning=%v", result.Warning, tt.wantWarning)
+			}
+			if (result.Hint != "") != tt.wantHint {
+				t.Fatalf("Hint = %q, want hint=%v", result.Hint, tt.wantHint)
+			}
+			if result.ProbeDetail != tt.wantDetail {
+				t.Fatalf("ProbeDetail = %q, want %q", result.ProbeDetail, tt.wantDetail)
+			}
+		})
+	}
+}
+
+func TestCheckWithToolProbesSanitizesAndTruncatesGitProbeDetail(t *testing.T) {
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}},
+		Entries: []manifest.Entry{{
+			Source: "configs/git/config", Target: "~/.gitconfig", Strategy: "copy", Tags: []string{"core"},
+			Dependencies: []manifest.Dependency{{Name: "git"}},
+		}},
+	}
+	output := "  xcrun: error: invalid active developer path\n\t(/Library/Developer/CommandLineTools), missing xcrun  " + strings.Repeat(" detail", 80)
+
+	report, err := deps.CheckWithToolProbes(m, deps.Options{Profile: "default", OS: "darwin"}, lookupSet("git"), fontLookupSet(),
+		func(command string, args ...string) (string, error) {
+			return output, errors.New("exit status 1")
+		})
+	if err != nil {
+		t.Fatalf("CheckWithToolProbes() error = %v", err)
+	}
+
+	detail := report.Results[0].ProbeDetail
+	if strings.ContainsAny(detail, "\n\r\t") {
+		t.Fatalf("ProbeDetail contains raw whitespace: %q", detail)
+	}
+	if !strings.Contains(detail, "xcrun: error: invalid active developer path (/Library/Developer/CommandLineTools), missing xcrun") {
+		t.Fatalf("ProbeDetail = %q, want sanitized xcrun error", detail)
+	}
+	if len(detail) > 240 {
+		t.Fatalf("ProbeDetail length = %d, want <= 240", len(detail))
+	}
+	if !strings.HasSuffix(detail, "...") {
+		t.Fatalf("ProbeDetail = %q, want truncation marker", detail)
 	}
 }
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -26,6 +26,7 @@ type Options struct {
 	OS         string
 	SourceRoot string
 	Home       string
+	ToolRunner deps.CommandRunner
 }
 
 // Report is the consolidated doctor diagnostic output for a profile.
@@ -77,7 +78,7 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options, look deps.Loo
 		Platform: Platform{Supported: supportedOS(opts.OS), OS: opts.OS},
 	}
 
-	depReport, err := deps.Check(m, deps.Options{Profile: opts.Profile, OS: opts.OS}, look, fontLook)
+	depReport, err := deps.CheckWithToolProbes(m, deps.Options{Profile: opts.Profile, OS: opts.OS}, look, fontLook, opts.ToolRunner)
 	if err != nil {
 		return Report{}, err
 	}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -1,6 +1,7 @@
 package doctor_test
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -201,6 +202,41 @@ func TestBuildReportsProvisionerReadiness(t *testing.T) {
 	}
 	if !equalStrings(item.Missing, []string{"engram"}) {
 		t.Fatalf("provisioner missing = %#v, want [engram]", item.Missing)
+	}
+}
+
+func TestBuildRunsReadOnlyGitProbe(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	writeFile(t, sourceRoot, "configs/git/config", "safe = true\n")
+
+	m := singleEntryManifest("configs/git/config")
+	m.Entries[0].Dependencies = []manifest.Dependency{{Name: "git"}, {Name: "starship"}}
+
+	var gotCommand string
+	var gotArgs []string
+	report, err := doctor.Build(m, state.Metadata{}, doctor.Options{
+		Profile: "default", OS: "darwin", SourceRoot: sourceRoot, Home: home,
+		ToolRunner: func(command string, args ...string) (string, error) {
+			gotCommand = command
+			gotArgs = append([]string(nil), args...)
+			return "xcrun: error: invalid active developer path", errors.New("exit status 1")
+		},
+	}, lookupSet("git", "starship"), fontLookupSet())
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if gotCommand != "git" || !equalStrings(gotArgs, []string{"--version"}) {
+		t.Fatalf("probe = %s %#v, want git [--version]", gotCommand, gotArgs)
+	}
+	if len(report.Dependencies.Results) != 2 {
+		t.Fatalf("Results len = %d, want 2 (%#v)", len(report.Dependencies.Results), report.Dependencies.Results)
+	}
+	if report.Dependencies.Results[0].Warning == "" || report.Dependencies.Results[0].Hint == "" {
+		t.Fatalf("git result = %#v, want warning and Xcode CLT hint", report.Dependencies.Results[0])
+	}
+	if report.Dependencies.Results[1].Warning != "" {
+		t.Fatalf("starship result = %#v, want no probe warning", report.Dependencies.Results[1])
 	}
 }
 


### PR DESCRIPTION
Closes #94

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Makes `dots doctor` probe Git executability with `git --version` instead of relying only on PATH lookup.
- Reports Git probe failures as dependency warnings with sanitized, bounded diagnostic detail.
- Adds a targeted macOS Xcode Command Line Tools hint for `xcrun: error: invalid active developer path` failures.

## Changes

| File | Change |
|------|--------|
| `internal/deps/deps.go` | Added opt-in tool probes, warning/hint/detail fields, and sanitized/truncated probe detail handling. |
| `internal/doctor/doctor.go` | Wires doctor dependency checks through tool probes. |
| `internal/cli/deps.go` | Adds the production read-only command-output runner used by doctor. |
| `internal/cli/doctor.go` | Injects the Git probe runner into doctor diagnostics. |
| `internal/cli/render_doctor.go` | Renders dependency warnings, detail, and remediation hints. |
| `internal/deps/deps_test.go` | Covers Git probe success, missing Git, generic failure, xcrun hinting, platform boundary, and detail sanitization/truncation. |
| `internal/doctor/doctor_test.go` | Verifies doctor runs the read-only Git probe through the injected runner. |
| `internal/cli/render_doctor_golden_test.go` / `internal/cli/testdata/doctor_git_toolchain_warning.golden` | Adds golden coverage for broken Git toolchain output. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: N/A — this changes doctor diagnostics, not dotfile plan/install behavior.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed. N/A — behavior is covered by CLI golden tests.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
