### PR TITLE
feat(config): manage portable Warp configuration

### DIFF
--- a/configs/warp/README.md
+++ b/configs/warp/README.md
@@ -1,0 +1,85 @@
+# Warp configuration
+
+`configs/warp/settings.toml` and `configs/warp/keybindings.yaml` are the
+repository-managed Warp terminal preference slice. They are copied into stable
+channel config paths for macOS and Linux through the `desktop` profile.
+
+The Source of Truth is intentionally small: theme, terminal font family,
+terminal font size, and authored keybindings. Warp writes changes from its UI
+back into these live config files, so `dots` uses `copy` instead of `symlink` to
+prevent live Warp writes from mutating the repository source. Warp stores broader
+account, cloud, workspace, agent, session, cache, database, log, and generated
+runtime state near these files; that state is excluded from version control.
+
+## Managed paths
+
+| Platform | Source | Target |
+| --- | --- | --- |
+| macOS | `configs/warp/settings.toml` | `~/.warp/settings.toml` |
+| macOS | `configs/warp/keybindings.yaml` | `~/.warp/keybindings.yaml` |
+| Linux | `configs/warp/settings.toml` | `~/.config/warp-terminal/settings.toml` |
+| Linux | `configs/warp/keybindings.yaml` | `~/.config/warp-terminal/keybindings.yaml` |
+
+Preview channel paths and Windows paths are out of scope for this slice.
+
+## Portability classification
+
+The live Warp configuration must be classified before adoption:
+
+| Category | Examples | Repository decision |
+| --- | --- | --- |
+| **Portable** | selected built-in theme, terminal font family, terminal font size, intentional custom keybindings | Managed in `configs/warp/settings.toml` and `configs/warp/keybindings.yaml`. |
+| **Machine-specific** | custom theme absolute paths, shell overrides, working directories, window sizing, display ergonomics, OS integrations | Excluded unless a stable cross-platform representation is proven. |
+| **Account/cloud** | account state, Settings Sync state, cloud workspace state, authenticated agent or team state | Never committed. |
+| **Generated/runtime** | sessions, history, logs, caches, databases, Codebase Context indexes, MCP logs, temporary files | Never committed. |
+| **Private** | secrets, tokens, private paths, hostnames, machine IDs | Excluded. |
+
+Warp's documentation classifies `settings.toml` and `keybindings.yaml` as
+non-portable config because the complete live files can contain preferences that
+should not move between machines. `dots` manages only the authored portable
+subset above; do not adopt a full live Warp config without reviewing every key.
+If Warp later writes additional live settings, treat them as Drift and classify
+them before updating the repository source.
+
+The macOS entries intentionally do not declare a command dependency: Warp's
+Homebrew cask installs `Warp.app`, but does not install a stable `warp` binary on
+`PATH` by default. Until `dots` supports application-bundle dependency probes,
+macOS Warp presence is documented but not auto-detected.
+
+## Sandbox validation
+
+Validate Warp config changes with temporary directories only. Never run against
+the maintainer's real `$HOME` or live Warp configuration.
+
+```bash
+sandbox_root="$(mktemp -d)"
+sandbox_home="$sandbox_root/home"
+sandbox_state="$sandbox_root/state"
+sandbox_cache="$sandbox_root/cache"
+sandbox_gopath="$sandbox_root/gopath"
+sandbox_modcache="$sandbox_root/modcache"
+mkdir -p "$sandbox_home" "$sandbox_state" "$sandbox_cache" "$sandbox_gopath" "$sandbox_modcache"
+
+HOME="$sandbox_home" \
+GOCACHE="$sandbox_cache" \
+GOPATH="$sandbox_gopath" \
+GOMODCACHE="$sandbox_modcache" \
+XDG_CACHE_HOME="$sandbox_cache" \
+go run ./cmd/dots install \
+  --profile desktop \
+  --yes \
+  --home "$sandbox_home" \
+  --source-root "$PWD" \
+  --state-root "$sandbox_state"
+
+HOME="$sandbox_home" \
+GOCACHE="$sandbox_cache" \
+GOPATH="$sandbox_gopath" \
+GOMODCACHE="$sandbox_modcache" \
+XDG_CACHE_HOME="$sandbox_cache" \
+go run ./cmd/dots status \
+  --profile desktop \
+  --home "$sandbox_home" \
+  --source-root "$PWD" \
+  --state-root "$sandbox_state"
+```

--- a/configs/warp/keybindings.yaml
+++ b/configs/warp/keybindings.yaml
@@ -1,0 +1,6 @@
+# Warp portable keybindings managed by dots.
+#
+# This file contains only authored shortcuts that should follow the user across
+# supported desktop machines. Do not copy Warp's full generated/default keyset.
+---
+"input:clear_screen": alt-shift-K

--- a/configs/warp/settings.toml
+++ b/configs/warp/settings.toml
@@ -1,0 +1,12 @@
+# Warp portable preferences managed by dots.
+#
+# Keep this file intentionally small. Warp stores many account, cloud, agent,
+# session, and runtime preferences near this file; those are not part of the
+# repository-owned Source of Truth.
+
+[appearance.themes]
+theme = "dark"
+
+[appearance.text]
+font_name = "Cascadia Code NF"
+font_size = 20.0

--- a/dots.yaml
+++ b/dots.yaml
@@ -136,6 +136,40 @@ entries:
       - name: ghostty
         command: ghostty
         brew: ghostty
+  - source: configs/warp/settings.toml
+    target: ~/.warp/settings.toml
+    strategy: copy
+    tags:
+      - desktop
+    os:
+      - darwin
+  - source: configs/warp/keybindings.yaml
+    target: ~/.warp/keybindings.yaml
+    strategy: copy
+    tags:
+      - desktop
+    os:
+      - darwin
+  - source: configs/warp/settings.toml
+    target: ~/.config/warp-terminal/settings.toml
+    strategy: copy
+    tags:
+      - desktop
+    os:
+      - linux
+    dependencies:
+      - name: Warp
+        command: warp-terminal
+  - source: configs/warp/keybindings.yaml
+    target: ~/.config/warp-terminal/keybindings.yaml
+    strategy: copy
+    tags:
+      - desktop
+    os:
+      - linux
+    dependencies:
+      - name: Warp
+        command: warp-terminal
   - source: configs/atuin/config.toml
     target: ~/.config/atuin/config.toml
     strategy: symlink

--- a/internal/cli/warp_config_test.go
+++ b/internal/cli/warp_config_test.go
@@ -1,0 +1,184 @@
+package cli_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/cli"
+	"github.com/yersonargotev/dots/internal/manifest"
+)
+
+func TestWarpDesktopProfileInstallsAndReportsAlignedInSandbox(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	stubGentleAIProvisionerTools(t)
+
+	install := cli.NewRootCommand()
+	var installOut bytes.Buffer
+	install.SetOut(&installOut)
+	install.SetErr(&installOut)
+	install.SetArgs([]string{
+		"install",
+		"--file", filepath.Join(repoRoot, "dots.yaml"),
+		"--profile", "desktop",
+		"--source-root", repoRoot,
+		"--home", home,
+		"--state-root", stateRoot,
+		"--yes",
+	})
+
+	if err := install.Execute(); err != nil {
+		t.Fatalf("dots install failed in sandbox: %v\noutput:\n%s", err, installOut.String())
+	}
+
+	wantTargets := warpTargetsForOS(t, home)
+	for source, target := range wantTargets {
+		info, err := os.Lstat(target)
+		if err != nil {
+			t.Fatalf("warp target %s missing after sandbox install: %v\ninstall output:\n%s", target, err, installOut.String())
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			t.Fatalf("warp target %s mode = %v, want regular copy, not symlink", target, info.Mode())
+		}
+		if !info.Mode().IsRegular() {
+			t.Fatalf("warp target %s mode = %v, want regular copy", target, info.Mode())
+		}
+		wantSource := filepath.Join(repoRoot, filepath.FromSlash(source))
+		wantContent, err := os.ReadFile(wantSource)
+		if err != nil {
+			t.Fatalf("read warp source %s: %v", wantSource, err)
+		}
+		gotContent, err := os.ReadFile(target)
+		if err != nil {
+			t.Fatalf("read warp target %s: %v", target, err)
+		}
+		if string(gotContent) != string(wantContent) {
+			t.Fatalf("warp target %s content differs from source %s", target, wantSource)
+		}
+	}
+
+	managedSettings, err := os.ReadFile(filepath.Join(repoRoot, "configs", "warp", "settings.toml"))
+	if err != nil {
+		t.Fatalf("read managed warp settings: %v", err)
+	}
+	for _, want := range []string{
+		`theme = "dark"`,
+		`font_name = "Cascadia Code NF"`,
+		"font_size = 20.0",
+	} {
+		if !strings.Contains(string(managedSettings), want) {
+			t.Fatalf("managed warp settings missing %q", want)
+		}
+	}
+
+	managedKeybindings, err := os.ReadFile(filepath.Join(repoRoot, "configs", "warp", "keybindings.yaml"))
+	if err != nil {
+		t.Fatalf("read managed warp keybindings: %v", err)
+	}
+	if !strings.Contains(string(managedKeybindings), `"input:clear_screen": alt-shift-K`) {
+		t.Fatalf("managed warp keybindings missing clear-screen binding")
+	}
+
+	manifestFile, err := manifest.LoadFile(filepath.Join(repoRoot, "dots.yaml"))
+	if err != nil {
+		t.Fatalf("load dots manifest: %v", err)
+	}
+	wantEntries := map[string]map[string]bool{
+		"configs/warp/settings.toml": {
+			"~/.warp/settings.toml":                 false,
+			"~/.config/warp-terminal/settings.toml": false,
+		},
+		"configs/warp/keybindings.yaml": {
+			"~/.warp/keybindings.yaml":                 false,
+			"~/.config/warp-terminal/keybindings.yaml": false,
+		},
+	}
+	for i := range manifestFile.Entries {
+		entry := &manifestFile.Entries[i]
+		targets, ok := wantEntries[entry.Source]
+		if !ok {
+			continue
+		}
+		if _, ok := targets[entry.Target]; !ok {
+			continue
+		}
+		if entry.Strategy != "copy" {
+			t.Fatalf("Warp entry %s -> %s strategy = %q, want copy", entry.Source, entry.Target, entry.Strategy)
+		}
+		if !manifest.SharesTag(entry.Tags, []string{"desktop"}) {
+			t.Fatalf("Warp entry %s -> %s tags = %#v, want desktop", entry.Source, entry.Target, entry.Tags)
+		}
+		wantOS := "linux"
+		if strings.HasPrefix(entry.Target, "~/.warp/") {
+			wantOS = "darwin"
+		}
+		if len(entry.OS) != 1 || entry.OS[0] != wantOS {
+			t.Fatalf("Warp entry %s -> %s OS = %#v, want [%s]", entry.Source, entry.Target, entry.OS, wantOS)
+		}
+		targets[entry.Target] = true
+	}
+	for source, targets := range wantEntries {
+		for target, found := range targets {
+			if !found {
+				t.Fatalf("dots manifest missing Warp managed entry %s -> %s", source, target)
+			}
+		}
+	}
+
+	status := cli.NewRootCommand()
+	var statusOut bytes.Buffer
+	status.SetOut(&statusOut)
+	status.SetErr(&statusOut)
+	status.SetArgs([]string{
+		"status",
+		"--file", filepath.Join(repoRoot, "dots.yaml"),
+		"--profile", "desktop",
+		"--source-root", repoRoot,
+		"--home", home,
+		"--state-root", stateRoot,
+	})
+
+	if err := status.Execute(); err != nil {
+		t.Fatalf("dots status failed in sandbox: %v\noutput:\n%s", err, statusOut.String())
+	}
+
+	got := statusOut.String()
+	wantStatusLines := []string{"Summary:", "0 conflict"}
+	for source, target := range wantTargets {
+		wantStatusLines = append(wantStatusLines, source+" -> "+target)
+	}
+	for _, want := range wantStatusLines {
+		if !strings.Contains(got, want) {
+			t.Fatalf("status output missing %q\noutput:\n%s", want, got)
+		}
+	}
+}
+
+func warpTargetsForOS(t *testing.T, home string) map[string]string {
+	t.Helper()
+
+	switch runtime.GOOS {
+	case "darwin":
+		return map[string]string{
+			"configs/warp/settings.toml":    filepath.Join(home, ".warp", "settings.toml"),
+			"configs/warp/keybindings.yaml": filepath.Join(home, ".warp", "keybindings.yaml"),
+		}
+	case "linux":
+		return map[string]string{
+			"configs/warp/settings.toml":    filepath.Join(home, ".config", "warp-terminal", "settings.toml"),
+			"configs/warp/keybindings.yaml": filepath.Join(home, ".config", "warp-terminal", "keybindings.yaml"),
+		}
+	default:
+		t.Fatalf("unsupported OS for Warp managed entries: %s", runtime.GOOS)
+		return nil
+	}
+}


### PR DESCRIPTION
Closes #53

## PR Type

- [x] New feature (`type:feature`)

## Summary

- Manage a conservative, portable slice of Warp config (theme, terminal font family/size, authored keybindings) for the macOS and Linux desktop profiles.
- Use `strategy: copy` instead of `symlink` so Warp's live UI write-backs cannot mutate the repository Source of Truth or leak account/cloud/runtime/private state into version control.
- macOS entries omit a `command` dependency because the Homebrew cask installs `Warp.app` without a stable `warp` binary on `PATH`, which would otherwise yield a false "missing" in dependency checks.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Add four Warp Managed Entries (macOS `~/.warp/*`, Linux `~/.config/warp-terminal/*`) with `strategy: copy`, `desktop` tag, and per-OS filters. |
| `configs/warp/settings.toml` | Portable settings slice: theme, terminal font name/size. |
| `configs/warp/keybindings.yaml` | Authored portable keybinding (`input:clear_screen`). |
| `configs/warp/README.md` | Document the portable subset, the copy-vs-symlink rationale, managed paths, and sandbox validation. |
| `internal/cli/warp_config_test.go` | Sandbox e2e: install under `desktop` asserts regular-file copies (not symlinks) whose content matches source, correlates each target path to its OS filter at the manifest level, and verifies `dots status` reports aligned with 0 conflicts. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan/install/status under `--profile desktop` with `--home`/`--source-root`/`--state-root` temp dirs

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #53`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
