### PR TITLE
feat(profile): add mobile skills profile

### DIFF
--- a/docs/adr/0009-mobile-tooling-profile.md
+++ b/docs/adr/0009-mobile-tooling-profile.md
@@ -1,0 +1,9 @@
+# Install Dart and Flutter agent skills through an explicit mobile profile
+
+The user wants Dart and Flutter agent skills available on demand without making mobile development part of the default, desktop, web, or broad agent setup. We add a dedicated `mobile` Profile/tag for the mobile workbench and attach two skills.sh provisioners: `dart-lang/skills` and `flutter/skills`.
+
+This keeps profile names aligned with user intent. Choosing `--profile mobile` means “prepare this machine/session for Dart and Flutter app work”. Choosing `--profile web` remains focused on frontend/browser tooling, choosing `--profile agents` remains focused on general agent setup, and choosing `--profile desktop` remains focused on terminal/editor/GUI machine configuration.
+
+**Considered Options**: Adding Dart and Flutter skills to `agents` was rejected because it would make mobile-specific guidance part of every agent setup. Adding them to `web` was rejected because Flutter can target the web, but the requested capability is primarily mobile app development. Adding Flutter or Dart SDK package-manager dependencies was rejected for now because the request only asked to install the upstream skills; SDK installation can be added later if the profile is expanded from agent guidance into full mobile runtime/toolchain setup.
+
+**Consequences**: Manifest profile selection now has a `mobile` tag. The mobile profile installs all upstream skills from `dart-lang/skills` and `flutter/skills` globally for Codex, Claude Code, and Antigravity through the pinned skills.sh CLI. Documentation and repository manifest tests must treat Dart and Flutter skills as mobile-scoped from this point forward. Initial implementation is tracked in [#149](https://github.com/yersonargotev/dots/issues/149).

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -43,6 +43,7 @@ Current Profiles:
 | `desktop` | `core`, `desktop` | Desktop dotfiles and desktop-only tool integrations; no gentle-ai agent setup. | `Desktop Nerd Font` via Homebrew cask `font-cascadia-code-nf`, detected with `CascadiaCodeNF*` |
 | `agents` | `core`, `agents` | Core dotfiles plus gentle-ai agent setup/cleanup. | None |
 | `web` | `core`, `web` | Optional frontend/browser workbench: web design skills plus Chrome DevTools integrations. | None |
+| `mobile` | `core`, `mobile` | Optional Dart and Flutter mobile development agent skills. | None |
 | `workstation` | `core`, `desktop`, `agents` | Full workstation setup when both desktop integrations and agent setup are desired; web tooling remains explicit opt-in. | `Desktop Nerd Font` via Homebrew cask `font-cascadia-code-nf`, detected with `CascadiaCodeNF*` |
 
 ## Managed Entries
@@ -208,6 +209,8 @@ Current Provisioners:
 | `skills` | `web` | all | Install `playwright-cli` from `microsoft/playwright-cli` globally for `codex`, `claude-code`, and `antigravity` through pinned `skills@1.5.12`, copying the skill and references into the agent skill roots. | `npx` |
 | `skills` | `web` | all | Install `frontend-design` from `anthropics/skills` globally for `codex`, `claude-code`, and `antigravity` through pinned `skills@1.5.12`. | `npx` |
 | `skills` | `web` | all | Install `vercel-react-best-practices`, `vercel-composition-patterns`, `vercel-react-view-transitions`, and `web-design-guidelines` from `vercel-labs/agent-skills` globally for `codex`, `claude-code`, and `antigravity` through pinned `skills@1.5.12`. | `npx` |
+| `skills` | `mobile` | all | Install the upstream Dart skill package from `dart-lang/skills` globally for `codex`, `claude-code`, and `antigravity` through pinned `skills@1.5.12`. | `npx` |
+| `skills` | `mobile` | all | Install the upstream Flutter skill package from `flutter/skills` globally for `codex`, `claude-code`, and `antigravity` through pinned `skills@1.5.12`. | `npx` |
 | `skills` | `agents` | all | Install the reviewed Matt Pocock engineering skill set from `mattpocock/skills/skills/engineering` globally for `codex`, `claude-code`, and `antigravity` through pinned `skills@1.5.12`. | `npx` |
 | `claude` | `web` | `darwin`, `linux` | Register marketplace `ChromeDevTools/chrome-devtools-mcp`. | `claude` |
 | `claude` | `web` | `darwin`, `linux` | Install `chrome-devtools-mcp` from `chrome-devtools-plugins` with user scope. | `claude` |

--- a/docs/update.md
+++ b/docs/update.md
@@ -69,7 +69,7 @@ Because no fast-forward is applied in a dry run, the rendered plan reflects the 
 
 ## Profiles and provisioners
 
-Provisioners are scoped by profile tags, exactly like file entries. The `default` profile selects no provisioners. The `desktop` profile selects desktop configuration and non-web desktop integrations. The `agents` profile selects gentle-ai setup/cleanup provisioners. The `web` profile selects frontend design skills plus Chrome DevTools for Claude, Codex, and the OpenCode overlay. Use `workstation` when you explicitly want both desktop integrations and agent setup; web tooling remains a separate opt-in. This is design-intent: desktop installs should configure desktop tools, not opt into SDD, gentle-dev agent setup, or browser/frontend tooling.
+Provisioners are scoped by profile tags, exactly like file entries. The `default` profile selects no provisioners. The `desktop` profile selects desktop configuration and non-web desktop integrations. The `agents` profile selects gentle-ai setup/cleanup provisioners. The `web` profile selects frontend design skills plus Chrome DevTools for Claude, Codex, and the OpenCode overlay. The `mobile` profile selects Dart and Flutter agent skills. Use `workstation` when you explicitly want both desktop integrations and agent setup; web and mobile tooling remain separate opt-ins. This is design-intent: desktop installs should configure desktop tools, not opt into SDD, gentle-dev agent setup, browser/frontend tooling, or mobile-specific skills.
 
 The gentle-ai provisioner can model cleanup before install by using separate entries in manifest order. Missing `action` still defaults to `install`; `yes` is only valid for `uninstall` because it confirms a cleanup action:
 
@@ -93,7 +93,7 @@ provisioners:
 To keep that requirement discoverable, both `install` and `update` print a one-line hint when the active profile skips provisioners another profile would select on this OS:
 
 ```
-Note: profile "default" skips provisioner(s); run with --profile agents, --profile desktop, or --profile web to include the relevant group.
+Note: profile "default" skips provisioner(s); run with --profile agents, --profile desktop, --profile mobile, or --profile web to include the relevant group.
 ```
 
 File entries are profile-scoped the same way, and the `default` profile silently omits profile-specific entries such as the `desktop` Ghostty/Zed configs and the `web` OpenCode MCP overlay. To close the same discoverability gap, both commands print a parallel hint for skipped file entries:

--- a/dots.yaml
+++ b/dots.yaml
@@ -23,6 +23,10 @@ profiles:
       - name: Playwright CLI
         command: playwright-cli
         brew: playwright-cli
+  mobile:
+    tags:
+      - core
+      - mobile
   workstation:
     tags:
       - core
@@ -440,6 +444,32 @@ provisioners:
         - vercel-composition-patterns
         - vercel-react-view-transitions
         - web-design-guidelines
+      global: true
+    dependencies:
+      - name: npx
+        command: npx
+  - tool: skills
+    tags:
+      - mobile
+    spec:
+      package: dart-lang/skills
+      agents:
+        - codex
+        - claude-code
+        - antigravity
+      global: true
+    dependencies:
+      - name: npx
+        command: npx
+  - tool: skills
+    tags:
+      - mobile
+    spec:
+      package: flutter/skills
+      agents:
+        - codex
+        - claude-code
+        - antigravity
       global: true
     dependencies:
       - name: npx

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -593,6 +593,55 @@ func TestRepositoryManifestIncludesAnthropicFrontendDesignSkillProvisioner(t *te
 	}
 }
 
+func TestRepositoryManifestMobileProfileIncludesDartAndFlutterSkills(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", ".."))
+	manifestPath := filepath.Join(root, "dots.yaml")
+
+	got, err := manifest.LoadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("LoadFile(%q) error = %v", manifestPath, err)
+	}
+
+	mobile, ok := got.Profiles["mobile"]
+	if !ok {
+		t.Fatal("repository manifest missing mobile profile")
+	}
+	if !sameStrings(mobile.Tags, []string{"core", "mobile"}) {
+		t.Fatalf("mobile profile tags = %#v, want [core mobile]", mobile.Tags)
+	}
+
+	for _, pkg := range []string{"dart-lang/skills", "flutter/skills"} {
+		t.Run(pkg, func(t *testing.T) {
+			var skills *manifest.Provisioner
+			for i := range got.Provisioners {
+				prov := &got.Provisioners[i]
+				if prov.Tool == "skills" && prov.Spec.Package == pkg {
+					skills = prov
+				}
+			}
+
+			if skills == nil {
+				t.Fatalf("repository manifest missing skills provisioner for %s", pkg)
+			}
+			if !hasString(skills.Tags, "mobile") {
+				t.Errorf("skills provisioner %#v missing mobile tag", skills.Spec)
+			}
+			if !sameStrings(skills.Spec.Agents, []string{"codex", "claude-code", "antigravity"}) {
+				t.Errorf("skills provisioner agents = %#v, want [codex claude-code antigravity]", skills.Spec.Agents)
+			}
+			if len(skills.Spec.Skills) != 0 {
+				t.Errorf("skills provisioner skills = %#v, want empty so the upstream package default installs all skills", skills.Spec.Skills)
+			}
+			if !skills.Spec.Global {
+				t.Errorf("skills provisioner global = false, want true")
+			}
+			if !hasDependency(skills.Dependencies, "npx") {
+				t.Errorf("skills provisioner missing npx dependency: %#v", skills.Dependencies)
+			}
+		})
+	}
+}
+
 func TestRepositoryManifestIncludesMattPocockEngineeringSkillsProvisioner(t *testing.T) {
 	root := filepath.Clean(filepath.Join("..", ".."))
 	manifestPath := filepath.Join(root, "dots.yaml")


### PR DESCRIPTION
Closes #149

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds an explicit `mobile` profile for Dart and Flutter agent skills.
- Installs upstream `dart-lang/skills` and `flutter/skills` globally for Codex, Claude Code, and Antigravity through the pinned skills.sh provisioner.
- Documents the profile boundary and records the decision in ADR 0009.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Added `mobile` profile and Dart/Flutter skills provisioners. |
| `internal/manifest/manifest_test.go` | Added repository manifest coverage for the mobile profile and skills provisioners. |
| `docs/manifest.md` | Documented the mobile profile and its provisioners. |
| `docs/update.md` | Documented mobile as a separate opt-in profile. |
| `docs/adr/0009-mobile-tooling-profile.md` | Recorded the scope decision for mobile skills. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed install dry-run: `go run ./cmd/dots install --dry-run --profile mobile --home <tmp>/home --source-root "$PWD" --state-root <tmp>/state --output json`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #149`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
