### PR TITLE
fix(install): load shared manifest on first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ The Bootstrapper:
 1. Detects the current Supported Platform.
 2. Downloads the matching GitHub Release Artifact and `checksums.txt` from the latest release by default.
 3. Performs Checksum Verification before installing the binary to `~/.local/bin/dots`.
-4. Clones the Source of Truth to `~/.local/share/dots` when the default Installed Repository is missing.
+4. Clones the Source of Truth to `~/.local/share/dots` when the default Installed Repository is missing or empty, using `DOTS_VERSION` as the Git ref when pinned.
 5. Runs `dots install` so the Dotfiles CLI owns the Install Plan and file changes.
 
-Set `DOTS_VERSION=v0.x.y` only when you intentionally need to pin a specific release. Use `DOTS_SOURCE_ROOT=/path/to/checkout` for development checkouts.
+Set `DOTS_VERSION=v0.x.y` only when you intentionally need to pin a specific release; the default Source of Truth clone uses that tag too. Use `DOTS_REPOSITORY_REF=<ref>` only when the binary release and Source of Truth ref must differ. Use `DOTS_SOURCE_ROOT=/path/to/checkout` for development checkouts.
 
 Requirements: `curl` or `wget`, `sha256sum` or `shasum`, plus `git` for first-time bootstrap cloning. Make sure `~/.local/bin` is on your `PATH` after install.
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ The Bootstrapper:
 1. Detects the current Supported Platform.
 2. Downloads the matching GitHub Release Artifact and `checksums.txt` from the latest release by default.
 3. Performs Checksum Verification before installing the binary to `~/.local/bin/dots`.
-4. Runs `dots install` so the Dotfiles CLI owns the Install Plan and file changes.
+4. Clones the Source of Truth to `~/.local/share/dots` when the default Installed Repository is missing.
+5. Runs `dots install` so the Dotfiles CLI owns the Install Plan and file changes.
 
-Set `DOTS_VERSION=v0.x.y` only when you intentionally need to pin a specific release.
+Set `DOTS_VERSION=v0.x.y` only when you intentionally need to pin a specific release. Use `DOTS_SOURCE_ROOT=/path/to/checkout` for development checkouts.
 
-Requirements: `curl` or `wget`, plus `sha256sum` or `shasum`. Make sure `~/.local/bin` is on your `PATH` after install.
+Requirements: `curl` or `wget`, `sha256sum` or `shasum`, plus `git` for first-time bootstrap cloning. Make sure `~/.local/bin` is on your `PATH` after install.
 
 ### Homebrew
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -101,7 +101,7 @@ Install the latest published v0.x release with the checksum-verified Bootstrappe
 curl -fsSL https://raw.githubusercontent.com/yersonargotev/dots/main/scripts/install.sh | bash
 ```
 
-The Bootstrapper downloads `checksums.txt` and the matching platform artifact from the latest GitHub Release by default, verifies the SHA-256 checksum, installs the executable as `~/.local/bin/dots`, and then uses that tested binary for setup. Before any real-home install, verify the installed binary version:
+The Bootstrapper downloads `checksums.txt` and the matching platform artifact from the latest GitHub Release by default, verifies the SHA-256 checksum, installs the executable as `~/.local/bin/dots`, clones the Source of Truth to `~/.local/share/dots` when needed, and then uses that tested binary for setup. Before any real-home install, verify the installed binary version:
 
 ```bash
 ~/.local/bin/dots --version

--- a/docs/release.md
+++ b/docs/release.md
@@ -101,7 +101,7 @@ Install the latest published v0.x release with the checksum-verified Bootstrappe
 curl -fsSL https://raw.githubusercontent.com/yersonargotev/dots/main/scripts/install.sh | bash
 ```
 
-The Bootstrapper downloads `checksums.txt` and the matching platform artifact from the latest GitHub Release by default, verifies the SHA-256 checksum, installs the executable as `~/.local/bin/dots`, clones the Source of Truth to `~/.local/share/dots` when needed, and then uses that tested binary for setup. Before any real-home install, verify the installed binary version:
+The Bootstrapper downloads `checksums.txt` and the matching platform artifact from the latest GitHub Release by default, verifies the SHA-256 checksum, installs the executable as `~/.local/bin/dots`, clones the Source of Truth to `~/.local/share/dots` when needed, and then uses that tested binary for setup. When `DOTS_VERSION=vX.Y.Z` is pinned, the default Source of Truth clone uses the same Git ref; `latest` keeps using the repository default branch. Before any real-home install, verify the installed binary version:
 
 ```bash
 ~/.local/bin/dots --version
@@ -114,7 +114,7 @@ For development checkouts, pass the Installed Repository override through the Bo
 DOTS_VERSION=v0.5.1 DOTS_SOURCE_ROOT="$PWD" bash scripts/install.sh
 ```
 
-`DOTS_VERSION` is optional. Use it only when you intentionally need to pin or test a specific release tag.
+`DOTS_VERSION` is optional. Use it only when you intentionally need to pin or test a specific release tag. Set `DOTS_REPOSITORY_REF` only when the release artifact and Source of Truth ref intentionally differ.
 
 ## Release details
 

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -87,12 +87,15 @@ func TestBootstrapperDelegatesWithoutSourceRootForDefaultInstalledRepository(t *
 	server := httptest.NewServer(http.FileServer(http.Dir(releaseRoot)))
 	t.Cleanup(server.Close)
 
+	sourceRepo := newBootstrapSourceRepo(t)
+	home := t.TempDir()
 	cmd := exec.Command("bash", filepath.Join(root, "scripts", "install.sh"))
 	cmd.Dir = root
 	cmd.Env = append(os.Environ(),
-		"HOME="+t.TempDir(),
+		"HOME="+home,
 		"DOTS_VERSION="+version,
 		"DOTS_RELEASE_BASE_URL="+server.URL,
+		"DOTS_REPOSITORY_URL="+sourceRepo,
 		"DOTS_INSTALL_DIR="+filepath.Join(t.TempDir(), "bin"),
 		"DOTS_OS=linux",
 		"DOTS_ARCH=arm64",
@@ -108,6 +111,9 @@ func TestBootstrapperDelegatesWithoutSourceRootForDefaultInstalledRepository(t *
 	}
 	if strings.TrimSpace(string(gotArgs)) != "install" {
 		t.Fatalf("delegated args = %q, want %q", strings.TrimSpace(string(gotArgs)), "install")
+	}
+	if _, err := os.Stat(filepath.Join(home, ".local", "share", "dots", "dots.yaml")); err != nil {
+		t.Fatalf("expected bootstrapper to clone default Installed Repository: %v\noutput:\n%s", err, output)
 	}
 }
 
@@ -136,6 +142,7 @@ func TestBootstrapperDefaultsToLatestReleaseArtifactWhenVersionIsUnset(t *testin
 		"HOME="+t.TempDir(),
 		"DOTS_RELEASE_BASE_URL="+server.URL,
 		"DOTS_INSTALL_DIR="+installDir,
+		"DOTS_SOURCE_ROOT="+filepath.Join(t.TempDir(), "checkout"),
 		"DOTS_OS=darwin",
 		"DOTS_ARCH=arm64",
 	)
@@ -156,8 +163,8 @@ func TestBootstrapperDefaultsToLatestReleaseArtifactWhenVersionIsUnset(t *testin
 	if err != nil {
 		t.Fatalf("expected bootstrapper to delegate to installed dots: %v\noutput:\n%s", err, output)
 	}
-	if strings.TrimSpace(string(gotArgs)) != "install" {
-		t.Fatalf("delegated args = %q, want %q", strings.TrimSpace(string(gotArgs)), "install")
+	if got := strings.TrimSpace(string(gotArgs)); !strings.HasPrefix(got, "install --source-root ") {
+		t.Fatalf("delegated args = %q, want install with explicit source root", got)
 	}
 }
 
@@ -278,6 +285,7 @@ func TestBootstrapperSelectsSupportedReleaseArtifacts(t *testing.T) {
 				"DOTS_VERSION="+version,
 				"DOTS_RELEASE_BASE_URL="+server.URL,
 				"DOTS_INSTALL_DIR="+installDir,
+				"DOTS_SOURCE_ROOT="+filepath.Join(t.TempDir(), "checkout"),
 				"DOTS_OS="+tt.os,
 				"DOTS_ARCH="+tt.arch,
 			)
@@ -289,6 +297,30 @@ func TestBootstrapperSelectsSupportedReleaseArtifacts(t *testing.T) {
 				t.Fatalf("bootstrap should download %s, got:\n%s", tt.artifact, output)
 			}
 		})
+	}
+}
+
+func newBootstrapSourceRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required for bootstrap source clone test")
+	}
+	repo := t.TempDir()
+	runBootstrapGit(t, repo, "init", "-b", "main")
+	runBootstrapGit(t, repo, "config", "user.email", "dots@test.local")
+	runBootstrapGit(t, repo, "config", "user.name", "dots test")
+	writeFile(t, filepath.Join(repo, "dots.yaml"), "version: 1\nprofiles: {default: {tags: [core]}}\nentries: []\n", 0o600)
+	runBootstrapGit(t, repo, "add", "dots.yaml")
+	runBootstrapGit(t, repo, "commit", "-m", "initial")
+	return repo
+}
+
+func runBootstrapGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, output)
 	}
 }
 

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -117,6 +117,143 @@ func TestBootstrapperDelegatesWithoutSourceRootForDefaultInstalledRepository(t *
 	}
 }
 
+func TestBootstrapperClonesPinnedVersionRefForDefaultInstalledRepository(t *testing.T) {
+	root := repoRoot(t)
+	version := "v0.99.0"
+	artifact := "dots_v0.99.0_linux_arm64"
+	releaseRoot := t.TempDir()
+	versionDir := filepath.Join(releaseRoot, version)
+	if err := os.MkdirAll(versionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	logPath := filepath.Join(t.TempDir(), "dots-args.log")
+	artifactBody := fmt.Sprintf("#!/usr/bin/env bash\nset -euo pipefail\nprintf '%%s\\n' \"$*\" > %q\n", logPath)
+	writeFile(t, filepath.Join(versionDir, artifact), artifactBody, 0o644)
+	writeFile(t, filepath.Join(versionDir, "checksums.txt"), fmt.Sprintf("%s  %s\n", sha256Hex([]byte(artifactBody)), artifact), 0o644)
+
+	server := httptest.NewServer(http.FileServer(http.Dir(releaseRoot)))
+	t.Cleanup(server.Close)
+
+	sourceRepo := newBootstrapSourceRepo(t)
+	writeFile(t, filepath.Join(sourceRepo, "dots.yaml"), "version: 1\nprofiles: {default: {tags: [main]}}\nentries: []\n", 0o600)
+	runBootstrapGit(t, sourceRepo, "add", "dots.yaml")
+	runBootstrapGit(t, sourceRepo, "commit", "-m", "main change")
+
+	home := t.TempDir()
+	cmd := exec.Command("bash", filepath.Join(root, "scripts", "install.sh"))
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(),
+		"HOME="+home,
+		"DOTS_VERSION="+version,
+		"DOTS_RELEASE_BASE_URL="+server.URL,
+		"DOTS_REPOSITORY_URL="+sourceRepo,
+		"DOTS_INSTALL_DIR="+filepath.Join(t.TempDir(), "bin"),
+		"DOTS_OS=linux",
+		"DOTS_ARCH=arm64",
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bootstrap install failed: %v\n%s", err, output)
+	}
+
+	manifest, err := os.ReadFile(filepath.Join(home, ".local", "share", "dots", "dots.yaml"))
+	if err != nil {
+		t.Fatalf("expected cloned manifest: %v\noutput:\n%s", err, output)
+	}
+	if strings.Contains(string(manifest), "main") || !strings.Contains(string(manifest), "core") {
+		t.Fatalf("cloned manifest should come from %s tag, got:\n%s", version, manifest)
+	}
+}
+
+func TestBootstrapperRecoversEmptyDefaultInstalledRepository(t *testing.T) {
+	root := repoRoot(t)
+	version := "v0.99.0"
+	artifact := "dots_v0.99.0_linux_arm64"
+	releaseRoot := t.TempDir()
+	versionDir := filepath.Join(releaseRoot, version)
+	if err := os.MkdirAll(versionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	logPath := filepath.Join(t.TempDir(), "dots-args.log")
+	artifactBody := fmt.Sprintf("#!/usr/bin/env bash\nset -euo pipefail\nprintf '%%s\\n' \"$*\" > %q\n", logPath)
+	writeFile(t, filepath.Join(versionDir, artifact), artifactBody, 0o644)
+	writeFile(t, filepath.Join(versionDir, "checksums.txt"), fmt.Sprintf("%s  %s\n", sha256Hex([]byte(artifactBody)), artifact), 0o644)
+
+	server := httptest.NewServer(http.FileServer(http.Dir(releaseRoot)))
+	t.Cleanup(server.Close)
+
+	sourceRepo := newBootstrapSourceRepo(t)
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".local", "share", "dots"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("bash", filepath.Join(root, "scripts", "install.sh"))
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(),
+		"HOME="+home,
+		"DOTS_VERSION="+version,
+		"DOTS_RELEASE_BASE_URL="+server.URL,
+		"DOTS_REPOSITORY_URL="+sourceRepo,
+		"DOTS_INSTALL_DIR="+filepath.Join(t.TempDir(), "bin"),
+		"DOTS_OS=linux",
+		"DOTS_ARCH=arm64",
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bootstrap install failed: %v\n%s", err, output)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".local", "share", "dots", "dots.yaml")); err != nil {
+		t.Fatalf("expected bootstrapper to replace empty Installed Repository: %v\noutput:\n%s", err, output)
+	}
+}
+
+func TestBootstrapperRejectsNonRecoverableDefaultInstalledRepository(t *testing.T) {
+	root := repoRoot(t)
+	version := "v0.99.0"
+	artifact := "dots_v0.99.0_linux_arm64"
+	releaseRoot := t.TempDir()
+	versionDir := filepath.Join(releaseRoot, version)
+	if err := os.MkdirAll(versionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	logPath := filepath.Join(t.TempDir(), "dots-args.log")
+	artifactBody := fmt.Sprintf("#!/usr/bin/env bash\nset -euo pipefail\nprintf '%%s\\n' \"$*\" > %q\n", logPath)
+	writeFile(t, filepath.Join(versionDir, artifact), artifactBody, 0o644)
+	writeFile(t, filepath.Join(versionDir, "checksums.txt"), fmt.Sprintf("%s  %s\n", sha256Hex([]byte(artifactBody)), artifact), 0o644)
+
+	server := httptest.NewServer(http.FileServer(http.Dir(releaseRoot)))
+	t.Cleanup(server.Close)
+
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".local", "share", "dots", "partial.txt"), "partial clone\n", 0o600)
+
+	cmd := exec.Command("bash", filepath.Join(root, "scripts", "install.sh"))
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(),
+		"HOME="+home,
+		"DOTS_VERSION="+version,
+		"DOTS_RELEASE_BASE_URL="+server.URL,
+		"DOTS_REPOSITORY_URL="+newBootstrapSourceRepo(t),
+		"DOTS_INSTALL_DIR="+filepath.Join(t.TempDir(), "bin"),
+		"DOTS_OS=linux",
+		"DOTS_ARCH=arm64",
+	)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("bootstrap should reject non-recoverable Installed Repository\n%s", output)
+	}
+	if !strings.Contains(string(output), "does not contain a valid dots.yaml") {
+		t.Fatalf("non-recoverable Installed Repository should be explained, got:\n%s", output)
+	}
+	if _, err := os.Stat(logPath); !os.IsNotExist(err) {
+		t.Fatalf("non-recoverable Installed Repository should not delegate to dots install; stat error: %v", err)
+	}
+}
+
 func TestBootstrapperDefaultsToLatestReleaseArtifactWhenVersionIsUnset(t *testing.T) {
 	root := repoRoot(t)
 	version := "v0.99.1"
@@ -312,6 +449,7 @@ func newBootstrapSourceRepo(t *testing.T) string {
 	writeFile(t, filepath.Join(repo, "dots.yaml"), "version: 1\nprofiles: {default: {tags: [core]}}\nentries: []\n", 0o600)
 	runBootstrapGit(t, repo, "add", "dots.yaml")
 	runBootstrapGit(t, repo, "commit", "-m", "initial")
+	runBootstrapGit(t, repo, "tag", "v0.99.0")
 	return repo
 }
 
@@ -319,6 +457,10 @@ func runBootstrapGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_CONFIG_GLOBAL="+os.DevNull,
+		"GIT_CONFIG_NOSYSTEM=1",
+	)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git %v failed: %v\n%s", args, err, output)
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1732,3 +1732,116 @@ func TestBackupsListCommandRejectsDefaultMetadataLeafSymlinkEscapeBeforeReadingM
 		t.Fatal("backups list Execute() error = nil, want Backup Metadata leaf symlink escape error")
 	}
 }
+
+func TestCommandsLoadDefaultManifestFromInstalledRepository(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Chdir(t.TempDir())
+
+	sourceRoot := filepath.Join(home, ".local", "share", "dots")
+	writeCLIInstalledRepository(t, sourceRoot, `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+    os: [darwin, linux]
+`)
+
+	for _, tt := range []struct {
+		name         string
+		args         []string
+		want         string
+		wantFindings bool
+	}{
+		{
+			name: "plan",
+			args: []string{"plan", "--home", home},
+			want: "Summary: 1 create, 0 conflict, 0 unchanged, 0 missing-source",
+		},
+		{
+			name: "install dry run",
+			args: []string{"install", "--dry-run", "--home", home},
+			want: "Summary: 1 create, 0 conflict, 0 unchanged, 0 missing-source",
+		},
+		{
+			name:         "status",
+			args:         []string{"status", "--home", home},
+			want:         "missing",
+			wantFindings: true,
+		},
+		{
+			name:         "doctor",
+			args:         []string{"doctor", "--home", home},
+			want:         `Doctor for profile "default"`,
+			wantFindings: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := cli.NewRootCommand()
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+			if tt.wantFindings {
+				requireFindings(t, err)
+			} else if err != nil {
+				t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+			}
+			if got := out.String(); !strings.Contains(got, tt.want) {
+				t.Fatalf("output missing %q\noutput:\n%s", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestDepsCommandsLoadDefaultManifestFromInstalledRepository(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+	t.Chdir(t.TempDir())
+
+	sourceRoot := filepath.Join(home, ".local", "share", "dots")
+	writeCLIInstalledRepository(t, sourceRoot, `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+    dependencies:
+      - name: absenttool
+`)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"deps", "check", "--home", home})
+
+	requireFindings(t, cmd.Execute())
+	if got := out.String(); !strings.Contains(got, "missing  absenttool") {
+		t.Fatalf("deps check did not load default manifest from Installed Repository\noutput:\n%s", got)
+	}
+}
+
+func writeCLIInstalledRepository(t *testing.T, sourceRoot, manifestContent string) {
+	t.Helper()
+	srcPath := filepath.Join(sourceRoot, "configs/zsh/zshrc")
+	if err := os.MkdirAll(filepath.Dir(srcPath), 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	if err := os.WriteFile(srcPath, []byte("export A=1\n"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceRoot, "dots.yaml"), []byte(manifestContent), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1800,7 +1800,7 @@ entries:
 	}
 }
 
-func TestDepsCommandsLoadDefaultManifestFromInstalledRepository(t *testing.T) {
+func TestDepsReadCommandsLoadDefaultManifestFromInstalledRepository(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("PATH", t.TempDir())
@@ -1820,15 +1820,34 @@ entries:
       - name: absenttool
 `)
 
-	cmd := cli.NewRootCommand()
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"deps", "check", "--home", home})
+	for _, tt := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "check",
+			args: []string{"deps", "check", "--home", home},
+			want: "missing  absenttool",
+		},
+		{
+			name: "plan",
+			args: []string{"deps", "plan", "--home", home},
+			want: "absenttool",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := cli.NewRootCommand()
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs(tt.args)
 
-	requireFindings(t, cmd.Execute())
-	if got := out.String(); !strings.Contains(got, "missing  absenttool") {
-		t.Fatalf("deps check did not load default manifest from Installed Repository\noutput:\n%s", got)
+			requireFindings(t, cmd.Execute())
+			if got := out.String(); !strings.Contains(got, tt.want) {
+				t.Fatalf("deps %s did not load default manifest from Installed Repository\noutput:\n%s", tt.name, got)
+			}
+		})
 	}
 }
 

--- a/internal/cli/deps.go
+++ b/internal/cli/deps.go
@@ -45,7 +45,7 @@ func newDepsCheckCommand(profile *string) *cobra.Command {
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			resolvedHome := resolveDepsHome(home)
-			m, err := manifest.LoadFile(resolveManifestPath(cmd, file, defaultSourceRoot(resolvedHome)))
+			m, err := loadDepsManifest(cmd, file, resolvedHome)
 			if err != nil {
 				return err
 			}
@@ -86,7 +86,7 @@ func newDepsPlanCommand(profile *string) *cobra.Command {
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			resolvedHome := resolveDepsHome(home)
-			m, err := manifest.LoadFile(resolveManifestPath(cmd, file, defaultSourceRoot(resolvedHome)))
+			m, err := loadDepsManifest(cmd, file, resolvedHome)
 			if err != nil {
 				return err
 			}
@@ -133,7 +133,7 @@ func newDepsInstallCommand(profile *string) *cobra.Command {
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			resolvedHome, _ := os.UserHomeDir()
-			m, err := manifest.LoadFile(resolveManifestPath(cmd, file, defaultSourceRoot(resolvedHome)))
+			m, err := loadDepsManifest(cmd, file, resolvedHome)
 			if err != nil {
 				return err
 			}
@@ -197,6 +197,10 @@ func newDepsInstallCommand(profile *string) *cobra.Command {
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview dependency install actions without executing package managers")
 	cmd.Flags().BoolVar(&yes, "yes", false, "execute dependency install actions without interactive confirmation")
 	return cmd
+}
+
+func loadDepsManifest(cmd *cobra.Command, file, home string) (*manifest.Manifest, error) {
+	return manifest.LoadFile(resolveManifestPath(cmd, file, defaultSourceRoot(home)))
 }
 
 func runDepsInstall(cmd *cobra.Command, m manifest.Manifest, options deps.Options, tier deps.Tier) error {

--- a/internal/cli/deps.go
+++ b/internal/cli/deps.go
@@ -44,7 +44,8 @@ func newDepsCheckCommand(profile *string) *cobra.Command {
 		// misuse of the command, so do not dump the usage block on failure.
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			m, err := manifest.LoadFile(file)
+			resolvedHome := resolveDepsHome(home)
+			m, err := manifest.LoadFile(resolveManifestPath(cmd, file, defaultSourceRoot(resolvedHome)))
 			if err != nil {
 				return err
 			}
@@ -52,7 +53,7 @@ func newDepsCheckCommand(profile *string) *cobra.Command {
 			report, err := deps.Check(*m, deps.Options{
 				Profile: *profile,
 				OS:      runtime.GOOS,
-			}, lookupCommand, fontInstalled(runtime.GOOS, resolveDepsHome(home)))
+			}, lookupCommand, fontInstalled(runtime.GOOS, resolvedHome))
 			if err != nil {
 				return err
 			}
@@ -84,7 +85,8 @@ func newDepsPlanCommand(profile *string) *cobra.Command {
 		// not misuse of the command, so do not dump the usage block on failure.
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			m, err := manifest.LoadFile(file)
+			resolvedHome := resolveDepsHome(home)
+			m, err := manifest.LoadFile(resolveManifestPath(cmd, file, defaultSourceRoot(resolvedHome)))
 			if err != nil {
 				return err
 			}
@@ -97,7 +99,7 @@ func newDepsPlanCommand(profile *string) *cobra.Command {
 			report, err := deps.Plan(*m, deps.Options{
 				Profile: *profile,
 				OS:      runtime.GOOS,
-			}, lookupCommand, fontInstalled(runtime.GOOS, resolveDepsHome(home)), resolvedTier)
+			}, lookupCommand, fontInstalled(runtime.GOOS, resolvedHome), resolvedTier)
 			if err != nil {
 				return err
 			}
@@ -130,7 +132,8 @@ func newDepsInstallCommand(profile *string) *cobra.Command {
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			m, err := manifest.LoadFile(file)
+			resolvedHome, _ := os.UserHomeDir()
+			m, err := manifest.LoadFile(resolveManifestPath(cmd, file, defaultSourceRoot(resolvedHome)))
 			if err != nil {
 				return err
 			}
@@ -145,8 +148,7 @@ func newDepsInstallCommand(profile *string) *cobra.Command {
 				OS:      runtime.GOOS,
 			}
 
-			home, _ := os.UserHomeDir()
-			report, err := deps.InstallDryRun(*m, options, lookupCommand, fontInstalled(runtime.GOOS, home), resolvedTier)
+			report, err := deps.InstallDryRun(*m, options, lookupCommand, fontInstalled(runtime.GOOS, resolvedHome), resolvedTier)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -27,12 +27,12 @@ func newDoctorCommand() *cobra.Command {
 		// misuse of the command, so do not dump the usage block on failure.
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			m, err := manifest.LoadFile(file)
+			paths, err := resolvePaths(home, sourceRoot, stateRoot)
 			if err != nil {
 				return err
 			}
 
-			paths, err := resolvePaths(home, sourceRoot, stateRoot)
+			m, err := manifest.LoadFile(resolveManifestPath(cmd, file, paths.SourceRoot))
 			if err != nil {
 				return err
 			}

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -38,12 +38,12 @@ func newInstallCommand() *cobra.Command {
 		// Domain installation failures are user-facing conflicts, not command misuse.
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			m, err := manifest.LoadFile(file)
+			paths, err := resolvePaths(home, sourceRoot, stateRoot)
 			if err != nil {
 				return err
 			}
 
-			paths, err := resolvePaths(home, sourceRoot, stateRoot)
+			m, err := manifest.LoadFile(resolveManifestPath(cmd, file, paths.SourceRoot))
 			if err != nil {
 				return err
 			}

--- a/internal/cli/paths.go
+++ b/internal/cli/paths.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/spf13/cobra"
 )
 
 type resolvedPaths struct {
@@ -42,4 +44,16 @@ func defaultSourceRoot(home string) string {
 // Installation Metadata (installed.json) is recorded.
 func defaultStateRoot(home string) string {
 	return filepath.Join(home, ".local", "state", "dots")
+}
+
+// resolveManifestPath returns the Install Manifest path for a command. When
+// --file is omitted, the manifest belongs to the Installed Repository instead
+// of the caller's current directory, so a released binary can use the shared
+// Source of Truth at ~/.local/share/dots/dots.yaml from any cwd. Explicit
+// --file values keep normal caller-relative behavior for development and tests.
+func resolveManifestPath(cmd *cobra.Command, file, sourceRoot string) string {
+	if cmd.Flags().Changed("file") {
+		return file
+	}
+	return filepath.Join(sourceRoot, file)
 }

--- a/internal/cli/plan.go
+++ b/internal/cli/plan.go
@@ -25,12 +25,12 @@ func newPlanCommand() *cobra.Command {
 		// misuse of the command, so do not dump the usage block on failure.
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			m, err := manifest.LoadFile(file)
+			paths, err := resolvePaths(home, sourceRoot, stateRoot)
 			if err != nil {
 				return err
 			}
 
-			paths, err := resolvePaths(home, sourceRoot, stateRoot)
+			m, err := manifest.LoadFile(resolveManifestPath(cmd, file, paths.SourceRoot))
 			if err != nil {
 				return err
 			}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -28,12 +28,12 @@ func newStatusCommand() *cobra.Command {
 		// misuse of the command, so do not dump the usage block on failure.
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			m, err := manifest.LoadFile(file)
+			paths, err := resolvePaths(home, sourceRoot, stateRoot)
 			if err != nil {
 				return err
 			}
 
-			paths, err := resolvePaths(home, sourceRoot, stateRoot)
+			m, err := manifest.LoadFile(resolveManifestPath(cmd, file, paths.SourceRoot))
 			if err != nil {
 				return err
 			}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,6 +8,7 @@ Install the dots CLI from a checksum-verified GitHub Release Artifact, then dele
 Environment:
   DOTS_VERSION           Release tag to install, for example v0.x.y. Defaults to latest.
   DOTS_RELEASE_BASE_URL  Release asset base URL. Defaults to https://github.com/yersonargotev/dots/releases/download.
+  DOTS_REPOSITORY_URL    Source of Truth Git URL. Defaults to https://github.com/yersonargotev/dots.git.
   DOTS_INSTALL_DIR       Directory where the dots command is installed. Defaults to ~/.local/bin.
   DOTS_SOURCE_ROOT       Optional development checkout/Installed Repository override passed to dots install.
   DOTS_OS                Test override for platform OS detection.
@@ -29,7 +30,9 @@ version="${DOTS_VERSION:-latest}"
 default_release_base_url="https://github.com/yersonargotev/dots/releases/download"
 release_base_url="${DOTS_RELEASE_BASE_URL:-$default_release_base_url}"
 install_dir="${DOTS_INSTALL_DIR:-$HOME/.local/bin}"
-source_root="${DOTS_SOURCE_ROOT:-}"
+repository_url="${DOTS_REPOSITORY_URL:-https://github.com/yersonargotev/dots.git}"
+source_root="${DOTS_SOURCE_ROOT:-$HOME/.local/share/dots}"
+source_root_explicit="${DOTS_SOURCE_ROOT:-}"
 
 case "${DOTS_OS:-$(uname -s)}" in
   Darwin|darwin) goos="darwin" ;;
@@ -114,8 +117,22 @@ install -m 0755 "$artifact_path" "$install_path"
 
 echo "Installed dots to $install_path"
 
+if [[ -z "$source_root_explicit" ]]; then
+  if [[ -e "$source_root" && ! -d "$source_root" ]]; then
+    fail "default Installed Repository path exists but is not a directory: $source_root"
+  fi
+  if [[ ! -d "$source_root" ]]; then
+    if ! command -v git >/dev/null 2>&1; then
+      fail "git is required to clone the Source of Truth into $source_root"
+    fi
+    mkdir -p "$(dirname "$source_root")"
+    echo "Cloning Source of Truth to $source_root"
+    git clone --depth 1 "$repository_url" "$source_root"
+  fi
+fi
+
 args=(install)
-if [[ -n "$source_root" ]]; then
+if [[ -n "$source_root_explicit" ]]; then
   args+=(--source-root "$source_root")
 fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,6 +9,7 @@ Environment:
   DOTS_VERSION           Release tag to install, for example v0.x.y. Defaults to latest.
   DOTS_RELEASE_BASE_URL  Release asset base URL. Defaults to https://github.com/yersonargotev/dots/releases/download.
   DOTS_REPOSITORY_URL    Source of Truth Git URL. Defaults to https://github.com/yersonargotev/dots.git.
+  DOTS_REPOSITORY_REF    Optional Source of Truth Git ref. Defaults to DOTS_VERSION when pinned; default branch for latest.
   DOTS_INSTALL_DIR       Directory where the dots command is installed. Defaults to ~/.local/bin.
   DOTS_SOURCE_ROOT       Optional development checkout/Installed Repository override passed to dots install.
   DOTS_OS                Test override for platform OS detection.
@@ -31,6 +32,7 @@ default_release_base_url="https://github.com/yersonargotev/dots/releases/downloa
 release_base_url="${DOTS_RELEASE_BASE_URL:-$default_release_base_url}"
 install_dir="${DOTS_INSTALL_DIR:-$HOME/.local/bin}"
 repository_url="${DOTS_REPOSITORY_URL:-https://github.com/yersonargotev/dots.git}"
+repository_ref="${DOTS_REPOSITORY_REF:-}"
 source_root="${DOTS_SOURCE_ROOT:-$HOME/.local/share/dots}"
 source_root_explicit="${DOTS_SOURCE_ROOT:-}"
 
@@ -117,17 +119,57 @@ install -m 0755 "$artifact_path" "$install_path"
 
 echo "Installed dots to $install_path"
 
+valid_source_root() {
+  local dir="$1"
+  [[ -f "$dir/dots.yaml" && -s "$dir/dots.yaml" ]]
+}
+
+clone_source_root() {
+  local destination="$1"
+  local parent
+  local tmp_clone
+  parent="$(dirname "$destination")"
+  mkdir -p "$parent"
+  tmp_clone="$(mktemp -d "$parent/.dots-clone.XXXXXX")"
+  cleanup_clone() {
+    rm -rf "$tmp_clone"
+  }
+  trap 'cleanup; cleanup_clone' EXIT
+
+  local clone_args=(clone --depth 1)
+  if [[ -n "$repository_ref" ]]; then
+    clone_args+=(--branch "$repository_ref")
+  elif [[ "$version" != "latest" ]]; then
+    clone_args+=(--branch "$version")
+  fi
+  clone_args+=("$repository_url" "$tmp_clone")
+
+  echo "Cloning Source of Truth to $destination"
+  git "${clone_args[@]}"
+  if ! valid_source_root "$tmp_clone"; then
+    fail "cloned Source of Truth does not contain a valid dots.yaml at repository root"
+  fi
+  mv "$tmp_clone" "$destination"
+  trap cleanup EXIT
+}
+
 if [[ -z "$source_root_explicit" ]]; then
   if [[ -e "$source_root" && ! -d "$source_root" ]]; then
     fail "default Installed Repository path exists but is not a directory: $source_root"
+  fi
+  if [[ -d "$source_root" ]]; then
+    if ! valid_source_root "$source_root"; then
+      if [[ -n "$(find "$source_root" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
+        fail "default Installed Repository path exists but does not contain a valid dots.yaml: $source_root. Move it aside or set DOTS_SOURCE_ROOT."
+      fi
+      rmdir "$source_root"
+    fi
   fi
   if [[ ! -d "$source_root" ]]; then
     if ! command -v git >/dev/null 2>&1; then
       fail "git is required to clone the Source of Truth into $source_root"
     fi
-    mkdir -p "$(dirname "$source_root")"
-    echo "Cloning Source of Truth to $source_root"
-    git clone --depth 1 "$repository_url" "$source_root"
+    clone_source_root "$source_root"
   fi
 fi
 


### PR DESCRIPTION
Closes #133

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Load omitted `--file` manifests from the resolved Installed Repository instead of the caller's cwd.
- Clone the Source of Truth into `~/.local/share/dots` during first-time bootstrap when the default repository is missing.
- Document and test the new first-run behavior.

## Changes

| File | Change |
|------|--------|
| `internal/cli/paths.go` | Adds shared default manifest path resolution. |
| `internal/cli/{install,plan,status,doctor,deps}.go` | Uses the Installed Repository manifest when `--file` is omitted. |
| `scripts/install.sh` | Clones the Source of Truth on first bootstrap unless `DOTS_SOURCE_ROOT` is explicit. |
| `internal/cli/cli_test.go` | Covers default manifest loading outside a checkout. |
| `internal/bootstrap/bootstrap_test.go` | Covers first-time bootstrap repository cloning. |
| `README.md`, `docs/release.md` | Documents bootstrap clone behavior and git requirement. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp>`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #133`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
