### PR TITLE
feat(agents): provision Matt Pocock engineering skills

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -205,6 +205,7 @@ Current Provisioners:
 | `gentle-ai` | `agents` | all | Install global stable neutral custom setup for `claude-code` with `engram`, `context7`, `persona`, and `permissions`. | `gentle-ai`, `engram` |
 | `gentle-ai` | `agents` | all | Install global stable neutral custom setup for `antigravity` with `engram`, `context7`, and `persona` only; no `sdd` or `permissions`. | `gentle-ai`, `engram` |
 | `skills` | `agents` | all | Install `web-design-guidelines` from `vercel-labs/agent-skills` globally for `codex`, `claude-code`, and `antigravity` through pinned `skills@1.5.12`. | `npx` |
+| `skills` | `agents` | all | Install the reviewed Matt Pocock engineering skill set from `mattpocock/skills/skills/engineering` globally for `codex`, `claude-code`, and `antigravity` through pinned `skills@1.5.12`. | `npx` |
 | `claude` | `desktop` | `darwin`, `linux` | Register marketplace `ChromeDevTools/chrome-devtools-mcp`. | `claude` |
 | `claude` | `desktop` | `darwin`, `linux` | Install `chrome-devtools-mcp` from `chrome-devtools-plugins` with user scope. | `claude` |
 | `codex` | `desktop` | `darwin`, `linux` | Add MCP server `chrome-devtools` using `npx -y chrome-devtools-mcp@latest --no-performance-crux`. | `codex` |

--- a/dots.yaml
+++ b/dots.yaml
@@ -402,6 +402,35 @@ provisioners:
     dependencies:
       - name: npx
         command: npx
+  - tool: skills
+    tags:
+      - agents
+    spec:
+      package: mattpocock/skills/skills/engineering
+      agents:
+        - codex
+        - claude-code
+        - antigravity
+      skills:
+        - ask-matt
+        - codebase-design
+        - diagnosing-bugs
+        - domain-modeling
+        - grill-with-docs
+        - implement
+        - improve-codebase-architecture
+        - prototype
+        - resolving-merge-conflicts
+        - setup-matt-pocock-skills
+        - tdd
+        - to-issues
+        - to-prd
+        - triage
+      global: true
+      copy: true
+    dependencies:
+      - name: npx
+        command: npx
   - tool: claude
     tags:
       - desktop

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -487,6 +487,44 @@ func TestRepositoryManifestIncludesExternalSkillsProvisioner(t *testing.T) {
 	}
 }
 
+func TestRepositoryManifestIncludesMattPocockEngineeringSkillsProvisioner(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", ".."))
+	manifestPath := filepath.Join(root, "dots.yaml")
+
+	got, err := manifest.LoadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("LoadFile(%q) error = %v", manifestPath, err)
+	}
+
+	var skills *manifest.Provisioner
+	for i := range got.Provisioners {
+		prov := &got.Provisioners[i]
+		if prov.Tool == "skills" && prov.Spec.Package == "mattpocock/skills/skills/engineering" {
+			skills = prov
+		}
+	}
+
+	if skills == nil {
+		t.Fatal("repository manifest missing skills provisioner for mattpocock/skills/skills/engineering")
+	}
+	if !hasString(skills.Tags, "agents") {
+		t.Errorf("skills provisioner %#v missing agents tag", skills.Spec)
+	}
+	if !sameStrings(skills.Spec.Agents, []string{"codex", "claude-code", "antigravity"}) {
+		t.Errorf("skills provisioner agents = %#v, want [codex claude-code antigravity]", skills.Spec.Agents)
+	}
+	wantSkills := []string{"ask-matt", "codebase-design", "diagnosing-bugs", "domain-modeling", "grill-with-docs", "implement", "improve-codebase-architecture", "prototype", "resolving-merge-conflicts", "setup-matt-pocock-skills", "tdd", "to-issues", "to-prd", "triage"}
+	if !sameStrings(skills.Spec.Skills, wantSkills) {
+		t.Errorf("skills provisioner skills = %#v, want %#v", skills.Spec.Skills, wantSkills)
+	}
+	if !skills.Spec.Global || !skills.Spec.Copy {
+		t.Errorf("skills provisioner global/copy = %v/%v, want true/true", skills.Spec.Global, skills.Spec.Copy)
+	}
+	if !hasDependency(skills.Dependencies, "npx") {
+		t.Errorf("skills provisioner missing npx dependency: %#v", skills.Dependencies)
+	}
+}
+
 func TestRepositoryManifestIncludesGentleAICleanupBeforeBasicInstall(t *testing.T) {
 	root := filepath.Clean(filepath.Join("..", ".."))
 	manifestPath := filepath.Join(root, "dots.yaml")


### PR DESCRIPTION
Closes #143

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds Matt Pocock's engineering skills to the `agents` Install Profile through the existing allowlisted `skills` provisioner.
- Limits the external source to `mattpocock/skills/skills/engineering` instead of installing the full repository.
- Documents the new provisioner and adds repository-manifest coverage for the expected package, agents, skill list, and `copy` behavior.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Adds a `skills` provisioner for `mattpocock/skills/skills/engineering`, targeting `codex`, `claude-code`, and `antigravity`. |
| `internal/manifest/manifest_test.go` | Verifies the repository manifest includes the Matt Pocock engineering skills provisioner with the expected explicit skill set. |
| `docs/manifest.md` | Documents the new current provisioner. |

## Test Plan

- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed status check: `go run ./cmd/dots status --profile agents --home <tmp> --state-root <tmp> --source-root "$PWD" --output json` showed the Matt Pocock provisioner in the agent provisioner plan.
- [x] Sandboxed upstream CLI check: `HOME=<tmp> npx --yes skills@1.5.12 add mattpocock/skills/skills/engineering ... --global --copy` found and selected all 14 declared engineering skills.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #143`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
