### PR TITLE
feat(agents): bootstrap CodeGraph provisioning

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,19 +1,5 @@
-# CodeGraph data files
-# These are local to each machine and should not be committed
-
-# Database
-*.db
-*.db-wal
-*.db-shm
-
-# Cache
-cache/
-
-# Logs
-*.log
-
-# Hook markers
-.dirty
-
-# Daemon runtime
-daemon.pid
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -128,7 +128,8 @@ Current dependency package coverage:
 | `engram` | `engram` | `gentleman-programming/tap/engram` | Manual | Manual | Manual |
 | `claude` | `claude` | Manual | Manual | Manual | Manual |
 | `codex` | `codex` | Manual | Manual | Manual | Manual |
-| `codegraph` | `codegraph` | Manual | Manual | Manual | Manual |
+| `curl` | `curl` | `curl` | `curl` | `curl` | `curl` |
+| `npx` | `npx` | Manual | Manual | Manual | Manual |
 
 ## Provisioners
 
@@ -137,7 +138,7 @@ installed and only after their declared Dependencies are present.
 
 | Field | Required | Supported values |
 |-------|----------|------------------|
-| `tool` | Yes | `gentle-ai`, `claude`, `codex`, or `skills`. |
+| `tool` | Yes | `gentle-ai`, `claude`, `codex`, `codegraph`, or `skills`. |
 | `tags` | Yes | Non-empty strings matched against the selected Profile. |
 | `os` | No | `darwin`, `linux`; empty means all supported operating systems. |
 | `spec` | Yes | Tool-specific declaration. Each spec must speak exactly one tool dialect. |
@@ -175,6 +176,26 @@ Constraints:
 - `command` must contain at least one non-empty argument.
 - `env` keys must not be empty.
 - Codex specs must not mix gentle-ai or Claude fields.
+
+### `codegraph` spec
+
+Supported fields: `scope`, `agents`, and `yes`.
+
+`codegraph` renders one fixed shell invocation. It first checks whether
+`codegraph` is already on `PATH`; when missing, it runs CodeGraph's official
+`curl -fsSL https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh | sh`
+bootstrap, adds `$HOME/.local/bin` to the child process `PATH`, and then runs
+`codegraph install` to wire MCP config plus instructions for the selected
+agents.
+
+Constraints:
+
+- `agents` is required and renders the comma-separated `--target` list.
+- `scope`, when set, must be `global` or `local` and renders `--location`.
+- `yes` is required and must be `true`; it renders CodeGraph's non-interactive
+  `--yes` flag.
+- CodeGraph specs must not mix gentle-ai action/channel/persona/preset/sdd,
+  Claude, Codex MCP, or skills.sh fields.
 
 ### `skills` spec
 
@@ -216,7 +237,7 @@ Current Provisioners:
 | `claude` | `web` | `darwin`, `linux` | Register marketplace `ChromeDevTools/chrome-devtools-mcp`. | `claude` |
 | `claude` | `web` | `darwin`, `linux` | Install `chrome-devtools-mcp` from `chrome-devtools-plugins` with user scope. | `claude` |
 | `codex` | `web` | `darwin`, `linux` | Add MCP server `chrome-devtools` using `npx -y chrome-devtools-mcp@latest --no-performance-crux`. | `codex` |
-| `codex` | `desktop` | `darwin`, `linux` | Add MCP server `codegraph` using `codegraph serve --mcp`. | `codex`, `codegraph` |
+| `codegraph` | `agents` | `darwin`, `linux` | Reuse `codegraph` when already on `PATH`; otherwise install it with the official curl bootstrap, then run `codegraph install --target codex,claude,antigravity,opencode --location global --yes` so CodeGraph configures MCP plus instructions for Codex, Claude Code, Antigravity, and OpenCode. | `curl` |
 
 ## Selection rules
 

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -191,6 +191,8 @@ agents.
 Constraints:
 
 - `agents` is required and renders the comma-separated `--target` list.
+  Supported CodeGraph targets are `codex`, `claude`, `antigravity`, and
+  `opencode`.
 - `scope`, when set, must be `global` or `local` and renders `--location`.
 - `yes` is required and must be `true`; it renders CodeGraph's non-interactive
   `--yes` flag.

--- a/dots.yaml
+++ b/dots.yaml
@@ -560,20 +560,24 @@ provisioners:
     dependencies:
       - name: codex
         command: codex
-  - tool: codex
+  - tool: codegraph
     tags:
-      - desktop
+      - agents
     os:
       - darwin
       - linux
     spec:
-      mcp: codegraph
-      command:
-        - codegraph
-        - serve
-        - --mcp
+      scope: global
+      agents:
+        - codex
+        - claude
+        - antigravity
+        - opencode
+      yes: true
     dependencies:
-      - name: codex
-        command: codex
-      - name: codegraph
-        command: codegraph
+      - name: curl
+        command: curl
+        brew: curl
+        apt: curl
+        dnf: curl
+        pacman: curl

--- a/internal/cli/claude_config_test.go
+++ b/internal/cli/claude_config_test.go
@@ -35,6 +35,7 @@ func TestClaudeAgentsProfileSeedsUserBaselineInSandbox(t *testing.T) {
 	stubDir := t.TempDir()
 	writeExecStub(t, filepath.Join(stubDir, "gentle-ai"), "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$HOME/gentle-ai-args\"\n")
 	writeExecStub(t, filepath.Join(stubDir, "engram"), "#!/bin/sh\nexit 0\n")
+	writeExecStub(t, filepath.Join(stubDir, "codegraph"), "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$HOME/codegraph-args\"\n")
 	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	install := cli.NewRootCommand()
@@ -187,9 +188,19 @@ func TestClaudeAgentsProfileSeedsUserBaselineInSandbox(t *testing.T) {
 	if strings.Contains(string(gotArgs), "install --scope global --channel stable --persona neutral --preset custom --agents codex,claude-code,opencode") {
 		t.Fatalf("provisioner argv = %q, want basic install without opencode", gotArgs)
 	}
+	gotCodeGraphArgs, err := os.ReadFile(filepath.Join(home, "codegraph-args"))
+	if err != nil {
+		t.Fatalf("codegraph provisioner did not run under the sandbox HOME %q: %v", home, err)
+	}
+	if !strings.Contains(string(gotCodeGraphArgs), "install --target codex,claude,antigravity,opencode --location global --yes") {
+		t.Fatalf("codegraph argv = %q, want CodeGraph installer for codex, claude, antigravity, and opencode", gotCodeGraphArgs)
+	}
 	// And it must never have escaped into the inherited real HOME.
 	if _, err := os.Stat(filepath.Join(realHome, "gentle-ai-args")); err == nil {
 		t.Fatalf("provisioner wrote into the inherited HOME %q instead of the sandbox", realHome)
+	}
+	if _, err := os.Stat(filepath.Join(realHome, "codegraph-args")); err == nil {
+		t.Fatalf("codegraph provisioner wrote into the inherited HOME %q instead of the sandbox", realHome)
 	}
 	if _, err := os.Stat(filepath.Join(realHome, ".config", "opencode", "opencode.json")); err == nil {
 		t.Fatalf("OpenCode generated config escaped into the inherited HOME %q", realHome)
@@ -256,6 +267,7 @@ cat > "$HOME/.claude/settings.json" <<'JSON'
 JSON
 `)
 	writeExecStub(t, filepath.Join(stubDir, "engram"), "#!/bin/sh\nexit 0\n")
+	writeExecStub(t, filepath.Join(stubDir, "codegraph"), "#!/bin/sh\nexit 0\n")
 	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	install := cli.NewRootCommand()

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -156,10 +156,31 @@ func runProvisioners(cmd *cobra.Command, m manifest.Manifest, profile, home stri
 	if err != nil {
 		return err
 	}
+	if agents := selectedCodeGraphAgents(selected); len(agents) > 0 {
+		return codexconfig.EnsureCodeGraphMode(home, agents...)
+	}
 	if !selectedProvisionersAffectCodex(selected) {
 		return nil
 	}
 	return codexconfig.EnsureCodeGraphMode(home)
+}
+
+func selectedCodeGraphAgents(selected []manifest.Provisioner) []string {
+	var agents []string
+	seen := map[string]bool{}
+	for _, prov := range selected {
+		if prov.Tool != "codegraph" {
+			continue
+		}
+		for _, agent := range prov.Spec.Agents {
+			if seen[agent] {
+				continue
+			}
+			seen[agent] = true
+			agents = append(agents, agent)
+		}
+	}
+	return agents
 }
 
 func selectedProvisionersAffectCodex(selected []manifest.Provisioner) bool {

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -167,6 +167,9 @@ func selectedProvisionersAffectCodex(selected []manifest.Provisioner) bool {
 		if prov.Tool == "codex" {
 			return true
 		}
+		if prov.Tool == "codegraph" && provisionerAgentsInclude(prov, "codex") {
+			return true
+		}
 		if prov.Tool == "gentle-ai" && provisionerAgentsInclude(prov, "codex") {
 			return true
 		}

--- a/internal/cli/provision_runner_test.go
+++ b/internal/cli/provision_runner_test.go
@@ -188,6 +188,70 @@ printf '%s\n' "$*" > "$HOME/skills-args"
 	}
 }
 
+func TestRunProvisionersWritesCodeGraphInstructionsForSelectedAgents(t *testing.T) {
+	home := t.TempDir()
+	stubDir := t.TempDir()
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	script := `#!/bin/sh
+if [ "$1" != "install" ]; then
+  exit 9
+fi
+printf '%s\n' "$*" > "$HOME/codegraph-args"
+`
+	if err := os.WriteFile(filepath.Join(stubDir, "codegraph"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write codegraph stub: %v", err)
+	}
+
+	m := manifest.Manifest{
+		Version: 1,
+		Profiles: map[string]manifest.Profile{
+			"default": {Tags: []string{"agents"}},
+		},
+		Provisioners: []manifest.Provisioner{
+			{
+				Tool: "codegraph", Tags: []string{"agents"},
+				Spec: manifest.ProvisionerSpec{
+					Scope:  "global",
+					Agents: []string{"codex", "claude", "antigravity", "opencode"},
+					Yes:    true,
+				},
+			},
+		},
+	}
+
+	cmd := NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	if err := runProvisioners(cmd, m, "default", home); err != nil {
+		t.Fatalf("runProvisioners() error = %v\noutput:\n%s", err, out.String())
+	}
+
+	wantArgs := "install --target codex,claude,antigravity,opencode --location global --yes\n"
+	gotArgs, err := os.ReadFile(filepath.Join(home, "codegraph-args"))
+	if err != nil {
+		t.Fatalf("codegraph provisioner did not write args into sandbox home %q: %v", home, err)
+	}
+	if string(gotArgs) != wantArgs {
+		t.Fatalf("codegraph args = %q, want %q", gotArgs, wantArgs)
+	}
+	for _, path := range []string{
+		filepath.Join(home, ".codex", "AGENTS.md"),
+		filepath.Join(home, ".claude", "CLAUDE.md"),
+		filepath.Join(home, ".gemini", "GEMINI.md"),
+	} {
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("missing CodeGraph instructions %s: %v", path, err)
+		}
+		if !strings.Contains(string(got), "Do NOT use CodeGraph as proof for runtime behavior.") {
+			t.Fatalf("%s missing runtime-verification guidance\ncontent:\n%s", path, got)
+		}
+	}
+}
+
 func TestSelectedProvisionersAffectCodex(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/codexconfig/codegraph.go
+++ b/internal/codexconfig/codegraph.go
@@ -1,9 +1,10 @@
-// Package codexconfig manages dots-owned overlays inside Codex configuration
-// files without taking ownership of the whole file.
+// Package codexconfig manages dots-owned CodeGraph overlays inside agent
+// instruction files without taking ownership of the whole file.
 package codexconfig
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -18,34 +19,66 @@ const (
 )
 
 const codeGraphInstructions = "CodeGraph Mode: enabled\n\n" +
-	"If `.codegraph/` exists in the project, use CodeGraph first for architecture, trace, impact, and symbol-discovery questions instead of re-deriving the same answer with grep/read loops.\n\n" +
-	"Use CodeGraph by intent:\n\n" +
-	"- `codegraph_context`: map a feature or area first.\n" +
-	"- `codegraph_trace`: trace how one symbol reaches another.\n" +
-	"- `codegraph_explore`: inspect related symbols in one bounded call.\n" +
+	"If `.codegraph/` exists in the project, use CodeGraph first for architecture questions, symbol discovery, call flow, impact analysis, and locating relevant files before edits.\n\n" +
+	"Prefer:\n\n" +
+	"- `codegraph_explore` for understanding an area or flow.\n" +
+	"- `codegraph_node` for one symbol or file.\n" +
 	"- `codegraph_search`: find a symbol by name.\n" +
-	"- `codegraph_callers` / `codegraph_callees`: walk call flow.\n" +
-	"- `codegraph_impact`: check affected code before edits.\n" +
-	"- `codegraph_node`: inspect one symbol.\n" +
-	"- `codegraph_files`: inspect indexed file structure.\n" +
-	"- `codegraph_status`: verify index health.\n\n" +
-	"Treat CodeGraph-returned source as already read. Use raw file reads only to verify details CodeGraph did not cover.\n\n" +
+	"- `codegraph_callers` for caller impact.\n\n" +
+	"Treat CodeGraph-returned source as already read.\n\n" +
+	"Do NOT use CodeGraph as proof for runtime behavior. Always verify CLI behavior, installers, filesystem writes, `$HOME` and config paths, network tools, GitHub, and CI with real commands or tests.\n\n" +
 	"If `.codegraph/` is missing, ask before running `codegraph init -i`."
 
 // EnsureCodeGraphMode inserts or updates the dots-owned CodeGraph instruction
-// block in <home>/.codex/AGENTS.md. It migrates the old manual gentle-ai block
+// block in the selected agents' instruction files. With no agents it preserves
+// the historical Codex-only behavior. It migrates the old manual gentle-ai block
 // to dots markers while preserving non-managed content.
-func EnsureCodeGraphMode(home string) error {
-	path := filepath.Join(home, ".codex", "AGENTS.md")
+func EnsureCodeGraphMode(home string, agents ...string) error {
+	for _, path := range codeGraphInstructionPaths(home, agents) {
+		if err := upsertCodeGraphMode(path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func codeGraphInstructionPaths(home string, agents []string) []string {
+	if len(agents) == 0 {
+		return []string{filepath.Join(home, ".codex", "AGENTS.md")}
+	}
+
+	var paths []string
+	seen := map[string]bool{}
+	add := func(path string) {
+		if seen[path] {
+			return
+		}
+		seen[path] = true
+		paths = append(paths, path)
+	}
+	for _, agent := range agents {
+		switch agent {
+		case "codex":
+			add(filepath.Join(home, ".codex", "AGENTS.md"))
+		case "claude", "claude-code":
+			add(filepath.Join(home, ".claude", "CLAUDE.md"))
+		case "antigravity":
+			add(filepath.Join(home, ".gemini", "GEMINI.md"))
+		}
+	}
+	return paths
+}
+
+func upsertCodeGraphMode(path string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
+		return fmt.Errorf("create agent instructions directory: %w", err)
 	}
 
 	mode := os.FileMode(0o600)
 	content, err := os.ReadFile(path)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
-			return err
+			return fmt.Errorf("read agent instructions %s: %w", path, err)
 		}
 	} else if info, statErr := os.Stat(path); statErr == nil {
 		mode = info.Mode().Perm()
@@ -53,7 +86,10 @@ func EnsureCodeGraphMode(home string) error {
 
 	updated, err := textblock.Upsert(string(content), textblock.Markers{Start: codeGraphStart, End: codeGraphEnd}, codeGraphInstructions, textblock.Markers{Start: legacyCodeGraphStart, End: legacyCodeGraphEnd})
 	if err != nil {
-		return err
+		return fmt.Errorf("update agent instructions %s: %w", path, err)
 	}
-	return os.WriteFile(path, []byte(updated), mode)
+	if err := os.WriteFile(path, []byte(updated), mode); err != nil {
+		return fmt.Errorf("write agent instructions %s: %w", path, err)
+	}
+	return nil
 }

--- a/internal/codexconfig/codegraph_test.go
+++ b/internal/codexconfig/codegraph_test.go
@@ -15,7 +15,27 @@ func TestEnsureCodeGraphModeCreatesAgentsFileWhenMissing(t *testing.T) {
 	}
 
 	got := readCodexAgents(t, home)
-	assertCodeGraphBlock(t, got)
+	assertCodeGraphBlock(t, filepath.Join(home, ".codex", "AGENTS.md"), got)
+}
+
+func TestEnsureCodeGraphModeCreatesSelectedAgentInstructionFiles(t *testing.T) {
+	home := t.TempDir()
+
+	if err := EnsureCodeGraphMode(home, "codex", "claude", "antigravity", "opencode"); err != nil {
+		t.Fatalf("EnsureCodeGraphMode() error = %v", err)
+	}
+
+	for _, path := range []string{
+		filepath.Join(home, ".codex", "AGENTS.md"),
+		filepath.Join(home, ".claude", "CLAUDE.md"),
+		filepath.Join(home, ".gemini", "GEMINI.md"),
+	} {
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read generated instructions %s: %v", path, err)
+		}
+		assertCodeGraphBlock(t, path, string(got))
+	}
 }
 
 func TestEnsureCodeGraphModePreservesExistingContent(t *testing.T) {
@@ -37,7 +57,7 @@ func TestEnsureCodeGraphModePreservesExistingContent(t *testing.T) {
 	if !strings.Contains(got, before) {
 		t.Fatalf("AGENTS.md did not preserve existing content %q\ncontent:\n%s", before, got)
 	}
-	assertCodeGraphBlock(t, got)
+	assertCodeGraphBlock(t, path, got)
 }
 
 func TestEnsureCodeGraphModeUpdatesExistingDotsBlockIdempotently(t *testing.T) {
@@ -58,7 +78,7 @@ func TestEnsureCodeGraphModeUpdatesExistingDotsBlockIdempotently(t *testing.T) {
 	}
 
 	got := readCodexAgents(t, home)
-	assertCodeGraphBlock(t, got)
+	assertCodeGraphBlock(t, filepath.Join(home, ".codex", "AGENTS.md"), got)
 	if strings.Contains(got, "stale instructions") {
 		t.Fatalf("AGENTS.md kept stale managed block content\ncontent:\n%s", got)
 	}
@@ -86,7 +106,7 @@ func TestEnsureCodeGraphModeMigratesLegacyGentleAIBlock(t *testing.T) {
 	}
 
 	got := readCodexAgents(t, home)
-	assertCodeGraphBlock(t, got)
+	assertCodeGraphBlock(t, filepath.Join(home, ".codex", "AGENTS.md"), got)
 	for _, legacy := range []string{legacyCodeGraphStart, legacyCodeGraphEnd, "manual codegraph instructions"} {
 		if strings.Contains(got, legacy) {
 			t.Fatalf("AGENTS.md kept legacy content %q\ncontent:\n%s", legacy, got)
@@ -106,19 +126,25 @@ func readCodexAgents(t *testing.T, home string) string {
 	return string(got)
 }
 
-func assertCodeGraphBlock(t *testing.T, content string) {
+func assertCodeGraphBlock(t *testing.T, path, content string) {
 	t.Helper()
 	for _, want := range []string{
 		codeGraphStart,
 		"CodeGraph Mode: enabled",
 		"If `.codegraph/` exists in the project, use CodeGraph first",
-		"`codegraph_context`: map a feature or area first.",
+		"`codegraph_explore` for understanding an area or flow.",
 		"Treat CodeGraph-returned source as already read.",
+		"Do NOT use CodeGraph as proof for runtime behavior.",
 		"If `.codegraph/` is missing, ask before running `codegraph init -i`.",
 		codeGraphEnd,
 	} {
 		if !strings.Contains(content, want) {
-			t.Fatalf("AGENTS.md missing %q\ncontent:\n%s", want, content)
+			t.Fatalf("%s missing %q\ncontent:\n%s", path, want, content)
+		}
+	}
+	for _, ghostTool := range []string{"codegraph_context", "codegraph_trace", "codegraph_files", "codegraph_status"} {
+		if strings.Contains(content, ghostTool) {
+			t.Fatalf("%s kept unsupported tool %q\ncontent:\n%s", path, ghostTool, content)
 		}
 	}
 }

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -55,9 +55,10 @@ type Provisioner struct {
 // tool; the tool owns how they render into agent config. The scalar/list flags
 // map 1:1 to gentle-ai's install/uninstall flags. The Claude fields (Marketplace, Plugin,
 // From) describe a single idempotent `claude` invocation, the codex MCP fields
-// (MCP, Command, Env) a single `codex mcp add` invocation, and Package drives
-// one `npx --yes skills@1.5.12 add` invocation. The dialects are mutually exclusive: a spec
-// speaks exactly one of them.
+// (MCP, Command, Env) a single `codex mcp add` invocation, Package drives
+// one `npx --yes skills@1.5.12 add` invocation, and the codegraph dialect reuses
+// Agents, Scope, and Yes to render a fixed bootstrap-and-install script. The
+// dialects are mutually exclusive: a spec speaks exactly one of them.
 type ProvisionerSpec struct {
 	Action     string   `yaml:"action,omitempty"`
 	Scope      string   `yaml:"scope,omitempty"`
@@ -255,7 +256,7 @@ func (m Manifest) Validate() error {
 			return fmt.Errorf("provisioners[%d].tool is required", i)
 		}
 		if !allowedProvisionerTool(prov.Tool) {
-			return fmt.Errorf("provisioners[%d].tool must be one of claude, codex, gentle-ai, skills", i)
+			return fmt.Errorf("provisioners[%d].tool must be one of claude, codegraph, codex, gentle-ai, skills", i)
 		}
 		if len(prov.Tags) == 0 {
 			return fmt.Errorf("provisioners[%d].tags is required", i)
@@ -278,6 +279,10 @@ func (m Manifest) Validate() error {
 			}
 		case "codex":
 			if err := validateCodexSpec(prov.Spec, i); err != nil {
+				return err
+			}
+		case "codegraph":
+			if err := validateCodeGraphSpec(prov.Spec, i); err != nil {
 				return err
 			}
 		case "skills":
@@ -461,6 +466,48 @@ func validateCodexSpec(s ProvisionerSpec, i int) error {
 	return nil
 }
 
+// validateCodeGraphSpec enforces the CodeGraph installer contract: it drives one
+// non-interactive install through a fixed shell script so dots can bootstrap the
+// codegraph binary when it is absent, then wire the selected agents to
+// `codegraph serve --mcp`.
+func validateCodeGraphSpec(s ProvisionerSpec, i int) error {
+	if s.usesClaudeFields() {
+		return fmt.Errorf("provisioners[%d].spec must not set claude fields (marketplace, plugin, from) for the codegraph tool", i)
+	}
+	if s.usesMCPFields() {
+		return fmt.Errorf("provisioners[%d].spec must not set codex MCP fields (mcp, command, env) for the codegraph tool", i)
+	}
+	if s.usesSkillsFields() {
+		return fmt.Errorf("provisioners[%d].spec must not set skills.sh fields (package, global, copy) for the codegraph tool", i)
+	}
+	if strings.TrimSpace(s.Action) != "" ||
+		strings.TrimSpace(s.Channel) != "" ||
+		strings.TrimSpace(s.Persona) != "" ||
+		strings.TrimSpace(s.Preset) != "" ||
+		strings.TrimSpace(s.SDDMode) != "" ||
+		hasNonEmptyString(s.Components) ||
+		hasNonEmptyString(s.Skills) {
+		return fmt.Errorf("provisioners[%d].spec must not set gentle-ai fields (action, channel, persona, preset, sdd-mode, components, skills) for the codegraph tool", i)
+	}
+	if !hasNonEmptyString(s.Agents) {
+		return fmt.Errorf("provisioners[%d].spec.agents is required for the codegraph tool", i)
+	}
+	if !s.Yes {
+		return fmt.Errorf("provisioners[%d].spec.yes must be true for the codegraph tool", i)
+	}
+	if j, ok := indexOfEmptyString(s.Agents); ok {
+		return fmt.Errorf("provisioners[%d].spec.agents[%d] must not be empty", i, j)
+	}
+	if err := validateSkillsDataValues(s.Agents, fmt.Sprintf("provisioners[%d].spec.agents", i)); err != nil {
+		return err
+	}
+	scope := strings.TrimSpace(s.Scope)
+	if scope != "" && scope != "global" && scope != "local" {
+		return fmt.Errorf("provisioners[%d].spec.scope must be one of global, local for the codegraph tool", i)
+	}
+	return nil
+}
+
 // validateSkillsSpec enforces the skills.sh provisioner contract: it drives one
 // exact `npx --yes skills@1.5.12 add <package>` invocation with optional target agents and
 // selected skill names. It does not accept gentle-ai scalar/action fields,
@@ -625,11 +672,11 @@ func allowedOS(osName string) bool {
 }
 
 // allowedProvisionerTool enforces the provisioner allowlist. dots is never a
-// generic command runner: gentle-ai, claude, codex, and skills are the only
-// accepted provisioner tools, each driven through a fixed set of subcommands.
+// generic command runner: gentle-ai, claude, codex, codegraph, and skills are the
+// only accepted provisioner tools, each driven through a fixed set of subcommands.
 func allowedProvisionerTool(tool string) bool {
 	switch strings.TrimSpace(tool) {
-	case "gentle-ai", "claude", "codex", "skills":
+	case "gentle-ai", "claude", "codex", "codegraph", "skills":
 		return true
 	default:
 		return false

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -501,11 +501,25 @@ func validateCodeGraphSpec(s ProvisionerSpec, i int) error {
 	if err := validateSkillsDataValues(s.Agents, fmt.Sprintf("provisioners[%d].spec.agents", i)); err != nil {
 		return err
 	}
+	for j, agent := range s.Agents {
+		if !allowedCodeGraphAgent(strings.TrimSpace(agent)) {
+			return fmt.Errorf("provisioners[%d].spec.agents[%d] must be one of antigravity, claude, codex, opencode for the codegraph tool", i, j)
+		}
+	}
 	scope := strings.TrimSpace(s.Scope)
 	if scope != "" && scope != "global" && scope != "local" {
 		return fmt.Errorf("provisioners[%d].spec.scope must be one of global, local for the codegraph tool", i)
 	}
 	return nil
+}
+
+func allowedCodeGraphAgent(agent string) bool {
+	switch agent {
+	case "antigravity", "claude", "codex", "opencode":
+		return true
+	default:
+		return false
+	}
 }
 
 // validateSkillsSpec enforces the skills.sh provisioner contract: it drives one

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -1547,6 +1547,17 @@ provisioners:
 			want: "provisioners[0].spec.yes must be true for the codegraph tool",
 		},
 		{
+			name: "codegraph spec rejects unsupported agent target",
+			provisioner: `  - tool: codegraph
+    tags: [core]
+    spec:
+      scope: global
+      agents: [claude-code]
+      yes: true
+`,
+			want: "provisioners[0].spec.agents[0] must be one of antigravity, claude, codex, opencode for the codegraph tool",
+		},
+		{
 			name: "skills spec without package",
 			provisioner: `  - tool: skills
     tags: [core]

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -361,6 +361,57 @@ provisioners:
 	}
 }
 
+func TestLoadFileParsesCodeGraphProvisioner(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dots.yaml")
+	content := []byte(`version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+provisioners:
+  - tool: codegraph
+    tags: [agents]
+    os: [darwin, linux]
+    spec:
+      scope: global
+      agents: [codex, claude, antigravity, opencode]
+      yes: true
+    dependencies:
+      - name: curl
+        command: curl
+`)
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	got, err := manifest.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+
+	if len(got.Provisioners) != 1 {
+		t.Fatalf("Provisioners len = %d, want 1", len(got.Provisioners))
+	}
+	codegraph := got.Provisioners[0]
+	if codegraph.Tool != "codegraph" {
+		t.Fatalf("Provisioner[0].Tool = %q, want codegraph", codegraph.Tool)
+	}
+	if codegraph.Spec.Scope != "global" || !codegraph.Spec.Yes {
+		t.Fatalf("Provisioner[0].Spec scalar flags = %#v, want global/yes", codegraph.Spec)
+	}
+	if !sameStrings(codegraph.Spec.Agents, []string{"codex", "claude", "antigravity", "opencode"}) {
+		t.Fatalf("Provisioner[0].Spec.Agents = %#v, want [codex claude antigravity opencode]", codegraph.Spec.Agents)
+	}
+	if codegraph.Dependencies[0].Name != "curl" || codegraph.Dependencies[0].Command != "curl" {
+		t.Fatalf("Provisioner[0].Dependencies[0] = %#v, want curl command dependency", codegraph.Dependencies[0])
+	}
+}
+
 func TestLoadFileParsesSkillsProvisioner(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "dots.yaml")
@@ -811,7 +862,7 @@ func TestRepositoryManifestDesktopProfileDoesNotSelectGentleAIProvisioners(t *te
 	}
 }
 
-func TestRepositoryManifestIncludesCodeGraphCodexProvisioner(t *testing.T) {
+func TestRepositoryManifestIncludesCodeGraphProvisioner(t *testing.T) {
 	root := filepath.Clean(filepath.Join("..", ".."))
 	manifestPath := filepath.Join(root, "dots.yaml")
 
@@ -820,28 +871,31 @@ func TestRepositoryManifestIncludesCodeGraphCodexProvisioner(t *testing.T) {
 		t.Fatalf("LoadFile(%q) error = %v", manifestPath, err)
 	}
 
-	var codex *manifest.Provisioner
+	var codegraph *manifest.Provisioner
 	for i := range got.Provisioners {
 		prov := &got.Provisioners[i]
-		if prov.Tool == "codex" && prov.Spec.MCP == "codegraph" {
-			codex = prov
+		if prov.Tool == "codegraph" {
+			codegraph = prov
 		}
 	}
 
-	if codex == nil {
-		t.Fatal("repository manifest missing codex MCP provisioner for codegraph")
+	if codegraph == nil {
+		t.Fatal("repository manifest missing codegraph provisioner")
 	}
-	if !hasString(codex.Tags, "desktop") {
-		t.Errorf("codegraph codex provisioner %#v missing desktop tag", codex.Spec)
+	if !hasString(codegraph.Tags, "agents") {
+		t.Errorf("codegraph provisioner %#v missing agents tag", codegraph.Spec)
 	}
-	if !sameStrings(codex.OS, []string{"darwin", "linux"}) {
-		t.Errorf("codegraph codex provisioner OS = %#v, want [darwin linux]", codex.OS)
+	if !sameStrings(codegraph.OS, []string{"darwin", "linux"}) {
+		t.Errorf("codegraph provisioner OS = %#v, want [darwin linux]", codegraph.OS)
 	}
-	if !sameStrings(codex.Spec.Command, []string{"codegraph", "serve", "--mcp"}) {
-		t.Errorf("codegraph codex command = %#v, want [codegraph serve --mcp]", codex.Spec.Command)
+	if codegraph.Spec.Scope != "global" || !codegraph.Spec.Yes {
+		t.Errorf("codegraph provisioner scalar flags = %#v, want global/yes", codegraph.Spec)
 	}
-	if !hasDependency(codex.Dependencies, "codegraph") {
-		t.Errorf("codegraph codex provisioner missing codegraph dependency: %#v", codex.Dependencies)
+	if !sameStrings(codegraph.Spec.Agents, []string{"codex", "claude", "antigravity", "opencode"}) {
+		t.Errorf("codegraph provisioner agents = %#v, want [codex claude antigravity opencode]", codegraph.Spec.Agents)
+	}
+	if !hasDependency(codegraph.Dependencies, "curl") {
+		t.Errorf("codegraph provisioner missing curl dependency: %#v", codegraph.Dependencies)
 	}
 }
 
@@ -1331,7 +1385,7 @@ provisioners:
     spec:
       scope: global
 `,
-			want: "provisioners[0].tool must be one of claude, codex, gentle-ai, skills",
+			want: "provisioners[0].tool must be one of claude, codegraph, codex, gentle-ai, skills",
 		},
 		{
 			name: "claude spec sets neither marketplace nor plugin",
@@ -1460,6 +1514,37 @@ provisioners:
       from: chrome-devtools-plugins
 `,
 			want: "provisioners[0].spec must not set claude fields (marketplace, plugin, from) for the codex tool",
+		},
+		{
+			name: "codegraph spec requires agents",
+			provisioner: `  - tool: codegraph
+    tags: [core]
+    spec:
+      scope: global
+      yes: true
+`,
+			want: "provisioners[0].spec.agents is required for the codegraph tool",
+		},
+		{
+			name: "codegraph spec rejects unsupported scope",
+			provisioner: `  - tool: codegraph
+    tags: [core]
+    spec:
+      scope: workspace
+      agents: [codex]
+      yes: true
+`,
+			want: "provisioners[0].spec.scope must be one of global, local for the codegraph tool",
+		},
+		{
+			name: "codegraph spec requires yes",
+			provisioner: `  - tool: codegraph
+    tags: [core]
+    spec:
+      scope: global
+      agents: [codex]
+`,
+			want: "provisioners[0].spec.yes must be true for the codegraph tool",
 		},
 		{
 			name: "skills spec without package",

--- a/internal/provision/plan.go
+++ b/internal/provision/plan.go
@@ -109,10 +109,11 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 // ~/.claude for claude-code, ~/.codex for codex, ~/.config/opencode for opencode,
 // and ~/.gemini for antigravity. claude writes marketplace and plugin state under
 // ~/.claude and the user MCP/plugin registry in ~/.claude.json. codex records MCP
-// servers in ~/.codex/config.toml, under ~/.codex. skills.sh installs global
-// skills under the user-level agent skill directories selected by its --agent
-// flags. For skills@1.5.12, codex and antigravity share ~/.agents/skills;
-// claude-code uses ~/.claude/skills.
+// servers in ~/.codex/config.toml, under ~/.codex. codegraph writes MCP config
+// and instructions for the selected agents. skills.sh installs global skills
+// under the user-level agent skill directories selected by its --agent flags.
+// For skills@1.5.12, codex and antigravity share ~/.agents/skills; claude-code
+// uses ~/.claude/skills.
 func managedRoots(prov manifest.Provisioner) []string {
 	switch prov.Tool {
 	case "gentle-ai":
@@ -134,11 +135,43 @@ func managedRoots(prov manifest.Provisioner) []string {
 		return []string{"~/.claude", "~/.claude.json"}
 	case "codex":
 		return []string{"~/.codex"}
+	case "codegraph":
+		return codeGraphRoots(prov.Spec.Agents)
 	case "skills":
 		return skillsRoots(prov.Spec.Agents)
 	default:
 		return nil
 	}
+}
+
+func codeGraphRoots(agents []string) []string {
+	cleanAgents := cleanAgentList(agents)
+	if len(cleanAgents) == 0 {
+		return []string{"~/.codex", "~/.claude", "~/.claude.json", "~/.config/opencode", "~/.gemini"}
+	}
+	var roots []string
+	seen := map[string]bool{}
+	add := func(root string) {
+		if seen[root] {
+			return
+		}
+		seen[root] = true
+		roots = append(roots, root)
+	}
+	for _, agent := range cleanAgents {
+		switch agent {
+		case "codex":
+			add("~/.codex")
+		case "claude":
+			add("~/.claude")
+			add("~/.claude.json")
+		case "opencode":
+			add("~/.config/opencode")
+		case "antigravity":
+			add("~/.gemini")
+		}
+	}
+	return roots
 }
 
 func skillsRoots(agents []string) []string {

--- a/internal/provision/plan.go
+++ b/internal/provision/plan.go
@@ -109,11 +109,12 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 // ~/.claude for claude-code, ~/.codex for codex, ~/.config/opencode for opencode,
 // and ~/.gemini for antigravity. claude writes marketplace and plugin state under
 // ~/.claude and the user MCP/plugin registry in ~/.claude.json. codex records MCP
-// servers in ~/.codex/config.toml, under ~/.codex. codegraph writes MCP config
-// and instructions for the selected agents. skills.sh installs global skills
-// under the user-level agent skill directories selected by its --agent flags.
-// For skills@1.5.12, codex and antigravity share ~/.agents/skills; claude-code
-// uses ~/.claude/skills.
+// servers in ~/.codex/config.toml, under ~/.codex. codegraph writes its own
+// installed versions and shim under ~/.codegraph and ~/.local/bin, plus MCP
+// config and instructions for the selected agents. skills.sh installs global
+// skills under the user-level agent skill directories selected by its --agent
+// flags. For skills@1.5.12, codex and antigravity share ~/.agents/skills;
+// claude-code uses ~/.claude/skills.
 func managedRoots(prov manifest.Provisioner) []string {
 	switch prov.Tool {
 	case "gentle-ai":
@@ -145,12 +146,15 @@ func managedRoots(prov manifest.Provisioner) []string {
 }
 
 func codeGraphRoots(agents []string) []string {
+	roots := []string{"~/.codegraph", "~/.local/bin"}
+	seen := map[string]bool{
+		"~/.codegraph": true,
+		"~/.local/bin": true,
+	}
 	cleanAgents := cleanAgentList(agents)
 	if len(cleanAgents) == 0 {
-		return []string{"~/.codex", "~/.claude", "~/.claude.json", "~/.config/opencode", "~/.gemini"}
+		return append(roots, "~/.codex", "~/.claude", "~/.claude.json", "~/.config/opencode", "~/.gemini")
 	}
-	var roots []string
-	seen := map[string]bool{}
 	add := func(root string) {
 		if seen[root] {
 			return

--- a/internal/provision/plan_test.go
+++ b/internal/provision/plan_test.go
@@ -197,15 +197,16 @@ func TestPlanResolvesCodexProvisioner(t *testing.T) {
 	}
 }
 
-func TestPlanResolvesCodeGraphCodexProvisioner(t *testing.T) {
-	codex := manifest.Provisioner{
-		Tool: "codex", Tags: []string{"core"},
+func TestPlanResolvesCodeGraphProvisioner(t *testing.T) {
+	codegraph := manifest.Provisioner{
+		Tool: "codegraph", Tags: []string{"core"},
 		Spec: manifest.ProvisionerSpec{
-			MCP:     "codegraph",
-			Command: []string{"codegraph", "serve", "--mcp"},
+			Scope:  "global",
+			Agents: []string{"codex", "claude", "antigravity", "opencode"},
+			Yes:    true,
 		},
 	}
-	m := manifestWithProvisioners(codex)
+	m := manifestWithProvisioners(codegraph)
 
 	p, err := provision.Build(m, provision.Options{Profile: "default", OS: "darwin"})
 	if err != nil {
@@ -216,12 +217,22 @@ func TestPlanResolvesCodeGraphCodexProvisioner(t *testing.T) {
 	}
 
 	step := p.Steps[0]
-	wantArgs := []string{"mcp", "add", "codegraph", "--", "codegraph", "serve", "--mcp"}
-	if !reflect.DeepEqual(step.Args, wantArgs) {
-		t.Fatalf("codegraph codex args = %#v, want %#v", step.Args, wantArgs)
+	if step.Executable != "sh" {
+		t.Fatalf("codegraph step executable = %q, want sh", step.Executable)
 	}
-	if !reflect.DeepEqual(step.Targets, []string{"~/.codex"}) {
-		t.Fatalf("codegraph codex targets = %#v, want [~/.codex]", step.Targets)
+	wantArgs := []string{
+		"-c",
+		"set -eu\nif ! command -v codegraph >/dev/null 2>&1; then\n\tcurl -fsSL https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh | sh\nfi\nexport PATH=\"$HOME/.local/bin:$PATH\"\ncodegraph install --target \"$1\" --location \"$2\" --yes",
+		"codegraph-install",
+		"codex,claude,antigravity,opencode",
+		"global",
+	}
+	if !reflect.DeepEqual(step.Args, wantArgs) {
+		t.Fatalf("codegraph args = %#v, want %#v", step.Args, wantArgs)
+	}
+	wantTargets := []string{"~/.codex", "~/.claude", "~/.claude.json", "~/.gemini", "~/.config/opencode"}
+	if !reflect.DeepEqual(step.Targets, wantTargets) {
+		t.Fatalf("codegraph targets = %#v, want %#v", step.Targets, wantTargets)
 	}
 }
 

--- a/internal/provision/plan_test.go
+++ b/internal/provision/plan_test.go
@@ -230,7 +230,7 @@ func TestPlanResolvesCodeGraphProvisioner(t *testing.T) {
 	if !reflect.DeepEqual(step.Args, wantArgs) {
 		t.Fatalf("codegraph args = %#v, want %#v", step.Args, wantArgs)
 	}
-	wantTargets := []string{"~/.codex", "~/.claude", "~/.claude.json", "~/.gemini", "~/.config/opencode"}
+	wantTargets := []string{"~/.codegraph", "~/.local/bin", "~/.codex", "~/.claude", "~/.claude.json", "~/.gemini", "~/.config/opencode"}
 	if !reflect.DeepEqual(step.Targets, wantTargets) {
 		t.Fatalf("codegraph targets = %#v, want %#v", step.Targets, wantTargets)
 	}

--- a/internal/provision/provision.go
+++ b/internal/provision/provision.go
@@ -13,6 +13,12 @@ import (
 )
 
 const skillsCLIPackage = "skills@1.5.12"
+const codeGraphInstallScript = `set -eu
+if ! command -v codegraph >/dev/null 2>&1; then
+	curl -fsSL https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh | sh
+fi
+export PATH="$HOME/.local/bin:$PATH"
+codegraph install --target "$1" --location "$2" --yes`
 
 // RenderCommand resolves a Provisioner into the exact executable and argv that
 // would run it. It is PURE: it performs no I/O and never invokes the tool, so it
@@ -22,6 +28,8 @@ func RenderCommand(p manifest.Provisioner) (executable string, args []string) {
 	switch p.Tool {
 	case "claude":
 		return p.Tool, renderClaudeArgs(p.Spec)
+	case "codegraph":
+		return "sh", renderCodeGraphArgs(p.Spec)
 	case "codex":
 		return p.Tool, renderCodexArgs(p.Spec)
 	case "skills":
@@ -29,6 +37,18 @@ func RenderCommand(p manifest.Provisioner) (executable string, args []string) {
 	default:
 		return p.Tool, renderGentleAIArgs(p.Spec)
 	}
+}
+
+// renderCodeGraphArgs renders one non-interactive CodeGraph installer run. The
+// fixed shell script follows CodeGraph's official bootstrap path when the binary
+// is absent, then runs the installed CLI to wire MCP config for selected agents.
+func renderCodeGraphArgs(spec manifest.ProvisionerSpec) []string {
+	target := joinNonEmpty(spec.Agents)
+	location := strings.TrimSpace(spec.Scope)
+	if location == "" {
+		location = "global"
+	}
+	return []string{"-c", codeGraphInstallScript, "codegraph-install", target, location}
 }
 
 // renderGentleAIArgs renders the selected gentle-ai action plus its flags in a

--- a/internal/provision/provision_test.go
+++ b/internal/provision/provision_test.go
@@ -161,6 +161,25 @@ func TestRenderCommand(t *testing.T) {
 			wantArgs: []string{"mcp", "add", "chrome-devtools", "--", "npx", "chrome-devtools-mcp@latest"},
 		},
 		{
+			name: "codegraph install renders official bootstrap script for selected agents",
+			prov: manifest.Provisioner{
+				Tool: "codegraph",
+				Spec: manifest.ProvisionerSpec{
+					Scope:  "global",
+					Agents: []string{"codex", "claude", "antigravity", "opencode"},
+					Yes:    true,
+				},
+			},
+			wantExec: "sh",
+			wantArgs: []string{
+				"-c",
+				"set -eu\nif ! command -v codegraph >/dev/null 2>&1; then\n\tcurl -fsSL https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh | sh\nfi\nexport PATH=\"$HOME/.local/bin:$PATH\"\ncodegraph install --target \"$1\" --location \"$2\" --yes",
+				"codegraph-install",
+				"codex,claude,antigravity,opencode",
+				"global",
+			},
+		},
+		{
 			name: "skills add renders package with repeated agent and skill flags",
 			prov: manifest.Provisioner{
 				Tool: "skills",


### PR DESCRIPTION
Closes #153

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds a first-class CodeGraph provisioner for the `agents` profile.
- Bootstraps CodeGraph via the official curl installer only when `codegraph` is absent.
- Wires CodeGraph MCP/instructions for Codex, Claude Code, Antigravity, and OpenCode.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Replaces Codex-only CodeGraph MCP registration with an `agents`-scoped CodeGraph provisioner. |
| `internal/manifest/manifest.go` | Adds validation for the `codegraph` provisioner dialect. |
| `internal/provision/provision.go` | Renders the fixed bootstrap-and-install shell invocation. |
| `internal/provision/plan.go` | Reports affected agent config roots for CodeGraph. |
| `internal/cli/install.go` | Preserves Codex CodeGraph instruction setup when CodeGraph targets Codex. |
| `docs/manifest.md` | Documents CodeGraph provisioning behavior and dependency coverage. |
| `.codegraph/.gitignore` | Ignores generated CodeGraph runtime/index files except the marker file. |
| `*_test.go` | Covers render, manifest validation, repository manifest expectations, planning, and sandboxed install behavior. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed CodeGraph bootstrap/wiring with temporary `HOME` and filtered `PATH`.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #153`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
