### PR TITLE
feat(config): model shared desktop nerd font

### DIFF
--- a/configs/ghostty/README.md
+++ b/configs/ghostty/README.md
@@ -11,10 +11,18 @@ outside version control.
 ## Prerequisites
 
 - **`ghostty`** — declared as an advisory dependency for the desktop profile.
-  `dots install` does not install packages. `dots deps plan` and the explicit
-  `dots deps install` workflow can report/use Homebrew guidance where available;
-  Linux package mappings are intentionally omitted until package names are
-  verified for each distro.
+- **Desktop Nerd Font** — declared on the `desktop` profile as shared desktop
+  infrastructure, not as a Zed-owned dependency. Ghostty local overrides,
+  terminals, and editors can consume the same requirement. The primary macOS
+  package is the Homebrew cask `font-cascadia-code-nf`, detected through
+  `CascadiaCodeNF*` font files; compatible files such as
+  `CaskaydiaCoveNerdFont*` also satisfy the dependency. This is not VS Code
+  configuration management.
+
+`dots install` does not install packages. `dots deps plan` and the explicit
+`dots deps install` workflow can report/use Homebrew guidance where available;
+Linux package mappings are intentionally omitted until package names are
+verified for each distro.
 
 ## Portability classification
 
@@ -23,7 +31,7 @@ The live `~/.config/ghostty/config` file was classified before adoption:
 | Category | Examples | Repository decision |
 | --- | --- | --- |
 | **Portable** | Catppuccin Mocha palette, foreground/background/cursor/selection colors, split divider color, intentional keybindings for terminal workflow and Zellij/tmux forwarding | Managed in `configs/ghostty/config.ghostty`. |
-| **Machine-specific** | font family, font size, window dimensions, opacity/blur, window padding ergonomics, explicit shell/command paths, initial working directories, OS integrations, display/GPU/host-dependent behavior | Excluded from the shared file. Documented in `configs/ghostty/config.local.ghostty.example`. |
+| **Machine-specific** | font family, font size, window dimensions, opacity/blur, window padding ergonomics, explicit shell/command paths, initial working directories, OS integrations, display/GPU/host-dependent behavior | Excluded from the shared file. Font family can use the shared Desktop Nerd Font from local overrides; documented in `configs/ghostty/config.local.ghostty.example`. |
 | **Generated** | logs, caches, sessions, backups, temporary files, generated state, local shaders | Never committed. |
 | **Private** | secrets, authenticated state, private paths, hostnames, machine IDs | Excluded. |
 

--- a/configs/ghostty/config.local.ghostty.example
+++ b/configs/ghostty/config.local.ghostty.example
@@ -7,7 +7,9 @@
 
 # Fonts are machine-specific because installed font names and comfortable sizes
 # differ across hosts, displays, and operating systems.
-# font-family = "CaskaydiaCove Nerd Font Mono"
+# font-family = "Cascadia Code NF"
+# Compatible fallback family names such as "CaskaydiaCove Nerd Font Mono" may
+# also work when those files are already installed.
 # font-size = 20
 
 # Window and rendering ergonomics depend on monitor size, compositor/GPU, and

--- a/configs/zed/README.md
+++ b/configs/zed/README.md
@@ -17,9 +17,12 @@ compiled extensions stay outside version control.
 ## Prerequisites
 
 - **`zed`** — declared as an advisory dependency for the desktop profile.
-- **CaskaydiaCove Nerd Font** — declared as an advisory dependency. Zed degrades
-  to a fallback font when it is absent, so `dots install` does not fail when the
-  font is missing.
+- **Desktop Nerd Font** — declared on the `desktop` profile, not on Zed itself,
+  so Ghostty-only or other desktop slices can satisfy the same shared font
+  requirement without selecting Zed. The primary macOS package is the Homebrew
+  cask `font-cascadia-code-nf`, detected through `CascadiaCodeNF*` font files.
+  Compatible installed files such as `CaskaydiaCoveNerdFont*` also satisfy the
+  dependency. This does not manage VS Code configuration.
 
 `dots install` does not install packages. `dots deps plan` and the explicit
 `dots deps install` workflow can report/use Homebrew guidance where available;
@@ -53,7 +56,7 @@ The live `~/.config/zed/` directory was classified before adoption:
 | Category | Examples | Repository decision |
 | --- | --- | --- |
 | **Portable** | panel docks, `vim_mode`, `theme` (system/One Light/Catppuccin Mocha (blue)), `icon_theme`, `ui_font_family`, Copilot/agent preferences, declared extensions, the two intentional keybindings, the custom Catppuccin blue theme | Managed in `configs/zed/`. |
-| **Machine-specific** | `buffer_font_family` and font sizes. Zed has no user-level local include (no `settings.local.json`), so these stay in the shared `settings.json`; the font is declared as an advisory dependency instead of extracted. | Kept in `settings.json`; font handled via dependency declaration. |
+| **Machine-specific** | `buffer_font_family` and font sizes. Zed has no user-level local include (no `settings.local.json`), so these stay in the shared `settings.json`; the Nerd Font is modeled as a shared desktop advisory dependency instead of Zed-owned state. | Kept in `settings.json`; font handled via the desktop dependency declaration. |
 | **Generated** | `conversations/`, `prompts/`, compiled `extensions/`, extension index/DB, caches, logs | Never committed (see `.gitignore`). |
 | **Private** | secrets, authenticated state (Copilot auth lives outside the authored files), private paths, machine IDs | Excluded. |
 

--- a/configs/zed/settings.json
+++ b/configs/zed/settings.json
@@ -44,7 +44,7 @@
   },
   "icon_theme": "Catppuccin Mocha",
   "ui_font_family": ".ZedSans",
-  "buffer_font_family": "CaskaydiaCove Nerd Font",
+  "buffer_font_family": "Cascadia Code NF",
   "vim_mode": true,
   "ui_font_size": 16,
   "buffer_font_size": 16.0,

--- a/dots.yaml
+++ b/dots.yaml
@@ -7,6 +7,12 @@ profiles:
     tags:
       - core
       - desktop
+    dependencies:
+      - name: Desktop Nerd Font
+        brew_cask: font-cascadia-code-nf
+        font_match: "CascadiaCodeNF*"
+        font_fallback_matches:
+          - "CaskaydiaCoveNerdFont*"
 entries:
   - source: configs/zsh/zshrc
     target: ~/.zshrc
@@ -198,9 +204,6 @@ entries:
       - name: zed
         command: zed
         brew: zed
-      - name: CascadiaCode Nerd Font
-        brew_cask: font-cascadia-code-nf
-        font_match: "CascadiaCodeNF*"
   - source: configs/zed/keymap.json
     target: ~/.config/zed/keymap.json
     strategy: symlink

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -322,6 +322,83 @@ entries:
 	}
 }
 
+func TestDoctorCommandReportsProfileFontDependencyPresentThroughFallbackFile(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+
+	srcPath := filepath.Join(sourceRoot, "configs/ghostty/config.ghostty")
+	if err := os.MkdirAll(filepath.Dir(srcPath), 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	if err := os.WriteFile(srcPath, []byte("theme = catppuccin-mocha\n"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	targetPath := filepath.Join(home, ".config", "ghostty", "config.ghostty")
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	if err := os.Symlink(srcPath, targetPath); err != nil {
+		t.Fatalf("symlink target: %v", err)
+	}
+	for _, dir := range []string{
+		filepath.Join(home, "Library", "Fonts"),
+		filepath.Join(home, ".local", "share", "fonts"),
+	} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("create font dir %q: %v", dir, err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "CaskaydiaCoveNerdFont-Regular.ttf"), []byte("font"), 0o600); err != nil {
+			t.Fatalf("write fallback font: %v", err)
+		}
+	}
+
+	manifestPath := filepath.Join(home, "dots.yaml")
+	content := []byte(`version: 1
+profiles:
+  desktop:
+    tags: [desktop]
+    dependencies:
+      - name: Desktop Nerd Font
+        brew_cask: font-cascadia-code-nf
+        font_match: "DefinitelyMissingCascadiaCodeNF*"
+        font_fallback_matches:
+          - "CaskaydiaCoveNerdFont*"
+entries:
+  - source: configs/ghostty/config.ghostty
+    target: ~/.config/ghostty/config.ghostty
+    strategy: symlink
+    tags: [desktop]
+`)
+	if err := os.WriteFile(manifestPath, content, 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"doctor", "--file", manifestPath, "--profile", "desktop", "--home", home, "--source-root", sourceRoot})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+
+	got := out.String()
+	for _, want := range []string{
+		`Doctor for profile "desktop"`,
+		"Dependencies: ok (1 present, 0 missing)",
+		"Configuration: ok (1 ok, 0 concerns)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("doctor output missing %q\noutput:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "missing dependency: Desktop Nerd Font") {
+		t.Fatalf("doctor output reported fallback font as missing\noutput:\n%s", got)
+	}
+}
+
 func TestPlanCommandFailsOnUnknownProfile(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -1167,6 +1244,104 @@ entries:
 		"present  presenttool",
 		"missing  absenttool",
 		"Summary: 1 present, 1 missing",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("deps check output missing %q\noutput:\n%s", want, got)
+		}
+	}
+}
+
+func TestDepsCheckCommandReportsMissingFontWithFallbacks(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+
+	manifestPath := writeCLIManifest(t, home, `version: 1
+profiles:
+  default:
+    tags: [desktop]
+entries:
+  - source: configs/zed/settings.json
+    target: ~/.config/zed/settings.json
+    strategy: symlink
+    tags: [desktop]
+    dependencies:
+      - name: Desktop Nerd Font
+        brew_cask: font-cascadia-code-nf
+        font_match: "DefinitelyMissingCascadiaCodeNF*"
+        font_fallback_matches:
+          - "DefinitelyMissingCaskaydiaCoveNerdFont*"
+`)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"deps", "check", "--file", manifestPath})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+
+	got := out.String()
+	for _, want := range []string{
+		`Dependencies for profile "default"`,
+		"missing  Desktop Nerd Font",
+		"Summary: 0 present, 1 missing",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("deps check output missing %q\noutput:\n%s", want, got)
+		}
+	}
+}
+
+func TestDepsCheckCommandDetectsFallbackFontFileInUserFontDirectory(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+
+	for _, dir := range []string{
+		filepath.Join(home, "Library", "Fonts"),
+		filepath.Join(home, ".local", "share", "fonts"),
+	} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("create font dir %q: %v", dir, err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "CaskaydiaCoveNerdFont-Regular.ttf"), []byte("font"), 0o600); err != nil {
+			t.Fatalf("write fallback font: %v", err)
+		}
+	}
+
+	manifestPath := writeCLIManifest(t, home, `version: 1
+profiles:
+  default:
+    tags: [desktop]
+entries:
+  - source: configs/zed/settings.json
+    target: ~/.config/zed/settings.json
+    strategy: symlink
+    tags: [desktop]
+    dependencies:
+      - name: Desktop Nerd Font
+        brew_cask: font-cascadia-code-nf
+        font_match: "DefinitelyMissingCascadiaCodeNF*"
+        font_fallback_matches:
+          - "CaskaydiaCoveNerdFont*"
+`)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"deps", "check", "--file", manifestPath})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+
+	got := out.String()
+	for _, want := range []string{
+		`Dependencies for profile "default"`,
+		"present  Desktop Nerd Font",
+		"Summary: 1 present, 0 missing",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("deps check output missing %q\noutput:\n%s", want, got)

--- a/internal/deps/deps.go
+++ b/internal/deps/deps.go
@@ -72,7 +72,7 @@ func CheckWithToolProbes(m manifest.Manifest, opts Options, look Lookup, fontLoo
 
 func dependencyPresent(dep manifest.Dependency, look Lookup, fontLook FontLookup) bool {
 	if dep.IsFont() {
-		return fontLook(strings.TrimSpace(dep.FontMatch))
+		return fontPresent(dep.FontMatches(), fontLook)
 	}
 	return look(dep.Probe())
 }
@@ -80,9 +80,10 @@ func dependencyPresent(dep manifest.Dependency, look Lookup, fontLook FontLookup
 func checkResult(dep manifest.Dependency, look Lookup, fontLook FontLookup) Result {
 	if dep.IsFont() {
 		// A font has no executable on PATH; detect it as an installed asset
-		// by scanning the workstation font directories for a matching file.
-		match := strings.TrimSpace(dep.FontMatch)
-		return Result{Name: dep.Name, Command: match, Present: fontLook(match)}
+		// by scanning the workstation font directories for any compatible file
+		// pattern, starting with the primary match.
+		matches := dep.FontMatches()
+		return Result{Name: dep.Name, Command: fontProbeLabel(matches), Present: fontPresent(matches, fontLook)}
 	}
 	probe := dep.Probe()
 	return Result{Name: dep.Name, Command: probe, Present: look(probe)}
@@ -119,9 +120,26 @@ func probeDetail(output string, err error) string {
 	return detail[:maxProbeDetailLen-len("...")] + "..."
 }
 
-// selectDependencies gathers the Dependencies of every Managed Entry and
-// Provisioner that belongs to the Profile and passes the OS filter, deduplicated
-// by name in first-declared order.
+func fontPresent(matches []string, fontLook FontLookup) bool {
+	for _, match := range matches {
+		if fontLook(match) {
+			return true
+		}
+	}
+	return false
+}
+
+func fontProbeLabel(matches []string) string {
+	if len(matches) == 0 {
+		return ""
+	}
+	return strings.Join(matches, ", ")
+}
+
+// selectDependencies gathers the Dependencies declared directly by the Profile,
+// then every Managed Entry and Provisioner that belongs to the Profile and
+// passes the OS filter, deduplicated by name in first-declared order.
+
 func selectDependencies(m manifest.Manifest, opts Options) ([]manifest.Dependency, error) {
 	profile, ok := m.Profiles[opts.Profile]
 	if !ok {
@@ -143,6 +161,7 @@ func selectDependencies(m manifest.Manifest, opts Options) ([]manifest.Dependenc
 		}
 	}
 
+	addDependencies(profile.Dependencies)
 	for _, entry := range m.Entries {
 		if !manifest.SharesTag(entry.Tags, profile.Tags) {
 			continue

--- a/internal/deps/deps_test.go
+++ b/internal/deps/deps_test.go
@@ -59,6 +59,76 @@ func TestCheckDetectsFontDependencyByScanNotPath(t *testing.T) {
 	}
 }
 
+func TestCheckDetectsFontDependencyByFallbackMatch(t *testing.T) {
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"desktop"}}},
+		Entries: []manifest.Entry{
+			{
+				Source: "configs/zed/settings.json", Target: "~/.config/zed/settings.json", Strategy: "symlink", Tags: []string{"desktop"},
+				Dependencies: []manifest.Dependency{
+					{
+						Name:                "Desktop Nerd Font",
+						FontMatch:           "CascadiaCodeNF*",
+						FontFallbackMatches: []string{"CaskaydiaCoveNerdFont*"},
+						BrewCask:            "font-cascadia-code-nf",
+					},
+				},
+			},
+		},
+	}
+
+	report, err := deps.Check(m, deps.Options{Profile: "default", OS: "darwin"},
+		lookupSet(), fontLookupSet("CaskaydiaCoveNerdFont*"))
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+	if len(report.Results) != 1 {
+		t.Fatalf("Results len = %d, want 1 (%#v)", len(report.Results), report.Results)
+	}
+	if !report.Results[0].Present {
+		t.Fatalf("Results[0] = %#v, want present through compatible fallback font", report.Results[0])
+	}
+}
+
+func TestCheckIncludesProfileDependenciesBeforeEntryDependencies(t *testing.T) {
+	m := manifest.Manifest{
+		Version: 1,
+		Profiles: map[string]manifest.Profile{
+			"default": {
+				Tags: []string{"desktop"},
+				Dependencies: []manifest.Dependency{
+					{Name: "Desktop Nerd Font", BrewCask: "font-cascadia-code-nf", FontMatch: "CascadiaCodeNF*"},
+				},
+			},
+		},
+		Entries: []manifest.Entry{
+			{
+				Source: "configs/ghostty/config.ghostty", Target: "~/.config/ghostty/config.ghostty", Strategy: "symlink", Tags: []string{"desktop"},
+				Dependencies: []manifest.Dependency{{Name: "ghostty", Command: "ghostty", Brew: "ghostty"}},
+			},
+		},
+	}
+
+	report, err := deps.Check(m, deps.Options{Profile: "default", OS: "darwin"}, lookupSet("ghostty"), fontLookupSet("CascadiaCodeNF*"))
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+
+	want := []deps.Result{
+		{Name: "Desktop Nerd Font", Command: "CascadiaCodeNF*", Present: true},
+		{Name: "ghostty", Command: "ghostty", Present: true},
+	}
+	if len(report.Results) != len(want) {
+		t.Fatalf("Results len = %d, want %d (%#v)", len(report.Results), len(want), report.Results)
+	}
+	for i := range want {
+		if report.Results[i] != want[i] {
+			t.Fatalf("Results[%d] = %#v, want %#v", i, report.Results[i], want[i])
+		}
+	}
+}
+
 func TestCheckReportsPresentAndMissingForProfile(t *testing.T) {
 	m := manifest.Manifest{
 		Version:  1,

--- a/internal/deps/install.go
+++ b/internal/deps/install.go
@@ -149,8 +149,12 @@ func Install(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup
 }
 
 func actionPresent(action InstallAction, look Lookup, fontLook FontLookup) bool {
-	if action.FontMatch != "" {
-		return fontLook(action.FontMatch)
+	matches := action.FontMatches
+	if len(matches) == 0 && action.FontMatch != "" {
+		matches = []string{action.FontMatch}
+	}
+	if len(matches) > 0 {
+		return fontPresent(matches, fontLook)
 	}
 	return look(action.Probe)
 }

--- a/internal/deps/install_test.go
+++ b/internal/deps/install_test.go
@@ -281,6 +281,33 @@ func TestInstallYesExecutesHomebrewCaskActionsThroughRunner(t *testing.T) {
 	}
 }
 
+func TestInstallYesAcceptsFallbackFontAfterCaskInstall(t *testing.T) {
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"desktop"}}},
+		Entries: []manifest.Entry{
+			{
+				Source: "configs/zed/settings.json", Target: "~/.config/zed/settings.json", Strategy: "symlink", Tags: []string{"desktop"},
+				Dependencies: []manifest.Dependency{
+					{Name: "Desktop Nerd Font", BrewCask: "font-cascadia-code-nf", FontMatch: "CascadiaCodeNF*", FontFallbackMatches: []string{"CaskaydiaCoveNerdFont*"}},
+				},
+			},
+		},
+	}
+	installedFallback := false
+	runner := &recordingRunner{afterRun: func() { installedFallback = true }}
+
+	report, err := deps.Install(m, deps.Options{Profile: "default", OS: "darwin"}, lookupSet(), func(match string) bool {
+		return installedFallback && match == "CaskaydiaCoveNerdFont*"
+	}, deps.TierHomebrew, runner)
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if len(report.Items) != 1 || report.Items[0].Status != deps.InstallStatusInstalled {
+		t.Fatalf("report items = %#v, want installed when fallback font satisfies re-probe", report.Items)
+	}
+}
+
 func TestInstallDryRunReportsInstallableActions(t *testing.T) {
 	report, err := deps.InstallDryRun(planManifest(), deps.Options{Profile: "default", OS: "darwin"}, lookupSet("tmux"), fontLookupSet(), deps.TierHomebrew)
 	if err != nil {

--- a/internal/deps/plan.go
+++ b/internal/deps/plan.go
@@ -12,13 +12,14 @@ import (
 // Manual is set when the dependency has no executable package-manager action for
 // the active Tier.
 type InstallAction struct {
-	Dependency string
-	Probe      string
-	FontMatch  string
-	Package    string
-	Executable string
-	Args       []string
-	Manual     string
+	Dependency  string
+	Probe       string
+	FontMatch   string
+	FontMatches []string
+	Package     string
+	Executable  string
+	Args        []string
+	Manual      string
 }
 
 // Guidance is the advisory installation hint for one missing Dependency. Command
@@ -65,16 +66,22 @@ func Plan(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup, t
 // Dependency under a Tier.
 func actionFor(dep manifest.Dependency, tier Tier) InstallAction {
 	pkg, executable, args := tierPackage(dep, tier)
+	fontMatches := dep.FontMatches()
+	fontMatch := ""
+	if len(fontMatches) > 0 {
+		fontMatch = fontMatches[0]
+	}
 	if pkg == "" {
-		return InstallAction{Dependency: dep.Name, Probe: dep.Probe(), FontMatch: strings.TrimSpace(dep.FontMatch), Manual: manualNote(dep, tier)}
+		return InstallAction{Dependency: dep.Name, Probe: dep.Probe(), FontMatch: fontMatch, FontMatches: fontMatches, Manual: manualNote(dep, tier)}
 	}
 	return InstallAction{
-		Dependency: dep.Name,
-		Probe:      dep.Probe(),
-		FontMatch:  strings.TrimSpace(dep.FontMatch),
-		Package:    pkg,
-		Executable: executable,
-		Args:       append(args, pkg),
+		Dependency:  dep.Name,
+		Probe:       dep.Probe(),
+		FontMatch:   fontMatch,
+		FontMatches: fontMatches,
+		Package:     pkg,
+		Executable:  executable,
+		Args:        append(args, pkg),
 	}
 }
 
@@ -115,14 +122,24 @@ func tierPackage(dep manifest.Dependency, tier Tier) (pkg, executable string, ar
 func manualNote(dep manifest.Dependency, tier Tier) string {
 	if dep.IsFont() && tier != TierHomebrew {
 		name := strings.TrimSpace(dep.Name)
-		match := strings.TrimSpace(dep.FontMatch)
+		matchHint := fontMatchHint(dep.FontMatches())
 		if cask := strings.TrimSpace(dep.BrewCask); cask != "" {
-			return fmt.Sprintf("obtain the font files for %q manually on Linux using Homebrew cask token %q as the package/source clue; copy .ttf/.otf files into ~/.local/share/fonts; run fc-cache -f ~/.local/share/fonts; rerun dots deps check; dots will detect files matching font_match %q", name, cask, match)
+			return fmt.Sprintf("obtain the font files for %q manually on Linux using Homebrew cask token %q as the package/source clue; copy .ttf/.otf files into ~/.local/share/fonts; run fc-cache -f ~/.local/share/fonts; rerun dots deps check; dots will detect files matching %s", name, cask, matchHint)
 		}
-		return fmt.Sprintf("obtain the font files for %q manually on Linux; copy .ttf/.otf files into ~/.local/share/fonts; run fc-cache -f ~/.local/share/fonts; rerun dots deps check; dots will detect files matching font_match %q", name, match)
+		return fmt.Sprintf("obtain the font files for %q manually on Linux; copy .ttf/.otf files into ~/.local/share/fonts; run fc-cache -f ~/.local/share/fonts; rerun dots deps check; dots will detect files matching %s", name, matchHint)
 	}
 	if tier == TierGeneric {
 		return fmt.Sprintf("install %q with your distribution's package manager", dep.Name)
 	}
 	return fmt.Sprintf("no %s package declared for %q; install it manually", tier, dep.Name)
+}
+
+func fontMatchHint(matches []string) string {
+	if len(matches) == 0 {
+		return `font_match ""`
+	}
+	if len(matches) == 1 {
+		return fmt.Sprintf("font_match %q", matches[0])
+	}
+	return fmt.Sprintf("font_match %q or compatible fallback patterns %q", matches[0], matches[1:])
 }

--- a/internal/deps/plan_test.go
+++ b/internal/deps/plan_test.go
@@ -156,6 +156,29 @@ func TestPlanKeepsCaskOnlyFontsManualOutsideHomebrew(t *testing.T) {
 	}
 }
 
+func TestPlanSkipsFontDependencyWhenFallbackMatchIsInstalled(t *testing.T) {
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"desktop"}}},
+		Entries: []manifest.Entry{
+			{
+				Source: "configs/zed/settings.json", Target: "~/.config/zed/settings.json", Strategy: "symlink", Tags: []string{"desktop"},
+				Dependencies: []manifest.Dependency{
+					{Name: "Desktop Nerd Font", BrewCask: "font-cascadia-code-nf", FontMatch: "CascadiaCodeNF*", FontFallbackMatches: []string{"CaskaydiaCoveNerdFont*"}},
+				},
+			},
+		},
+	}
+
+	report, err := deps.Plan(m, deps.Options{Profile: "default", OS: "darwin"}, lookupSet(), fontLookupSet("CaskaydiaCoveNerdFont*"), deps.TierHomebrew)
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+	if len(report.Actions) != 0 {
+		t.Fatalf("Actions len = %d, want 0 when fallback font is installed (%#v)", len(report.Actions), report.Actions)
+	}
+}
+
 func TestPlanProducesTierGuidanceForMissingDependencies(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -18,7 +18,8 @@ type Manifest struct {
 }
 
 type Profile struct {
-	Tags []string `yaml:"tags"`
+	Tags         []string     `yaml:"tags"`
+	Dependencies []Dependency `yaml:"dependencies,omitempty"`
 }
 
 type Entry struct {
@@ -100,12 +101,35 @@ type Dependency struct {
 	// this case-insensitive glob (e.g. "CascadiaCodeNF*"). A font has no
 	// executable on the path, so it must be probed as an installed asset.
 	FontMatch string `yaml:"font_match,omitempty"`
+	// FontFallbackMatches declares compatible installed-font filename globs that
+	// satisfy the same dependency when the primary font file pattern is absent.
+	FontFallbackMatches []string `yaml:"font_fallback_matches,omitempty"`
 }
 
 // IsFont reports whether the Dependency is detected as an installed font asset
-// rather than an executable on PATH. It is true exactly when FontMatch is set.
+// rather than an executable on PATH. It is true when any font match pattern is set.
 func (d Dependency) IsFont() bool {
-	return strings.TrimSpace(d.FontMatch) != ""
+	return len(d.FontMatches()) > 0
+}
+
+// FontMatches returns the primary installed-font filename glob followed by any
+// compatible fallback globs, trimming whitespace and dropping blank patterns.
+func (d Dependency) FontMatches() []string {
+	matches := make([]string, 0, 1+len(d.FontFallbackMatches))
+	seen := map[string]bool{}
+	add := func(match string) {
+		match = strings.TrimSpace(match)
+		if match == "" || seen[match] {
+			return
+		}
+		seen[match] = true
+		matches = append(matches, match)
+	}
+	add(d.FontMatch)
+	for _, match := range d.FontFallbackMatches {
+		add(match)
+	}
+	return matches
 }
 
 // Probe is the command name used to detect a Dependency's presence in PATH. It
@@ -156,12 +180,18 @@ func (m Manifest) Validate() error {
 	}
 	sort.Strings(names)
 	for _, name := range names {
-		tags := m.Profiles[name].Tags
+		profile := m.Profiles[name]
+		tags := profile.Tags
 		if len(tags) == 0 {
 			return fmt.Errorf("profiles[%q].tags is required", name)
 		}
 		if i, ok := indexOfEmptyTag(tags); ok {
 			return fmt.Errorf("profiles[%q].tags[%d] must not be empty", name, i)
+		}
+		for j, dep := range profile.Dependencies {
+			if err := validateDependency(dep, fmt.Sprintf("profiles[%q].dependencies[%d]", name, j)); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -268,6 +298,11 @@ func validateDependency(dep Dependency, path string) error {
 	}
 	if dep.BrewCask != "" && strings.TrimSpace(dep.BrewCask) == "" {
 		return fmt.Errorf("%s.brew_cask must not be empty", path)
+	}
+	for i, match := range dep.FontFallbackMatches {
+		if strings.TrimSpace(match) == "" {
+			return fmt.Errorf("%s.font_fallback_matches[%d] must not be empty", path, i)
+		}
 	}
 	if strings.TrimSpace(dep.Brew) != "" && strings.TrimSpace(dep.BrewCask) != "" {
 		return fmt.Errorf("%s must not set both brew and brew_cask", path)

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -100,6 +100,8 @@ entries:
       - name: CascadiaCode Nerd Font
         brew_cask: font-cascadia-code-nf
         font_match: "CascadiaCodeNF*"
+        font_fallback_matches:
+          - "CaskaydiaCoveNerdFont*"
 `)
 	if err := os.WriteFile(path, content, 0o600); err != nil {
 		t.Fatalf("write manifest: %v", err)
@@ -120,8 +122,45 @@ entries:
 	if deps[1].Name != "ripgrep" || deps[1].Command != "rg" || deps[1].Brew != "ripgrep" {
 		t.Fatalf("Dependencies[1] = %#v, want ripgrep with rg command", deps[1])
 	}
-	if deps[2].Name != "CascadiaCode Nerd Font" || deps[2].BrewCask != "font-cascadia-code-nf" || deps[2].FontMatch != "CascadiaCodeNF*" {
-		t.Fatalf("Dependencies[2] = %#v, want Homebrew cask font dependency", deps[2])
+	if deps[2].Name != "CascadiaCode Nerd Font" || deps[2].BrewCask != "font-cascadia-code-nf" || deps[2].FontMatch != "CascadiaCodeNF*" || !sameStrings(deps[2].FontFallbackMatches, []string{"CaskaydiaCoveNerdFont*"}) {
+		t.Fatalf("Dependencies[2] = %#v, want Homebrew cask font dependency with fallback match", deps[2])
+	}
+}
+
+func TestLoadFileParsesProfileDependencies(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dots.yaml")
+	content := []byte(`version: 1
+profiles:
+  desktop:
+    tags: [core, desktop]
+    dependencies:
+      - name: Desktop Nerd Font
+        brew_cask: font-cascadia-code-nf
+        font_match: "CascadiaCodeNF*"
+        font_fallback_matches:
+          - "CaskaydiaCoveNerdFont*"
+entries:
+  - source: configs/ghostty/config.ghostty
+    target: ~/.config/ghostty/config.ghostty
+    strategy: symlink
+    tags: [desktop]
+`)
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	got, err := manifest.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+
+	deps := got.Profiles["desktop"].Dependencies
+	if len(deps) != 1 {
+		t.Fatalf("Profile dependencies len = %d, want 1 (%#v)", len(deps), deps)
+	}
+	if deps[0].Name != "Desktop Nerd Font" || deps[0].BrewCask != "font-cascadia-code-nf" || deps[0].FontMatch != "CascadiaCodeNF*" || !sameStrings(deps[0].FontFallbackMatches, []string{"CaskaydiaCoveNerdFont*"}) {
+		t.Fatalf("Profile dependency = %#v, want desktop font dependency with fallback match", deps[0])
 	}
 }
 
@@ -485,6 +524,7 @@ func TestDependencyIsFont(t *testing.T) {
 	}{
 		{name: "command dependency is not a font", dep: manifest.Dependency{Name: "tmux"}, want: false},
 		{name: "font_match marks a font dependency", dep: manifest.Dependency{Name: "CascadiaCode NF", FontMatch: "CascadiaCodeNF*"}, want: true},
+		{name: "fallback match marks a font dependency", dep: manifest.Dependency{Name: "Desktop Nerd Font", FontFallbackMatches: []string{"CaskaydiaCoveNerdFont*"}}, want: true},
 		{name: "blank font_match is not a font", dep: manifest.Dependency{Name: "tmux", FontMatch: "  "}, want: false},
 	}
 
@@ -494,6 +534,17 @@ func TestDependencyIsFont(t *testing.T) {
 				t.Fatalf("IsFont() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestDependencyFontMatches(t *testing.T) {
+	dep := manifest.Dependency{
+		FontMatch:           " CascadiaCodeNF* ",
+		FontFallbackMatches: []string{"", " CaskaydiaCoveNerdFont* ", "CascadiaCodeNF*"},
+	}
+	want := []string{"CascadiaCodeNF*", "CaskaydiaCoveNerdFont*"}
+	if got := dep.FontMatches(); !sameStrings(got, want) {
+		t.Fatalf("FontMatches() = %#v, want %#v", got, want)
 	}
 }
 
@@ -583,6 +634,22 @@ entries:
     tags: [core]
 `,
 			want: `profiles["default"].tags[0] must not be empty`,
+		},
+		{
+			name: "profile dependency without name",
+			content: `version: 1
+profiles:
+  default:
+    tags: [core]
+    dependencies:
+      - brew_cask: font-cascadia-code-nf
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+`,
+			want: `profiles["default"].dependencies[0].name is required`,
 		},
 		{
 			name: "unsupported strategy",
@@ -726,6 +793,24 @@ entries:
         brew_cask: font-cascadia-code-nf
 `,
 			want: `entries[0].dependencies[0] must not set both brew and brew_cask`,
+		},
+		{
+			name: "dependency with empty font fallback match",
+			content: `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/fonts
+    target: ~/.local/share/fonts
+    strategy: copy
+    tags: [core]
+    dependencies:
+      - name: CascadiaCode Nerd Font
+        font_match: "CascadiaCodeNF*"
+        font_fallback_matches: ["  "]
+`,
+			want: `entries[0].dependencies[0].font_fallback_matches[0] must not be empty`,
 		},
 		{
 			name: "missing entry target",
@@ -1063,6 +1148,19 @@ provisioners:
         brew_cask: font-cascadia-code-nf
 `,
 			want: "provisioners[0].dependencies[0] must not set both brew and brew_cask",
+		},
+		{
+			name: "dependency with empty font fallback match",
+			provisioner: `  - tool: gentle-ai
+    tags: [core]
+    spec:
+      scope: global
+    dependencies:
+      - name: CascadiaCode Nerd Font
+        font_match: "CascadiaCodeNF*"
+        font_fallback_matches: ["  "]
+`,
+			want: "provisioners[0].dependencies[0].font_fallback_matches[0] must not be empty",
 		},
 	}
 

--- a/internal/provision/apply.go
+++ b/internal/provision/apply.go
@@ -2,7 +2,6 @@ package provision
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/yersonargotev/dots/internal/deps"
 	"github.com/yersonargotev/dots/internal/manifest"
@@ -93,9 +92,9 @@ func missingDependencies(prov manifest.Provisioner, look deps.Lookup, fontLook d
 	var missing []string
 	for _, dep := range prov.Dependencies {
 		if dep.IsFont() {
-			match := strings.TrimSpace(dep.FontMatch)
-			if !fontLook(match) {
-				missing = append(missing, match)
+			matches := dep.FontMatches()
+			if !fontDependencyPresent(matches, fontLook) {
+				missing = append(missing, fontDependencyLabel(matches))
 			}
 			continue
 		}
@@ -105,4 +104,20 @@ func missingDependencies(prov manifest.Provisioner, look deps.Lookup, fontLook d
 		}
 	}
 	return missing
+}
+
+func fontDependencyPresent(matches []string, fontLook deps.FontLookup) bool {
+	for _, match := range matches {
+		if fontLook(match) {
+			return true
+		}
+	}
+	return false
+}
+
+func fontDependencyLabel(matches []string) string {
+	if len(matches) == 0 {
+		return ""
+	}
+	return matches[0]
 }

--- a/internal/provision/apply_test.go
+++ b/internal/provision/apply_test.go
@@ -149,6 +149,23 @@ func TestApplyUnknownProfileIsError(t *testing.T) {
 	}
 }
 
+func TestApplyAcceptsProvisionerFontFallbackDependency(t *testing.T) {
+	prov := gentleAIProvisioner("codex")
+	prov.Dependencies = append(prov.Dependencies, manifest.Dependency{
+		Name: "Desktop Nerd Font", BrewCask: "font-cascadia-code-nf", FontMatch: "CascadiaCodeNF*", FontFallbackMatches: []string{"CaskaydiaCoveNerdFont*"},
+	})
+	m := manifestWithProvisioners(prov)
+	runner := &fakeRunner{}
+
+	report, err := provision.Apply(m, provision.Options{Profile: "default", OS: "darwin"}, lookupWith("gentle-ai", "engram"), fontLookupWith("CaskaydiaCoveNerdFont*"), runner)
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if len(report.Items) != 1 || report.Items[0].Status != provision.RunStatusProvisioned {
+		t.Fatalf("report.Items = %#v, want provisioned item when fallback font is installed", report.Items)
+	}
+}
+
 func TestApplyUsesFontLookupForProvisionerFontDependencies(t *testing.T) {
 	prov := gentleAIProvisioner("codex")
 	prov.Dependencies = append(prov.Dependencies, manifest.Dependency{

--- a/internal/provision/check_test.go
+++ b/internal/provision/check_test.go
@@ -52,6 +52,22 @@ func TestCheckReportsReadiness(t *testing.T) {
 	})
 }
 
+func TestCheckAcceptsProvisionerFontFallbackDependency(t *testing.T) {
+	prov := gentleAIProvisioner("codex")
+	prov.Dependencies = append(prov.Dependencies, manifest.Dependency{
+		Name: "Desktop Nerd Font", BrewCask: "font-cascadia-code-nf", FontMatch: "CascadiaCodeNF*", FontFallbackMatches: []string{"CaskaydiaCoveNerdFont*"},
+	})
+	m := manifestWithProvisioners(prov)
+
+	report, err := provision.Check(m, provision.Options{Profile: "default", OS: "darwin"}, lookupWith("gentle-ai", "engram"), fontLookupWith("CaskaydiaCoveNerdFont*"))
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+	if len(report.Items) != 1 || len(report.Items[0].Missing) != 0 {
+		t.Fatalf("readiness = %#v, want no missing deps when fallback font is installed", report.Items)
+	}
+}
+
 func TestCheckUsesFontLookupForProvisionerFontDependencies(t *testing.T) {
 	prov := gentleAIProvisioner("codex")
 	prov.Dependencies = append(prov.Dependencies, manifest.Dependency{


### PR DESCRIPTION
Closes #89

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Models the Nerd Font as a shared `desktop` profile dependency instead of a Zed-owned dependency.
- Adds primary plus fallback font-file matching so compatible Cascadia/Caskaydia Nerd Font installs satisfy dependency checks.
- Updates Zed/Ghostty documentation and tests for profile-level font dependency behavior.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Moves `Desktop Nerd Font` to `profiles.desktop.dependencies` with primary and fallback font matches. |
| `internal/manifest/manifest.go` | Adds profile-level dependencies and fallback font match validation. |
| `internal/deps/*` | Uses normalized primary/fallback font matches across check, plan, install, and re-probe flows. |
| `internal/provision/*` | Accepts fallback font matches for provisioner readiness and apply checks. |
| `configs/zed/*` | Sets Zed primary font to `Cascadia Code NF` and documents desktop-profile ownership. |
| `configs/ghostty/*` | Documents shared desktop font usage through local Ghostty overrides. |
| `internal/**/*_test.go` | Adds coverage for profile dependencies, fallback detection, doctor output, install re-probe, and provisioners. |

## Test Plan

- [x] `go test -count=1 ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile desktop --source-root "$PWD" --home <tmp> --state-root <tmp>`
- [x] Sandboxed doctor check with fallback font file under temporary home.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #89`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
