### PR TITLE
docs: document issue+PR flow for documentation changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,11 @@ dots doctor --home "$SANDBOX"   # inspect without touching real config
 - **Pull requests.** Use [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md).
   Include `Closes #<issue-number>`, exactly one `type:*` label, validation
   evidence, and the dotfiles safety checklist when config paths are involved.
+- **Docs follow the same flow.** Documentation changes (`*.md`, `docs/`,
+  including this file) go through issue + PR like code — never push docs directly
+  to `main`. Open an issue, branch, then a PR labeled `type:docs` with
+  `Closes #<issue-number>`; `main` is branch-protected and requires the
+  `Test, vet and build` check on every PR.
 - **Domain docs.** Single-context layout: `CONTEXT.md` at the root and ADRs under
   `docs/adr/`. Read the relevant ADR before changing architecture or workflow.
   See [`docs/agents/domain.md`](docs/agents/domain.md).


### PR DESCRIPTION
Closes #108

## PR Type

- [x] Documentation only (`type:docs`)

## Summary

- Add an explicit AGENTS.md convention: documentation changes (`*.md`, `docs/`, including AGENTS.md itself) go through issue + PR, never a direct push to `main`.
- Anchor the rule to branch protection and the required `Test, vet and build` check.

## Changes

| File | Change |
|------|--------|
| `AGENTS.md` | New "Docs follow the same flow" bullet under Contribution conventions documenting the issue + PR flow for docs. |

## Test Plan

- [x] Docs-only change; no code paths touched. `go test`/`go vet`/`gofmt` unaffected.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration.
- [x] No CLI validation against home/config paths was needed.

## Contributor Checklist

- [x] Linked issue with `Closes #108`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated agent instructions for the workflow change.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.