### PR TITLE
fix(install): keep agent setup out of desktop profile

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -37,10 +37,12 @@ A Profile is selected by commands such as `dots plan`, `dots install`,
 
 Current Profiles:
 
-| Profile | Tags | Profile Dependencies |
-|---------|------|----------------------|
-| `default` | `core` | None |
-| `desktop` | `core`, `desktop` | `Desktop Nerd Font` via Homebrew cask `font-cascadia-code-nf`, detected with `CascadiaCodeNF*` |
+| Profile | Tags | Intent | Profile Dependencies |
+|---------|------|--------|----------------------|
+| `default` | `core` | Core dotfiles without provisioners. | None |
+| `desktop` | `core`, `desktop` | Desktop dotfiles and desktop-only tool integrations; no gentle-ai agent setup. | `Desktop Nerd Font` via Homebrew cask `font-cascadia-code-nf`, detected with `CascadiaCodeNF*` |
+| `agents` | `core`, `agents` | Core dotfiles plus gentle-ai agent setup/cleanup. | None |
+| `workstation` | `core`, `desktop`, `agents` | Full workstation setup when both desktop integrations and agent setup are desired. | `Desktop Nerd Font` via Homebrew cask `font-cascadia-code-nf`, detected with `CascadiaCodeNF*` |
 
 ## Managed Entries
 
@@ -176,9 +178,9 @@ Current Provisioners:
 
 | Tool | Tags | OS | Rendered intent | Dependencies |
 |------|------|----|-----------------|--------------|
-| `gentle-ai` | `core` | all | Uninstall `sdd` for `codex`, `claude-code`, and `opencode` with `--yes`. | `gentle-ai` |
-| `gentle-ai` | `core` | all | Install global stable neutral custom setup for `codex` with `engram`, `context7`, and `persona`. | `gentle-ai`, `engram` |
-| `gentle-ai` | `core` | all | Install global stable neutral custom setup for `claude-code` with `engram`, `context7`, `persona`, and `permissions`. | `gentle-ai`, `engram` |
+| `gentle-ai` | `agents` | all | Uninstall `sdd` for `codex`, `claude-code`, and `opencode` with `--yes`. | `gentle-ai` |
+| `gentle-ai` | `agents` | all | Install global stable neutral custom setup for `codex` with `engram`, `context7`, and `persona`. | `gentle-ai`, `engram` |
+| `gentle-ai` | `agents` | all | Install global stable neutral custom setup for `claude-code` with `engram`, `context7`, `persona`, and `permissions`. | `gentle-ai`, `engram` |
 | `claude` | `desktop` | `darwin`, `linux` | Register marketplace `ChromeDevTools/chrome-devtools-mcp`. | `claude` |
 | `claude` | `desktop` | `darwin`, `linux` | Install `chrome-devtools-mcp` from `chrome-devtools-plugins` with user scope. | `claude` |
 | `codex` | `desktop` | `darwin`, `linux` | Add MCP server `chrome-devtools` using `npx -y chrome-devtools-mcp@latest --no-performance-crux`. | `codex` |

--- a/docs/update.md
+++ b/docs/update.md
@@ -63,21 +63,21 @@ Because no fast-forward is applied in a dry run, the rendered plan reflects the 
 
 ## Profiles and provisioners
 
-Provisioners are scoped by profile tags, exactly like file entries. The `default` profile selects only `core`-tagged provisioners (gentle-ai); the chrome-devtools integration for Claude, Codex, and the OpenCode overlay is tagged `desktop` and is only provisioned under `--profile desktop`. This is design-intent — chrome-devtools drives a real browser and does not belong in headless or server installs.
+Provisioners are scoped by profile tags, exactly like file entries. The `default` profile selects no provisioners. The `desktop` profile selects only desktop integrations such as chrome-devtools for Claude, Codex, and the OpenCode overlay. The `agents` profile selects gentle-ai setup/cleanup provisioners. Use `workstation` when you explicitly want both desktop integrations and agent setup. This is design-intent: desktop installs should configure desktop tools, not opt into SDD or gentle-dev agent setup.
 
 The gentle-ai provisioner can model cleanup before install by using separate entries in manifest order. Missing `action` still defaults to `install`; `yes` is only valid for `uninstall` because it confirms a cleanup action:
 
 ```yaml
 provisioners:
   - tool: gentle-ai
-    tags: [core]
+    tags: [agents]
     spec:
       action: uninstall
       agents: [codex, claude-code, opencode]
       components: [sdd]
       yes: true
   - tool: gentle-ai
-    tags: [core]
+    tags: [agents]
     spec:
       preset: custom
       agents: [codex, claude-code]
@@ -87,7 +87,7 @@ provisioners:
 To keep that requirement discoverable, both `install` and `update` print a one-line hint when the active profile skips provisioners another profile would select on this OS:
 
 ```
-Note: profile "default" skips 3 provisioner(s); run with --profile desktop to include them.
+Note: profile "default" skips 7 provisioner(s); run with --profile workstation to include them.
 ```
 
 File entries are profile-scoped the same way, and the `default` profile silently omits the `desktop`-tagged ones (the Ghostty and Zed configs, plus the OpenCode MCP overlay). To close the same discoverability gap, both commands print a parallel hint for skipped file entries:

--- a/dots.yaml
+++ b/dots.yaml
@@ -11,6 +11,19 @@ profiles:
       - name: Desktop Nerd Font
         brew_cask: font-cascadia-code-nf
         font_match: "CascadiaCodeNF*"
+  agents:
+    tags:
+      - core
+      - agents
+  workstation:
+    tags:
+      - core
+      - desktop
+      - agents
+    dependencies:
+      - name: Desktop Nerd Font
+        brew_cask: font-cascadia-code-nf
+        font_match: "CascadiaCodeNF*"
 entries:
   - source: configs/zsh/zshrc
     target: ~/.zshrc
@@ -295,7 +308,7 @@ entries:
 provisioners:
   - tool: gentle-ai
     tags:
-      - core
+      - agents
     spec:
       action: uninstall
       agents:
@@ -311,7 +324,7 @@ provisioners:
         brew: gentleman-programming/tap/gentle-ai
   - tool: gentle-ai
     tags:
-      - core
+      - agents
     spec:
       scope: global
       channel: stable
@@ -332,7 +345,7 @@ provisioners:
         brew: gentleman-programming/tap/engram
   - tool: gentle-ai
     tags:
-      - core
+      - agents
     spec:
       scope: global
       channel: stable

--- a/internal/cli/claude_config_test.go
+++ b/internal/cli/claude_config_test.go
@@ -11,14 +11,14 @@ import (
 	"github.com/yersonargotev/dots/internal/cli"
 )
 
-// TestClaudeDefaultProfileSeedsUserBaselineInSandbox proves that dots seeds the
+// TestClaudeAgentsProfileSeedsUserBaselineInSandbox proves that dots seeds the
 // user-owned Claude settings baseline and the portable statusLine script with a
 // copy strategy (regular files, not symlinks) before the gentle-ai provisioner
 // runs, that the provisioner is invoked for the claude-code agent, and that the
 // provisioner never escapes the threaded sandbox HOME. The gentle-ai/engram
 // tools are stubbed so the provisioner step exits cleanly without merging its
 // own keys, keeping the sandbox aligned.
-func TestClaudeDefaultProfileSeedsUserBaselineInSandbox(t *testing.T) {
+func TestClaudeAgentsProfileSeedsUserBaselineInSandbox(t *testing.T) {
 	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
 	if err != nil {
 		t.Fatalf("resolve repo root: %v", err)
@@ -44,7 +44,7 @@ func TestClaudeDefaultProfileSeedsUserBaselineInSandbox(t *testing.T) {
 	install.SetArgs([]string{
 		"install",
 		"--file", filepath.Join(repoRoot, "dots.yaml"),
-		"--profile", "default",
+		"--profile", "agents",
 		"--source-root", repoRoot,
 		"--home", home,
 		"--state-root", stateRoot,
@@ -258,7 +258,7 @@ JSON
 	install.SetArgs([]string{
 		"install",
 		"--file", filepath.Join(repoRoot, "dots.yaml"),
-		"--profile", "default",
+		"--profile", "agents",
 		"--source-root", repoRoot,
 		"--home", home,
 		"--state-root", stateRoot,
@@ -275,7 +275,7 @@ JSON
 	statusCmd.SetArgs([]string{
 		"status",
 		"--file", filepath.Join(repoRoot, "dots.yaml"),
-		"--profile", "default",
+		"--profile", "agents",
 		"--source-root", repoRoot,
 		"--home", home,
 		"--state-root", stateRoot,

--- a/internal/cli/provision_hint_test.go
+++ b/internal/cli/provision_hint_test.go
@@ -47,6 +47,33 @@ provisioners:
       - name: codex
 `
 
+const skippedSupersetProvisionerHintManifest = `version: 1
+profiles:
+  default:
+    tags: [core]
+  desktop:
+    tags: [core, desktop]
+  agents:
+    tags: [core, agents]
+  workstation:
+    tags: [core, desktop, agents]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+provisioners:
+  - tool: claude
+    tags: [desktop]
+    spec:
+      marketplace: ChromeDevTools/chrome-devtools-mcp
+  - tool: codex
+    tags: [agents]
+    spec:
+      mcp: chrome-devtools
+      command: [npx, -y, chrome-devtools-mcp@latest]
+`
+
 const skippedEntryHintManifest = `version: 1
 profiles:
   default:
@@ -142,6 +169,50 @@ func TestUpdateDryRunHintsSkippedDesktopEntries(t *testing.T) {
 	want := `Note: profile "default" skips 2 file entries; run with --profile desktop to include them.`
 	if !strings.Contains(out, want) {
 		t.Fatalf("update --dry-run output missing skipped-entry hint %q\noutput:\n%s", want, out)
+	}
+}
+
+// TestInstallDryRunPrefersSupersetProvisionerHint proves the hint recommends a
+// profile that preserves the active provisioners and adds the skipped ones.
+func TestInstallDryRunPrefersSupersetProvisionerHint(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile string
+		want    string
+	}{
+		{
+			name:    "desktop keeps desktop provisioners and adds agents",
+			profile: "desktop",
+			want:    `Note: profile "desktop" skips 1 provisioner(s); run with --profile workstation to include them.`,
+		},
+		{
+			name:    "agents keeps agent provisioners and adds desktop",
+			profile: "agents",
+			want:    `Note: profile "agents" skips 1 provisioner(s); run with --profile workstation to include them.`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			sourceRoot := t.TempDir()
+			t.Setenv("HOME", t.TempDir())
+			writeCLISource(t, sourceRoot, "configs/zsh/zshrc", "managed\n")
+			manifestPath := writeCLIManifest(t, home, skippedSupersetProvisionerHintManifest)
+
+			cmd := cli.NewRootCommand()
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs([]string{"install", "--dry-run", "--profile", tt.profile, "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
+
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+			}
+			if !strings.Contains(out.String(), tt.want) {
+				t.Fatalf("install --dry-run output missing skipped-provisioner hint %q\noutput:\n%s", tt.want, out.String())
+			}
+		})
 	}
 }
 

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/plan"
+	"github.com/yersonargotev/dots/internal/provision"
 )
 
 func TestLoadFileAcceptsMinimalValidManifest(t *testing.T) {
@@ -425,6 +426,11 @@ func TestRepositoryManifestIncludesGentleAICleanupBeforeBasicInstall(t *testing.
 	if claudeInstall == nil {
 		t.Fatal("repository manifest missing gentle-ai claude basic install provisioner")
 	}
+	for _, prov := range []*manifest.Provisioner{cleanup, codexInstall, claudeInstall} {
+		if !sameStrings(prov.Tags, []string{"agents"}) {
+			t.Fatalf("gentle-ai provisioner tags = %#v, want [agents] so desktop installs do not apply SDD/gentle-dev agent setup", prov.Tags)
+		}
+	}
 	if cleanup.Spec.Yes != true {
 		t.Fatalf("gentle-ai cleanup yes = %v, want true", cleanup.Spec.Yes)
 	}
@@ -456,6 +462,44 @@ func TestRepositoryManifestIncludesGentleAICleanupBeforeBasicInstall(t *testing.
 		if &got.Provisioners[i] == codexInstall || &got.Provisioners[i] == claudeInstall {
 			t.Fatal("gentle-ai install provisioner appears before cleanup")
 		}
+	}
+}
+
+func TestRepositoryManifestDesktopProfileDoesNotSelectGentleAIProvisioners(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", ".."))
+	manifestPath := filepath.Join(root, "dots.yaml")
+
+	got, err := manifest.LoadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("LoadFile(%q) error = %v", manifestPath, err)
+	}
+
+	desktop, err := provision.Build(*got, provision.Options{Profile: "desktop", OS: "darwin"})
+	if err != nil {
+		t.Fatalf("provision.Build(desktop) error = %v", err)
+	}
+	for _, step := range desktop.Steps {
+		if step.Tool == "gentle-ai" {
+			t.Fatalf("desktop profile selected gentle-ai provisioner args %#v; desktop must not install SDD or gentle-dev agent setup", step.Args)
+		}
+	}
+
+	agents, err := provision.Build(*got, provision.Options{Profile: "agents", OS: "darwin"})
+	if err != nil {
+		t.Fatalf("provision.Build(agents) error = %v", err)
+	}
+	if len(agents.Steps) == 0 {
+		t.Fatal("agents profile selected no provisioners, want gentle-ai setup there")
+	}
+	foundGentleAI := false
+	for _, step := range agents.Steps {
+		if step.Tool == "gentle-ai" {
+			foundGentleAI = true
+			break
+		}
+	}
+	if !foundGentleAI {
+		t.Fatal("agents profile did not select gentle-ai provisioners")
 	}
 }
 

--- a/internal/profilesel/profilesel.go
+++ b/internal/profilesel/profilesel.go
@@ -44,7 +44,9 @@ type Selector func(profileName, os string) (map[int]bool, error)
 // for every profile so switching profiles would not recover them. The reported
 // Count is the suggested profile's coverage of the skipped set, so the caller's
 // remediation message stays accurate even when no single profile is a superset of
-// every omission.
+// every omission. When possible, Skipped prefers a suggested profile whose
+// selection is a superset of the active profile so the user does not lose items
+// they already selected while adding skipped ones.
 func Skipped(profiles map[string]manifest.Profile, active, os string, sel Selector) (Hint, bool, error) {
 	activeSet, err := sel(active, os)
 	if err != nil {
@@ -80,15 +82,34 @@ func Skipped(profiles map[string]manifest.Profile, active, os string, sel Select
 	}
 
 	var (
-		suggested string
-		best      int
+		suggested     string
+		best          int
+		bestPreserves bool
 	)
 	for _, name := range others {
+		set := selections[name]
 		covered := 0
-		for i := range selections[name] {
+		for i := range set {
 			if skipped[i] {
 				covered++
 			}
+		}
+
+		preservesActive := covered > 0
+		for i := range activeSet {
+			if !set[i] {
+				preservesActive = false
+				break
+			}
+		}
+
+		if preservesActive != bestPreserves {
+			if preservesActive {
+				best = covered
+				suggested = name
+				bestPreserves = true
+			}
+			continue
 		}
 		if covered > best {
 			best = covered

--- a/internal/profilesel/profilesel_test.go
+++ b/internal/profilesel/profilesel_test.go
@@ -63,6 +63,32 @@ func TestSkipped(t *testing.T) {
 			wantCount:     1,   // union of skipped is {1,2}=2, but each other profile recovers only 1
 			wantSuggested: "a", // alphabetical tie-break on equal coverage
 		},
+		{
+			name:     "prefers superset over equal coverage candidate that drops active selection",
+			profiles: profileNames("agents", "desktop", "workstation"),
+			selections: map[string]map[int]bool{
+				"agents":      {0: true, 1: true},
+				"desktop":     {0: true, 2: true},
+				"workstation": {0: true, 1: true, 2: true},
+			},
+			active:        "agents",
+			wantOK:        true,
+			wantCount:     1,
+			wantSuggested: "workstation",
+		},
+		{
+			name:     "prefers superset over higher coverage candidate that drops active selection",
+			profiles: profileNames("active", "partial", "superset"),
+			selections: map[string]map[int]bool{
+				"active":   {0: true, 1: true},
+				"partial":  {0: true, 2: true, 3: true},
+				"superset": {0: true, 1: true, 2: true},
+			},
+			active:        "active",
+			wantOK:        true,
+			wantCount:     1,
+			wantSuggested: "superset",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Closes #135

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Moves gentle-ai agent provisioning off the shared `core` tag and behind an explicit `agents` profile.
- Keeps `desktop` limited to desktop integrations, so it no longer runs gentle-ai, SDD cleanup, or gentle-dev-related setup.
- Adds `workstation` as the explicit full setup profile combining desktop integrations and agent provisioning.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Adds `agents` and `workstation` profiles; retags gentle-ai provisioners from `core` to `agents`. |
| `internal/manifest/manifest_test.go` | Adds regression coverage proving `desktop` does not select gentle-ai provisioners and `agents` still does. |
| `internal/cli/claude_config_test.go` | Updates gentle-ai provisioning install/status coverage to use the explicit `agents` profile. |
| `docs/manifest.md` | Documents the new profile split and updated provisioner tags. |
| `docs/update.md` | Updates profile/provisioner guidance and skipped-provisioner hint example. |

## Test Plan

- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp> --state-root <tmp>`
- [x] Sandboxed dry-run: `go run ./cmd/dots install --profile desktop --dry-run --output json --home <tmp>/home --source-root "$PWD" --state-root <tmp>/state`
- [x] Sandboxed dry-run: `go run ./cmd/dots install --profile workstation --dry-run --output json --home <tmp>/home --source-root "$PWD" --state-root <tmp>/state`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #135`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
