### PR TITLE
docs(manifest): document supported configuration

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -1,0 +1,201 @@
+# Install Manifest Configuration
+
+`dots.yaml` is the Install Manifest: the reviewable contract that tells `dots`
+which Managed Configuration to install, which Dependencies to check, and which
+allowlisted Provisioners to run.
+
+Use this page when reviewing a manifest change. It shows both the supported
+configuration surface and the configuration currently declared by this repository.
+
+## Supported manifest shape
+
+```yaml
+version: 1
+profiles: {}
+entries: []
+provisioners: []
+```
+
+| Field | Required | Meaning |
+|-------|----------|---------|
+| `version` | Yes | Manifest schema version. Only `1` is supported. |
+| `profiles` | Yes | Named installation selections. A Profile selects entries and provisioners by matching tags. |
+| `entries` | Yes | Managed Entries that install repository-owned files or directories into `$HOME`. |
+| `provisioners` | No | Allowlisted external tool invocations run after file entries are installed. |
+
+Unknown YAML fields are rejected during manifest loading.
+
+## Profiles
+
+A Profile is selected by commands such as `dots plan`, `dots install`,
+`dots status`, and `dots deps check`.
+
+| Field | Required | Supported values |
+|-------|----------|------------------|
+| `tags` | Yes | Non-empty strings. Entries and Provisioners are selected when at least one tag matches. |
+| `dependencies` | No | Profile-level Dependencies, using the same dependency fields as entries. |
+
+Current Profiles:
+
+| Profile | Tags | Profile Dependencies |
+|---------|------|----------------------|
+| `default` | `core` | None |
+| `desktop` | `core`, `desktop` | `Desktop Nerd Font` via Homebrew cask `font-cascadia-code-nf`, detected with `CascadiaCodeNF*` |
+
+## Managed Entries
+
+A Managed Entry declares one repository source and one target under `$HOME`.
+Targets must be `~` or `~/...`; `dots` rejects targets that escape the selected
+home directory.
+
+| Field | Required | Supported values |
+|-------|----------|------------------|
+| `source` | Yes | Repository-relative path to Managed Configuration. |
+| `target` | Yes | Home-relative target: `~` or `~/...`. |
+| `strategy` | Yes | `symlink`, `copy`, or `template` in the manifest schema. Current install execution supports `symlink` and `copy`. |
+| `ownership` | No | Empty, or `json-subset`. `json-subset` requires `strategy: copy`. |
+| `tags` | Yes | Non-empty strings matched against the selected Profile. |
+| `os` | No | `darwin`, `linux`; empty means all supported operating systems. |
+| `dependencies` | No | Entry-level Dependencies. |
+
+Current Managed Entries:
+
+| Source | Target | Strategy | Tags | OS | Dependencies |
+|--------|--------|----------|------|----|--------------|
+| `configs/zsh/zshrc` | `~/.zshrc` | `symlink` | `core` | `darwin`, `linux` | `zsh` |
+| `configs/zsh/zimrc` | `~/.zimrc` | `symlink` | `core` | `darwin`, `linux` | `zsh` |
+| `configs/zsh/zshenv` | `~/.zshenv` | `symlink` | `core` | `darwin`, `linux` | `zsh` |
+| `configs/git/gitconfig` | `~/.gitconfig` | `symlink` | `core` | `darwin`, `linux` | `git` |
+| `configs/starship/starship.toml` | `~/.config/starship.toml` | `symlink` | `core` | `darwin`, `linux` | `starship` |
+| `configs/tmux/tmux.conf` | `~/.tmux.conf` | `symlink` | `core` | `darwin`, `linux` | `tmux` |
+| `configs/zellij/config.kdl` | `~/.config/zellij/config.kdl` | `symlink` | `core` | `darwin`, `linux` | `zellij` |
+| `configs/zellij/layouts/default.kdl` | `~/.config/zellij/layouts/default.kdl` | `symlink` | `core` | `darwin`, `linux` | `zellij` |
+| `configs/ghostty/config.ghostty` | `~/.config/ghostty/config.ghostty` | `symlink` | `desktop` | `darwin`, `linux` | `ghostty` |
+| `configs/warp/settings.toml` | `~/.warp/settings.toml` | `copy` | `desktop` | `darwin` | None |
+| `configs/warp/keybindings.yaml` | `~/.warp/keybindings.yaml` | `copy` | `desktop` | `darwin` | None |
+| `configs/warp/settings.toml` | `~/.config/warp-terminal/settings.toml` | `copy` | `desktop` | `linux` | `Warp` |
+| `configs/warp/keybindings.yaml` | `~/.config/warp-terminal/keybindings.yaml` | `copy` | `desktop` | `linux` | `Warp` |
+| `configs/atuin/config.toml` | `~/.config/atuin/config.toml` | `symlink` | `core` | `darwin`, `linux` | `atuin` |
+| `configs/atuin/themes/catppuccin-mocha.toml` | `~/.config/atuin/themes/catppuccin-mocha.toml` | `symlink` | `core` | `darwin`, `linux` | `atuin` |
+| `configs/bat/config` | `~/.config/bat/config` | `symlink` | `core` | `darwin`, `linux` | `bat` |
+| `configs/nvim` | `~/.config/nvim` | `symlink` | `core` | `darwin`, `linux` | `neovim` |
+| `configs/zed/settings.json` | `~/.config/zed/settings.json` | `symlink` | `desktop` | `darwin`, `linux` | `zed` |
+| `configs/zed/keymap.json` | `~/.config/zed/keymap.json` | `symlink` | `desktop` | `darwin`, `linux` | `zed` |
+| `configs/zed/themes/catppuccin-blue.json` | `~/.config/zed/themes/catppuccin-blue.json` | `symlink` | `desktop` | `darwin`, `linux` | `zed` |
+| `configs/claude/settings.json` | `~/.claude/settings.json` | `copy` | `core` | `darwin`, `linux` | None; owns JSON subset |
+| `configs/claude/statusline-command.sh` | `~/.claude/statusline-command.sh` | `copy` | `core` | `darwin`, `linux` | None |
+| `configs/opencode/mcp.json` | `~/.config/opencode-dots.json` | `symlink` | `desktop` | `darwin`, `linux` | `opencode` |
+
+## Dependencies
+
+Dependencies can be declared on Profiles, Managed Entries, and Provisioners.
+They are detection and installation guidance, not arbitrary shell hooks.
+
+| Field | Required | Meaning |
+|-------|----------|---------|
+| `name` | Yes | Human-readable dependency name. Also used as the executable probe when `command` is omitted. |
+| `command` | No | Executable name to probe on `PATH`. |
+| `brew` | No | Homebrew formula token. Mutually exclusive with `brew_cask`. |
+| `brew_cask` | No | Homebrew cask token. Renders as `brew install --cask <token>`. |
+| `apt` | No | Debian/Ubuntu package name. |
+| `dnf` | No | Fedora package name. |
+| `pacman` | No | Arch package name. |
+| `font_match` | No | Installed-font filename glob used for Font Dependencies. |
+| `font_fallback_matches` | No | Additional filename globs that can satisfy the same Font Dependency. |
+
+Current dependency package coverage:
+
+| Dependency | Detection | macOS/Homebrew | Debian/Ubuntu | Fedora | Arch |
+|------------|-----------|----------------|---------------|--------|------|
+| `Desktop Nerd Font` | Font glob `CascadiaCodeNF*` | `brew install --cask font-cascadia-code-nf` | Manual | Manual | Manual |
+| `zsh` | `zsh` | `zsh` | `zsh` | `zsh` | `zsh` |
+| `git` | `git` | `git` | `git` | `git` | `git` |
+| `starship` | `starship` | `starship` | `starship` | `starship` | `starship` |
+| `tmux` | `tmux` | `tmux` | `tmux` | `tmux` | `tmux` |
+| `zellij` | `zellij` | `zellij` | `zellij` | `zellij` | `zellij` |
+| `ghostty` | `ghostty` | `ghostty` | Manual | Manual | Manual |
+| `Warp` | `warp-terminal` | Manual | Manual | Manual | Manual |
+| `atuin` | `atuin` | `atuin` | Manual | Manual | Manual |
+| `bat` | `bat` | `bat` | `bat` | `bat` | `bat` |
+| `neovim` | `nvim` | `neovim` | `neovim` | `neovim` | `neovim` |
+| `zed` | `zed` | `zed` | Manual | Manual | Manual |
+| `opencode` | `opencode` | Manual | Manual | Manual | Manual |
+| `gentle-ai` | `gentle-ai` | `gentleman-programming/tap/gentle-ai` | Manual | Manual | Manual |
+| `engram` | `engram` | `gentleman-programming/tap/engram` | Manual | Manual | Manual |
+| `claude` | `claude` | Manual | Manual | Manual | Manual |
+| `codex` | `codex` | Manual | Manual | Manual | Manual |
+| `codegraph` | `codegraph` | Manual | Manual | Manual | Manual |
+
+## Provisioners
+
+Provisioners are a closed allowlist. They run after selected Managed Entries are
+installed and only after their declared Dependencies are present.
+
+| Field | Required | Supported values |
+|-------|----------|------------------|
+| `tool` | Yes | `gentle-ai`, `claude`, or `codex`. |
+| `tags` | Yes | Non-empty strings matched against the selected Profile. |
+| `os` | No | `darwin`, `linux`; empty means all supported operating systems. |
+| `spec` | Yes | Tool-specific declaration. Each spec must speak exactly one tool dialect. |
+| `dependencies` | No | Dependencies required before running the Provisioner. |
+
+### `gentle-ai` spec
+
+Supported fields: `action`, `scope`, `channel`, `persona`, `preset`, `sdd-mode`,
+`agents`, `components`, `skills`, and `yes`.
+
+Constraints:
+
+- `action` may be `install`, `uninstall`, or omitted. Omitted defaults to `install`.
+- `persona` may be `gentleman` or `neutral`.
+- `yes` is only valid with `action: uninstall`.
+- `uninstall` must not set install-only fields: `scope`, `channel`, `persona`,
+  `preset`, `sdd-mode`, or `skills`.
+
+### `claude` spec
+
+Supported shapes:
+
+- `marketplace: <source>` renders a marketplace registration.
+- `plugin: <name>` plus `from: <marketplace>` renders a plugin install.
+
+Claude specs must not mix gentle-ai fields or Codex MCP fields.
+
+### `codex` spec
+
+Supported fields: `mcp`, `command`, and `env`.
+
+Constraints:
+
+- `mcp` is required.
+- `command` must contain at least one non-empty argument.
+- `env` keys must not be empty.
+- Codex specs must not mix gentle-ai or Claude fields.
+
+Current Provisioners:
+
+| Tool | Tags | OS | Rendered intent | Dependencies |
+|------|------|----|-----------------|--------------|
+| `gentle-ai` | `core` | all | Uninstall `sdd` for `codex`, `claude-code`, and `opencode` with `--yes`. | `gentle-ai` |
+| `gentle-ai` | `core` | all | Install global stable neutral custom setup for `codex` with `engram`, `context7`, and `persona`. | `gentle-ai`, `engram` |
+| `gentle-ai` | `core` | all | Install global stable neutral custom setup for `claude-code` with `engram`, `context7`, `persona`, and `permissions`. | `gentle-ai`, `engram` |
+| `claude` | `desktop` | `darwin`, `linux` | Register marketplace `ChromeDevTools/chrome-devtools-mcp`. | `claude` |
+| `claude` | `desktop` | `darwin`, `linux` | Install `chrome-devtools-mcp` from `chrome-devtools-plugins` with user scope. | `claude` |
+| `codex` | `desktop` | `darwin`, `linux` | Add MCP server `chrome-devtools` using `npx -y chrome-devtools-mcp@latest --no-performance-crux`. | `codex` |
+| `codex` | `desktop` | `darwin`, `linux` | Add MCP server `codegraph` using `codegraph serve --mcp`. | `codex`, `codegraph` |
+
+## Selection rules
+
+1. The chosen Profile provides tags.
+2. A Managed Entry or Provisioner is selected when any of its tags matches the Profile tags.
+3. If `os` is empty, the item matches all supported operating systems.
+4. If `os` is set, the item only matches the current OS (`darwin` or `linux`).
+5. Selected Managed Entries are installed before selected Provisioners run.
+
+## Related docs
+
+- [`CONTEXT.md`](../CONTEXT.md) defines the domain vocabulary.
+- [`docs/scope.md`](scope.md) explains why the MVP Configuration Set is intentionally bounded.
+- [`docs/adr/0003-claude-plugin-provisioner.md`](adr/0003-claude-plugin-provisioner.md) records the Claude plugin provisioner decision.
+- [`docs/adr/0004-codex-mcp-provisioner.md`](adr/0004-codex-mcp-provisioner.md) records the Codex MCP provisioner decision.
+- [`docs/adr/0005-opencode-mcp-config-overlay.md`](adr/0005-opencode-mcp-config-overlay.md) records the OpenCode config overlay decision.

--- a/docs/scope.md
+++ b/docs/scope.md
@@ -83,7 +83,7 @@ v1 distribution starts with GitHub Release Artifacts plus Checksum Verification 
 
 ### The MVP Configuration Set keeps the feedback loop tight
 
-The bounded `dots.yaml` manifest is enough to prove symlink, template, copy, Local Extension Point, dependency, status, backup, conflict, and desktop-profile behavior. Pulling generated editor state, machine-local state, secrets, runtime caches, or non-portable app configuration into v1 would blur whether failures come from installer design or application-specific complexity.
+The bounded [`dots.yaml` manifest](manifest.md) is enough to prove symlink, template, copy, Local Extension Point, dependency, status, backup, conflict, and desktop-profile behavior. Pulling generated editor state, machine-local state, secrets, runtime caches, or non-portable app configuration into v1 would blur whether failures come from installer design or application-specific complexity.
 
 ## Alignment references
 


### PR DESCRIPTION
Closes #131

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [x] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds `docs/manifest.md` as the single reference for supported `dots.yaml` configuration.
- Documents current Profiles, Managed Entries, Dependencies, and Provisioners configured by this repository.
- Links `docs/scope.md` to the new Install Manifest reference from the MVP Configuration Set section.

## Changes

| File | Change |
|------|--------|
| `docs/manifest.md` | Documents supported manifest fields, constrained values, current managed config, dependencies, provisioners, and selection rules. |
| `docs/scope.md` | Links the bounded `dots.yaml` manifest mention to the new documentation page. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [ ] `go run ./cmd/dots manifest validate --file dots.yaml` — skipped; there is no manifest subcommand in this repo.
- [ ] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp>` — skipped; documentation-only change.
- [x] Markdown links checked by local Python script.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #131`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
