### PR TITLE
fix(gentle-ai): avoid codex gentle-dev permissions

### DIFF
--- a/dots.yaml
+++ b/dots.yaml
@@ -319,6 +319,26 @@ provisioners:
       preset: custom
       agents:
         - codex
+      components:
+        - engram
+        - context7
+        - persona
+    dependencies:
+      - name: gentle-ai
+        command: gentle-ai
+        brew: gentleman-programming/tap/gentle-ai
+      - name: engram
+        command: engram
+        brew: gentleman-programming/tap/engram
+  - tool: gentle-ai
+    tags:
+      - core
+    spec:
+      scope: global
+      channel: stable
+      persona: neutral
+      preset: custom
+      agents:
         - claude-code
       components:
         - engram

--- a/internal/cli/claude_config_test.go
+++ b/internal/cli/claude_config_test.go
@@ -169,8 +169,14 @@ func TestClaudeDefaultProfileSeedsUserBaselineInSandbox(t *testing.T) {
 	if !strings.Contains(string(gotArgs), "uninstall --agents codex,claude-code,opencode --components sdd --yes") {
 		t.Fatalf("provisioner argv = %q, want it to cleanup legacy SDD for codex,claude-code,opencode before install", gotArgs)
 	}
-	if !strings.Contains(string(gotArgs), "install --scope global --channel stable --persona neutral --preset custom --agents codex,claude-code") {
-		t.Fatalf("provisioner argv = %q, want it to install agents codex,claude-code", gotArgs)
+	if !strings.Contains(string(gotArgs), "install --scope global --channel stable --persona neutral --preset custom --agents codex --components engram,context7,persona") {
+		t.Fatalf("provisioner argv = %q, want codex install without permissions", gotArgs)
+	}
+	if !strings.Contains(string(gotArgs), "install --scope global --channel stable --persona neutral --preset custom --agents claude-code --components engram,context7,persona,permissions") {
+		t.Fatalf("provisioner argv = %q, want claude-code install with permissions", gotArgs)
+	}
+	if strings.Contains(string(gotArgs), "--agents codex --components engram,context7,persona,permissions") {
+		t.Fatalf("provisioner argv = %q, want codex install without permissions because it installs gentle-dev", gotArgs)
 	}
 	if strings.Contains(string(gotArgs), "install --scope global --channel stable --persona neutral --preset custom --agents codex,claude-code,opencode") {
 		t.Fatalf("provisioner argv = %q, want basic install without opencode", gotArgs)
@@ -187,7 +193,8 @@ func TestClaudeDefaultProfileSeedsUserBaselineInSandbox(t *testing.T) {
 	for _, want := range []string{
 		"configs/claude/settings.json",
 		"configs/claude/statusline-command.sh",
-		"codex,claude-code",
+		"--agents codex --components engram,context7,persona",
+		"--agents claude-code --components engram,context7,persona,permissions",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("install output missing %q\noutput:\n%s", want, out)

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -400,7 +400,7 @@ func TestRepositoryManifestIncludesGentleAICleanupBeforeBasicInstall(t *testing.
 		t.Fatalf("LoadFile(%q) error = %v", manifestPath, err)
 	}
 
-	var cleanup, install *manifest.Provisioner
+	var cleanup, codexInstall, claudeInstall *manifest.Provisioner
 	for i := range got.Provisioners {
 		prov := &got.Provisioners[i]
 		if prov.Tool != "gentle-ai" {
@@ -409,16 +409,21 @@ func TestRepositoryManifestIncludesGentleAICleanupBeforeBasicInstall(t *testing.
 		switch {
 		case cleanup == nil && prov.Spec.Action == "uninstall":
 			cleanup = prov
-		case install == nil && (prov.Spec.Action == "" || prov.Spec.Action == "install"):
-			install = prov
+		case codexInstall == nil && sameStrings(prov.Spec.Agents, []string{"codex"}):
+			codexInstall = prov
+		case claudeInstall == nil && sameStrings(prov.Spec.Agents, []string{"claude-code"}):
+			claudeInstall = prov
 		}
 	}
 
 	if cleanup == nil {
 		t.Fatal("repository manifest missing gentle-ai uninstall cleanup provisioner")
 	}
-	if install == nil {
-		t.Fatal("repository manifest missing gentle-ai basic install provisioner")
+	if codexInstall == nil {
+		t.Fatal("repository manifest missing gentle-ai codex basic install provisioner")
+	}
+	if claudeInstall == nil {
+		t.Fatal("repository manifest missing gentle-ai claude basic install provisioner")
 	}
 	if cleanup.Spec.Yes != true {
 		t.Fatalf("gentle-ai cleanup yes = %v, want true", cleanup.Spec.Yes)
@@ -429,20 +434,26 @@ func TestRepositoryManifestIncludesGentleAICleanupBeforeBasicInstall(t *testing.
 	if !sameStrings(cleanup.Spec.Components, []string{"sdd"}) {
 		t.Fatalf("gentle-ai cleanup components = %#v, want [sdd]", cleanup.Spec.Components)
 	}
-	if install.Spec.Preset != "custom" {
-		t.Fatalf("gentle-ai install preset = %q, want custom", install.Spec.Preset)
+	if codexInstall.Spec.Preset != "custom" {
+		t.Fatalf("gentle-ai codex install preset = %q, want custom", codexInstall.Spec.Preset)
 	}
-	if !sameStrings(install.Spec.Agents, []string{"codex", "claude-code"}) {
-		t.Fatalf("gentle-ai install agents = %#v, want [codex claude-code]", install.Spec.Agents)
+	if !sameStrings(codexInstall.Spec.Components, []string{"engram", "context7", "persona"}) {
+		t.Fatalf("gentle-ai codex install components = %#v, want [engram context7 persona]", codexInstall.Spec.Components)
 	}
-	if !sameStrings(install.Spec.Components, []string{"engram", "context7", "persona", "permissions"}) {
-		t.Fatalf("gentle-ai install components = %#v, want [engram context7 persona permissions]", install.Spec.Components)
+	if hasString(codexInstall.Spec.Components, "permissions") {
+		t.Fatalf("gentle-ai codex install components = %#v, must not include permissions because it installs gentle-dev", codexInstall.Spec.Components)
+	}
+	if claudeInstall.Spec.Preset != "custom" {
+		t.Fatalf("gentle-ai claude install preset = %q, want custom", claudeInstall.Spec.Preset)
+	}
+	if !sameStrings(claudeInstall.Spec.Components, []string{"engram", "context7", "persona", "permissions"}) {
+		t.Fatalf("gentle-ai claude install components = %#v, want [engram context7 persona permissions]", claudeInstall.Spec.Components)
 	}
 	for i := range got.Provisioners {
 		if &got.Provisioners[i] == cleanup {
 			break
 		}
-		if &got.Provisioners[i] == install {
+		if &got.Provisioners[i] == codexInstall || &got.Provisioners[i] == claudeInstall {
 			t.Fatal("gentle-ai install provisioner appears before cleanup")
 		}
 	}


### PR DESCRIPTION
Closes #129

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Split the default gentle-ai install into separate Codex and Claude Code provisioners.
- Keep Codex on `engram,context7,persona` so it does not install the `permissions` component that creates `gentle-dev`.
- Preserve Claude Code permissions installation and add regression assertions for the split commands.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Splits the combined Codex/Claude gentle-ai install so Codex omits `permissions` and Claude Code keeps it. |
| `internal/manifest/manifest_test.go` | Asserts the repository manifest has separate Codex and Claude Code install provisioners and that Codex excludes `permissions`. |
| `internal/cli/claude_config_test.go` | Updates sandbox install assertions to expect the split gentle-ai commands. |

## Test Plan

- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp>`
- [x] Dry-run checked provisioner commands: `go run ./cmd/dots install --profile default --source-root "$PWD" --dry-run --no-tui`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory for this PR change.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #129`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
