### PR TITLE
feat(ghostty): manage font baseline

### DIFF
--- a/configs/ghostty/README.md
+++ b/configs/ghostty/README.md
@@ -12,12 +12,10 @@ outside version control.
 
 - **`ghostty`** — declared as an advisory dependency for the desktop profile.
 - **Desktop Nerd Font** — declared on the `desktop` profile as shared desktop
-  infrastructure, not as a Zed-owned dependency. Ghostty local overrides,
-  terminals, and editors can consume the same requirement. The primary macOS
-  package is the Homebrew cask `font-cascadia-code-nf`, detected through
-  `CascadiaCodeNF*` font files; compatible files such as
-  `CaskaydiaCoveNerdFont*` also satisfy the dependency. This is not VS Code
-  configuration management.
+  infrastructure. Ghostty consumes this shared requirement for the managed
+  `font-family` baseline (`Cascadia Code NF`). The primary macOS package is the
+  Homebrew cask `font-cascadia-code-nf`, detected through `CascadiaCodeNF*` font
+  files.
 
 `dots install` does not install packages. `dots deps plan` and the explicit
 `dots deps install` workflow can report/use Homebrew guidance where available;
@@ -30,8 +28,8 @@ The live `~/.config/ghostty/config` file was classified before adoption:
 
 | Category | Examples | Repository decision |
 | --- | --- | --- |
-| **Portable** | Catppuccin Mocha palette, foreground/background/cursor/selection colors, split divider color, intentional keybindings for terminal workflow and Zellij/tmux forwarding | Managed in `configs/ghostty/config.ghostty`. |
-| **Machine-specific** | font family, font size, window dimensions, opacity/blur, window padding ergonomics, explicit shell/command paths, initial working directories, OS integrations, display/GPU/host-dependent behavior | Excluded from the shared file. Font family can use the shared Desktop Nerd Font from local overrides; documented in `configs/ghostty/config.local.ghostty.example`. |
+| **Portable** | font family, font size, Catppuccin Mocha palette, foreground/background/cursor/selection colors, split divider color, intentional keybindings for terminal workflow and Zellij/tmux forwarding | Managed in `configs/ghostty/config.ghostty`. |
+| **Machine-specific** | window dimensions, opacity/blur, window padding ergonomics, explicit shell/command paths, initial working directories, OS integrations, display/GPU/host-dependent behavior | Excluded from the shared file; document deliberate host-specific exceptions in `configs/ghostty/config.local.ghostty.example`. |
 | **Generated** | logs, caches, sessions, backups, temporary files, generated state, local shaders | Never committed. |
 | **Private** | secrets, authenticated state, private paths, hostnames, machine IDs | Excluded. |
 
@@ -44,7 +42,9 @@ legacy file can override the repository-managed Source of Truth after install.
 Before switching a real workstation to this slice, classify the legacy file, move
 portable settings into `configs/ghostty/config.ghostty`, move machine-specific
 settings into `~/.config/ghostty/config.local.ghostty`, then archive or remove
-the legacy `~/.config/ghostty/config` file. Do the same review for macOS
+the legacy `~/.config/ghostty/config` file. Do not leave duplicated font, color,
+or keybinding settings in the legacy file because they can override the managed
+Source of Truth. Do the same review for macOS
 Application Support Ghostty config files if they exist.
 
 Do not delete the legacy file blindly: it is user state until it has been

--- a/configs/ghostty/config.ghostty
+++ b/configs/ghostty/config.ghostty
@@ -1,10 +1,15 @@
 # Ghostty portable preferences managed by dots.
 #
-# Machine-specific settings such as font family/size, window dimensions,
-# opacity/blur, shell paths, working directories, and platform integrations live
-# in the optional local file below. Ghostty resolves this relative to this file
-# and ignores it when it does not exist.
+# Machine-specific settings such as window dimensions, opacity/blur, shell paths,
+# working directories, and platform integrations live in the optional local file
+# below. Ghostty resolves this relative to this file and ignores it when it does
+# not exist.
 config-file = ?config.local.ghostty
+
+# Shared font baseline. The Desktop Nerd Font dependency keeps this portable
+# across supported desktop hosts.
+font-family = "Cascadia Code NF"
+font-size = 20
 
 # Catppuccin Mocha palette and terminal colors.
 palette = 0=#45475a

--- a/configs/ghostty/config.local.ghostty.example
+++ b/configs/ghostty/config.local.ghostty.example
@@ -5,12 +5,9 @@
 #
 # Keep this file local unless a setting is explicitly reviewed as portable.
 
-# Fonts are machine-specific because installed font names and comfortable sizes
-# differ across hosts, displays, and operating systems.
-# font-family = "Cascadia Code NF"
-# Compatible fallback family names such as "CaskaydiaCove Nerd Font Mono" may
-# also work when those files are already installed.
-# font-size = 20
+# Font family and size are managed in config.ghostty. Add font overrides here
+# only for a deliberate host-specific exception; local values loaded from this
+# file override the shared Source of Truth.
 
 # Window and rendering ergonomics depend on monitor size, compositor/GPU, and
 # personal workspace layout.

--- a/dots.yaml
+++ b/dots.yaml
@@ -11,8 +11,6 @@ profiles:
       - name: Desktop Nerd Font
         brew_cask: font-cascadia-code-nf
         font_match: "CascadiaCodeNF*"
-        font_fallback_matches:
-          - "CaskaydiaCoveNerdFont*"
 entries:
   - source: configs/zsh/zshrc
     target: ~/.zshrc

--- a/internal/cli/ghostty_config_test.go
+++ b/internal/cli/ghostty_config_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/yersonargotev/dots/internal/cli"
+	"github.com/yersonargotev/dots/internal/manifest"
 )
 
 func TestGhosttyDesktopProfileInstallsAndReportsAlignedInSandbox(t *testing.T) {
@@ -53,6 +54,52 @@ func TestGhosttyDesktopProfileInstallsAndReportsAlignedInSandbox(t *testing.T) {
 	}
 	if gotSource != wantSource {
 		t.Fatalf("ghostty symlink = %q, want %q", gotSource, wantSource)
+	}
+
+	managedConfig, err := os.ReadFile(wantSource)
+	if err != nil {
+		t.Fatalf("read managed ghostty config: %v", err)
+	}
+	for _, want := range []string{
+		`font-family = "Cascadia Code NF"`,
+		"font-size = 20",
+	} {
+		if !strings.Contains(string(managedConfig), want) {
+			t.Fatalf("managed ghostty config missing %q", want)
+		}
+	}
+
+	manifestFile, err := manifest.LoadFile(filepath.Join(repoRoot, "dots.yaml"))
+	if err != nil {
+		t.Fatalf("load dots manifest: %v", err)
+	}
+	var ghosttyEntry *manifest.Entry
+	for i := range manifestFile.Entries {
+		entry := &manifestFile.Entries[i]
+		if entry.Source == "configs/ghostty/config.ghostty" {
+			ghosttyEntry = entry
+			break
+		}
+	}
+	if ghosttyEntry == nil {
+		t.Fatal("dots manifest missing Ghostty managed entry")
+	}
+	if !manifest.SharesTag(ghosttyEntry.Tags, []string{"desktop"}) {
+		t.Fatalf("Ghostty managed entry tags = %#v, want desktop", ghosttyEntry.Tags)
+	}
+	desktopProfile, ok := manifestFile.Profiles["desktop"]
+	if !ok {
+		t.Fatal("dots manifest missing desktop profile")
+	}
+	foundDesktopFontDependency := false
+	for _, dep := range desktopProfile.Dependencies {
+		if dep.BrewCask == "font-cascadia-code-nf" && dep.FontMatch == "CascadiaCodeNF*" {
+			foundDesktopFontDependency = true
+			break
+		}
+	}
+	if !foundDesktopFontDependency {
+		t.Fatalf("desktop profile dependencies = %#v, want font-cascadia-code-nf with CascadiaCodeNF*", desktopProfile.Dependencies)
 	}
 
 	localExample := filepath.Join(repoRoot, "configs", "ghostty", "config.local.ghostty.example")


### PR DESCRIPTION
Closes #111

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Manage Ghostty font family and size in the repository-owned `config.ghostty` Source of Truth.
- Keep Ghostty aligned with the shared desktop `Cascadia Code NF` dependency that is already installed/detected.
- Document legacy config migration and strengthen sandbox regression coverage.

## Changes

| File | Change |
|------|--------|
| `configs/ghostty/config.ghostty` | Adds managed `font-family = "Cascadia Code NF"` and `font-size = 20`. |
| `configs/ghostty/config.local.ghostty.example` | Clarifies that font overrides should be deliberate host-specific exceptions. |
| `configs/ghostty/README.md` | Updates portability classification, shared font dependency docs, and legacy config migration guidance. |
| `dots.yaml` | Keeps Ghostty consuming the shared desktop Nerd Font dependency instead of adding a duplicate entry dependency. |
| `internal/cli/ghostty_config_test.go` | Adds sandbox regression assertions for managed Ghostty font settings and desktop profile font dependency linkage. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile desktop --source-root "$PWD" --home <tmp> --state-root <tmp> --output json`
- [x] `go run ./cmd/dots deps check --file dots.yaml --profile desktop --output json`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
