### PR TITLE
feat(agents): install writing great skills

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -241,7 +241,7 @@ Current Provisioners:
 | `skills` | `mobile` | all | Install the upstream Flutter skill package from `flutter/skills` globally for `codex`, `claude-code`, `antigravity`, `opencode`, and `github-copilot` through pinned `skills@1.5.12`. | `npx` |
 | `skills` | `mobile` | all | Install `android-cli` from `android/skills` globally for `codex`, `claude-code`, `antigravity`, `opencode`, and `github-copilot` through pinned `skills@1.5.12`. | `npx` |
 | `skills` | `agents` | all | Install the reviewed Matt Pocock engineering skill set from `mattpocock/skills/skills/engineering` globally for `codex`, `claude-code`, `antigravity`, `opencode`, and `github-copilot` through pinned `skills@1.5.12`. | `npx` |
-| `skills` | `agents` | all | Install `review` from `mattpocock/skills` globally for `codex`, `claude-code`, `antigravity`, `opencode`, and `github-copilot` through pinned `skills@1.5.12`, copying the skill into agent skill roots. | `npx` |
+| `skills` | `agents` | all | Install `review` and `writing-great-skills` from `mattpocock/skills` globally for `codex`, `claude-code`, `antigravity`, `opencode`, and `github-copilot` through pinned `skills@1.5.12`, copying the skills into agent skill roots. | `npx` |
 | `claude` | `web` | `darwin`, `linux` | Register marketplace `ChromeDevTools/chrome-devtools-mcp`. | `claude` |
 | `claude` | `web` | `darwin`, `linux` | Install `chrome-devtools-mcp` from `chrome-devtools-plugins` with user scope. | `claude` |
 | `codex` | `web` | `darwin`, `linux` | Add MCP server `chrome-devtools` using `npx -y chrome-devtools-mcp@latest --no-performance-crux`. | `codex` |

--- a/dots.yaml
+++ b/dots.yaml
@@ -597,6 +597,7 @@ provisioners:
         - github-copilot
       skills:
         - review
+        - writing-great-skills
       global: true
       copy: true
     dependencies:

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -752,19 +752,22 @@ func TestRepositoryManifestIncludesMattPocockReviewSkillProvisioner(t *testing.T
 	var skills *manifest.Provisioner
 	for i := range got.Provisioners {
 		prov := &got.Provisioners[i]
-		if prov.Tool == "skills" && prov.Spec.Package == "mattpocock/skills" && sameStrings(prov.Spec.Skills, []string{"review"}) {
+		if prov.Tool == "skills" && prov.Spec.Package == "mattpocock/skills" {
 			skills = prov
 		}
 	}
 
 	if skills == nil {
-		t.Fatal("repository manifest missing skills provisioner for mattpocock/skills review")
+		t.Fatal("repository manifest missing skills provisioner for mattpocock/skills review bundle")
 	}
 	if !hasString(skills.Tags, "agents") {
 		t.Errorf("skills provisioner %#v missing agents tag", skills.Spec)
 	}
 	if !sameStrings(skills.Spec.Agents, []string{"codex", "claude-code", "antigravity", "opencode", "github-copilot"}) {
 		t.Errorf("skills provisioner agents = %#v, want [codex claude-code antigravity opencode github-copilot]", skills.Spec.Agents)
+	}
+	if !sameStrings(skills.Spec.Skills, []string{"review", "writing-great-skills"}) {
+		t.Errorf("skills provisioner skills = %#v, want [review writing-great-skills]", skills.Spec.Skills)
 	}
 	if !skills.Spec.Global || !skills.Spec.Copy {
 		t.Errorf("skills provisioner global/copy = %v/%v, want true/true", skills.Spec.Global, skills.Spec.Copy)


### PR DESCRIPTION
Closes #161

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Installs Matt Pocock's `writing-great-skills` with the existing `review` skill bundle.
- Keeps the same supported agent targets, global install, and copy behavior.
- Updates manifest documentation and repository manifest tests.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Adds `writing-great-skills` to the existing `mattpocock/skills` provisioner. |
| `docs/manifest.md` | Documents the expanded Matt Pocock review skill bundle. |
| `internal/manifest/manifest_test.go` | Verifies the repository manifest includes both `review` and `writing-great-skills`. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go build ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed install smoke test: `HOME=<tmp>/home XDG_CONFIG_HOME=<tmp>/config XDG_DATA_HOME=<tmp>/data XDG_STATE_HOME=<tmp>/state npx --yes skills@1.5.12 add mattpocock/skills --skill review --skill writing-great-skills --agent codex --global --copy`
- [x] Sandboxed dry-run render: `go run ./cmd/dots install --dry-run --profile agents --home <tmp>/home --source-root "$PWD" --state-root <tmp>/state --file dots.yaml`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label: `type:feature`.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
