### PR TITLE
test(backups): cover install and restore safety e2e

### DIFF
--- a/docs/backups.md
+++ b/docs/backups.md
@@ -71,6 +71,25 @@ Planned changes:
 Dry run: no files changed.
 ```
 
+## Sandbox validation
+
+Before using `dots install` against a real home directory, validate the safety
+guarantee in a temporary sandbox: create a small manifest, pre-create the target
+file under `--home`, run `dots install --no-tui` and choose `replace`, then run
+`dots backups restore <set>` with the same `--home` and `--state-root`. The
+expected result is:
+
+- install records a `pre-install conflict protection` Backup Set before
+  replacing the user-owned target;
+- the managed file or symlink is installed under the sandbox home;
+- restore returns the original content; and
+- restore records a `pre-restore safety backup` for the managed state it
+  overwrote.
+
+The regression test `TestInstallReplaceAndBackupRestoreEndToEndUsesSandbox`
+covers this journey with temporary `--home`, `--source-root`, and `--state-root`
+paths only.
+
 ## References
 
 - [`docs/scope.md`](scope.md) — automatic backup restore was deferred from v1 and delivered in v1.1.

--- a/internal/cli/backups.go
+++ b/internal/cli/backups.go
@@ -117,8 +117,16 @@ func newBackupsRestoreCommand() *cobra.Command {
 			// inside the home sandbox regardless of where the state root lives.
 			// Trusting an explicit external state root's *location* must never
 			// extend to trusting the *targets* recorded in its metadata.
+			//
+			// Validate the parent path rather than rejecting a symlink leaf: the
+			// normal install replace flow can leave a managed symlink at the
+			// target, and restore must be able to back up and remove that symlink
+			// without following it.
 			for _, target := range set.Targets {
-				if err := plan.ValidateFilePathInsideHomeNoSymlinkEscape(target, paths.Home, "restore target"); err != nil {
+				if err := plan.ValidateResolvedTarget(target, paths.Home); err != nil {
+					return err
+				}
+				if err := plan.ValidateTargetParentInsideHome(target, paths.Home); err != nil {
 					return err
 				}
 			}

--- a/internal/cli/install_restore_e2e_test.go
+++ b/internal/cli/install_restore_e2e_test.go
@@ -1,0 +1,154 @@
+package cli_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/backups"
+	"github.com/yersonargotev/dots/internal/cli"
+)
+
+func TestInstallReplaceAndBackupRestoreEndToEndUsesSandbox(t *testing.T) {
+	realHomeSentinel := t.TempDir()
+	t.Setenv("HOME", realHomeSentinel)
+	if err := os.WriteFile(filepath.Join(realHomeSentinel, ".zshrc"), []byte("real home must stay untouched\n"), 0o600); err != nil {
+		t.Fatalf("write real-home sentinel: %v", err)
+	}
+
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	manifestPath := filepath.Join(sourceRoot, "dots.yaml")
+	sourceRel := "configs/zsh/zshrc"
+	sourcePath := filepath.Join(sourceRoot, sourceRel)
+	target := filepath.Join(home, ".zshrc")
+
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("mkdir source parent: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte("managed zshrc\n"), 0o600); err != nil {
+		t.Fatalf("write managed source: %v", err)
+	}
+	if err := os.WriteFile(manifestPath, []byte(`version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+    os: [darwin, linux]
+`), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("original user zshrc\n"), 0o600); err != nil {
+		t.Fatalf("write existing target: %v", err)
+	}
+
+	installOut, err := runRootCommand(t, "r\n",
+		"install",
+		"--file", manifestPath,
+		"--home", home,
+		"--source-root", sourceRoot,
+		"--state-root", stateRoot,
+		"--no-tui",
+	)
+	if err != nil {
+		t.Fatalf("install Execute() error = %v\n%s", err, installOut)
+	}
+
+	meta, err := backups.Load(backups.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load Backup Metadata after install: %v", err)
+	}
+	if len(meta.Sets) != 1 {
+		t.Fatalf("Backup Sets after install = %d, want 1", len(meta.Sets))
+	}
+	installSet := meta.Sets[0]
+	if installSet.Reason != "pre-install conflict protection" {
+		t.Fatalf("install Backup Set reason = %q", installSet.Reason)
+	}
+	if len(installSet.Targets) != 1 || installSet.Targets[0] != target {
+		t.Fatalf("install Backup Set targets = %#v, want [%q]", installSet.Targets, target)
+	}
+	preserved, err := os.ReadFile(backups.FilePath(stateRoot, installSet.ID, 1, target))
+	if err != nil {
+		t.Fatalf("read preserved install backup: %v", err)
+	}
+	if string(preserved) != "original user zshrc\n" {
+		t.Fatalf("install backup preserved %q, want original user content", preserved)
+	}
+
+	linkDest, err := os.Readlink(target)
+	if err != nil {
+		t.Fatalf("installed target is not a symlink: %v", err)
+	}
+	if linkDest != sourcePath {
+		t.Fatalf("installed symlink points to %q, want %q", linkDest, sourcePath)
+	}
+
+	restoreOut, err := runRootCommand(t, "",
+		"backups", "restore", installSet.ID,
+		"--home", home,
+		"--state-root", stateRoot,
+	)
+	if err != nil {
+		t.Fatalf("restore Execute() error = %v\n%s", err, restoreOut)
+	}
+
+	restored, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read restored target: %v", err)
+	}
+	if string(restored) != "original user zshrc\n" {
+		t.Fatalf("restored target = %q, want original user content", restored)
+	}
+
+	meta, err = backups.Load(backups.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load Backup Metadata after restore: %v", err)
+	}
+	if len(meta.Sets) != 2 {
+		t.Fatalf("Backup Sets after restore = %d, want install set + restore safety set", len(meta.Sets))
+	}
+	safetySet := meta.Sets[1]
+	if safetySet.ID == installSet.ID {
+		t.Fatalf("restore did not create a distinct safety Backup Set")
+	}
+	if safetySet.Reason != backups.RestoreSafetyReason {
+		t.Fatalf("restore safety reason = %q, want %q", safetySet.Reason, backups.RestoreSafetyReason)
+	}
+	safetyPreserved := backups.FilePath(stateRoot, safetySet.ID, 1, target)
+	safetyDest, err := os.Readlink(safetyPreserved)
+	if err != nil {
+		t.Fatalf("restore safety backup did not preserve current symlink: %v", err)
+	}
+	if safetyDest != sourcePath {
+		t.Fatalf("restore safety backup symlink points to %q, want %q", safetyDest, sourcePath)
+	}
+
+	if got, err := os.ReadFile(filepath.Join(realHomeSentinel, ".zshrc")); err != nil {
+		t.Fatalf("read real-home sentinel: %v", err)
+	} else if string(got) != "real home must stay untouched\n" {
+		t.Fatalf("real HOME sentinel changed to %q", got)
+	}
+	if _, err := os.Stat(filepath.Join(realHomeSentinel, ".local", "state", "dots")); !os.IsNotExist(err) {
+		t.Fatalf("real HOME state root was touched, stat err = %v", err)
+	}
+}
+
+func runRootCommand(t *testing.T, stdin string, args ...string) (string, error) {
+	t.Helper()
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetIn(strings.NewReader(stdin))
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), err
+}


### PR DESCRIPTION
Closes #80

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [x] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds a CLI-level sandbox regression test for install replacement and Backup Set restore safety.
- Allows `backups restore` to restore over managed symlink leaves while preserving target-inside-home and parent symlink-escape validation.
- Documents the sandbox validation journey and expected safety guarantees.

## Changes

| File | Change |
|------|--------|
| `internal/cli/install_restore_e2e_test.go` | Adds an end-to-end sandbox test covering install replace, backup creation, restore, pre-restore safety backup, and real `HOME` sentinel safety. |
| `internal/cli/backups.go` | Validates restore targets by lexical home containment and parent path safety so managed symlink leaves can be backed up and replaced safely. |
| `docs/backups.md` | Documents the sandbox validation scenario and backup/restore guarantees. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: covered by `TestInstallReplaceAndBackupRestoreEndToEndUsesSandbox` with temporary `--home`, `--source-root`, and `--state-root`.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
