### PR TITLE
feat(agents): provision Antigravity with gentle-ai

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -178,9 +178,10 @@ Current Provisioners:
 
 | Tool | Tags | OS | Rendered intent | Dependencies |
 |------|------|----|-----------------|--------------|
-| `gentle-ai` | `agents` | all | Uninstall `sdd` for `codex`, `claude-code`, and `opencode` with `--yes`. | `gentle-ai` |
+| `gentle-ai` | `agents` | all | Uninstall `sdd` for `codex`, `claude-code`, `opencode`, and `antigravity` with `--yes`. | `gentle-ai` |
 | `gentle-ai` | `agents` | all | Install global stable neutral custom setup for `codex` with `engram`, `context7`, and `persona`. | `gentle-ai`, `engram` |
 | `gentle-ai` | `agents` | all | Install global stable neutral custom setup for `claude-code` with `engram`, `context7`, `persona`, and `permissions`. | `gentle-ai`, `engram` |
+| `gentle-ai` | `agents` | all | Install global stable neutral custom setup for `antigravity` with `engram`, `context7`, and `persona` only; no `sdd` or `permissions`. | `gentle-ai`, `engram` |
 | `claude` | `desktop` | `darwin`, `linux` | Register marketplace `ChromeDevTools/chrome-devtools-mcp`. | `claude` |
 | `claude` | `desktop` | `darwin`, `linux` | Install `chrome-devtools-mcp` from `chrome-devtools-plugins` with user scope. | `claude` |
 | `codex` | `desktop` | `darwin`, `linux` | Add MCP server `chrome-devtools` using `npx -y chrome-devtools-mcp@latest --no-performance-crux`. | `codex` |

--- a/dots.yaml
+++ b/dots.yaml
@@ -315,6 +315,7 @@ provisioners:
         - codex
         - claude-code
         - opencode
+        - antigravity
       components:
         - sdd
       yes: true
@@ -358,6 +359,27 @@ provisioners:
         - context7
         - persona
         - permissions
+    dependencies:
+      - name: gentle-ai
+        command: gentle-ai
+        brew: gentleman-programming/tap/gentle-ai
+      - name: engram
+        command: engram
+        brew: gentleman-programming/tap/engram
+  - tool: gentle-ai
+    tags:
+      - agents
+    spec:
+      scope: global
+      channel: stable
+      persona: neutral
+      preset: custom
+      agents:
+        - antigravity
+      components:
+        - engram
+        - context7
+        - persona
     dependencies:
       - name: gentle-ai
         command: gentle-ai

--- a/internal/cli/claude_config_test.go
+++ b/internal/cli/claude_config_test.go
@@ -166,8 +166,8 @@ func TestClaudeAgentsProfileSeedsUserBaselineInSandbox(t *testing.T) {
 	if err != nil {
 		t.Fatalf("provisioner did not run under the sandbox HOME %q: %v", home, err)
 	}
-	if !strings.Contains(string(gotArgs), "uninstall --agents codex,claude-code,opencode --components sdd --yes") {
-		t.Fatalf("provisioner argv = %q, want it to cleanup legacy SDD for codex,claude-code,opencode before install", gotArgs)
+	if !strings.Contains(string(gotArgs), "uninstall --agents codex,claude-code,opencode,antigravity --components sdd --yes") {
+		t.Fatalf("provisioner argv = %q, want it to cleanup legacy SDD for codex,claude-code,opencode,antigravity before install", gotArgs)
 	}
 	if !strings.Contains(string(gotArgs), "install --scope global --channel stable --persona neutral --preset custom --agents codex --components engram,context7,persona") {
 		t.Fatalf("provisioner argv = %q, want codex install without permissions", gotArgs)
@@ -175,8 +175,14 @@ func TestClaudeAgentsProfileSeedsUserBaselineInSandbox(t *testing.T) {
 	if !strings.Contains(string(gotArgs), "install --scope global --channel stable --persona neutral --preset custom --agents claude-code --components engram,context7,persona,permissions") {
 		t.Fatalf("provisioner argv = %q, want claude-code install with permissions", gotArgs)
 	}
+	if !strings.Contains(string(gotArgs), "install --scope global --channel stable --persona neutral --preset custom --agents antigravity --components engram,context7,persona") {
+		t.Fatalf("provisioner argv = %q, want antigravity install without SDD or permissions", gotArgs)
+	}
 	if strings.Contains(string(gotArgs), "--agents codex --components engram,context7,persona,permissions") {
 		t.Fatalf("provisioner argv = %q, want codex install without permissions because it installs gentle-dev", gotArgs)
+	}
+	if strings.Contains(string(gotArgs), "--agents antigravity --components engram,context7,persona,permissions") || strings.Contains(string(gotArgs), "--agents antigravity --components engram,context7,persona,sdd") {
+		t.Fatalf("provisioner argv = %q, want antigravity install without SDD or permissions", gotArgs)
 	}
 	if strings.Contains(string(gotArgs), "install --scope global --channel stable --persona neutral --preset custom --agents codex,claude-code,opencode") {
 		t.Fatalf("provisioner argv = %q, want basic install without opencode", gotArgs)
@@ -195,6 +201,7 @@ func TestClaudeAgentsProfileSeedsUserBaselineInSandbox(t *testing.T) {
 		"configs/claude/statusline-command.sh",
 		"--agents codex --components engram,context7,persona",
 		"--agents claude-code --components engram,context7,persona,permissions",
+		"--agents antigravity --components engram,context7,persona",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("install output missing %q\noutput:\n%s", want, out)

--- a/internal/cli/install_provision_test.go
+++ b/internal/cli/install_provision_test.go
@@ -66,7 +66,7 @@ func TestInstallDryRunRendersProvisionerWithoutInvoking(t *testing.T) {
 	for _, want := range []string{
 		`Provisioners for profile "default"`,
 		"gentle-ai install --scope global --persona neutral --agents codex",
-		"affects: ~/.claude, ~/.codex, ~/.gentle-ai",
+		"affects: ~/.codex, ~/.gentle-ai",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("dry-run output missing %q\noutput:\n%s", want, got)

--- a/internal/cli/render_provision_golden_test.go
+++ b/internal/cli/render_provision_golden_test.go
@@ -24,7 +24,7 @@ func TestRenderProvisionPlanGolden(t *testing.T) {
 						Tool:       "gentle-ai",
 						Executable: "gentle-ai",
 						Args:       []string{"install", "--scope", "global", "--persona", "neutral", "--agents", "codex"},
-						Targets:    []string{"~/.claude", "~/.codex", "~/.gentle-ai"},
+						Targets:    []string{"~/.codex", "~/.gentle-ai"},
 					},
 				},
 			},

--- a/internal/cli/status_provision_test.go
+++ b/internal/cli/status_provision_test.go
@@ -34,7 +34,7 @@ func TestStatusListsDeclaredProvisioners(t *testing.T) {
 	for _, want := range []string{
 		`Declared provisioners for profile "default"`,
 		"gentle-ai install --scope global --persona neutral --agents codex",
-		"affects: ~/.claude, ~/.codex, ~/.gentle-ai",
+		"affects: ~/.codex, ~/.gentle-ai",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("status output missing %q\noutput:\n%s", want, got)

--- a/internal/cli/testdata/provision_single.golden
+++ b/internal/cli/testdata/provision_single.golden
@@ -2,6 +2,6 @@
 Provisioners for profile "default"
 
   gentle-ai install --scope global --persona neutral --agents codex
-    affects: ~/.claude, ~/.codex, ~/.gentle-ai
+    affects: ~/.codex, ~/.gentle-ai
 
 Summary: 1 provisioner(s)

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -401,7 +401,7 @@ func TestRepositoryManifestIncludesGentleAICleanupBeforeBasicInstall(t *testing.
 		t.Fatalf("LoadFile(%q) error = %v", manifestPath, err)
 	}
 
-	var cleanup, codexInstall, claudeInstall *manifest.Provisioner
+	var cleanup, codexInstall, claudeInstall, antigravityInstall *manifest.Provisioner
 	for i := range got.Provisioners {
 		prov := &got.Provisioners[i]
 		if prov.Tool != "gentle-ai" {
@@ -414,6 +414,8 @@ func TestRepositoryManifestIncludesGentleAICleanupBeforeBasicInstall(t *testing.
 			codexInstall = prov
 		case claudeInstall == nil && sameStrings(prov.Spec.Agents, []string{"claude-code"}):
 			claudeInstall = prov
+		case antigravityInstall == nil && sameStrings(prov.Spec.Agents, []string{"antigravity"}):
+			antigravityInstall = prov
 		}
 	}
 
@@ -426,7 +428,10 @@ func TestRepositoryManifestIncludesGentleAICleanupBeforeBasicInstall(t *testing.
 	if claudeInstall == nil {
 		t.Fatal("repository manifest missing gentle-ai claude basic install provisioner")
 	}
-	for _, prov := range []*manifest.Provisioner{cleanup, codexInstall, claudeInstall} {
+	if antigravityInstall == nil {
+		t.Fatal("repository manifest missing gentle-ai antigravity basic install provisioner")
+	}
+	for _, prov := range []*manifest.Provisioner{cleanup, codexInstall, claudeInstall, antigravityInstall} {
 		if !sameStrings(prov.Tags, []string{"agents"}) {
 			t.Fatalf("gentle-ai provisioner tags = %#v, want [agents] so desktop installs do not apply SDD/gentle-dev agent setup", prov.Tags)
 		}
@@ -434,8 +439,8 @@ func TestRepositoryManifestIncludesGentleAICleanupBeforeBasicInstall(t *testing.
 	if cleanup.Spec.Yes != true {
 		t.Fatalf("gentle-ai cleanup yes = %v, want true", cleanup.Spec.Yes)
 	}
-	if !sameStrings(cleanup.Spec.Agents, []string{"codex", "claude-code", "opencode"}) {
-		t.Fatalf("gentle-ai cleanup agents = %#v, want [codex claude-code opencode]", cleanup.Spec.Agents)
+	if !sameStrings(cleanup.Spec.Agents, []string{"codex", "claude-code", "opencode", "antigravity"}) {
+		t.Fatalf("gentle-ai cleanup agents = %#v, want [codex claude-code opencode antigravity]", cleanup.Spec.Agents)
 	}
 	if !sameStrings(cleanup.Spec.Components, []string{"sdd"}) {
 		t.Fatalf("gentle-ai cleanup components = %#v, want [sdd]", cleanup.Spec.Components)
@@ -455,11 +460,17 @@ func TestRepositoryManifestIncludesGentleAICleanupBeforeBasicInstall(t *testing.
 	if !sameStrings(claudeInstall.Spec.Components, []string{"engram", "context7", "persona", "permissions"}) {
 		t.Fatalf("gentle-ai claude install components = %#v, want [engram context7 persona permissions]", claudeInstall.Spec.Components)
 	}
+	if !sameStrings(antigravityInstall.Spec.Components, []string{"engram", "context7", "persona"}) {
+		t.Fatalf("gentle-ai antigravity install components = %#v, want [engram context7 persona]", antigravityInstall.Spec.Components)
+	}
+	if hasString(antigravityInstall.Spec.Components, "sdd") || hasString(antigravityInstall.Spec.Components, "permissions") {
+		t.Fatalf("gentle-ai antigravity install components = %#v, must not include sdd or permissions", antigravityInstall.Spec.Components)
+	}
 	for i := range got.Provisioners {
 		if &got.Provisioners[i] == cleanup {
 			break
 		}
-		if &got.Provisioners[i] == codexInstall || &got.Provisioners[i] == claudeInstall {
+		if &got.Provisioners[i] == codexInstall || &got.Provisioners[i] == claudeInstall || &got.Provisioners[i] == antigravityInstall {
 			t.Fatal("gentle-ai install provisioner appears before cleanup")
 		}
 	}

--- a/internal/provision/plan.go
+++ b/internal/provision/plan.go
@@ -105,7 +105,8 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 // managedRoots returns the well-known HOME-relative roots an allowlisted tool
 // manages, used as the advisory blast radius in the plan. gentle-ai owns its own
 // state under ~/.gentle-ai, the Claude agent layer under ~/.claude, and selected
-// agent-specific configuration roots. claude writes marketplace and plugin state
+// agent-specific configuration roots such as ~/.codex, ~/.config/opencode, and
+// ~/.gemini. claude writes marketplace and plugin state
 // under ~/.claude and the user MCP/plugin registry in ~/.claude.json. codex
 // records MCP servers in ~/.codex/config.toml, under ~/.codex.
 func managedRoots(prov manifest.Provisioner) []string {
@@ -117,6 +118,9 @@ func managedRoots(prov manifest.Provisioner) []string {
 		}
 		if includes(prov.Spec.Agents, "opencode") {
 			roots = append(roots, "~/.config/opencode")
+		}
+		if includes(prov.Spec.Agents, "antigravity") {
+			roots = append(roots, "~/.gemini")
 		}
 		return append(roots, "~/.gentle-ai")
 	case "claude":

--- a/internal/provision/plan.go
+++ b/internal/provision/plan.go
@@ -104,15 +104,18 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 
 // managedRoots returns the well-known HOME-relative roots an allowlisted tool
 // manages, used as the advisory blast radius in the plan. gentle-ai owns its own
-// state under ~/.gentle-ai, the Claude agent layer under ~/.claude, and selected
-// agent-specific configuration roots such as ~/.codex, ~/.config/opencode, and
-// ~/.gemini. claude writes marketplace and plugin state
-// under ~/.claude and the user MCP/plugin registry in ~/.claude.json. codex
-// records MCP servers in ~/.codex/config.toml, under ~/.codex.
+// state under ~/.gentle-ai plus the selected agent-specific configuration roots:
+// ~/.claude for claude-code, ~/.codex for codex, ~/.config/opencode for opencode,
+// and ~/.gemini for antigravity. claude writes marketplace and plugin state under
+// ~/.claude and the user MCP/plugin registry in ~/.claude.json. codex records MCP
+// servers in ~/.codex/config.toml, under ~/.codex.
 func managedRoots(prov manifest.Provisioner) []string {
 	switch prov.Tool {
 	case "gentle-ai":
-		roots := []string{"~/.claude"}
+		var roots []string
+		if includes(prov.Spec.Agents, "claude-code") {
+			roots = append(roots, "~/.claude")
+		}
 		if includes(prov.Spec.Agents, "codex") {
 			roots = append(roots, "~/.codex")
 		}

--- a/internal/provision/plan_test.go
+++ b/internal/provision/plan_test.go
@@ -225,6 +225,30 @@ func TestPlanResolvesCodeGraphCodexProvisioner(t *testing.T) {
 	}
 }
 
+func TestPlanResolvesAntigravityGentleAIProvisioner(t *testing.T) {
+	prov := manifest.Provisioner{
+		Tool: "gentle-ai", Tags: []string{"core"},
+		Spec: manifest.ProvisionerSpec{Scope: "global", Agents: []string{"antigravity"}},
+	}
+	m := manifestWithProvisioners(prov)
+
+	p, err := provision.Build(m, provision.Options{Profile: "default", OS: "darwin"})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if len(p.Steps) != 1 {
+		t.Fatalf("len(Plan.Steps) = %d, want 1", len(p.Steps))
+	}
+
+	step := p.Steps[0]
+	if !reflect.DeepEqual(step.Args, []string{"install", "--scope", "global", "--agents", "antigravity"}) {
+		t.Fatalf("antigravity gentle-ai args = %#v", step.Args)
+	}
+	if !reflect.DeepEqual(step.Targets, []string{"~/.claude", "~/.gemini", "~/.gentle-ai"}) {
+		t.Fatalf("antigravity targets = %#v, want [~/.claude ~/.gemini ~/.gentle-ai]", step.Targets)
+	}
+}
+
 func TestPlanEmptyWhenNoProvisionerSelected(t *testing.T) {
 	prov := manifest.Provisioner{
 		Tool: "gentle-ai", Tags: []string{"desktop"},

--- a/internal/provision/plan_test.go
+++ b/internal/provision/plan_test.go
@@ -120,8 +120,8 @@ func TestPlanResolvesSelectedProvisioners(t *testing.T) {
 	if !reflect.DeepEqual(step.Args, wantArgs) {
 		t.Fatalf("Step.Args = %#v, want %#v", step.Args, wantArgs)
 	}
-	if !reflect.DeepEqual(step.Targets, []string{"~/.claude", "~/.codex", "~/.config/opencode", "~/.gentle-ai"}) {
-		t.Fatalf("Step.Targets = %#v, want [~/.claude ~/.codex ~/.config/opencode ~/.gentle-ai]", step.Targets)
+	if !reflect.DeepEqual(step.Targets, []string{"~/.codex", "~/.config/opencode", "~/.gentle-ai"}) {
+		t.Fatalf("Step.Targets = %#v, want [~/.codex ~/.config/opencode ~/.gentle-ai]", step.Targets)
 	}
 }
 
@@ -225,6 +225,30 @@ func TestPlanResolvesCodeGraphCodexProvisioner(t *testing.T) {
 	}
 }
 
+func TestPlanResolvesClaudeCodeGentleAIProvisioner(t *testing.T) {
+	prov := manifest.Provisioner{
+		Tool: "gentle-ai", Tags: []string{"core"},
+		Spec: manifest.ProvisionerSpec{Scope: "global", Agents: []string{"claude-code"}},
+	}
+	m := manifestWithProvisioners(prov)
+
+	p, err := provision.Build(m, provision.Options{Profile: "default", OS: "darwin"})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if len(p.Steps) != 1 {
+		t.Fatalf("len(Plan.Steps) = %d, want 1", len(p.Steps))
+	}
+
+	step := p.Steps[0]
+	if !reflect.DeepEqual(step.Args, []string{"install", "--scope", "global", "--agents", "claude-code"}) {
+		t.Fatalf("claude-code gentle-ai args = %#v", step.Args)
+	}
+	if !reflect.DeepEqual(step.Targets, []string{"~/.claude", "~/.gentle-ai"}) {
+		t.Fatalf("claude-code targets = %#v, want [~/.claude ~/.gentle-ai]", step.Targets)
+	}
+}
+
 func TestPlanResolvesAntigravityGentleAIProvisioner(t *testing.T) {
 	prov := manifest.Provisioner{
 		Tool: "gentle-ai", Tags: []string{"core"},
@@ -244,8 +268,8 @@ func TestPlanResolvesAntigravityGentleAIProvisioner(t *testing.T) {
 	if !reflect.DeepEqual(step.Args, []string{"install", "--scope", "global", "--agents", "antigravity"}) {
 		t.Fatalf("antigravity gentle-ai args = %#v", step.Args)
 	}
-	if !reflect.DeepEqual(step.Targets, []string{"~/.claude", "~/.gemini", "~/.gentle-ai"}) {
-		t.Fatalf("antigravity targets = %#v, want [~/.claude ~/.gemini ~/.gentle-ai]", step.Targets)
+	if !reflect.DeepEqual(step.Targets, []string{"~/.gemini", "~/.gentle-ai"}) {
+		t.Fatalf("antigravity targets = %#v, want [~/.gemini ~/.gentle-ai]", step.Targets)
 	}
 }
 


### PR DESCRIPTION
Closes #141

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds Google Antigravity to the existing gentle-ai agent setup path.
- Installs Antigravity with `engram`, `context7`, and `persona` only.
- Extends SDD cleanup to Antigravity without adding `sdd` or `permissions` to the install path.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Adds Antigravity to gentle-ai SDD cleanup and adds a separate Antigravity basic install provisioner. |
| `internal/provision/plan.go` | Reports `~/.gemini` as the Antigravity blast-radius root. |
| `internal/manifest/manifest_test.go` | Enforces Antigravity provisioner shape and exclusion of `sdd` / `permissions`. |
| `internal/provision/plan_test.go` | Covers Antigravity provision planning and affected roots. |
| `internal/cli/claude_config_test.go` | Verifies sandboxed gentle-ai argv includes Antigravity without SDD or permissions. |
| `docs/manifest.md` | Documents the current Antigravity provisioner behavior. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [ ] `go run ./cmd/dots manifest validate --file dots.yaml` — skipped: this CLI has no `manifest validate` command.
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots install --profile agents --dry-run --home <tmp> --state-root <tmp> --source-root "$PWD"`
- [x] `go build ./...`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #141`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
