### PR TITLE
feat(install): support optional manifest tags

### DIFF
--- a/configs/antigravity/settings.json
+++ b/configs/antigravity/settings.json
@@ -1,0 +1,5 @@
+{
+  "toolPermission": "always-proceed",
+  "allowNonWorkspaceAccess": true,
+  "enableTerminalSandbox": false
+}

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -28,11 +28,13 @@ Unknown YAML fields are rejected during manifest loading.
 ## Profiles
 
 A Profile is selected by commands such as `dots plan`, `dots install`,
-`dots status`, and `dots deps check`.
+`dots status`, and `dots deps check`. Commands that expose `--tag` can add
+optional capability tags on top of the selected Profile without creating another
+Profile.
 
 | Field | Required | Supported values |
 |-------|----------|------------------|
-| `tags` | Yes | Non-empty strings. Entries and Provisioners are selected when at least one tag matches. |
+| `tags` | Yes | Non-empty strings. Entries and Provisioners are selected when at least one tag matches. Optional CLI `--tag` values join this set at runtime. |
 | `dependencies` | No | Profile-level Dependencies, using the same dependency fields as entries. |
 
 Current Profiles:
@@ -88,6 +90,7 @@ Current Managed Entries:
 | `configs/zed/themes/catppuccin-blue.json` | `~/.config/zed/themes/catppuccin-blue.json` | `symlink` | `desktop` | `darwin`, `linux` | `zed` |
 | `configs/claude/settings.json` | `~/.claude/settings.json` | `copy` | `core` | `darwin`, `linux` | None; owns JSON subset |
 | `configs/claude/statusline-command.sh` | `~/.claude/statusline-command.sh` | `copy` | `core` | `darwin`, `linux` | None |
+| `configs/antigravity/settings.json` | `~/.gemini/antigravity-cli/settings.json` | `copy` | `agents` | `darwin`, `linux` | None; owns JSON subset |
 | `configs/opencode/mcp.json` | `~/.config/opencode-dots.json` | `symlink` | `web` | `darwin`, `linux` | `opencode` |
 
 ## Dependencies
@@ -239,15 +242,16 @@ Current Provisioners:
 | `claude` | `web` | `darwin`, `linux` | Register marketplace `ChromeDevTools/chrome-devtools-mcp`. | `claude` |
 | `claude` | `web` | `darwin`, `linux` | Install `chrome-devtools-mcp` from `chrome-devtools-plugins` with user scope. | `claude` |
 | `codex` | `web` | `darwin`, `linux` | Add MCP server `chrome-devtools` using `npx -y chrome-devtools-mcp@latest --no-performance-crux`. | `codex` |
-| `codegraph` | `agents` | `darwin`, `linux` | Reuse `codegraph` when already on `PATH`; otherwise install it with the official curl bootstrap, then run `codegraph install --target codex,claude,antigravity,opencode --location global --yes` so CodeGraph configures MCP plus instructions for Codex, Claude Code, Antigravity, and OpenCode. | `curl` |
+| `codegraph` | `codegraph` | `darwin`, `linux` | Reuse `codegraph` when already on `PATH`; otherwise install it with the official curl bootstrap, then run `codegraph install --target codex,claude,antigravity,opencode --location global --yes` so CodeGraph configures MCP plus instructions for Codex, Claude Code, Antigravity, and OpenCode. Select with `--tag codegraph`. | `curl` |
 
 ## Selection rules
 
-1. The chosen Profile provides tags.
-2. A Managed Entry or Provisioner is selected when any of its tags matches the Profile tags.
-3. If `os` is empty, the item matches all supported operating systems.
-4. If `os` is set, the item only matches the current OS (`darwin` or `linux`).
-5. Selected Managed Entries are installed before selected Provisioners run.
+1. The chosen Profile provides the base tags.
+2. Each repeated `--tag` adds an optional tag to that selection. Duplicate tags are ignored.
+3. A Managed Entry or Provisioner is selected when any of its tags matches the effective tag set.
+4. If `os` is empty, the item matches all supported operating systems.
+5. If `os` is set, the item only matches the current OS (`darwin` or `linux`).
+6. Selected Managed Entries are installed before selected Provisioners run.
 
 ## Related docs
 

--- a/docs/update.md
+++ b/docs/update.md
@@ -47,7 +47,7 @@ Non-interactive runs (`--yes`) default every conflict to `skip`, so an unattende
 | Flag | Purpose |
 |------|---------|
 | `--dry-run` | Fetch and report the available fast-forward and the Install Plan without fast-forwarding the working tree or installing files. |
-| `--file`, `--profile` | Select the manifest and profile to install after updating. |
+| `--file`, `--profile`, `--tag` | Select the manifest, base profile, and optional capability tags to install after updating. Repeat `--tag` to include multiple opt-in tags. |
 | `--source-root` | Installed Repository to update (default `~/.local/share/dots`). |
 | `--home` | Target home directory; use a sandbox path to avoid touching real config. |
 | `--state-root` | State directory for Installation Metadata and Backup Sets. |
@@ -69,7 +69,7 @@ Because no fast-forward is applied in a dry run, the rendered plan reflects the 
 
 ## Profiles and provisioners
 
-Provisioners are scoped by profile tags, exactly like file entries. The `default` profile selects no provisioners. The `desktop` profile selects desktop configuration and non-web desktop integrations. The `agents` profile selects gentle-ai setup/cleanup provisioners. The `web` profile selects frontend design skills plus Chrome DevTools for Claude, Codex, and the OpenCode overlay. The `mobile` profile selects Dart and Flutter agent skills. Use `workstation` when you explicitly want both desktop integrations and agent setup; web and mobile tooling remain separate opt-ins. This is design-intent: desktop installs should configure desktop tools, not opt into SDD, gentle-dev agent setup, browser/frontend tooling, or mobile-specific skills.
+Provisioners are scoped by profile tags, exactly like file entries. The `default` profile selects no provisioners. The `desktop` profile selects desktop configuration and non-web desktop integrations. The `agents` profile selects gentle-ai setup/cleanup provisioners and agent settings baselines. CodeGraph is independent and selected with `--tag codegraph`. The `web` profile selects frontend design skills plus Chrome DevTools for Claude, Codex, and the OpenCode overlay. The `mobile` profile selects Dart and Flutter agent skills. Use `workstation` when you explicitly want both desktop integrations and agent setup; web and mobile tooling remain separate opt-ins. This is design-intent: desktop installs should configure desktop tools, not opt into SDD, gentle-dev agent setup, browser/frontend tooling, or mobile-specific skills.
 
 The gentle-ai provisioner can model cleanup before install by using separate entries in manifest order. Missing `action` still defaults to `install`; `yes` is only valid for `uninstall` because it confirms a cleanup action:
 

--- a/dots.yaml
+++ b/dots.yaml
@@ -302,6 +302,15 @@ entries:
     os:
       - darwin
       - linux
+  - source: configs/antigravity/settings.json
+    target: ~/.gemini/antigravity-cli/settings.json
+    strategy: copy
+    ownership: json-subset
+    tags:
+      - agents
+    os:
+      - darwin
+      - linux
   # OpenCode has no MCP install CLI and its global opencode.json is co-owned by
   # gentle-ai, so dots owns a separate fragment that OpenCode merges (not
   # replaces) via the OPENCODE_CONFIG env var set in zshenv. This keeps the
@@ -562,7 +571,7 @@ provisioners:
         command: codex
   - tool: codegraph
     tags:
-      - agents
+      - codegraph
     os:
       - darwin
       - linux

--- a/internal/cli/antigravity_config_test.go
+++ b/internal/cli/antigravity_config_test.go
@@ -1,0 +1,198 @@
+package cli_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/cli"
+)
+
+// TestAntigravityAgentsProfileSeedsUserBaselineInSandbox proves that dots seeds the
+// user-owned Antigravity settings baseline with a copy strategy (regular files, not symlinks)
+// before the gentle-ai provisioner runs, that the settings contain the expected baseline keys,
+// and that the provisioner does not escape the sandbox HOME.
+func TestAntigravityAgentsProfileSeedsUserBaselineInSandbox(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	realHome := t.TempDir()
+	t.Setenv("HOME", realHome)
+
+	stubDir := t.TempDir()
+	writeExecStub(t, filepath.Join(stubDir, "gentle-ai"), "#!/bin/sh\nexit 0\n")
+	writeExecStub(t, filepath.Join(stubDir, "engram"), "#!/bin/sh\nexit 0\n")
+	writeExecStub(t, filepath.Join(stubDir, "codegraph"), "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	install := cli.NewRootCommand()
+	var installOut bytes.Buffer
+	install.SetOut(&installOut)
+	install.SetErr(&installOut)
+	install.SetArgs([]string{
+		"install",
+		"--file", filepath.Join(repoRoot, "dots.yaml"),
+		"--profile", "agents",
+		"--source-root", repoRoot,
+		"--home", home,
+		"--state-root", stateRoot,
+		"--yes",
+	})
+
+	if err := install.Execute(); err != nil {
+		t.Fatalf("dots install failed in sandbox: %v\noutput:\n%s", err, installOut.String())
+	}
+
+	settingsTarget := filepath.Join(home, ".gemini", "antigravity-cli", "settings.json")
+
+	info, err := os.Lstat(settingsTarget)
+	if err != nil {
+		t.Fatalf("antigravity settings target missing after sandbox install: %v\ninstall output:\n%s", err, installOut.String())
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("antigravity target %q is a symlink, want a regular copied file", settingsTarget)
+	}
+
+	got, err := os.ReadFile(settingsTarget)
+	if err != nil {
+		t.Fatalf("read copied antigravity target %q: %v", settingsTarget, err)
+	}
+	want, err := os.ReadFile(filepath.Join(repoRoot, "configs", "antigravity", "settings.json"))
+	if err != nil {
+		t.Fatalf("read antigravity source: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("copied antigravity target %q content differs from source", settingsTarget)
+	}
+
+	var parsed struct {
+		ToolPermission          *string `json:"toolPermission"`
+		AllowNonWorkspaceAccess *bool   `json:"allowNonWorkspaceAccess"`
+		EnableTerminalSandbox   *bool   `json:"enableTerminalSandbox"`
+	}
+	if err := json.Unmarshal(got, &parsed); err != nil {
+		t.Fatalf("seeded settings.json is not valid JSON: %v", err)
+	}
+
+	if parsed.ToolPermission == nil || *parsed.ToolPermission != "always-proceed" {
+		t.Errorf("toolPermission key incorrect or missing, got: %v", parsed.ToolPermission)
+	}
+	if parsed.AllowNonWorkspaceAccess == nil || *parsed.AllowNonWorkspaceAccess != true {
+		t.Errorf("allowNonWorkspaceAccess key incorrect or missing, got: %v", parsed.AllowNonWorkspaceAccess)
+	}
+	if parsed.EnableTerminalSandbox == nil || *parsed.EnableTerminalSandbox != false {
+		t.Errorf("enableTerminalSandbox key incorrect or missing, got: %v", parsed.EnableTerminalSandbox)
+	}
+}
+
+// TestAntigravitySettingsProvisionerAdditionsDoNotDrift proves that adding extra keys to
+// the installed ~/.gemini/antigravity-cli/settings.json (like those managed by the agent at runtime)
+// does not trigger a drift state, whereas changing the managed baseline keys does.
+func TestAntigravitySettingsProvisionerAdditionsDoNotDrift(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	realHome := t.TempDir()
+	t.Setenv("HOME", realHome)
+
+	stubDir := t.TempDir()
+	writeExecStub(t, filepath.Join(stubDir, "gentle-ai"), "#!/bin/sh\nexit 0\n")
+	writeExecStub(t, filepath.Join(stubDir, "engram"), "#!/bin/sh\nexit 0\n")
+	writeExecStub(t, filepath.Join(stubDir, "codegraph"), "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	// 1. Run the initial install
+	install := cli.NewRootCommand()
+	var installOut bytes.Buffer
+	install.SetOut(&installOut)
+	install.SetErr(&installOut)
+	install.SetArgs([]string{
+		"install",
+		"--file", filepath.Join(repoRoot, "dots.yaml"),
+		"--profile", "agents",
+		"--source-root", repoRoot,
+		"--home", home,
+		"--state-root", stateRoot,
+		"--yes",
+	})
+	if err := install.Execute(); err != nil {
+		t.Fatalf("dots install failed in sandbox: %v\noutput:\n%s", err, installOut.String())
+	}
+
+	settingsTarget := filepath.Join(home, ".gemini", "antigravity-cli", "settings.json")
+
+	// 2. Simulate runtime state keys added by the agent to settings.json
+	extraConfig := `{
+		"toolPermission": "always-proceed",
+		"allowNonWorkspaceAccess": true,
+		"enableTerminalSandbox": false,
+		"runtimeStateKey": "some-runtime-value",
+		"anotherExtraSettings": [1, 2, 3]
+	}`
+	if err := os.WriteFile(settingsTarget, []byte(extraConfig), 0o600); err != nil {
+		t.Fatalf("failed to write simulated runtime settings: %v", err)
+	}
+
+	// 3. Verify status command shows 'ok' (no drift) because it's a subset match
+	statusCmd := cli.NewRootCommand()
+	var statusOut bytes.Buffer
+	statusCmd.SetOut(&statusOut)
+	statusCmd.SetErr(&statusOut)
+	statusCmd.SetArgs([]string{
+		"status",
+		"--file", filepath.Join(repoRoot, "dots.yaml"),
+		"--profile", "agents",
+		"--source-root", repoRoot,
+		"--home", home,
+		"--state-root", stateRoot,
+	})
+	if err := statusCmd.Execute(); err != nil {
+		t.Fatalf("dots status failed: %v\noutput:\n%s", err, statusOut.String())
+	}
+
+	gotStatus := statusOut.String()
+	if !strings.Contains(gotStatus, "ok           copy      configs/antigravity/settings.json") {
+		t.Fatalf("status output missing ok Antigravity settings entry after runtime additions\noutput:\n%s", gotStatus)
+	}
+
+	// 4. Modify one of the managed baseline keys to trigger drift
+	driftConfig := `{
+		"toolPermission": "ask",
+		"allowNonWorkspaceAccess": true,
+		"enableTerminalSandbox": false,
+		"runtimeStateKey": "some-runtime-value"
+	}`
+	if err := os.WriteFile(settingsTarget, []byte(driftConfig), 0o600); err != nil {
+		t.Fatalf("failed to write drift settings: %v", err)
+	}
+
+	// 5. Verify status command shows 'drifted'
+	statusCmd2 := cli.NewRootCommand()
+	var statusOut2 bytes.Buffer
+	statusCmd2.SetOut(&statusOut2)
+	statusCmd2.SetErr(&statusOut2)
+	statusCmd2.SetArgs([]string{
+		"status",
+		"--file", filepath.Join(repoRoot, "dots.yaml"),
+		"--profile", "agents",
+		"--source-root", repoRoot,
+		"--home", home,
+		"--state-root", stateRoot,
+	})
+	// status exits with 2 when findings are found, so we check status return
+	_ = statusCmd2.Execute()
+
+	gotStatus2 := statusOut2.String()
+	if !strings.Contains(gotStatus2, "drifted      copy      configs/antigravity/settings.json") {
+		t.Fatalf("status output should show drifted state for modified baseline key\noutput:\n%s", gotStatus2)
+	}
+}

--- a/internal/cli/claude_config_test.go
+++ b/internal/cli/claude_config_test.go
@@ -188,12 +188,8 @@ func TestClaudeAgentsProfileSeedsUserBaselineInSandbox(t *testing.T) {
 	if strings.Contains(string(gotArgs), "install --scope global --channel stable --persona neutral --preset custom --agents codex,claude-code,opencode") {
 		t.Fatalf("provisioner argv = %q, want basic install without opencode", gotArgs)
 	}
-	gotCodeGraphArgs, err := os.ReadFile(filepath.Join(home, "codegraph-args"))
-	if err != nil {
-		t.Fatalf("codegraph provisioner did not run under the sandbox HOME %q: %v", home, err)
-	}
-	if !strings.Contains(string(gotCodeGraphArgs), "install --target codex,claude,antigravity,opencode --location global --yes") {
-		t.Fatalf("codegraph argv = %q, want CodeGraph installer for codex, claude, antigravity, and opencode", gotCodeGraphArgs)
+	if _, err := os.ReadFile(filepath.Join(home, "codegraph-args")); !os.IsNotExist(err) {
+		t.Fatalf("agents profile should not run CodeGraph without --tag codegraph: %v", err)
 	}
 	// And it must never have escaped into the inherited real HOME.
 	if _, err := os.Stat(filepath.Join(realHome, "gentle-ai-args")); err == nil {

--- a/internal/cli/deps.go
+++ b/internal/cli/deps.go
@@ -17,7 +17,10 @@ import (
 )
 
 func newDepsCommand() *cobra.Command {
-	var profile string
+	var (
+		profile   string
+		extraTags []string
+	)
 
 	cmd := &cobra.Command{
 		Use:   "deps",
@@ -25,13 +28,14 @@ func newDepsCommand() *cobra.Command {
 		Long:  "deps reports which external Dependencies a profile needs, offers OS-aware installation guidance, and can execute missing install actions with explicit confirmation.",
 	}
 	cmd.PersistentFlags().StringVarP(&profile, "profile", "p", "default", "profile to inspect")
-	cmd.AddCommand(newDepsCheckCommand(&profile))
-	cmd.AddCommand(newDepsPlanCommand(&profile))
-	cmd.AddCommand(newDepsInstallCommand(&profile))
+	cmd.PersistentFlags().StringArrayVar(&extraTags, "tag", nil, "include an additional manifest tag; repeat to include multiple tags")
+	cmd.AddCommand(newDepsCheckCommand(&profile, &extraTags))
+	cmd.AddCommand(newDepsPlanCommand(&profile, &extraTags))
+	cmd.AddCommand(newDepsInstallCommand(&profile, &extraTags))
 	return cmd
 }
 
-func newDepsCheckCommand(profile *string) *cobra.Command {
+func newDepsCheckCommand(profile *string, extraTags *[]string) *cobra.Command {
 	var (
 		file string
 		home string
@@ -51,8 +55,9 @@ func newDepsCheckCommand(profile *string) *cobra.Command {
 			}
 
 			report, err := deps.Check(*m, deps.Options{
-				Profile: *profile,
-				OS:      runtime.GOOS,
+				Profile:   *profile,
+				ExtraTags: *extraTags,
+				OS:        runtime.GOOS,
 			}, lookupCommand, fontInstalled(runtime.GOOS, resolvedHome))
 			if err != nil {
 				return err
@@ -70,7 +75,7 @@ func newDepsCheckCommand(profile *string) *cobra.Command {
 	return cmd
 }
 
-func newDepsPlanCommand(profile *string) *cobra.Command {
+func newDepsPlanCommand(profile *string, extraTags *[]string) *cobra.Command {
 	var (
 		file string
 		tier string
@@ -97,8 +102,9 @@ func newDepsPlanCommand(profile *string) *cobra.Command {
 			}
 
 			report, err := deps.Plan(*m, deps.Options{
-				Profile: *profile,
-				OS:      runtime.GOOS,
+				Profile:   *profile,
+				ExtraTags: *extraTags,
+				OS:        runtime.GOOS,
 			}, lookupCommand, fontInstalled(runtime.GOOS, resolvedHome), resolvedTier)
 			if err != nil {
 				return err
@@ -117,7 +123,7 @@ func newDepsPlanCommand(profile *string) *cobra.Command {
 	return cmd
 }
 
-func newDepsInstallCommand(profile *string) *cobra.Command {
+func newDepsInstallCommand(profile *string, extraTags *[]string) *cobra.Command {
 	var (
 		file   string
 		tier   string
@@ -144,8 +150,9 @@ func newDepsInstallCommand(profile *string) *cobra.Command {
 			}
 
 			options := deps.Options{
-				Profile: *profile,
-				OS:      runtime.GOOS,
+				Profile:   *profile,
+				ExtraTags: *extraTags,
+				OS:        runtime.GOOS,
 			}
 
 			report, err := deps.InstallDryRun(*m, options, lookupCommand, fontInstalled(runtime.GOOS, resolvedHome), resolvedTier)

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -14,6 +14,7 @@ func newDoctorCommand() *cobra.Command {
 	var (
 		file       string
 		profile    string
+		extraTags  []string
 		sourceRoot string
 		home       string
 		stateRoot  string
@@ -53,6 +54,7 @@ func newDoctorCommand() *cobra.Command {
 
 			report, err := doctor.Build(*m, meta, doctor.Options{
 				Profile:    profile,
+				ExtraTags:  extraTags,
 				OS:         runtime.GOOS,
 				SourceRoot: paths.SourceRoot,
 				Home:       paths.Home,
@@ -71,6 +73,7 @@ func newDoctorCommand() *cobra.Command {
 
 	cmd.Flags().StringVarP(&file, "file", "f", "dots.yaml", "manifest file to inspect")
 	cmd.Flags().StringVarP(&profile, "profile", "p", "default", "profile to inspect")
+	cmd.Flags().StringArrayVar(&extraTags, "tag", nil, "include an additional manifest tag; repeat to include multiple tags")
 	cmd.Flags().StringVar(&sourceRoot, "source-root", "", "installed repository root (default ~/.local/share/dots)")
 	cmd.Flags().StringVar(&home, "home", "", "target home directory to inspect (default: the current user's home); use a sandbox path to inspect without touching real config")
 	cmd.Flags().StringVar(&stateRoot, "state-root", "", "state directory for Installation Metadata (default ~/.local/state/dots)")

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -23,6 +23,7 @@ func newInstallCommand() *cobra.Command {
 	var (
 		file       string
 		profile    string
+		extraTags  []string
 		sourceRoot string
 		home       string
 		stateRoot  string
@@ -55,6 +56,7 @@ func newInstallCommand() *cobra.Command {
 
 			p, err := plan.Build(*m, plan.Options{
 				Profile:    profile,
+				ExtraTags:  extraTags,
 				OS:         runtime.GOOS,
 				SourceRoot: paths.SourceRoot,
 				Home:       paths.Home,
@@ -64,7 +66,7 @@ func newInstallCommand() *cobra.Command {
 				return err
 			}
 
-			provPlan, err := provision.Build(*m, provision.Options{Profile: profile, OS: runtime.GOOS})
+			provPlan, err := provision.Build(*m, provision.Options{Profile: profile, ExtraTags: extraTags, OS: runtime.GOOS})
 			if err != nil {
 				return err
 			}
@@ -102,7 +104,7 @@ func newInstallCommand() *cobra.Command {
 				return nil
 			}
 
-			if err := runProvisioners(cmd, *m, profile, paths.Home); err != nil {
+			if err := runProvisioners(cmd, *m, profile, extraTags, paths.Home); err != nil {
 				return err
 			}
 			if wantsJSON(cmd) {
@@ -114,6 +116,7 @@ func newInstallCommand() *cobra.Command {
 
 	cmd.Flags().StringVarP(&file, "file", "f", "dots.yaml", "manifest file to install")
 	cmd.Flags().StringVarP(&profile, "profile", "p", "default", "profile to install")
+	cmd.Flags().StringArrayVar(&extraTags, "tag", nil, "include an additional manifest tag; repeat to include multiple tags")
 	cmd.Flags().StringVar(&sourceRoot, "source-root", "", "installed repository root (default ~/.local/share/dots)")
 	cmd.Flags().StringVar(&home, "home", "", "target home directory to install into (default: the current user's home); use a sandbox path to avoid touching real config")
 	cmd.Flags().StringVar(&stateRoot, "state-root", "", "state directory for Installation Metadata (default ~/.local/state/dots)")
@@ -129,7 +132,7 @@ func newInstallCommand() *cobra.Command {
 // temporary home. Apply stops at the first failing provisioner and returns the
 // error, which the caller surfaces; the tool's own stdout/stderr are streamed
 // through so its progress is visible.
-func runProvisioners(cmd *cobra.Command, m manifest.Manifest, profile, home string) error {
+func runProvisioners(cmd *cobra.Command, m manifest.Manifest, profile string, extraTags []string, home string) error {
 	ctx := cmd.Context()
 	if ctx == nil {
 		ctx = context.Background()
@@ -145,14 +148,14 @@ func runProvisioners(cmd *cobra.Command, m manifest.Manifest, profile, home stri
 		stdout: stdout,
 		stderr: cmd.ErrOrStderr(),
 	}
-	report, err := provision.Apply(m, provision.Options{Profile: profile, OS: runtime.GOOS}, lookupCommand, fontInstalled(runtime.GOOS, home), runner)
+	report, err := provision.Apply(m, provision.Options{Profile: profile, ExtraTags: extraTags, OS: runtime.GOOS}, lookupCommand, fontInstalled(runtime.GOOS, home), runner)
 	if !wantsJSON(cmd) {
 		renderProvisionReport(cmd.OutOrStdout(), report)
 	}
 	if err != nil {
 		return err
 	}
-	selected, err := provision.Select(m, provision.Options{Profile: profile, OS: runtime.GOOS})
+	selected, err := provision.Select(m, provision.Options{Profile: profile, ExtraTags: extraTags, OS: runtime.GOOS})
 	if err != nil {
 		return err
 	}

--- a/internal/cli/plan.go
+++ b/internal/cli/plan.go
@@ -12,6 +12,7 @@ func newPlanCommand() *cobra.Command {
 	var (
 		file       string
 		profile    string
+		extraTags  []string
 		sourceRoot string
 		home       string
 		stateRoot  string
@@ -45,6 +46,7 @@ func newPlanCommand() *cobra.Command {
 			// to the host so the dry-run reflects this machine.
 			p, err := plan.Build(*m, plan.Options{
 				Profile:    profile,
+				ExtraTags:  extraTags,
 				OS:         runtime.GOOS,
 				SourceRoot: paths.SourceRoot,
 				Home:       paths.Home,
@@ -63,6 +65,7 @@ func newPlanCommand() *cobra.Command {
 
 	cmd.Flags().StringVarP(&file, "file", "f", "dots.yaml", "manifest file to plan")
 	cmd.Flags().StringVarP(&profile, "profile", "p", "default", "profile to plan")
+	cmd.Flags().StringArrayVar(&extraTags, "tag", nil, "include an additional manifest tag; repeat to include multiple tags")
 	cmd.Flags().StringVar(&sourceRoot, "source-root", "", "installed repository root (default ~/.local/share/dots)")
 	cmd.Flags().StringVar(&home, "home", "", "target home directory to plan against (default: the current user's home); use a sandbox path to preview without touching real config")
 	cmd.Flags().StringVar(&stateRoot, "state-root", "", "state directory for Installation Metadata (default ~/.local/state/dots)")

--- a/internal/cli/provision_runner_test.go
+++ b/internal/cli/provision_runner_test.go
@@ -113,7 +113,7 @@ printf ok > "$HOME/first-attempt"
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
 
-	err := runProvisioners(cmd, m, "default", home)
+	err := runProvisioners(cmd, m, "default", nil, home)
 	if err == nil {
 		t.Fatal("runProvisioners() error = nil, want second provisioner failure")
 	}
@@ -171,7 +171,7 @@ printf '%s\n' "$*" > "$HOME/skills-args"
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
 
-	if err := runProvisioners(cmd, m, "default", home); err != nil {
+	if err := runProvisioners(cmd, m, "default", nil, home); err != nil {
 		t.Fatalf("runProvisioners() error = %v\noutput:\n%s", err, out.String())
 	}
 
@@ -210,7 +210,7 @@ printf '%s\n' "$*" > "$HOME/codegraph-args"
 		},
 		Provisioners: []manifest.Provisioner{
 			{
-				Tool: "codegraph", Tags: []string{"agents"},
+				Tool: "codegraph", Tags: []string{"codegraph"},
 				Spec: manifest.ProvisionerSpec{
 					Scope:  "global",
 					Agents: []string{"codex", "claude", "antigravity", "opencode"},
@@ -225,7 +225,7 @@ printf '%s\n' "$*" > "$HOME/codegraph-args"
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
 
-	if err := runProvisioners(cmd, m, "default", home); err != nil {
+	if err := runProvisioners(cmd, m, "default", []string{"codegraph"}, home); err != nil {
 		t.Fatalf("runProvisioners() error = %v\noutput:\n%s", err, out.String())
 	}
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -15,6 +15,7 @@ func newStatusCommand() *cobra.Command {
 	var (
 		file       string
 		profile    string
+		extraTags  []string
 		sourceRoot string
 		home       string
 		stateRoot  string
@@ -54,6 +55,7 @@ func newStatusCommand() *cobra.Command {
 
 			report, err := status.Build(*m, meta, status.Options{
 				Profile:    profile,
+				ExtraTags:  extraTags,
 				OS:         runtime.GOOS,
 				SourceRoot: paths.SourceRoot,
 				Home:       paths.Home,
@@ -62,7 +64,7 @@ func newStatusCommand() *cobra.Command {
 				return err
 			}
 
-			provPlan, err := provision.Build(*m, provision.Options{Profile: profile, OS: runtime.GOOS})
+			provPlan, err := provision.Build(*m, provision.Options{Profile: profile, ExtraTags: extraTags, OS: runtime.GOOS})
 			if err != nil {
 				return err
 			}
@@ -85,6 +87,7 @@ func newStatusCommand() *cobra.Command {
 
 	cmd.Flags().StringVarP(&file, "file", "f", "dots.yaml", "manifest file to evaluate")
 	cmd.Flags().StringVarP(&profile, "profile", "p", "default", "profile to evaluate")
+	cmd.Flags().StringArrayVar(&extraTags, "tag", nil, "include an additional manifest tag; repeat to include multiple tags")
 	cmd.Flags().StringVar(&sourceRoot, "source-root", "", "installed repository root (default ~/.local/share/dots)")
 	cmd.Flags().StringVar(&home, "home", "", "target home directory to evaluate (default: the current user's home); use a sandbox path to inspect without touching real config")
 	cmd.Flags().StringVar(&stateRoot, "state-root", "", "state directory for Installation Metadata (default ~/.local/state/dots)")

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -18,6 +18,7 @@ func newUpdateCommand() *cobra.Command {
 	var (
 		file       string
 		profile    string
+		extraTags  []string
 		sourceRoot string
 		home       string
 		stateRoot  string
@@ -92,6 +93,7 @@ func newUpdateCommand() *cobra.Command {
 
 			p, err := plan.Build(*m, plan.Options{
 				Profile:    profile,
+				ExtraTags:  extraTags,
 				OS:         runtime.GOOS,
 				SourceRoot: paths.SourceRoot,
 				Home:       paths.Home,
@@ -101,7 +103,7 @@ func newUpdateCommand() *cobra.Command {
 				return err
 			}
 
-			provPlan, err := provision.Build(*m, provision.Options{Profile: profile, OS: runtime.GOOS})
+			provPlan, err := provision.Build(*m, provision.Options{Profile: profile, ExtraTags: extraTags, OS: runtime.GOOS})
 			if err != nil {
 				return err
 			}
@@ -138,7 +140,7 @@ func newUpdateCommand() *cobra.Command {
 			// Mirror install: managed agent configuration stays aligned with the
 			// Source of Truth only if the same provisioners install runs are
 			// re-applied after an update, not just the file plan.
-			if err := runProvisioners(cmd, *m, profile, paths.Home); err != nil {
+			if err := runProvisioners(cmd, *m, profile, extraTags, paths.Home); err != nil {
 				return err
 			}
 			if wantsJSON(cmd) {
@@ -150,6 +152,7 @@ func newUpdateCommand() *cobra.Command {
 
 	cmd.Flags().StringVarP(&file, "file", "f", "dots.yaml", "manifest file to install after updating")
 	cmd.Flags().StringVarP(&profile, "profile", "p", "default", "profile to install after updating")
+	cmd.Flags().StringArrayVar(&extraTags, "tag", nil, "include an additional manifest tag; repeat to include multiple tags")
 	cmd.Flags().StringVar(&sourceRoot, "source-root", "", "installed repository root to update (default ~/.local/share/dots)")
 	cmd.Flags().StringVar(&home, "home", "", "target home directory to install into (default: the current user's home); use a sandbox path to avoid touching real config")
 	cmd.Flags().StringVar(&stateRoot, "state-root", "", "state directory for Installation Metadata and Backup Sets (default ~/.local/state/dots)")

--- a/internal/deps/deps.go
+++ b/internal/deps/deps.go
@@ -26,8 +26,9 @@ type CommandRunner func(command string, args ...string) (string, error)
 
 // Options carries the resolved inputs needed to select Dependencies.
 type Options struct {
-	Profile string
-	OS      string
+	Profile   string
+	ExtraTags []string
+	OS        string
 }
 
 // Result is the presence finding for a single declared Dependency.
@@ -178,8 +179,9 @@ func selectDependencies(m manifest.Manifest, opts Options) ([]manifest.Dependenc
 	}
 
 	addDependencies(profile.Dependencies)
+	tags := manifest.SelectionTags(profile, opts.ExtraTags)
 	for _, entry := range m.Entries {
-		if !manifest.SharesTag(entry.Tags, profile.Tags) {
+		if !manifest.SharesTag(entry.Tags, tags) {
 			continue
 		}
 		if !manifest.MatchesOS(entry.OS, opts.OS) {
@@ -188,7 +190,7 @@ func selectDependencies(m manifest.Manifest, opts Options) ([]manifest.Dependenc
 		addDependencies(entry.Dependencies)
 	}
 	for _, prov := range m.Provisioners {
-		if !manifest.SharesTag(prov.Tags, profile.Tags) {
+		if !manifest.SharesTag(prov.Tags, tags) {
 			continue
 		}
 		if !manifest.MatchesOS(prov.OS, opts.OS) {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -23,6 +23,7 @@ import (
 // Options carries the resolved inputs needed to build read-only diagnostics.
 type Options struct {
 	Profile    string
+	ExtraTags  []string
 	OS         string
 	SourceRoot string
 	Home       string
@@ -89,7 +90,7 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options, look deps.Loo
 		Platform: Platform{Supported: supportedOS(opts.OS), OS: opts.OS},
 	}
 
-	depReport, err := deps.CheckWithToolProbes(m, deps.Options{Profile: opts.Profile, OS: opts.OS}, look, fontLook, opts.ToolRunner)
+	depReport, err := deps.CheckWithToolProbes(m, deps.Options{Profile: opts.Profile, ExtraTags: opts.ExtraTags, OS: opts.OS}, look, fontLook, opts.ToolRunner)
 	if err != nil {
 		return Report{}, err
 	}
@@ -97,6 +98,7 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options, look deps.Loo
 
 	statusReport, err := status.Build(m, meta, status.Options{
 		Profile:    opts.Profile,
+		ExtraTags:  opts.ExtraTags,
 		OS:         opts.OS,
 		SourceRoot: opts.SourceRoot,
 		Home:       opts.Home,
@@ -106,7 +108,7 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options, look deps.Loo
 	}
 	report.Configuration = statusReport
 
-	provReport, err := provision.Check(m, provision.Options{Profile: opts.Profile, OS: opts.OS}, look, fontLook)
+	provReport, err := provision.Check(m, provision.Options{Profile: opts.Profile, ExtraTags: opts.ExtraTags, OS: opts.OS}, look, fontLook)
 	if err != nil {
 		return Report{}, err
 	}
@@ -129,10 +131,12 @@ func ScanSecrets(m manifest.Manifest, opts Options) (SecretReport, error) {
 		return SecretReport{}, fmt.Errorf("profile %q not found", opts.Profile)
 	}
 
+	tags := manifest.SelectionTags(profile, opts.ExtraTags)
+
 	var report SecretReport
 	seen := map[string]bool{}
 	for _, entry := range m.Entries {
-		if !manifest.SharesTag(entry.Tags, profile.Tags) || !manifest.MatchesOS(entry.OS, opts.OS) || seen[entry.Source] {
+		if !manifest.SharesTag(entry.Tags, tags) || !manifest.MatchesOS(entry.OS, opts.OS) || seen[entry.Source] {
 			continue
 		}
 		seen[entry.Source] = true

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -607,6 +607,26 @@ func containsControl(value string) bool {
 // to a profile when at least one of its tags matches one of the profile's tags.
 // Centralizing it here keeps plan, status, deps, doctor, and provision filtering
 // through one rule instead of each carrying its own copy.
+// SelectionTags returns the effective tag set for a profile plus any
+// explicit tags requested by the caller. The profile tags stay first so selected
+// entries and provisioners preserve the manifest's role-oriented baseline while
+// --tag can opt into one-off capabilities without creating feature profiles.
+func SelectionTags(profile Profile, extraTags []string) []string {
+	tags := append([]string(nil), profile.Tags...)
+	seen := make(map[string]bool, len(tags)+len(extraTags))
+	for _, tag := range tags {
+		seen[tag] = true
+	}
+	for _, tag := range extraTags {
+		if seen[tag] {
+			continue
+		}
+		seen[tag] = true
+		tags = append(tags, tag)
+	}
+	return tags
+}
+
 func SharesTag(itemTags, profileTags []string) bool {
 	for _, it := range itemTags {
 		for _, pt := range profileTags {

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -882,8 +882,11 @@ func TestRepositoryManifestIncludesCodeGraphProvisioner(t *testing.T) {
 	if codegraph == nil {
 		t.Fatal("repository manifest missing codegraph provisioner")
 	}
-	if !hasString(codegraph.Tags, "agents") {
-		t.Errorf("codegraph provisioner %#v missing agents tag", codegraph.Spec)
+	if !hasString(codegraph.Tags, "codegraph") {
+		t.Errorf("codegraph provisioner %#v missing codegraph tag", codegraph.Spec)
+	}
+	if hasString(codegraph.Tags, "agents") {
+		t.Errorf("codegraph provisioner tags = %#v, want independent from agents tag", codegraph.Tags)
 	}
 	if !sameStrings(codegraph.OS, []string{"darwin", "linux"}) {
 		t.Errorf("codegraph provisioner OS = %#v, want [darwin linux]", codegraph.OS)

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -59,6 +59,7 @@ func (p Plan) HasFindings() bool {
 // Options carries the resolved inputs needed to compute a Plan.
 type Options struct {
 	Profile    string
+	ExtraTags  []string
 	OS         string
 	SourceRoot string
 	Home       string
@@ -75,9 +76,11 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 		return Plan{}, fmt.Errorf("profile %q not found", opts.Profile)
 	}
 
+	tags := manifest.SelectionTags(profile, opts.ExtraTags)
+
 	plan := Plan{Profile: opts.Profile}
 	for _, entry := range m.Entries {
-		if !manifest.SharesTag(entry.Tags, profile.Tags) {
+		if !manifest.SharesTag(entry.Tags, tags) {
 			continue
 		}
 		if !manifest.MatchesOS(entry.OS, opts.OS) {

--- a/internal/provision/plan.go
+++ b/internal/provision/plan.go
@@ -10,8 +10,9 @@ import (
 
 // Options carries the resolved inputs needed to select and plan Provisioners.
 type Options struct {
-	Profile string
-	OS      string
+	Profile   string
+	ExtraTags []string
+	OS        string
 }
 
 // Step is a single planned Provisioner invocation: the exact resolved command
@@ -35,7 +36,7 @@ type Plan struct {
 // intersect the Profile's tags) and pass the OS filter, preserving manifest
 // order. It mirrors the Entry selection used by deps, plan, and status.
 func Select(m manifest.Manifest, opts Options) ([]manifest.Provisioner, error) {
-	indices, err := selectedIndices(m, opts.Profile, opts.OS)
+	indices, err := selectedIndices(m, opts.Profile, opts.OS, opts.ExtraTags)
 	if err != nil {
 		return nil, err
 	}
@@ -54,15 +55,17 @@ func Select(m manifest.Manifest, opts Options) ([]manifest.Provisioner, error) {
 // provisioner identity across profiles (which provisioner, not just how many)
 // without depending on struct equality, and keeps Select and SkippedProvisioners
 // filtering through one tag/OS rule.
-func selectedIndices(m manifest.Manifest, profileName, os string) (map[int]bool, error) {
+func selectedIndices(m manifest.Manifest, profileName, os string, extraTags []string) (map[int]bool, error) {
 	profile, ok := m.Profiles[profileName]
 	if !ok {
 		return nil, fmt.Errorf("profile %q not found", profileName)
 	}
 
+	tags := manifest.SelectionTags(profile, extraTags)
+
 	indices := make(map[int]bool)
 	for i, prov := range m.Provisioners {
-		if manifest.SharesTag(prov.Tags, profile.Tags) && manifest.MatchesOS(prov.OS, os) {
+		if manifest.SharesTag(prov.Tags, tags) && manifest.MatchesOS(prov.OS, os) {
 			indices[i] = true
 		}
 	}
@@ -77,7 +80,7 @@ func selectedIndices(m manifest.Manifest, profileName, os string) (map[int]bool,
 // scoping used by Select.
 func SkippedProvisioners(m manifest.Manifest, opts Options) (profilesel.Hint, bool, error) {
 	return profilesel.Skipped(m.Profiles, opts.Profile, opts.OS, func(name, os string) (map[int]bool, error) {
-		return selectedIndices(m, name, os)
+		return selectedIndices(m, name, os, nil)
 	})
 }
 

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -71,6 +71,7 @@ func (r Report) HasFindings() bool {
 // Options carries the resolved inputs needed to evaluate status.
 type Options struct {
 	Profile    string
+	ExtraTags  []string
 	OS         string
 	SourceRoot string
 	Home       string
@@ -84,9 +85,11 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options) (Report, erro
 		return Report{}, fmt.Errorf("profile %q not found", opts.Profile)
 	}
 
+	tags := manifest.SelectionTags(profile, opts.ExtraTags)
+
 	report := Report{Profile: opts.Profile}
 	for _, entry := range m.Entries {
-		if !manifest.SharesTag(entry.Tags, profile.Tags) {
+		if !manifest.SharesTag(entry.Tags, tags) {
 			continue
 		}
 


### PR DESCRIPTION
Closes #155

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds repeatable `--tag` selection for optional manifest capabilities on top of a base profile.
- Moves CodeGraph out of the `agents` tag so it is installed only with `--tag codegraph`.
- Adds an Antigravity settings baseline scoped to `agents` with JSON subset ownership for runtime additions.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Tags CodeGraph as `codegraph` and adds Antigravity settings under `agents`. |
| `internal/manifest/manifest.go` | Adds effective selection tag composition for profile tags plus explicit tags. |
| `internal/plan`, `internal/provision`, `internal/deps`, `internal/status`, `internal/doctor` | Threads extra tag selection through planning, provisioning, dependency, status, and doctor surfaces. |
| `internal/cli/*.go` | Adds `--tag` flag to install/update/plan/status/doctor/deps and passes it consistently. |
| `configs/antigravity/settings.json` | Adds dots-owned Antigravity settings baseline. |
| `internal/cli/*_test.go`, `internal/manifest/manifest_test.go` | Covers CodeGraph decoupling and Antigravity JSON subset behavior. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed install dry-runs verified `--profile agents` excludes CodeGraph and `--profile agents --tag codegraph` includes it.
- [x] `go build ./...`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #155`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
