### PR TITLE
fix(agents): install gentle-ai for supported agents

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -43,7 +43,7 @@ Current Profiles:
 |---------|------|--------|----------------------|
 | `default` | `core` | Core dotfiles without provisioners. | None |
 | `desktop` | `core`, `desktop` | Desktop dotfiles and desktop-only tool integrations; no gentle-ai agent setup. | `Desktop Nerd Font` via Homebrew cask `font-cascadia-code-nf`, detected with `CascadiaCodeNF*` |
-| `agents` | `core`, `agents` | Core dotfiles plus gentle-ai agent setup/cleanup. | None |
+| `agents` | `core`, `agents` | Core dotfiles plus gentle-ai agent setup/cleanup and shared engineering skills for supported agents. | None |
 | `web` | `core`, `web` | Optional frontend/browser workbench: web design skills plus Chrome DevTools integrations. | None |
 | `mobile` | `core`, `mobile` | Optional Dart and Flutter mobile development agent skills. | None |
 | `workstation` | `core`, `desktop`, `agents` | Full workstation setup when both desktop integrations and agent setup are desired; web tooling remains explicit opt-in. | `Desktop Nerd Font` via Homebrew cask `font-cascadia-code-nf`, detected with `CascadiaCodeNF*` |
@@ -228,17 +228,19 @@ Current Provisioners:
 
 | Tool | Tags | OS | Rendered intent | Dependencies |
 |------|------|----|-----------------|--------------|
-| `gentle-ai` | `agents` | all | Uninstall `sdd` for `codex`, `claude-code`, `opencode`, and `antigravity` with `--yes`. | `gentle-ai` |
+| `gentle-ai` | `agents` | all | Uninstall `sdd` for `codex`, `claude-code`, `opencode`, `antigravity`, and `vscode-copilot` with `--yes`. | `gentle-ai` |
 | `gentle-ai` | `agents` | all | Install global stable neutral custom setup for `codex` with `engram`, `context7`, and `persona`. | `gentle-ai`, `engram` |
 | `gentle-ai` | `agents` | all | Install global stable neutral custom setup for `claude-code` with `engram`, `context7`, `persona`, and `permissions`. | `gentle-ai`, `engram` |
 | `gentle-ai` | `agents` | all | Install global stable neutral custom setup for `antigravity` with `engram`, `context7`, and `persona` only; no `sdd` or `permissions`. | `gentle-ai`, `engram` |
-| `skills` | `web` | all | Install `playwright-cli` from `microsoft/playwright-cli` globally for `codex`, `claude-code`, and `antigravity` through pinned `skills@1.5.12`, copying the skill and references into the agent skill roots. | `npx` |
-| `skills` | `web` | all | Install `frontend-design` from `anthropics/skills` globally for `codex`, `claude-code`, and `antigravity` through pinned `skills@1.5.12`. | `npx` |
-| `skills` | `web` | all | Install `vercel-react-best-practices`, `vercel-composition-patterns`, `vercel-react-view-transitions`, and `web-design-guidelines` from `vercel-labs/agent-skills` globally for `codex`, `claude-code`, and `antigravity` through pinned `skills@1.5.12`. | `npx` |
-| `skills` | `mobile` | all | Install the upstream Dart skill package from `dart-lang/skills` globally for `codex`, `claude-code`, and `antigravity` through pinned `skills@1.5.12`. | `npx` |
-| `skills` | `mobile` | all | Install the upstream Flutter skill package from `flutter/skills` globally for `codex`, `claude-code`, and `antigravity` through pinned `skills@1.5.12`. | `npx` |
-| `skills` | `mobile` | all | Install `android-cli` from `android/skills` globally for `codex`, `claude-code`, and `antigravity` through pinned `skills@1.5.12`. | `npx` |
-| `skills` | `agents` | all | Install the reviewed Matt Pocock engineering skill set from `mattpocock/skills/skills/engineering` globally for `codex`, `claude-code`, and `antigravity` through pinned `skills@1.5.12`. | `npx` |
+| `gentle-ai` | `agents` | all | Install global stable neutral custom setup for `opencode` with `engram`, `context7`, and `persona` only; no `sdd` or `permissions`. | `gentle-ai`, `engram` |
+| `gentle-ai` | `agents` | all | Install global stable neutral custom setup for `vscode-copilot` with `engram`, `context7`, and `persona` only; no `sdd` or `permissions`. | `gentle-ai`, `engram` |
+| `skills` | `web` | all | Install `playwright-cli` from `microsoft/playwright-cli` globally for `codex`, `claude-code`, `antigravity`, `opencode`, and `github-copilot` through pinned `skills@1.5.12`, copying the skill and references into the agent skill roots. | `npx` |
+| `skills` | `web` | all | Install `frontend-design` from `anthropics/skills` globally for `codex`, `claude-code`, `antigravity`, `opencode`, and `github-copilot` through pinned `skills@1.5.12`. | `npx` |
+| `skills` | `web` | all | Install `vercel-react-best-practices`, `vercel-composition-patterns`, `vercel-react-view-transitions`, and `web-design-guidelines` from `vercel-labs/agent-skills` globally for `codex`, `claude-code`, `antigravity`, `opencode`, and `github-copilot` through pinned `skills@1.5.12`. | `npx` |
+| `skills` | `mobile` | all | Install the upstream Dart skill package from `dart-lang/skills` globally for `codex`, `claude-code`, `antigravity`, `opencode`, and `github-copilot` through pinned `skills@1.5.12`. | `npx` |
+| `skills` | `mobile` | all | Install the upstream Flutter skill package from `flutter/skills` globally for `codex`, `claude-code`, `antigravity`, `opencode`, and `github-copilot` through pinned `skills@1.5.12`. | `npx` |
+| `skills` | `mobile` | all | Install `android-cli` from `android/skills` globally for `codex`, `claude-code`, `antigravity`, `opencode`, and `github-copilot` through pinned `skills@1.5.12`. | `npx` |
+| `skills` | `agents` | all | Install the reviewed Matt Pocock engineering skill set from `mattpocock/skills/skills/engineering` globally for `codex`, `claude-code`, `antigravity`, `opencode`, and `github-copilot` through pinned `skills@1.5.12`. | `npx` |
 | `claude` | `web` | `darwin`, `linux` | Register marketplace `ChromeDevTools/chrome-devtools-mcp`. | `claude` |
 | `claude` | `web` | `darwin`, `linux` | Install `chrome-devtools-mcp` from `chrome-devtools-plugins` with user scope. | `claude` |
 | `codex` | `web` | `darwin`, `linux` | Add MCP server `chrome-devtools` using `npx -y chrome-devtools-mcp@latest --no-performance-crux`. | `codex` |

--- a/docs/update.md
+++ b/docs/update.md
@@ -69,7 +69,7 @@ Because no fast-forward is applied in a dry run, the rendered plan reflects the 
 
 ## Profiles and provisioners
 
-Provisioners are scoped by profile tags, exactly like file entries. The `default` profile selects no provisioners. The `desktop` profile selects desktop configuration and non-web desktop integrations. The `agents` profile selects gentle-ai setup/cleanup provisioners and agent settings baselines. CodeGraph is independent and selected with `--tag codegraph`. The `web` profile selects frontend design skills plus Chrome DevTools for Claude, Codex, and the OpenCode overlay. The `mobile` profile selects Dart and Flutter agent skills. Use `workstation` when you explicitly want both desktop integrations and agent setup; web and mobile tooling remain separate opt-ins. This is design-intent: desktop installs should configure desktop tools, not opt into SDD, gentle-dev agent setup, browser/frontend tooling, or mobile-specific skills.
+Provisioners are scoped by profile tags, exactly like file entries. The `default` profile selects no provisioners. The `desktop` profile selects desktop configuration and non-web desktop integrations. The `agents` profile selects gentle-ai setup/cleanup provisioners for Codex, Claude Code, OpenCode, Antigravity, and VS Code Copilot, plus agent settings baselines and shared engineering skills. CodeGraph is independent and selected with `--tag codegraph`. The `web` profile selects frontend design skills plus Chrome DevTools for Claude, Codex, and the OpenCode overlay. The `mobile` profile selects Dart and Flutter agent skills. Use `workstation` when you explicitly want both desktop integrations and agent setup; web and mobile tooling remain separate opt-ins. This is design-intent: desktop installs should configure desktop tools, not opt into SDD, gentle-dev agent setup, browser/frontend tooling, or mobile-specific skills.
 
 The gentle-ai provisioner can model cleanup before install by using separate entries in manifest order. Missing `action` still defaults to `install`; `yes` is only valid for `uninstall` because it confirms a cleanup action:
 
@@ -79,14 +79,14 @@ provisioners:
     tags: [agents]
     spec:
       action: uninstall
-      agents: [codex, claude-code, opencode]
+      agents: [codex, claude-code, opencode, antigravity, vscode-copilot]
       components: [sdd]
       yes: true
   - tool: gentle-ai
     tags: [agents]
     spec:
       preset: custom
-      agents: [codex, claude-code]
+      agents: [claude-code]
       components: [engram, context7, persona, permissions]
 ```
 

--- a/dots.yaml
+++ b/dots.yaml
@@ -337,6 +337,7 @@ provisioners:
         - claude-code
         - opencode
         - antigravity
+        - vscode-copilot
       components:
         - sdd
       yes: true
@@ -397,6 +398,50 @@ provisioners:
       preset: custom
       agents:
         - antigravity
+      components:
+        - engram
+        - context7
+        - persona
+    dependencies:
+      - name: gentle-ai
+        command: gentle-ai
+        brew: gentleman-programming/tap/gentle-ai
+      - name: engram
+        command: engram
+        brew: gentleman-programming/tap/engram
+  - tool: gentle-ai
+    tags:
+      - agents
+    spec:
+      scope: global
+      channel: stable
+      persona: neutral
+      preset: custom
+      agents:
+        - opencode
+      components:
+        - engram
+        - context7
+        - persona
+    dependencies:
+      - name: gentle-ai
+        command: gentle-ai
+        brew: gentleman-programming/tap/gentle-ai
+      - name: engram
+        command: engram
+        brew: gentleman-programming/tap/engram
+  - tool: gentle-ai
+    tags:
+      - agents
+    os:
+      - darwin
+    spec:
+      scope: global
+      channel: stable
+      persona: neutral
+      preset: custom
+      agents:
+        - vscode-copilot
       components:
         - engram
         - context7

--- a/dots.yaml
+++ b/dots.yaml
@@ -433,8 +433,6 @@ provisioners:
   - tool: gentle-ai
     tags:
       - agents
-    os:
-      - darwin
     spec:
       scope: global
       channel: stable

--- a/dots.yaml
+++ b/dots.yaml
@@ -460,6 +460,8 @@ provisioners:
         - codex
         - claude-code
         - antigravity
+        - opencode
+        - github-copilot
       skills:
         - playwright-cli
       global: true
@@ -476,6 +478,8 @@ provisioners:
         - codex
         - claude-code
         - antigravity
+        - opencode
+        - github-copilot
       skills:
         - frontend-design
       global: true
@@ -491,6 +495,8 @@ provisioners:
         - codex
         - claude-code
         - antigravity
+        - opencode
+        - github-copilot
       skills:
         - vercel-react-best-practices
         - vercel-composition-patterns
@@ -509,6 +515,8 @@ provisioners:
         - codex
         - claude-code
         - antigravity
+        - opencode
+        - github-copilot
       global: true
     dependencies:
       - name: npx
@@ -522,6 +530,8 @@ provisioners:
         - codex
         - claude-code
         - antigravity
+        - opencode
+        - github-copilot
       global: true
     dependencies:
       - name: npx
@@ -535,6 +545,8 @@ provisioners:
         - codex
         - claude-code
         - antigravity
+        - opencode
+        - github-copilot
       skills:
         - android-cli
       global: true
@@ -550,6 +562,8 @@ provisioners:
         - codex
         - claude-code
         - antigravity
+        - opencode
+        - github-copilot
       skills:
         - ask-matt
         - codebase-design

--- a/internal/cli/claude_config_test.go
+++ b/internal/cli/claude_config_test.go
@@ -167,8 +167,8 @@ func TestClaudeAgentsProfileSeedsUserBaselineInSandbox(t *testing.T) {
 	if err != nil {
 		t.Fatalf("provisioner did not run under the sandbox HOME %q: %v", home, err)
 	}
-	if !strings.Contains(string(gotArgs), "uninstall --agents codex,claude-code,opencode,antigravity --components sdd --yes") {
-		t.Fatalf("provisioner argv = %q, want it to cleanup legacy SDD for codex,claude-code,opencode,antigravity before install", gotArgs)
+	if !strings.Contains(string(gotArgs), "uninstall --agents codex,claude-code,opencode,antigravity,vscode-copilot --components sdd --yes") {
+		t.Fatalf("provisioner argv = %q, want it to cleanup legacy SDD for codex,claude-code,opencode,antigravity,vscode-copilot before install", gotArgs)
 	}
 	if !strings.Contains(string(gotArgs), "install --scope global --channel stable --persona neutral --preset custom --agents codex --components engram,context7,persona") {
 		t.Fatalf("provisioner argv = %q, want codex install without permissions", gotArgs)
@@ -179,14 +179,26 @@ func TestClaudeAgentsProfileSeedsUserBaselineInSandbox(t *testing.T) {
 	if !strings.Contains(string(gotArgs), "install --scope global --channel stable --persona neutral --preset custom --agents antigravity --components engram,context7,persona") {
 		t.Fatalf("provisioner argv = %q, want antigravity install without SDD or permissions", gotArgs)
 	}
+	if !strings.Contains(string(gotArgs), "install --scope global --channel stable --persona neutral --preset custom --agents opencode --components engram,context7,persona") {
+		t.Fatalf("provisioner argv = %q, want opencode install without SDD or permissions", gotArgs)
+	}
+	if !strings.Contains(string(gotArgs), "install --scope global --channel stable --persona neutral --preset custom --agents vscode-copilot --components engram,context7,persona") {
+		t.Fatalf("provisioner argv = %q, want vscode-copilot install without SDD or permissions", gotArgs)
+	}
 	if strings.Contains(string(gotArgs), "--agents codex --components engram,context7,persona,permissions") {
 		t.Fatalf("provisioner argv = %q, want codex install without permissions because it installs gentle-dev", gotArgs)
 	}
 	if strings.Contains(string(gotArgs), "--agents antigravity --components engram,context7,persona,permissions") || strings.Contains(string(gotArgs), "--agents antigravity --components engram,context7,persona,sdd") {
 		t.Fatalf("provisioner argv = %q, want antigravity install without SDD or permissions", gotArgs)
 	}
+	if strings.Contains(string(gotArgs), "--agents opencode --components engram,context7,persona,permissions") || strings.Contains(string(gotArgs), "--agents opencode --components engram,context7,persona,sdd") {
+		t.Fatalf("provisioner argv = %q, want opencode install without SDD or permissions", gotArgs)
+	}
+	if strings.Contains(string(gotArgs), "--agents vscode-copilot --components engram,context7,persona,permissions") || strings.Contains(string(gotArgs), "--agents vscode-copilot --components engram,context7,persona,sdd") {
+		t.Fatalf("provisioner argv = %q, want vscode-copilot install without SDD or permissions", gotArgs)
+	}
 	if strings.Contains(string(gotArgs), "install --scope global --channel stable --persona neutral --preset custom --agents codex,claude-code,opencode") {
-		t.Fatalf("provisioner argv = %q, want basic install without opencode", gotArgs)
+		t.Fatalf("provisioner argv = %q, want basic installs split per agent", gotArgs)
 	}
 	if _, err := os.ReadFile(filepath.Join(home, "codegraph-args")); !os.IsNotExist(err) {
 		t.Fatalf("agents profile should not run CodeGraph without --tag codegraph: %v", err)
@@ -209,6 +221,8 @@ func TestClaudeAgentsProfileSeedsUserBaselineInSandbox(t *testing.T) {
 		"--agents codex --components engram,context7,persona",
 		"--agents claude-code --components engram,context7,persona,permissions",
 		"--agents antigravity --components engram,context7,persona",
+		"--agents opencode --components engram,context7,persona",
+		"--agents vscode-copilot --components engram,context7,persona",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("install output missing %q\noutput:\n%s", want, out)

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -550,8 +550,8 @@ func TestRepositoryManifestIncludesPlaywrightCLISkillProvisioner(t *testing.T) {
 	if !hasString(skills.Tags, "web") {
 		t.Errorf("skills provisioner %#v missing web tag", skills.Spec)
 	}
-	if !sameStrings(skills.Spec.Agents, []string{"codex", "claude-code", "antigravity"}) {
-		t.Errorf("skills provisioner agents = %#v, want [codex claude-code antigravity]", skills.Spec.Agents)
+	if !sameStrings(skills.Spec.Agents, []string{"codex", "claude-code", "antigravity", "opencode", "github-copilot"}) {
+		t.Errorf("skills provisioner agents = %#v, want [codex claude-code antigravity opencode github-copilot]", skills.Spec.Agents)
 	}
 	if !sameStrings(skills.Spec.Skills, []string{"playwright-cli"}) {
 		t.Errorf("skills provisioner skills = %#v, want [playwright-cli]", skills.Spec.Skills)
@@ -587,8 +587,8 @@ func TestRepositoryManifestIncludesExternalSkillsProvisioner(t *testing.T) {
 	if !hasString(skills.Tags, "web") {
 		t.Errorf("skills provisioner %#v missing web tag", skills.Spec)
 	}
-	if !sameStrings(skills.Spec.Agents, []string{"codex", "claude-code", "antigravity"}) {
-		t.Errorf("skills provisioner agents = %#v, want [codex claude-code antigravity]", skills.Spec.Agents)
+	if !sameStrings(skills.Spec.Agents, []string{"codex", "claude-code", "antigravity", "opencode", "github-copilot"}) {
+		t.Errorf("skills provisioner agents = %#v, want [codex claude-code antigravity opencode github-copilot]", skills.Spec.Agents)
 	}
 	wantSkills := []string{
 		"vercel-react-best-practices",
@@ -630,8 +630,8 @@ func TestRepositoryManifestIncludesAnthropicFrontendDesignSkillProvisioner(t *te
 	if !hasString(skills.Tags, "web") {
 		t.Errorf("skills provisioner %#v missing web tag", skills.Spec)
 	}
-	if !sameStrings(skills.Spec.Agents, []string{"codex", "claude-code", "antigravity"}) {
-		t.Errorf("skills provisioner agents = %#v, want [codex claude-code antigravity]", skills.Spec.Agents)
+	if !sameStrings(skills.Spec.Agents, []string{"codex", "claude-code", "antigravity", "opencode", "github-copilot"}) {
+		t.Errorf("skills provisioner agents = %#v, want [codex claude-code antigravity opencode github-copilot]", skills.Spec.Agents)
 	}
 	if !sameStrings(skills.Spec.Skills, []string{"frontend-design"}) {
 		t.Errorf("skills provisioner skills = %#v, want [frontend-design]", skills.Spec.Skills)
@@ -686,8 +686,8 @@ func TestRepositoryManifestMobileProfileIncludesMobileSkills(t *testing.T) {
 			if !hasString(skills.Tags, "mobile") {
 				t.Errorf("skills provisioner %#v missing mobile tag", skills.Spec)
 			}
-			if !sameStrings(skills.Spec.Agents, []string{"codex", "claude-code", "antigravity"}) {
-				t.Errorf("skills provisioner agents = %#v, want [codex claude-code antigravity]", skills.Spec.Agents)
+			if !sameStrings(skills.Spec.Agents, []string{"codex", "claude-code", "antigravity", "opencode", "github-copilot"}) {
+				t.Errorf("skills provisioner agents = %#v, want [codex claude-code antigravity opencode github-copilot]", skills.Spec.Agents)
 			}
 			if !sameStrings(skills.Spec.Skills, pkg.wantSkills) {
 				t.Errorf("skills provisioner skills = %#v, want %#v", skills.Spec.Skills, pkg.wantSkills)
@@ -725,8 +725,8 @@ func TestRepositoryManifestIncludesMattPocockEngineeringSkillsProvisioner(t *tes
 	if !hasString(skills.Tags, "agents") {
 		t.Errorf("skills provisioner %#v missing agents tag", skills.Spec)
 	}
-	if !sameStrings(skills.Spec.Agents, []string{"codex", "claude-code", "antigravity"}) {
-		t.Errorf("skills provisioner agents = %#v, want [codex claude-code antigravity]", skills.Spec.Agents)
+	if !sameStrings(skills.Spec.Agents, []string{"codex", "claude-code", "antigravity", "opencode", "github-copilot"}) {
+		t.Errorf("skills provisioner agents = %#v, want [codex claude-code antigravity opencode github-copilot]", skills.Spec.Agents)
 	}
 	wantSkills := []string{"ask-matt", "codebase-design", "diagnosing-bugs", "domain-modeling", "grill-with-docs", "implement", "improve-codebase-architecture", "prototype", "resolving-merge-conflicts", "setup-matt-pocock-skills", "tdd", "to-issues", "to-prd", "triage"}
 	if !sameStrings(skills.Spec.Skills, wantSkills) {

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -749,7 +749,7 @@ func TestRepositoryManifestIncludesGentleAICleanupBeforeBasicInstall(t *testing.
 		t.Fatalf("LoadFile(%q) error = %v", manifestPath, err)
 	}
 
-	var cleanup, codexInstall, claudeInstall, antigravityInstall *manifest.Provisioner
+	var cleanup, codexInstall, claudeInstall, antigravityInstall, opencodeInstall, copilotInstall *manifest.Provisioner
 	for i := range got.Provisioners {
 		prov := &got.Provisioners[i]
 		if prov.Tool != "gentle-ai" {
@@ -764,6 +764,10 @@ func TestRepositoryManifestIncludesGentleAICleanupBeforeBasicInstall(t *testing.
 			claudeInstall = prov
 		case antigravityInstall == nil && sameStrings(prov.Spec.Agents, []string{"antigravity"}):
 			antigravityInstall = prov
+		case opencodeInstall == nil && sameStrings(prov.Spec.Agents, []string{"opencode"}):
+			opencodeInstall = prov
+		case copilotInstall == nil && sameStrings(prov.Spec.Agents, []string{"vscode-copilot"}):
+			copilotInstall = prov
 		}
 	}
 
@@ -779,7 +783,13 @@ func TestRepositoryManifestIncludesGentleAICleanupBeforeBasicInstall(t *testing.
 	if antigravityInstall == nil {
 		t.Fatal("repository manifest missing gentle-ai antigravity basic install provisioner")
 	}
-	for _, prov := range []*manifest.Provisioner{cleanup, codexInstall, claudeInstall, antigravityInstall} {
+	if opencodeInstall == nil {
+		t.Fatal("repository manifest missing gentle-ai opencode basic install provisioner")
+	}
+	if copilotInstall == nil {
+		t.Fatal("repository manifest missing gentle-ai vscode-copilot basic install provisioner")
+	}
+	for _, prov := range []*manifest.Provisioner{cleanup, codexInstall, claudeInstall, antigravityInstall, opencodeInstall, copilotInstall} {
 		if !sameStrings(prov.Tags, []string{"agents"}) {
 			t.Fatalf("gentle-ai provisioner tags = %#v, want [agents] so desktop installs do not apply SDD/gentle-dev agent setup", prov.Tags)
 		}
@@ -787,8 +797,8 @@ func TestRepositoryManifestIncludesGentleAICleanupBeforeBasicInstall(t *testing.
 	if cleanup.Spec.Yes != true {
 		t.Fatalf("gentle-ai cleanup yes = %v, want true", cleanup.Spec.Yes)
 	}
-	if !sameStrings(cleanup.Spec.Agents, []string{"codex", "claude-code", "opencode", "antigravity"}) {
-		t.Fatalf("gentle-ai cleanup agents = %#v, want [codex claude-code opencode antigravity]", cleanup.Spec.Agents)
+	if !sameStrings(cleanup.Spec.Agents, []string{"codex", "claude-code", "opencode", "antigravity", "vscode-copilot"}) {
+		t.Fatalf("gentle-ai cleanup agents = %#v, want [codex claude-code opencode antigravity vscode-copilot]", cleanup.Spec.Agents)
 	}
 	if !sameStrings(cleanup.Spec.Components, []string{"sdd"}) {
 		t.Fatalf("gentle-ai cleanup components = %#v, want [sdd]", cleanup.Spec.Components)
@@ -814,11 +824,23 @@ func TestRepositoryManifestIncludesGentleAICleanupBeforeBasicInstall(t *testing.
 	if hasString(antigravityInstall.Spec.Components, "sdd") || hasString(antigravityInstall.Spec.Components, "permissions") {
 		t.Fatalf("gentle-ai antigravity install components = %#v, must not include sdd or permissions", antigravityInstall.Spec.Components)
 	}
+	if !sameStrings(opencodeInstall.Spec.Components, []string{"engram", "context7", "persona"}) {
+		t.Fatalf("gentle-ai opencode install components = %#v, want [engram context7 persona]", opencodeInstall.Spec.Components)
+	}
+	if hasString(opencodeInstall.Spec.Components, "sdd") || hasString(opencodeInstall.Spec.Components, "permissions") {
+		t.Fatalf("gentle-ai opencode install components = %#v, must not include sdd or permissions", opencodeInstall.Spec.Components)
+	}
+	if !sameStrings(copilotInstall.Spec.Components, []string{"engram", "context7", "persona"}) {
+		t.Fatalf("gentle-ai vscode-copilot install components = %#v, want [engram context7 persona]", copilotInstall.Spec.Components)
+	}
+	if hasString(copilotInstall.Spec.Components, "sdd") || hasString(copilotInstall.Spec.Components, "permissions") {
+		t.Fatalf("gentle-ai vscode-copilot install components = %#v, must not include sdd or permissions", copilotInstall.Spec.Components)
+	}
 	for i := range got.Provisioners {
 		if &got.Provisioners[i] == cleanup {
 			break
 		}
-		if &got.Provisioners[i] == codexInstall || &got.Provisioners[i] == claudeInstall || &got.Provisioners[i] == antigravityInstall {
+		if &got.Provisioners[i] == codexInstall || &got.Provisioners[i] == claudeInstall || &got.Provisioners[i] == antigravityInstall || &got.Provisioners[i] == opencodeInstall || &got.Provisioners[i] == copilotInstall {
 			t.Fatal("gentle-ai install provisioner appears before cleanup")
 		}
 	}

--- a/internal/provision/plan.go
+++ b/internal/provision/plan.go
@@ -110,7 +110,7 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 // manages, used as the advisory blast radius in the plan. gentle-ai owns its own
 // state under ~/.gentle-ai plus the selected agent-specific configuration roots:
 // ~/.claude for claude-code, ~/.codex for codex, ~/.config/opencode for opencode,
-// ~/.gemini for antigravity, and VS Code user config for vscode-copilot. claude writes marketplace and plugin state under
+// ~/.gemini for antigravity, and both macOS/Linux VS Code user config roots for vscode-copilot. claude writes marketplace and plugin state under
 // ~/.claude and the user MCP/plugin registry in ~/.claude.json. codex records MCP
 // servers in ~/.codex/config.toml, under ~/.codex. codegraph writes its own
 // installed versions and shim under ~/.codegraph and ~/.local/bin, plus MCP
@@ -136,7 +136,7 @@ func managedRoots(prov manifest.Provisioner) []string {
 			roots = append(roots, "~/.gemini")
 		}
 		if includes(prov.Spec.Agents, "vscode-copilot") {
-			roots = append(roots, "~/Library/Application Support/Code/User")
+			roots = append(roots, "~/Library/Application Support/Code/User", "~/.config/Code/User")
 		}
 		return append(roots, "~/.gentle-ai")
 	case "claude":

--- a/internal/provision/plan.go
+++ b/internal/provision/plan.go
@@ -116,7 +116,9 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 // installed versions and shim under ~/.codegraph and ~/.local/bin, plus MCP
 // config and instructions for the selected agents. skills.sh installs global
 // skills under the user-level agent skill directories selected by its --agent
-// flags. Keep these roots aligned with the pinned skills@1.5.12 agent registry.
+// flags. Keep these roots aligned with the pinned skills@1.5.12 agent registry:
+// claude-code writes to ~/.claude/skills; codex, antigravity, opencode, and
+// github-copilot write to ~/.agents/skills.
 func managedRoots(prov manifest.Provisioner) []string {
 	switch prov.Tool {
 	case "gentle-ai":
@@ -203,16 +205,8 @@ func skillsRoots(agents []string) []string {
 
 func skillsRoot(agent string) string {
 	switch agent {
-	case "antigravity":
-		return "~/.gemini/antigravity/skills"
 	case "claude-code":
 		return "~/.claude/skills"
-	case "codex":
-		return "~/.codex/skills"
-	case "github-copilot":
-		return "~/.copilot/skills"
-	case "opencode":
-		return "~/.config/opencode/skills"
 	default:
 		return "~/.agents/skills"
 	}

--- a/internal/provision/plan.go
+++ b/internal/provision/plan.go
@@ -110,7 +110,7 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 // manages, used as the advisory blast radius in the plan. gentle-ai owns its own
 // state under ~/.gentle-ai plus the selected agent-specific configuration roots:
 // ~/.claude for claude-code, ~/.codex for codex, ~/.config/opencode for opencode,
-// and ~/.gemini for antigravity. claude writes marketplace and plugin state under
+// ~/.gemini for antigravity, and VS Code user config for vscode-copilot. claude writes marketplace and plugin state under
 // ~/.claude and the user MCP/plugin registry in ~/.claude.json. codex records MCP
 // servers in ~/.codex/config.toml, under ~/.codex. codegraph writes its own
 // installed versions and shim under ~/.codegraph and ~/.local/bin, plus MCP
@@ -133,6 +133,9 @@ func managedRoots(prov manifest.Provisioner) []string {
 		}
 		if includes(prov.Spec.Agents, "antigravity") {
 			roots = append(roots, "~/.gemini")
+		}
+		if includes(prov.Spec.Agents, "vscode-copilot") {
+			roots = append(roots, "~/Library/Application Support/Code/User")
 		}
 		return append(roots, "~/.gentle-ai")
 	case "claude":

--- a/internal/provision/plan.go
+++ b/internal/provision/plan.go
@@ -116,8 +116,7 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 // installed versions and shim under ~/.codegraph and ~/.local/bin, plus MCP
 // config and instructions for the selected agents. skills.sh installs global
 // skills under the user-level agent skill directories selected by its --agent
-// flags. For skills@1.5.12, codex and antigravity share ~/.agents/skills;
-// claude-code uses ~/.claude/skills.
+// flags. Keep these roots aligned with the pinned skills@1.5.12 agent registry.
 func managedRoots(prov manifest.Provisioner) []string {
 	switch prov.Tool {
 	case "gentle-ai":
@@ -192,10 +191,7 @@ func skillsRoots(agents []string) []string {
 	roots := make([]string, 0, len(cleanAgents))
 	seen := map[string]bool{}
 	for _, agent := range cleanAgents {
-		root := "~/.agents/skills"
-		if agent == "claude-code" {
-			root = "~/.claude/skills"
-		}
+		root := skillsRoot(agent)
 		if seen[root] {
 			continue
 		}
@@ -203,6 +199,23 @@ func skillsRoots(agents []string) []string {
 		roots = append(roots, root)
 	}
 	return roots
+}
+
+func skillsRoot(agent string) string {
+	switch agent {
+	case "antigravity":
+		return "~/.gemini/antigravity/skills"
+	case "claude-code":
+		return "~/.claude/skills"
+	case "codex":
+		return "~/.codex/skills"
+	case "github-copilot":
+		return "~/.copilot/skills"
+	case "opencode":
+		return "~/.config/opencode/skills"
+	default:
+		return "~/.agents/skills"
+	}
 }
 
 func cleanAgentList(values []string) []string {

--- a/internal/provision/plan_test.go
+++ b/internal/provision/plan_test.go
@@ -284,6 +284,31 @@ func TestPlanResolvesAntigravityGentleAIProvisioner(t *testing.T) {
 	}
 }
 
+func TestPlanResolvesVSCodeCopilotGentleAIProvisioner(t *testing.T) {
+	prov := manifest.Provisioner{
+		Tool: "gentle-ai", Tags: []string{"core"},
+		Spec: manifest.ProvisionerSpec{Scope: "global", Agents: []string{"vscode-copilot"}},
+	}
+	m := manifestWithProvisioners(prov)
+
+	p, err := provision.Build(m, provision.Options{Profile: "default", OS: "linux"})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if len(p.Steps) != 1 {
+		t.Fatalf("len(Plan.Steps) = %d, want 1", len(p.Steps))
+	}
+
+	step := p.Steps[0]
+	if !reflect.DeepEqual(step.Args, []string{"install", "--scope", "global", "--agents", "vscode-copilot"}) {
+		t.Fatalf("vscode-copilot gentle-ai args = %#v", step.Args)
+	}
+	wantTargets := []string{"~/Library/Application Support/Code/User", "~/.config/Code/User", "~/.gentle-ai"}
+	if !reflect.DeepEqual(step.Targets, wantTargets) {
+		t.Fatalf("vscode-copilot targets = %#v, want %#v", step.Targets, wantTargets)
+	}
+}
+
 func TestPlanResolvesSkillsProvisioner(t *testing.T) {
 	skills := manifest.Provisioner{
 		Tool: "skills", Tags: []string{"core"},

--- a/internal/provision/plan_test.go
+++ b/internal/provision/plan_test.go
@@ -289,7 +289,7 @@ func TestPlanResolvesSkillsProvisioner(t *testing.T) {
 		Tool: "skills", Tags: []string{"core"},
 		Spec: manifest.ProvisionerSpec{
 			Package: "vercel-labs/agent-skills",
-			Agents:  []string{"codex", "claude-code", "antigravity"},
+			Agents:  []string{"codex", "claude-code", "antigravity", "opencode", "github-copilot"},
 			Skills:  []string{"web-design-guidelines"},
 			Global:  true,
 		},
@@ -313,14 +313,17 @@ func TestPlanResolvesSkillsProvisioner(t *testing.T) {
 		"--agent", "codex",
 		"--agent", "claude-code",
 		"--agent", "antigravity",
+		"--agent", "opencode",
+		"--agent", "github-copilot",
 		"--skill", "web-design-guidelines",
 		"--global",
 	}
 	if !reflect.DeepEqual(step.Args, wantArgs) {
 		t.Fatalf("skills step args = %#v, want %#v", step.Args, wantArgs)
 	}
-	if !reflect.DeepEqual(step.Targets, []string{"~/.agents/skills", "~/.claude/skills"}) {
-		t.Fatalf("skills step targets = %#v, want [~/.agents/skills ~/.claude/skills]", step.Targets)
+	wantTargets := []string{"~/.codex/skills", "~/.claude/skills", "~/.gemini/antigravity/skills", "~/.config/opencode/skills", "~/.copilot/skills"}
+	if !reflect.DeepEqual(step.Targets, wantTargets) {
+		t.Fatalf("skills step targets = %#v, want %#v", step.Targets, wantTargets)
 	}
 }
 

--- a/internal/provision/plan_test.go
+++ b/internal/provision/plan_test.go
@@ -321,7 +321,7 @@ func TestPlanResolvesSkillsProvisioner(t *testing.T) {
 	if !reflect.DeepEqual(step.Args, wantArgs) {
 		t.Fatalf("skills step args = %#v, want %#v", step.Args, wantArgs)
 	}
-	wantTargets := []string{"~/.codex/skills", "~/.claude/skills", "~/.gemini/antigravity/skills", "~/.config/opencode/skills", "~/.copilot/skills"}
+	wantTargets := []string{"~/.agents/skills", "~/.claude/skills"}
 	if !reflect.DeepEqual(step.Targets, wantTargets) {
 		t.Fatalf("skills step targets = %#v, want %#v", step.Targets, wantTargets)
 	}

--- a/internal/provision/provision_test.go
+++ b/internal/provision/provision_test.go
@@ -185,7 +185,7 @@ func TestRenderCommand(t *testing.T) {
 				Tool: "skills",
 				Spec: manifest.ProvisionerSpec{
 					Package: " vercel-labs/agent-skills ",
-					Agents:  []string{"codex", "claude-code", "antigravity"},
+					Agents:  []string{"codex", "claude-code", "antigravity", "opencode", "github-copilot"},
 					Skills:  []string{"web-design-guidelines", "skill-creator"},
 					Global:  true,
 					Copy:    true,
@@ -197,6 +197,8 @@ func TestRenderCommand(t *testing.T) {
 				"--agent", "codex",
 				"--agent", "claude-code",
 				"--agent", "antigravity",
+				"--agent", "opencode",
+				"--agent", "github-copilot",
 				"--skill", "web-design-guidelines",
 				"--skill", "skill-creator",
 				"--global",


### PR DESCRIPTION
Closes #157

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds missing gentle-ai baseline install for OpenCode in the `agents` profile.
- Adds supported VS Code Copilot gentle-ai provisioning via `vscode-copilot`.
- Keeps CodeGraph targets unchanged because upstream CodeGraph does not support Copilot.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Adds OpenCode and VS Code Copilot gentle-ai install provisioners; adds `vscode-copilot` to SDD cleanup. |
| `internal/provision/plan.go` | Includes VS Code user config in the advisory blast radius for `vscode-copilot`. |
| `internal/manifest/manifest_test.go` | Verifies repository manifest includes OpenCode and VS Code Copilot gentle-ai provisioners. |
| `internal/cli/claude_config_test.go` | Verifies sandboxed agents profile output includes OpenCode and VS Code Copilot without SDD or permissions. |
| `docs/manifest.md` | Aligns documented provisioner targets with OpenCode, VS Code Copilot, and skills.sh supported agents. |
| `docs/update.md` | Clarifies the agents profile provisions supported gentle-ai agents and shared engineering skills. |

## Test Plan

- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed agents install dry-run with explicit `--home`, `--source-root`, and `--state-root`.
- [x] Sandboxed agents + CodeGraph dry-run confirmed CodeGraph targets remain `codex,claude,antigravity,opencode`.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #157`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
