### PR TITLE
test: derive expected manifest entry count from dots.yaml

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2,13 +2,17 @@ package cli_test
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/yersonargotev/dots/internal/backups"
 	"github.com/yersonargotev/dots/internal/cli"
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/plan"
 )
 
 func TestRootHelpIdentifiesDotsCLI(t *testing.T) {
@@ -1048,6 +1052,30 @@ func TestRepositoryGitConfigInstallsAndReportsAlignedInSandbox(t *testing.T) {
 		t.Fatalf("sandbox nvim symlink = %q, want %q", target, want)
 	}
 
+	// Derive the expected "ok" count from the loaded manifest rather than a
+	// hardcoded literal: install/status run for runtime.GOOS and the default
+	// profile, so a clean-home plan for the same inputs yields one create action
+	// per managed entry. On this freshly installed sandbox every managed entry
+	// must therefore report ok with zero conflict/drift.
+	loaded, err := manifest.LoadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("LoadFile(%q) error = %v", manifestPath, err)
+	}
+	countPlan, err := plan.Build(*loaded, plan.Options{
+		Profile:    "default",
+		OS:         runtime.GOOS,
+		SourceRoot: sourceRoot,
+		Home:       t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	wantManaged := len(countPlan.Actions)
+	if wantManaged == 0 {
+		t.Fatalf("no managed entries apply to profile \"default\" on %s; derived plan is empty", runtime.GOOS)
+	}
+	wantSummary := fmt.Sprintf("Summary: %d ok, 0 missing, 0 conflict, 0 skipped, 0 drifted, 0 unsupported", wantManaged)
+
 	got := statusOut.String()
 	for _, want := range []string{
 		"ok",
@@ -1055,7 +1083,7 @@ func TestRepositoryGitConfigInstallsAndReportsAlignedInSandbox(t *testing.T) {
 		"configs/zellij/config.kdl -> " + zellijConfigTarget,
 		"configs/zellij/layouts/default.kdl -> " + zellijLayoutTarget,
 		"configs/nvim -> " + nvimTarget,
-		"Summary: 14 ok, 0 missing, 0 conflict, 0 skipped, 0 drifted, 0 unsupported",
+		wantSummary,
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("status output missing %q\noutput:\n%s", want, got)

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -1793,8 +1793,26 @@ func TestRepositoryManifestPlansMVPConfigurationSetSafely(t *testing.T) {
 		t.Fatalf("Build() error = %v", err)
 	}
 
-	if len(p.Actions) != 14 {
-		t.Fatalf("len(Actions) = %d, want 14", len(p.Actions))
+	// Derive the expected action count from the loaded manifest instead of a
+	// hardcoded literal: every managed entry whose tags intersect the profile
+	// and that passes the OS filter must produce exactly one action. This is the
+	// same selection plan.Build applies, so adding or removing a dots.yaml entry
+	// never forces a magic-number bump here.
+	profile, ok := got.Profiles["default"]
+	if !ok {
+		t.Fatal("manifest missing profile \"default\"")
+	}
+	wantActions := 0
+	for _, entry := range got.Entries {
+		if manifest.SharesTag(entry.Tags, profile.Tags) && manifest.MatchesOS(entry.OS, "darwin") {
+			wantActions++
+		}
+	}
+	if wantActions == 0 {
+		t.Fatal("no managed entries apply to profile \"default\" on darwin; derived plan is empty")
+	}
+	if len(p.Actions) != wantActions {
+		t.Fatalf("len(Actions) = %d, want %d (derived from dots.yaml)", len(p.Actions), wantActions)
 	}
 	for _, action := range p.Actions {
 		if action.Status != plan.StatusCreate {


### PR DESCRIPTION
Closes #63

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [x] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Replace the hardcoded managed-entry count (`14`) in the repository-manifest tests with a value derived from the loaded `dots.yaml`.
- Reuse the exact selection `plan.Build` applies (`SharesTag` + `MatchesOS`), so adding or removing a slice entry no longer forces a magic-number bump or breaks unrelated tests.
- Make the CLI status-summary assertion correct on any OS by deriving `N` from a clean-home plan for `runtime.GOOS`, instead of a literal that only held on one platform.

## Changes

| File | Change |
|------|--------|
| `internal/manifest/manifest_test.go` | `TestRepositoryManifestPlansMVPConfigurationSetSafely` now counts entries applicable to the `default` profile on `darwin` and asserts `len(p.Actions)` matches that derived count; keeps the all-`create` invariant and guards against an empty plan. |
| `internal/cli/cli_test.go` | `TestRepositoryGitConfigInstallsAndReportsAlignedInSandbox` builds a clean-home plan for `runtime.GOOS`, takes `len(Actions)` as `N`, and formats the `Summary: N ok, ...` string via `fmt.Sprintf` instead of a literal. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [ ] `go run ./cmd/dots manifest validate --file dots.yaml` (n/a — no manifest or CLI behavior change)
- [ ] Sandboxed plan only when dotfiles behavior changes (n/a — test-only change)

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #63`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [ ] Updated docs or agent instructions when workflow behavior changed (n/a).
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.