### PR TITLE
docs(provisioners): document gentle-ai cleanup actions

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -205,7 +205,7 @@ The ordered construction plan for the Dotfiles CLI, starting with the project sk
 _Avoid_: roadmap, build order, task list
 
 **Provisioner**:
-An allowlisted external agent-configuration tool the Dotfiles CLI drives declaratively after Dependencies and Managed Entries are in place. dots versions only the invocation — the tool plus its declarative spec — and renders it into one exact, idempotent command (such as a `gentle-ai install`, a `claude plugin install`, or a `codex mcp add`). It never versions the Regenerated Content the tool owns. The allowlist is closed, so dots is never a generic command runner.
+An allowlisted external agent-configuration tool the Dotfiles CLI drives declaratively after Dependencies and Managed Entries are in place. dots versions only the invocation — the tool plus its declarative spec — and renders it into one exact, idempotent command (such as a `gentle-ai install`, a `gentle-ai uninstall`, a `claude plugin install`, or a `codex mcp add`). It never versions the Regenerated Content the tool owns. The allowlist is closed, so dots is never a generic command runner.
 _Avoid_: hook, post-install script, command runner
 
 **Provisioner Spec**:

--- a/docs/update.md
+++ b/docs/update.md
@@ -9,7 +9,7 @@
 3. **Fast-forwards only.** `update` fetches the upstream and advances the branch with `git merge --ff-only`. If the branch has diverged from its upstream, it cannot be fast-forwarded; `update` reports the divergence and asks you to resolve it manually with Git. It never performs an automatic merge or rebase.
 4. **Recomputes the Install Plan.** After the fast-forward, the manifest is loaded from the updated repository (so a manifest change pulled from upstream is honored) and a fresh Install Plan is computed against the current workstation state, surfacing any new Conflicts or Drift.
 5. **Applies safely.** The post-update install resolves conflicts exactly like `dots install`: interactive TUI by default, text prompts with `--no-tui`, or the conservative skip default with `--yes`. Any `replace` still creates a [Backup Set](../CONTEXT.md) before touching an existing target.
-6. **Runs provisioners.** After the file plan is applied, `update` runs the same provisioners `install` would for the active profile, so provisioner-managed agent configuration (gentle-ai regen, Claude plugins, Codex MCP server) stays aligned with the Source of Truth. Provisioners run only when the file apply was not canceled; a `--dry-run` renders the Provisioners plan section without executing anything. If conflict resolution is canceled, the whole run aborts before any provisioner can mutate tool-managed config.
+6. **Runs provisioners.** After the file plan is applied, `update` runs the same provisioners `install` would for the active profile, so provisioner-managed agent configuration (gentle-ai cleanup/install, Claude plugins, Codex MCP server) stays aligned with the Source of Truth. Provisioners run in manifest order, which allows a cleanup command to run before an install command. Provisioners run only when the file apply was not canceled; a `--dry-run` renders the Provisioners plan section without executing anything. If conflict resolution is canceled, the whole run aborts before any provisioner can mutate tool-managed config.
 
 ## Versioning model
 
@@ -64,6 +64,25 @@ Because no fast-forward is applied in a dry run, the rendered plan reflects the 
 ## Profiles and provisioners
 
 Provisioners are scoped by profile tags, exactly like file entries. The `default` profile selects only `core`-tagged provisioners (gentle-ai); the chrome-devtools integration for Claude, Codex, and the OpenCode overlay is tagged `desktop` and is only provisioned under `--profile desktop`. This is design-intent — chrome-devtools drives a real browser and does not belong in headless or server installs.
+
+The gentle-ai provisioner can model cleanup before install by using separate entries in manifest order. Missing `action` still defaults to `install`; `yes` is only valid for `uninstall` because it confirms a cleanup action:
+
+```yaml
+provisioners:
+  - tool: gentle-ai
+    tags: [core]
+    spec:
+      action: uninstall
+      agents: [codex, claude-code, opencode]
+      components: [sdd]
+      yes: true
+  - tool: gentle-ai
+    tags: [core]
+    spec:
+      preset: custom
+      agents: [codex, claude-code]
+      components: [engram, context7, persona, permissions]
+```
 
 To keep that requirement discoverable, both `install` and `update` print a one-line hint when the active profile skips provisioners another profile would select on this OS:
 


### PR DESCRIPTION
Closes #127

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [x] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Documents `gentle-ai uninstall` as part of the Provisioner contract.
- Explains that provisioners run in manifest order, enabling cleanup before install.
- Adds a focused YAML example for gentle-ai SDD cleanup followed by custom basic install.

## Changes

| File | Change |
|------|--------|
| `CONTEXT.md` | Adds `gentle-ai uninstall` to Provisioner examples. |
| `docs/update.md` | Documents cleanup/install ordering and the gentle-ai cleanup schema. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go build ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [ ] Sandboxed plan only when dotfiles behavior changes: not applicable; docs-only change.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #127`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
