### PR TITLE
feat(gentle-ai): clean SDD before basic install

### DIFF
--- a/dots.yaml
+++ b/dots.yaml
@@ -297,14 +297,34 @@ provisioners:
     tags:
       - core
     spec:
-      scope: global
-      channel: stable
-      persona: neutral
-      sdd-mode: multi
+      action: uninstall
       agents:
         - codex
         - claude-code
         - opencode
+      components:
+        - sdd
+      yes: true
+    dependencies:
+      - name: gentle-ai
+        command: gentle-ai
+        brew: gentleman-programming/tap/gentle-ai
+  - tool: gentle-ai
+    tags:
+      - core
+    spec:
+      scope: global
+      channel: stable
+      persona: neutral
+      preset: custom
+      agents:
+        - codex
+        - claude-code
+      components:
+        - engram
+        - context7
+        - persona
+        - permissions
     dependencies:
       - name: gentle-ai
         command: gentle-ai

--- a/internal/cli/claude_config_test.go
+++ b/internal/cli/claude_config_test.go
@@ -33,7 +33,7 @@ func TestClaudeDefaultProfileSeedsUserBaselineInSandbox(t *testing.T) {
 	// so the test can assert the resolved provisioner command, not just the
 	// rendered plan. engram only needs to be present on PATH for the dep check.
 	stubDir := t.TempDir()
-	writeExecStub(t, filepath.Join(stubDir, "gentle-ai"), "#!/bin/sh\nprintf '%s' \"$*\" > \"$HOME/gentle-ai-args\"\ncase \" $* \" in\n  *\" --agents codex,claude-code,opencode \"*)\n    mkdir -p \"$HOME/.config/opencode\"\n    printf '{\"generated\":true}' > \"$HOME/.config/opencode/opencode.json\"\n    ;;\nesac\n")
+	writeExecStub(t, filepath.Join(stubDir, "gentle-ai"), "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$HOME/gentle-ai-args\"\n")
 	writeExecStub(t, filepath.Join(stubDir, "engram"), "#!/bin/sh\nexit 0\n")
 	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
@@ -159,21 +159,25 @@ func TestClaudeDefaultProfileSeedsUserBaselineInSandbox(t *testing.T) {
 		t.Fatalf("repo must not version the gentle-ai-rendered configs/opencode/opencode.json: %v", err)
 	}
 
-	// The provisioner must have run, threaded to the sandbox HOME, with all
-	// agents resolved on its argv — not merely shown in the rendered plan.
+	// The provisioner must have run, threaded to the sandbox HOME, with the
+	// basic non-SDD agent set resolved on its argv — not merely shown in the
+	// rendered plan.
 	gotArgs, err := os.ReadFile(filepath.Join(home, "gentle-ai-args"))
 	if err != nil {
 		t.Fatalf("provisioner did not run under the sandbox HOME %q: %v", home, err)
 	}
-	if !strings.Contains(string(gotArgs), "--agents codex,claude-code,opencode") {
-		t.Fatalf("provisioner argv = %q, want it to install agents codex,claude-code,opencode", gotArgs)
+	if !strings.Contains(string(gotArgs), "uninstall --agents codex,claude-code,opencode --components sdd --yes") {
+		t.Fatalf("provisioner argv = %q, want it to cleanup legacy SDD for codex,claude-code,opencode before install", gotArgs)
+	}
+	if !strings.Contains(string(gotArgs), "install --scope global --channel stable --persona neutral --preset custom --agents codex,claude-code") {
+		t.Fatalf("provisioner argv = %q, want it to install agents codex,claude-code", gotArgs)
+	}
+	if strings.Contains(string(gotArgs), "install --scope global --channel stable --persona neutral --preset custom --agents codex,claude-code,opencode") {
+		t.Fatalf("provisioner argv = %q, want basic install without opencode", gotArgs)
 	}
 	// And it must never have escaped into the inherited real HOME.
 	if _, err := os.Stat(filepath.Join(realHome, "gentle-ai-args")); err == nil {
 		t.Fatalf("provisioner wrote into the inherited HOME %q instead of the sandbox", realHome)
-	}
-	if _, err := os.Stat(filepath.Join(home, ".config", "opencode", "opencode.json")); err != nil {
-		t.Fatalf("OpenCode generated config did not land under the sandbox HOME %q: %v", home, err)
 	}
 	if _, err := os.Stat(filepath.Join(realHome, ".config", "opencode", "opencode.json")); err == nil {
 		t.Fatalf("OpenCode generated config escaped into the inherited HOME %q", realHome)
@@ -183,7 +187,7 @@ func TestClaudeDefaultProfileSeedsUserBaselineInSandbox(t *testing.T) {
 	for _, want := range []string{
 		"configs/claude/settings.json",
 		"configs/claude/statusline-command.sh",
-		"codex,claude-code,opencode",
+		"codex,claude-code",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("install output missing %q\noutput:\n%s", want, out)

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -46,18 +46,21 @@ type Provisioner struct {
 
 // ProvisionerSpec carries the declarative values dots owns for an allowlisted
 // tool; the tool owns how they render into agent config. The scalar/list flags
-// map 1:1 to gentle-ai's install flags. The Claude fields (Marketplace, Plugin,
+// map 1:1 to gentle-ai's install/uninstall flags. The Claude fields (Marketplace, Plugin,
 // From) describe a single idempotent `claude` invocation, and the codex MCP
 // fields (MCP, Command, Env) a single `codex mcp add` invocation. The three
 // dialects are mutually exclusive: a spec speaks exactly one of them.
 type ProvisionerSpec struct {
+	Action     string   `yaml:"action,omitempty"`
 	Scope      string   `yaml:"scope,omitempty"`
 	Channel    string   `yaml:"channel,omitempty"`
 	Persona    string   `yaml:"persona,omitempty"`
+	Preset     string   `yaml:"preset,omitempty"`
 	SDDMode    string   `yaml:"sdd-mode,omitempty"`
 	Agents     []string `yaml:"agents,omitempty"`
 	Components []string `yaml:"components,omitempty"`
 	Skills     []string `yaml:"skills,omitempty"`
+	Yes        bool     `yaml:"yes,omitempty"`
 	// Marketplace registers a Claude Code plugin marketplace from a source
 	// (GitHub repo, URL, or path), rendering `claude plugin marketplace add
 	// <source>`. The marketplace name is derived by Claude from the source.
@@ -266,6 +269,16 @@ func (m Manifest) Validate() error {
 			if prov.Spec.usesMCPFields() {
 				return fmt.Errorf("provisioners[%d].spec must not set codex MCP fields (mcp, command, env) for the gentle-ai tool", i)
 			}
+			action := strings.TrimSpace(prov.Spec.Action)
+			if !allowedGentleAIAction(action) {
+				return fmt.Errorf("provisioners[%d].spec.action must be one of install, uninstall", i)
+			}
+			if prov.Spec.Yes && action != "uninstall" {
+				return fmt.Errorf("provisioners[%d].spec.yes is only valid when action is uninstall", i)
+			}
+			if action == "uninstall" && prov.Spec.usesGentleAIInstallOnlyFlags() {
+				return fmt.Errorf("provisioners[%d].spec uninstall action must not set install-only fields (scope, channel, persona, preset, sdd-mode, skills)", i)
+			}
 			if persona := strings.TrimSpace(prov.Spec.Persona); persona != "" && !allowedPersona(persona) {
 				return fmt.Errorf("provisioners[%d].spec.persona must be one of gentleman, neutral", i)
 			}
@@ -335,13 +348,29 @@ func (s ProvisionerSpec) usesMCPFields() bool {
 
 // usesGentleAIFlags reports whether the spec sets any gentle-ai install flag.
 func (s ProvisionerSpec) usesGentleAIFlags() bool {
-	return strings.TrimSpace(s.Scope) != "" ||
+	return strings.TrimSpace(s.Action) != "" ||
+		strings.TrimSpace(s.Scope) != "" ||
 		strings.TrimSpace(s.Channel) != "" ||
 		strings.TrimSpace(s.Persona) != "" ||
+		strings.TrimSpace(s.Preset) != "" ||
 		strings.TrimSpace(s.SDDMode) != "" ||
 		hasNonEmptyString(s.Agents) ||
 		hasNonEmptyString(s.Components) ||
+		hasNonEmptyString(s.Skills) ||
+		s.Yes
+}
+
+func (s ProvisionerSpec) usesGentleAIInstallOnlyFlags() bool {
+	return strings.TrimSpace(s.Scope) != "" ||
+		strings.TrimSpace(s.Channel) != "" ||
+		strings.TrimSpace(s.Persona) != "" ||
+		strings.TrimSpace(s.Preset) != "" ||
+		strings.TrimSpace(s.SDDMode) != "" ||
 		hasNonEmptyString(s.Skills)
+}
+
+func allowedGentleAIAction(action string) bool {
+	return action == "" || action == "install" || action == "uninstall"
 }
 
 // validateClaudeSpec enforces the claude provisioner contract: it drives exactly

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -181,9 +181,11 @@ provisioners:
     tags: [core]
     os: [darwin, linux]
     spec:
+      action: install
       scope: global
       channel: stable
       persona: neutral
+      preset: custom
       sdd-mode: strict
       agents: [codex]
       components: [engram]
@@ -216,8 +218,8 @@ provisioners:
 	if !sameStrings(prov.OS, []string{"darwin", "linux"}) {
 		t.Fatalf("Provisioner.OS = %#v, want [darwin linux]", prov.OS)
 	}
-	if prov.Spec.Scope != "global" || prov.Spec.Channel != "stable" || prov.Spec.Persona != "neutral" || prov.Spec.SDDMode != "strict" {
-		t.Fatalf("Provisioner.Spec scalar flags = %#v, want global/stable/neutral/strict", prov.Spec)
+	if prov.Spec.Action != "install" || prov.Spec.Scope != "global" || prov.Spec.Channel != "stable" || prov.Spec.Persona != "neutral" || prov.Spec.Preset != "custom" || prov.Spec.SDDMode != "strict" || prov.Spec.Yes {
+		t.Fatalf("Provisioner.Spec scalar flags = %#v, want install/global/stable/neutral/custom/strict/no yes", prov.Spec)
 	}
 	if !sameStrings(prov.Spec.Agents, []string{"codex"}) {
 		t.Fatalf("Provisioner.Spec.Agents = %#v, want [codex]", prov.Spec.Agents)
@@ -386,6 +388,63 @@ func TestRepositoryManifestIncludesChromeDevToolsCodexProvisioner(t *testing.T) 
 	}
 	if !hasDependency(codex.Dependencies, "codex") {
 		t.Errorf("codex provisioner missing codex dependency: %#v", codex.Dependencies)
+	}
+}
+
+func TestRepositoryManifestIncludesGentleAICleanupBeforeBasicInstall(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", ".."))
+	manifestPath := filepath.Join(root, "dots.yaml")
+
+	got, err := manifest.LoadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("LoadFile(%q) error = %v", manifestPath, err)
+	}
+
+	var cleanup, install *manifest.Provisioner
+	for i := range got.Provisioners {
+		prov := &got.Provisioners[i]
+		if prov.Tool != "gentle-ai" {
+			continue
+		}
+		switch {
+		case cleanup == nil && prov.Spec.Action == "uninstall":
+			cleanup = prov
+		case install == nil && (prov.Spec.Action == "" || prov.Spec.Action == "install"):
+			install = prov
+		}
+	}
+
+	if cleanup == nil {
+		t.Fatal("repository manifest missing gentle-ai uninstall cleanup provisioner")
+	}
+	if install == nil {
+		t.Fatal("repository manifest missing gentle-ai basic install provisioner")
+	}
+	if cleanup.Spec.Yes != true {
+		t.Fatalf("gentle-ai cleanup yes = %v, want true", cleanup.Spec.Yes)
+	}
+	if !sameStrings(cleanup.Spec.Agents, []string{"codex", "claude-code", "opencode"}) {
+		t.Fatalf("gentle-ai cleanup agents = %#v, want [codex claude-code opencode]", cleanup.Spec.Agents)
+	}
+	if !sameStrings(cleanup.Spec.Components, []string{"sdd"}) {
+		t.Fatalf("gentle-ai cleanup components = %#v, want [sdd]", cleanup.Spec.Components)
+	}
+	if install.Spec.Preset != "custom" {
+		t.Fatalf("gentle-ai install preset = %q, want custom", install.Spec.Preset)
+	}
+	if !sameStrings(install.Spec.Agents, []string{"codex", "claude-code"}) {
+		t.Fatalf("gentle-ai install agents = %#v, want [codex claude-code]", install.Spec.Agents)
+	}
+	if !sameStrings(install.Spec.Components, []string{"engram", "context7", "persona", "permissions"}) {
+		t.Fatalf("gentle-ai install components = %#v, want [engram context7 persona permissions]", install.Spec.Components)
+	}
+	for i := range got.Provisioners {
+		if &got.Provisioners[i] == cleanup {
+			break
+		}
+		if &got.Provisioners[i] == install {
+			t.Fatal("gentle-ai install provisioner appears before cleanup")
+		}
 	}
 }
 
@@ -1072,6 +1131,38 @@ provisioners:
       persona: senior-architect
 `,
 			want: "provisioners[0].spec.persona must be one of gentleman, neutral",
+		},
+		{
+			name: "unsupported gentle-ai action",
+			provisioner: `  - tool: gentle-ai
+    tags: [core]
+    spec:
+      action: sync
+`,
+			want: "provisioners[0].spec.action must be one of install, uninstall",
+		},
+		{
+			name: "yes without uninstall action",
+			provisioner: `  - tool: gentle-ai
+    tags: [core]
+    spec:
+      preset: custom
+      yes: true
+`,
+			want: "provisioners[0].spec.yes is only valid when action is uninstall",
+		},
+		{
+			name: "uninstall action rejects install-only fields",
+			provisioner: `  - tool: gentle-ai
+    tags: [core]
+    spec:
+      action: uninstall
+      scope: global
+      agents: [codex]
+      components: [sdd]
+      yes: true
+`,
+			want: "provisioners[0].spec uninstall action must not set install-only fields (scope, channel, persona, preset, sdd-mode, skills)",
 		},
 		{
 			name: "whitespace-only agents list is missing spec",

--- a/internal/provision/provision.go
+++ b/internal/provision/provision.go
@@ -27,18 +27,27 @@ func RenderCommand(p manifest.Provisioner) (executable string, args []string) {
 	}
 }
 
-// renderGentleAIArgs renders `install` plus gentle-ai's flags in a deterministic
-// order; unset scalar flags and empty list flags are omitted, and list values
-// are comma-joined.
+// renderGentleAIArgs renders the selected gentle-ai action plus its flags in a
+// deterministic order; unset scalar flags and empty list flags are omitted, and
+// list values are comma-joined. The action defaults to install for existing
+// manifests that only declare install flags.
 func renderGentleAIArgs(spec manifest.ProvisionerSpec) []string {
-	args := []string{"install"}
+	action := strings.TrimSpace(spec.Action)
+	if action == "" {
+		action = "install"
+	}
+	args := []string{action}
 	args = appendScalarFlag(args, "--scope", spec.Scope)
 	args = appendScalarFlag(args, "--channel", spec.Channel)
 	args = appendScalarFlag(args, "--persona", spec.Persona)
+	args = appendScalarFlag(args, "--preset", spec.Preset)
 	args = appendScalarFlag(args, "--sdd-mode", spec.SDDMode)
 	args = appendListFlag(args, "--agents", spec.Agents)
 	args = appendListFlag(args, "--components", spec.Components)
 	args = appendListFlag(args, "--skills", spec.Skills)
+	if spec.Yes {
+		args = append(args, "--yes")
+	}
 	return args
 }
 

--- a/internal/provision/provision_test.go
+++ b/internal/provision/provision_test.go
@@ -23,6 +23,7 @@ func TestRenderCommand(t *testing.T) {
 					Scope:      "global",
 					Channel:    "stable",
 					Persona:    "neutral",
+					Preset:     "custom",
 					SDDMode:    "strict",
 					Agents:     []string{"codex", "claude"},
 					Components: []string{"engram", "sdd"},
@@ -35,6 +36,7 @@ func TestRenderCommand(t *testing.T) {
 				"--scope", "global",
 				"--channel", "stable",
 				"--persona", "neutral",
+				"--preset", "custom",
 				"--sdd-mode", "strict",
 				"--agents", "codex,claude",
 				"--components", "engram,sdd",
@@ -54,6 +56,20 @@ func TestRenderCommand(t *testing.T) {
 			wantArgs: []string{"install", "--scope", "global", "--agents", "codex"},
 		},
 		{
+			name: "uninstall renders action with cleanup flags",
+			prov: manifest.Provisioner{
+				Tool: "gentle-ai",
+				Spec: manifest.ProvisionerSpec{
+					Action:     "uninstall",
+					Agents:     []string{"codex", "claude-code"},
+					Components: []string{"sdd"},
+					Yes:        true,
+				},
+			},
+			wantExec: "gentle-ai",
+			wantArgs: []string{"uninstall", "--agents", "codex,claude-code", "--components", "sdd", "--yes"},
+		},
+		{
 			name: "persona only",
 			prov: manifest.Provisioner{
 				Tool: "gentle-ai",
@@ -61,6 +77,15 @@ func TestRenderCommand(t *testing.T) {
 			},
 			wantExec: "gentle-ai",
 			wantArgs: []string{"install", "--persona", "gentleman"},
+		},
+		{
+			name: "preset only",
+			prov: manifest.Provisioner{
+				Tool: "gentle-ai",
+				Spec: manifest.ProvisionerSpec{Preset: "custom"},
+			},
+			wantExec: "gentle-ai",
+			wantArgs: []string{"install", "--preset", "custom"},
 		},
 		{
 			name: "whitespace scalars and list entries are trimmed and dropped",


### PR DESCRIPTION
Closes #125

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds a gentle-ai provisioner `action` so dots can render both `install` and `uninstall` flows.
- Adds validation for uninstall-only cleanup shape and keeps existing provisioners defaulting to install.
- Updates the repository manifest and sandbox CLI coverage so SDD cleanup runs before the basic custom install.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Adds SDD cleanup provisioner before the basic custom gentle-ai install. |
| `internal/manifest/manifest.go` | Adds `action`, `preset`, and `yes` schema/validation support for gentle-ai provisioners. |
| `internal/provision/provision.go` | Renders selected gentle-ai action with deterministic flags and default install behavior. |
| `internal/manifest/manifest_test.go` | Covers manifest parsing, repository cleanup ordering, and invalid action combinations. |
| `internal/provision/provision_test.go` | Covers uninstall rendering and preset rendering. |
| `internal/cli/claude_config_test.go` | Proves cleanup then install execute under sandbox HOME. |

## Test Plan

- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp> --state-root <tmp> --output json`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #125`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
