### PR TITLE
fix(update): preserve dirty installed repo changes

### DIFF
--- a/docs/update.md
+++ b/docs/update.md
@@ -5,7 +5,7 @@
 ## What it does
 
 1. **Validates Git state.** The source root must be a Git work tree. If it is not, `update` stops with an error instead of guessing.
-2. **Refuses to overwrite local work.** If the repository has any uncommitted changes (modified, staged, or untracked files), `update` reports the dirty state and stops. It never stashes, resets, or discards local changes on your behalf.
+2. **Preserves local Installed Repository changes.** If the repository has uncommitted changes (modified, staged, or untracked files), `update` moves them into Git's stash before continuing. This keeps customer updates self-healing while preserving local edits for inspection instead of discarding them.
 3. **Fast-forwards only.** `update` fetches the upstream and advances the branch with `git merge --ff-only`. If the branch has diverged from its upstream, it cannot be fast-forwarded; `update` reports the divergence and asks you to resolve it manually with Git. It never performs an automatic merge or rebase.
 4. **Recomputes the Install Plan.** After the fast-forward, the manifest is loaded from the updated repository (so a manifest change pulled from upstream is honored) and a fresh Install Plan is computed against the current workstation state, surfacing any new Conflicts or Drift.
 5. **Applies safely.** The post-update install resolves conflicts exactly like `dots install`: interactive TUI by default, text prompts with `--no-tui`, or the conservative skip default with `--yes`. Any `replace` still creates a [Backup Set](../CONTEXT.md) before touching an existing target.
@@ -20,7 +20,13 @@ Updated Installed Repository a1b2c3d -> e4f5a6b:
   e4f5a6b add tmux config
 ```
 
-Because the update path is fast-forward only, the local revision is always a strict ancestor of the new revision. This keeps the model auditable (you can always inspect the exact commits applied) and avoids dots ever rewriting history or fabricating merge commits. To roll back, use Git directly in the Installed Repository.
+Because the update path is fast-forward only, the local revision is always a strict ancestor of the new revision. This keeps the model auditable (you can always inspect the exact commits applied) and avoids dots ever rewriting history or fabricating merge commits. If local Installed Repository changes were present, `update` reports the stash reference that preserved them, for example:
+
+```
+Preserved local Installed Repository changes in stash@{0}.
+```
+
+To inspect those preserved edits, use Git directly in the Installed Repository. To roll back, use Git directly in the Installed Repository.
 
 ## Post-update conflict handling
 

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -31,8 +31,9 @@ func newUpdateCommand() *cobra.Command {
 		Short: "Update the Installed Repository and re-run the safe install flow",
 		Long: "update fast-forwards the Installed Repository (default ~/.local/share/dots) to its " +
 			"upstream, then recomputes the Install Plan and re-runs the selected provisioners so managed " +
-			"configuration stays aligned with the Source of Truth. It refuses to touch a repository with " +
-			"local changes and only ever applies a clean fast-forward, never a merge or rebase. Conflicts " +
+			"configuration stays aligned with the Source of Truth. If the Installed Repository has local " +
+			"changes, update preserves them in Git's stash before continuing, and only ever applies a clean " +
+			"fast-forward, never a merge or rebase. Conflicts " +
 			"during the post-update install are resolved exactly like dots install, creating a Backup Set " +
 			"before any replacement.",
 		// Domain failures (dirty repo, divergence, conflicts) are user-facing
@@ -47,13 +48,6 @@ func newUpdateCommand() *cobra.Command {
 			if !gitrepo.IsRepo(paths.SourceRoot) {
 				return fmt.Errorf("installed repository %s is not a git repository; clone the Source of Truth before updating", paths.SourceRoot)
 			}
-			clean, err := gitrepo.IsClean(paths.SourceRoot)
-			if err != nil {
-				return err
-			}
-			if !clean {
-				return fmt.Errorf("installed repository %s has local changes; commit or discard them before updating", paths.SourceRoot)
-			}
 
 			out := cmd.OutOrStdout()
 			var update gitrepo.Update
@@ -64,7 +58,14 @@ func newUpdateCommand() *cobra.Command {
 					if !yes {
 						return rejectInteractiveJSON(cmd)
 					}
+					preserved, ok, err := gitrepo.PreserveLocalChanges(paths.SourceRoot)
+					if err != nil {
+						return err
+					}
 					update, err = gitrepo.FastForward(paths.SourceRoot)
+					if ok {
+						update.PreservedChanges = preserved
+					}
 				}
 				if errors.Is(err, gitrepo.ErrNotFastForward) {
 					return fmt.Errorf("installed repository %s has diverged from its upstream and cannot be fast-forwarded; resolve it manually with git", paths.SourceRoot)
@@ -166,18 +167,28 @@ func newUpdateCommand() *cobra.Command {
 }
 
 // refreshRepository previews (dry run) or applies (real run) the fast-forward
-// update of the Installed Repository, reporting exactly what changed. It maps
+// update of the Installed Repository, preserving local changes before a real
+// update so customers do not need to recover with manual Git commands. It maps
 // the gitrepo divergence sentinel to a user-facing message that points back to
 // manual resolution, keeping dots out of automatic merge/rebase behavior.
 func refreshRepository(out io.Writer, sourceRoot string, dryRun bool) (gitrepo.Update, error) {
 	var (
-		upd gitrepo.Update
-		err error
+		upd       gitrepo.Update
+		err       error
+		preserved string
+		stashed   bool
 	)
 	if dryRun {
 		upd, err = gitrepo.Preview(sourceRoot)
 	} else {
+		preserved, stashed, err = gitrepo.PreserveLocalChanges(sourceRoot)
+		if err != nil {
+			return gitrepo.Update{}, err
+		}
 		upd, err = gitrepo.FastForward(sourceRoot)
+		if stashed {
+			upd.PreservedChanges = preserved
+		}
 	}
 	if errors.Is(err, gitrepo.ErrNotFastForward) {
 		return gitrepo.Update{}, fmt.Errorf("installed repository %s has diverged from its upstream and cannot be fast-forwarded; resolve it manually with git", sourceRoot)
@@ -192,6 +203,9 @@ func refreshRepository(out io.Writer, sourceRoot string, dryRun bool) (gitrepo.U
 // renderUpdate writes a deterministic summary of the fast-forward so the user
 // sees which commits were (or would be) applied before the Install Plan.
 func renderUpdate(out io.Writer, upd gitrepo.Update, dryRun bool) {
+	if upd.PreservedChanges != "" {
+		fmt.Fprintf(out, "Preserved local Installed Repository changes in %s.\n", upd.PreservedChanges)
+	}
 	if !upd.Changed() {
 		fmt.Fprintf(out, "Installed Repository already up to date at %s.\n\n", upd.OldRev)
 		return

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -58,14 +58,7 @@ func newUpdateCommand() *cobra.Command {
 					if !yes {
 						return rejectInteractiveJSON(cmd)
 					}
-					preserved, ok, err := gitrepo.PreserveLocalChanges(paths.SourceRoot)
-					if err != nil {
-						return err
-					}
-					update, err = gitrepo.FastForward(paths.SourceRoot)
-					if ok {
-						update.PreservedChanges = preserved
-					}
+					update, err = gitrepo.FastForwardPreservingLocalChanges(paths.SourceRoot)
 				}
 				if errors.Is(err, gitrepo.ErrNotFastForward) {
 					return fmt.Errorf("installed repository %s has diverged from its upstream and cannot be fast-forwarded; resolve it manually with git", paths.SourceRoot)
@@ -173,22 +166,13 @@ func newUpdateCommand() *cobra.Command {
 // manual resolution, keeping dots out of automatic merge/rebase behavior.
 func refreshRepository(out io.Writer, sourceRoot string, dryRun bool) (gitrepo.Update, error) {
 	var (
-		upd       gitrepo.Update
-		err       error
-		preserved string
-		stashed   bool
+		upd gitrepo.Update
+		err error
 	)
 	if dryRun {
 		upd, err = gitrepo.Preview(sourceRoot)
 	} else {
-		preserved, stashed, err = gitrepo.PreserveLocalChanges(sourceRoot)
-		if err != nil {
-			return gitrepo.Update{}, err
-		}
-		upd, err = gitrepo.FastForward(sourceRoot)
-		if stashed {
-			upd.PreservedChanges = preserved
-		}
+		upd, err = gitrepo.FastForwardPreservingLocalChanges(sourceRoot)
 	}
 	if errors.Is(err, gitrepo.ErrNotFastForward) {
 		return gitrepo.Update{}, fmt.Errorf("installed repository %s has diverged from its upstream and cannot be fast-forwarded; resolve it manually with git", sourceRoot)

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -147,12 +147,12 @@ entries:
 	}
 }
 
-func TestUpdateStopsOnDirtyRepo(t *testing.T) {
+func TestUpdatePreservesDirtyRepoThenFastForwards(t *testing.T) {
 	requireGitCLI(t)
 	home := t.TempDir()
 	t.Setenv("HOME", t.TempDir())
 
-	_, sourceRoot := newInstalledRepo(t, map[string]string{
+	origin, sourceRoot := newInstalledRepo(t, map[string]string{
 		"configs/zsh/zshrc": "export A=1\n",
 		"dots.yaml": `version: 1
 profiles:
@@ -165,28 +165,32 @@ entries:
     tags: [core]
 `,
 	})
+	advanceUpstream(t, origin, "update zsh config", map[string]string{
+		"configs/zsh/zshrc": "export A=2\n",
+	})
+
 	// A local edit makes the Installed Repository dirty.
 	localPath := filepath.Join(sourceRoot, "configs/zsh/zshrc")
 	if err := os.WriteFile(localPath, []byte("local edit\n"), 0o600); err != nil {
 		t.Fatalf("write local edit: %v", err)
 	}
 
-	cmd := cli.NewRootCommand()
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"update", "--file", filepath.Join(sourceRoot, "dots.yaml"),
-		"--home", home, "--source-root", sourceRoot})
-	if err := cmd.Execute(); err == nil {
-		t.Fatalf("update Execute() error = nil, want dirty-repo error\noutput:\n%s", out.String())
+	out := runUpdate(t, "--file", filepath.Join(sourceRoot, "dots.yaml"),
+		"--home", home, "--source-root", sourceRoot)
+
+	if !strings.Contains(out, "Preserved local Installed Repository changes in stash@{0}") {
+		t.Fatalf("update output missing preserved-changes notice\noutput:\n%s", out)
 	}
-	// The local edit must be preserved, never overwritten.
 	got, err := os.ReadFile(localPath)
 	if err != nil {
-		t.Fatalf("read local edit: %v", err)
+		t.Fatalf("read updated source: %v", err)
 	}
-	if string(got) != "local edit\n" {
-		t.Fatalf("local edit overwritten: got %q", got)
+	if string(got) != "export A=2\n" {
+		t.Fatalf("source after update = %q, want upstream content", got)
+	}
+	stashes := runGitOutput(t, sourceRoot, "stash", "list")
+	if !strings.Contains(stashes, "dots update preserved local Installed Repository changes") {
+		t.Fatalf("local edit was not preserved in stash\nstash list:\n%s", stashes)
 	}
 }
 
@@ -342,6 +346,11 @@ func gitIdentity(t *testing.T, dir string) {
 
 func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
+	_ = runGitOutput(t, dir, args...)
+}
+
+func runGitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
 	cmd := exec.Command("git", args...)
 	if dir != "" {
 		cmd.Dir = dir
@@ -353,5 +362,8 @@ func runGit(t *testing.T, dir string, args ...string) {
 	)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git %v: %v\n%s", args, err, out)
+	} else {
+		return string(out)
 	}
+	return ""
 }

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -194,6 +194,66 @@ entries:
 	}
 }
 
+func TestUpdateDirtyDivergedRepoDoesNotStash(t *testing.T) {
+	requireGitCLI(t)
+	home := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	origin, sourceRoot := newInstalledRepo(t, map[string]string{
+		"configs/zsh/zshrc": "export A=1\n",
+		"dots.yaml": `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+`,
+	})
+	advanceUpstream(t, origin, "update zsh config", map[string]string{
+		"configs/zsh/zshrc": "export A=2\n",
+	})
+
+	writeRepoFiles(t, sourceRoot, map[string]string{
+		"local-only.txt": "local commit\n",
+	})
+	runGit(t, sourceRoot, "add", "-A")
+	runGit(t, sourceRoot, "commit", "-m", "local commit")
+
+	localPath := filepath.Join(sourceRoot, "configs/zsh/zshrc")
+	if err := os.WriteFile(localPath, []byte("dirty local edit\n"), 0o600); err != nil {
+		t.Fatalf("write dirty local edit: %v", err)
+	}
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"update", "--file", filepath.Join(sourceRoot, "dots.yaml"),
+		"--home", home, "--source-root", sourceRoot})
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("update Execute() error = nil, want divergence error\noutput:\n%s", out.String())
+	}
+
+	got, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read dirty local edit: %v", err)
+	}
+	if string(got) != "dirty local edit\n" {
+		t.Fatalf("dirty local edit was mutated: got %q", got)
+	}
+	status := runGitOutput(t, sourceRoot, "status", "--short")
+	if !strings.Contains(status, "M configs/zsh/zshrc") {
+		t.Fatalf("dirty work tree was not preserved\nstatus:\n%s", status)
+	}
+	stashes := runGitOutput(t, sourceRoot, "stash", "list")
+	if strings.Contains(stashes, "dots update preserved local Installed Repository changes") {
+		t.Fatalf("diverged update stashed before proving fast-forwardability\nstash list:\n%s", stashes)
+	}
+}
+
 func TestUpdateFailsWhenSourceRootNotGitRepo(t *testing.T) {
 	requireGitCLI(t)
 	home := t.TempDir()

--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -22,9 +22,10 @@ var ErrNotFastForward = errors.New("installed repository cannot be fast-forwarde
 // Update describes the fast-forward an update did apply (FastForward) or would
 // apply (Preview), so callers can report exactly what changed.
 type Update struct {
-	OldRev   string   `json:"old_rev"`
-	NewRev   string   `json:"new_rev"`
-	Incoming []string `json:"incoming"`
+	OldRev           string   `json:"old_rev"`
+	NewRev           string   `json:"new_rev"`
+	Incoming         []string `json:"incoming"`
+	PreservedChanges string   `json:"preserved_changes,omitempty"`
 }
 
 // Changed reports whether the update moves (or would move) HEAD.
@@ -47,6 +48,25 @@ func IsClean(dir string) (bool, error) {
 		return false, err
 	}
 	return strings.TrimSpace(out) == "", nil
+}
+
+// PreserveLocalChanges moves any uncommitted Installed Repository changes into
+// Git's stash and leaves the work tree clean for a safe fast-forward. The stash
+// is intentionally not re-applied automatically: the Installed Repository is the
+// Source of Truth clone, so local edits are preserved for inspection without
+// blocking customers from receiving the latest reviewed manifest.
+func PreserveLocalChanges(dir string) (string, bool, error) {
+	clean, err := IsClean(dir)
+	if err != nil {
+		return "", false, err
+	}
+	if clean {
+		return "", false, nil
+	}
+	if _, err := run(dir, "stash", "push", "--include-untracked", "-m", "dots update preserved local Installed Repository changes"); err != nil {
+		return "", false, fmt.Errorf("preserve local changes for %s: %w", dir, err)
+	}
+	return "stash@{0}", true, nil
 }
 
 // Preview fetches remote refs and reports the fast-forward an update would apply

--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -131,6 +131,57 @@ func FastForward(dir string) (Update, error) {
 	return Update{OldRev: old, NewRev: newRev, Incoming: incoming}, nil
 }
 
+// FastForwardPreservingLocalChanges verifies that dir can fast-forward before
+// moving local changes out of the work tree. This preserves the fast-forward-only
+// safety invariant: when the branch has diverged, dots returns ErrNotFastForward
+// without mutating the user's Installed Repository state.
+func FastForwardPreservingLocalChanges(dir string) (Update, error) {
+	old, err := head(dir)
+	if err != nil {
+		return Update{}, err
+	}
+	if err := fetch(dir); err != nil {
+		return Update{}, err
+	}
+	upstream, err := upstreamRev(dir)
+	if err != nil {
+		return Update{}, err
+	}
+	if old != upstream && !canFastForward(dir) {
+		return Update{}, ErrNotFastForward
+	}
+
+	var incoming []string
+	if old != upstream {
+		incoming, err = incomingCommits(dir)
+		if err != nil {
+			return Update{}, err
+		}
+	}
+
+	preserved, stashed, err := PreserveLocalChanges(dir)
+	if err != nil {
+		return Update{}, err
+	}
+	upd := Update{OldRev: old, NewRev: old, Incoming: incoming}
+	if stashed {
+		upd.PreservedChanges = preserved
+	}
+	if old == upstream {
+		return upd, nil
+	}
+
+	if _, err := run(dir, "merge", "--ff-only", "@{u}"); err != nil {
+		return Update{}, ErrNotFastForward
+	}
+	newRev, err := head(dir)
+	if err != nil {
+		return Update{}, err
+	}
+	upd.NewRev = newRev
+	return upd, nil
+}
+
 func head(dir string) (string, error) {
 	out, err := run(dir, "rev-parse", "--short", "HEAD")
 	if err != nil {


### PR DESCRIPTION
Closes #138

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Preserve dirty Installed Repository changes in Git stash before a real `dots update`.
- Continue the fast-forward/install flow after preserving those changes so stale manifests can self-heal.
- Document the new preservation behavior and add regression coverage for dirty-repo recovery.

## Changes

| File | Change |
|------|--------|
| `internal/gitrepo/gitrepo.go` | Adds `PreserveLocalChanges` and reports the stash reference in update metadata. |
| `internal/cli/update.go` | Removes the dirty-repo hard stop for real updates and stashes before fast-forwarding. |
| `internal/cli/update_test.go` | Replaces the dirty-repo failure test with recovery coverage that verifies fast-forward and stash preservation. |
| `docs/update.md` | Updates workflow docs to describe preserving local Installed Repository changes. |

## Test Plan

- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan/update behavior covered by Go tests using temporary `--home`, `--source-root`, and Git repositories.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #138`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
