### PR TITLE
feat(release): generate GitHub release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
           else
             gh release create "$RELEASE_TAG" \
               --title "$RELEASE_TAG" \
-              --notes "First usable v0.x release target for dots. Assets include macOS/Linux amd64/arm64 binaries plus checksums.txt for Bootstrapper verification."
+              --generate-notes
           fi
 
       - name: Upload release assets

--- a/internal/release/release_automation_test.go
+++ b/internal/release/release_automation_test.go
@@ -59,6 +59,30 @@ func TestReleaseWorkflowPublishesBootstrapperConsumableArtifacts(t *testing.T) {
 	}
 }
 
+func TestReleaseWorkflowCreatesReleaseWithGeneratedNotes(t *testing.T) {
+	root := repoRoot(t)
+	workflow := readWorkflow(t, filepath.Join(root, ".github", "workflows", "release.yml"))
+	steps := workflowSteps(t, workflow)
+
+	createReleaseIndex := workflowStepIndex(t, steps, "GitHub Release creation with generated notes", func(step map[string]any) bool {
+		return stepName(step) == "Create GitHub Release if needed"
+	})
+	run := stepRun(steps[createReleaseIndex])
+
+	if !strings.Contains(run, "gh release create") {
+		t.Fatalf("release creation step should create the GitHub Release; run script:\n%s", run)
+	}
+	if !strings.Contains(run, "--generate-notes") {
+		t.Fatalf("release creation should ask GitHub to generate per-tag notes; run script:\n%s", run)
+	}
+	if strings.Contains(run, "--notes") {
+		t.Fatalf("release creation should not pass static release notes; run script:\n%s", run)
+	}
+	if strings.Contains(run, "First usable v0.x release target") {
+		t.Fatalf("release creation should not keep the old first-release notes body; run script:\n%s", run)
+	}
+}
+
 func TestReleaseWorkflowProvesTapAccessBeforePublishingReleaseAssets(t *testing.T) {
 	root := repoRoot(t)
 	workflow := readWorkflow(t, filepath.Join(root, ".github", "workflows", "release.yml"))


### PR DESCRIPTION
Closes #106

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Generates GitHub Release notes with GitHub's release notes API instead of reusing static text.
- Keeps the release title, release-exists guard, asset upload, and Homebrew tap publishing flow unchanged.
- Adds a regression test that prevents the old static release body from returning.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Replaces static `--notes` content with `--generate-notes` for new releases. |
| `internal/release/release_automation_test.go` | Adds workflow regression coverage for generated release notes and absence of the old static body. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan not applicable; release workflow change does not target home/config paths.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
