### PR TITLE
feat(deps): honor --home for sandbox font detection in check/plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,22 @@ SANDBOX="$(mktemp -d)"
 dots doctor --home "$SANDBOX"   # inspect without touching real config
 ```
 
+`deps` is the exception: it manages system-global tools and package managers,
+not `$HOME` files, so it has no `--source-root`/`--state-root` to sandbox and
+those flags are not offered. The only honest sandbox knob is `--home` on
+`deps check` and `deps plan`, which roots **font detection** at the environment
+under test instead of the operator's real home:
+
+```bash
+SANDBOX="$(mktemp -d)"; mkdir -p "$SANDBOX/home"
+dots deps check --file dots.yaml --home "$SANDBOX/home"
+dots deps plan  --file dots.yaml --home "$SANDBOX/home"
+```
+
+`deps install` takes no `--home`: it would only relabel font detection while the
+real install still hits the system, so its guardrails stay `--dry-run` and
+confirmation instead.
+
 ## Contribution conventions
 
 - **Issue first.** Issues and PRDs live in GitHub Issues for `yersonargotev/dots`.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,16 @@ dots deps install --yes  # execute installable actions without prompting
 
 `dots deps install` executes package managers with direct argv only after confirmation. It does not bypass `sudo`, does not run manual-only guidance, and does not promise rollback, version constraints, reinstall, or upgrade behavior.
 
+For honest fresh-machine validation, `deps check` and `deps plan` accept `--home` to root font detection at a sandbox instead of your real home:
+
+```bash
+tmp=$(mktemp -d); mkdir -p "$tmp/home"
+dots deps check --file dots.yaml --home "$tmp/home"
+dots deps plan  --file dots.yaml --home "$tmp/home"
+```
+
+Unlike `doctor`/`install`, deps commands manage system-global tools rather than `$HOME` files, so they intentionally do not offer `--source-root`/`--state-root` (inert and misleading here), and `deps install` takes no `--home` (it would only relabel font detection while the real install still touches the system).
+
 List Backup Metadata created by safe installs or restores:
 
 ```bash

--- a/internal/cli/deps.go
+++ b/internal/cli/deps.go
@@ -32,7 +32,10 @@ func newDepsCommand() *cobra.Command {
 }
 
 func newDepsCheckCommand(profile *string) *cobra.Command {
-	var file string
+	var (
+		file string
+		home string
+	)
 
 	cmd := &cobra.Command{
 		Use:   "check",
@@ -46,11 +49,10 @@ func newDepsCheckCommand(profile *string) *cobra.Command {
 				return err
 			}
 
-			home, _ := os.UserHomeDir()
 			report, err := deps.Check(*m, deps.Options{
 				Profile: *profile,
 				OS:      runtime.GOOS,
-			}, lookupCommand, fontInstalled(runtime.GOOS, home))
+			}, lookupCommand, fontInstalled(runtime.GOOS, resolveDepsHome(home)))
 			if err != nil {
 				return err
 			}
@@ -63,6 +65,7 @@ func newDepsCheckCommand(profile *string) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&file, "file", "f", "dots.yaml", "manifest file to inspect")
+	cmd.Flags().StringVar(&home, "home", "", "home directory rooting per-user font detection (default: the current user's home); use a sandbox path for honest fresh-machine validation")
 	return cmd
 }
 
@@ -70,6 +73,7 @@ func newDepsPlanCommand(profile *string) *cobra.Command {
 	var (
 		file string
 		tier string
+		home string
 	)
 
 	cmd := &cobra.Command{
@@ -90,11 +94,10 @@ func newDepsPlanCommand(profile *string) *cobra.Command {
 				return err
 			}
 
-			home, _ := os.UserHomeDir()
 			report, err := deps.Plan(*m, deps.Options{
 				Profile: *profile,
 				OS:      runtime.GOOS,
-			}, lookupCommand, fontInstalled(runtime.GOOS, home), resolvedTier)
+			}, lookupCommand, fontInstalled(runtime.GOOS, resolveDepsHome(home)), resolvedTier)
 			if err != nil {
 				return err
 			}
@@ -108,6 +111,7 @@ func newDepsPlanCommand(profile *string) *cobra.Command {
 
 	cmd.Flags().StringVarP(&file, "file", "f", "dots.yaml", "manifest file to inspect")
 	cmd.Flags().StringVar(&tier, "tier", "", "override the dependency plan tier (homebrew, debian, fedora, arch, generic); default: auto-detect from the host")
+	cmd.Flags().StringVar(&home, "home", "", "home directory rooting per-user font detection (default: the current user's home); use a sandbox path for honest fresh-machine validation")
 	return cmd
 }
 
@@ -270,6 +274,20 @@ func fontDirectories(goos, home string) []string {
 		)
 	}
 	return append(dirs, "/usr/share/fonts", "/usr/local/share/fonts")
+}
+
+// resolveDepsHome returns the home directory used to root per-user font
+// directories during deps font detection. An explicit --home wins so sandbox
+// readiness checks scan the environment under test rather than the operator's
+// real home; otherwise it falls back to the current user's home. A missing home
+// is not fatal: fontDirectories omits the per-user locations and detection
+// degrades to the system directories.
+func resolveDepsHome(flag string) string {
+	if flag != "" {
+		return flag
+	}
+	home, _ := os.UserHomeDir()
+	return home
 }
 
 // fontInstalled is the production FontLookup: it scans the OS font directories

--- a/internal/cli/deps_home_test.go
+++ b/internal/cli/deps_home_test.go
@@ -47,15 +47,6 @@ func writeProbeFont(t *testing.T, home string) {
 	}
 }
 
-func writeFontManifest(t *testing.T, dir string) string {
-	t.Helper()
-	path := filepath.Join(dir, "dots.yaml")
-	if err := os.WriteFile(path, []byte(fontManifest), 0o600); err != nil {
-		t.Fatalf("write manifest: %v", err)
-	}
-	return path
-}
-
 func TestDepsCheckHomeFlagDetectsSandboxFont(t *testing.T) {
 	// The real home stays empty; the font only exists under the sandbox home
 	// passed via --home, so a "present" result proves detection honored the flag.
@@ -64,7 +55,7 @@ func TestDepsCheckHomeFlagDetectsSandboxFont(t *testing.T) {
 
 	sandbox := t.TempDir()
 	writeProbeFont(t, sandbox)
-	manifestPath := writeFontManifest(t, t.TempDir())
+	manifestPath := writeCLIManifest(t, t.TempDir(), fontManifest)
 
 	cmd := cli.NewRootCommand()
 	var out bytes.Buffer
@@ -95,7 +86,7 @@ func TestDepsCheckHomeFlagIgnoresRealHomeFont(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
 
 	sandbox := t.TempDir()
-	manifestPath := writeFontManifest(t, t.TempDir())
+	manifestPath := writeCLIManifest(t, t.TempDir(), fontManifest)
 
 	// A missing dependency is a finding, so deps check exits with code 2.
 	var out, errOut bytes.Buffer
@@ -121,7 +112,7 @@ func TestDepsPlanHomeFlagDetectsSandboxFont(t *testing.T) {
 
 	sandbox := t.TempDir()
 	writeProbeFont(t, sandbox)
-	manifestPath := writeFontManifest(t, t.TempDir())
+	manifestPath := writeCLIManifest(t, t.TempDir(), fontManifest)
 
 	cmd := cli.NewRootCommand()
 	var out bytes.Buffer

--- a/internal/cli/deps_home_test.go
+++ b/internal/cli/deps_home_test.go
@@ -1,0 +1,140 @@
+package cli_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/cli"
+)
+
+// fontManifest declares a single profile whose only dependency is a font
+// detected by scanning the per-user font directories. The glob is unique enough
+// that no system font directory satisfies it, so detection hinges entirely on
+// which home roots the per-user font directories.
+const fontManifest = `version: 1
+profiles:
+  default:
+    tags: [core]
+    dependencies:
+      - name: Dots Home Flag Probe Font
+        brew_cask: font-dots-home-flag-probe
+        font_match: "DotsHomeFlagProbeNF*"
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+`
+
+// writeProbeFont drops a file matching the probe glob in every per-user font
+// directory dots scans, so the test stays OS-agnostic across darwin and linux.
+func writeProbeFont(t *testing.T, home string) {
+	t.Helper()
+	for _, dir := range []string{
+		filepath.Join(home, "Library", "Fonts"),
+		filepath.Join(home, ".local", "share", "fonts"),
+		filepath.Join(home, ".fonts"),
+	} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("create font dir %q: %v", dir, err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "DotsHomeFlagProbeNF-Regular.ttf"), []byte("font"), 0o600); err != nil {
+			t.Fatalf("write probe font: %v", err)
+		}
+	}
+}
+
+func writeFontManifest(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "dots.yaml")
+	if err := os.WriteFile(path, []byte(fontManifest), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	return path
+}
+
+func TestDepsCheckHomeFlagDetectsSandboxFont(t *testing.T) {
+	// The real home stays empty; the font only exists under the sandbox home
+	// passed via --home, so a "present" result proves detection honored the flag.
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("PATH", t.TempDir())
+
+	sandbox := t.TempDir()
+	writeProbeFont(t, sandbox)
+	manifestPath := writeFontManifest(t, t.TempDir())
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"deps", "check", "--file", manifestPath, "--home", sandbox})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "present  Dots Home Flag Probe Font") {
+		t.Fatalf("sandbox font not detected under --home\noutput:\n%s", got)
+	}
+	if !strings.Contains(got, "Summary: 1 present, 0 missing") {
+		t.Fatalf("unexpected summary\noutput:\n%s", got)
+	}
+}
+
+func TestDepsCheckHomeFlagIgnoresRealHomeFont(t *testing.T) {
+	// The font lives only in the real home; --home points at an empty sandbox.
+	// A "missing" result proves --home overrides the real home rather than
+	// dishonestly reporting the operator's own installed font.
+	realHome := t.TempDir()
+	writeProbeFont(t, realHome)
+	t.Setenv("HOME", realHome)
+	t.Setenv("PATH", t.TempDir())
+
+	sandbox := t.TempDir()
+	manifestPath := writeFontManifest(t, t.TempDir())
+
+	// A missing dependency is a finding, so deps check exits with code 2.
+	var out, errOut bytes.Buffer
+	code := cli.Run([]string{"deps", "check", "--file", manifestPath, "--home", sandbox}, &out, &errOut)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2 (findings)\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "missing  Dots Home Flag Probe Font") {
+		t.Fatalf("--home sandbox font detection leaked into real home\noutput:\n%s", got)
+	}
+	if !strings.Contains(got, "Summary: 0 present, 1 missing") {
+		t.Fatalf("unexpected summary\noutput:\n%s", got)
+	}
+}
+
+func TestDepsPlanHomeFlagDetectsSandboxFont(t *testing.T) {
+	// plan must route --home into the same font detection as check: a font under
+	// the sandbox home counts as installed and drops out of the plan.
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("PATH", t.TempDir())
+
+	sandbox := t.TempDir()
+	writeProbeFont(t, sandbox)
+	manifestPath := writeFontManifest(t, t.TempDir())
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"deps", "plan", "--file", manifestPath, "--home", sandbox, "--tier", "homebrew"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "All declared dependencies are already installed.") {
+		t.Fatalf("plan did not honor --home for sandbox font detection\noutput:\n%s", got)
+	}
+}


### PR DESCRIPTION
Closes #114

## PR Type

- [x] New feature (`type:feature`)

## Summary

- `deps check` and `deps plan` now accept `--home`, routing it into font dependency detection so sandbox/fresh-machine validation is honest.
- A font is reported present only when it exists under the provided `--home`, not because it lives in the operator's real home.
- Default behavior is unchanged when `--home` is omitted (falls back to the current user's home).

## Changes

| File | Change |
|------|--------|
| `internal/cli/deps.go` | Add `--home` flag to `check`/`plan`; new `resolveDepsHome` helper feeds `fontInstalled`. `install` untouched; no `--source-root`/`--state-root` added. |
| `internal/cli/deps_home_test.go` | New tests: sandbox font detected under `--home`; font in real home reported missing when `--home` points elsewhere; `plan` honors `--home`. |
| `README.md` | Document the deps-specific safe preflight and why deps omits `--source-root`/`--state-root` and `install --home`. |
| `AGENTS.md` | Same deps preflight guidance for agents (also updates `CLAUDE.md` via symlink). |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] Sandbox smoke: `dots deps check --file dots.yaml --home "$tmp/home"` and `deps plan ... --home "$tmp/home"` (exit 0), `deps install --help` confirms no `--home`.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] CLI validation targeting home/config paths used temporary directories and explicit `--home <tmp>` flags.

## Contributor Checklist

- [x] Linked `ready-for-agent` issue with `Closes #114`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs and agent instructions.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
