### PR TITLE
feat(upgrade): add dots-owned upgrade command

### DIFF
--- a/docs/scope.md
+++ b/docs/scope.md
@@ -53,8 +53,9 @@ Migration trigger: the day a genuinely hard, broad capability is needed (serious
 
 | Deferred item | Earliest target | Why it is deferred |
 |---------------|-----------------|--------------------|
-| Advanced dependency orchestration | Later than v1 | Rollback, version constraints, repository/tap/index refresh, reinstall, and upgrade behavior introduce package-manager state decisions beyond the guarded v1 install flow. |
+| Advanced dependency orchestration | Later than v1 | Rollback, version constraints, reinstall, and broad system package upgrades introduce package-manager state decisions beyond the guarded v1 install flow. |
 | `dots update` | v1.1 — **shipped** | Updating the Installed Repository introduces Git state, local changes, versioning, and post-update conflict handling. Delivered in v1.1; see [`docs/update.md`](update.md). |
+| `dots upgrade` | v1.2 — **shipped** | Upgrading the dots-owned system updates the `dots` binary first, then reuses `dots update` for the Installed Repository, Managed Entries, and Provisioners. It does not run broad system package upgrades; see [`docs/upgrade.md`](upgrade.md). |
 | Non-portable/generated application configurations | Later than v1 | Generated editor state, machine-local state, secrets, runtime caches, and non-portable app configs introduce runtime-state and dependency complexity that distracts from installer correctness. Authored editor files with stable paths are allowed when they fit the manifest install model. |
 | Windows support | Later than v1 | v1 focuses on macOS and Linux Supported Platforms only. Windows needs separate path, shell, package, and platform behavior decisions. |
 | Official WSL support | Later than v1 | WSL has mixed Windows/Linux filesystem and dependency concerns that should not be treated as generic Linux during the first release. |
@@ -75,7 +76,7 @@ The repository-owned Source of Truth must not absorb accidental local state. Ado
 
 ### Dependency installation stays behind explicit consent
 
-A Dependency Plan helps the user understand missing tools before any package-manager command runs. `dots deps install` uses the same preview, asks for confirmation by default, and executes direct argv-shaped package-manager actions only for installable Dependencies. It does not bypass `sudo`, does not execute manual guidance, and does not claim rollback, version constraints, reinstall, or upgrade behavior.
+A Dependency Plan helps the user understand missing tools before any package-manager command runs. `dots deps install` uses the same preview, asks for confirmation by default, and executes direct argv-shaped package-manager actions only for installable Dependencies. It does not bypass `sudo`, does not execute manual guidance, and does not claim rollback, version constraints, reinstall, or broad system upgrade behavior. `dots upgrade` is scoped separately to dots-owned surfaces only.
 
 ### Distribution starts with verifiable artifacts
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -1,0 +1,71 @@
+# `dots upgrade`
+
+`dots upgrade` refreshes the complete dots-owned system in one command: the
+[`dots` command](../CONTEXT.md#command-name), the
+[Installed Repository](../CONTEXT.md#installed-repository),
+[Managed Entries](../CONTEXT.md#managed-entry), and
+[Provisioners](../CONTEXT.md#provisioner). It does **not** run broad system
+package upgrades or manage non-dots dependencies.
+
+The command runs in two phases:
+
+1. **Binary phase** — detect how the current `dots` command was installed and
+   update only that command.
+2. **Source of Truth phase** — re-run the same safe flow as [`dots update`](update.md):
+   fast-forward the Installed Repository, compute the Install Plan, resolve
+   conflicts, apply Managed Entries, and re-run selected Provisioners.
+
+If the binary phase fails, `dots upgrade` stops before touching the Installed
+Repository or workstation home files.
+
+## Installation channels
+
+| Channel | Behavior |
+| --- | --- |
+| Homebrew Distribution | Runs `brew update`, then `brew upgrade yersonargotev/tap/dots`. |
+| Release Artifact / Bootstrapper | Downloads the latest Release Artifact, verifies its checksum, writes `dots.new`, preserves the current binary as `dots.old`, then atomically promotes the new binary. |
+| Development/local build | Aborts with a manual rebuild message. |
+
+After a successful binary change, `dots upgrade` execs the new binary through a
+hidden continuation phase so the Source of Truth phase runs with the updated
+code.
+
+## Previewing changes
+
+```bash
+dots upgrade --dry-run
+```
+
+Dry-run mode previews both phases without replacing the binary, updating the
+Installed Repository, writing Installation Metadata, or changing home files.
+
+## Machine output
+
+`dots upgrade` supports the Agent Output Contract:
+
+```bash
+dots upgrade --dry-run --output json
+dots upgrade --yes --output json
+```
+
+A real non-dry-run JSON upgrade requires `--yes` so Machine Output Mode never
+prompts on stdout.
+
+## Source of Truth flags
+
+The Source of Truth phase accepts the same relevant flags as `dots update`:
+
+```bash
+dots upgrade \
+  --file dots.yaml \
+  --profile default \
+  --tag desktop \
+  --source-root ~/.local/share/dots \
+  --home "$HOME" \
+  --state-root ~/.local/state/dots \
+  --yes \
+  --no-tui
+```
+
+Use temporary `--home`, `--source-root`, and `--state-root` values when testing
+upgrade behavior so real workstation configuration is never modified.

--- a/internal/cli/json_reports.go
+++ b/internal/cli/json_reports.go
@@ -8,6 +8,7 @@ import (
 	"github.com/yersonargotev/dots/internal/provision"
 	"github.com/yersonargotev/dots/internal/status"
 	"github.com/yersonargotev/dots/internal/uninstall"
+	"github.com/yersonargotev/dots/internal/upgrade"
 )
 
 type statusReport struct {
@@ -37,6 +38,14 @@ type installReport struct {
 
 type updateReport struct {
 	DryRun       bool           `json:"dry_run"`
+	Update       gitrepo.Update `json:"update"`
+	Plan         plan.Plan      `json:"plan"`
+	Provisioners provision.Plan `json:"provisioners"`
+}
+
+type upgradeReport struct {
+	DryRun       bool           `json:"dry_run"`
+	Binary       upgrade.Plan   `json:"binary"`
 	Update       gitrepo.Update `json:"update"`
 	Plan         plan.Plan      `json:"plan"`
 	Provisioners provision.Plan `json:"provisioners"`

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -56,6 +56,7 @@ func NewRootCommand() *cobra.Command {
 	root.AddCommand(newInstallCommand())
 	root.AddCommand(newUninstallCommand())
 	root.AddCommand(newUpdateCommand())
+	root.AddCommand(newUpgradeCommand())
 	root.AddCommand(newStatusCommand())
 	root.AddCommand(newBackupsCommand())
 	root.AddCommand(newDepsCommand())

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -14,6 +14,18 @@ import (
 	"github.com/yersonargotev/dots/internal/provision"
 )
 
+type updateOptions struct {
+	file       string
+	profile    string
+	extraTags  []string
+	sourceRoot string
+	home       string
+	stateRoot  string
+	dryRun     bool
+	yes        bool
+	noTUI      bool
+}
+
 func newUpdateCommand() *cobra.Command {
 	var (
 		file       string
@@ -41,112 +53,8 @@ func newUpdateCommand() *cobra.Command {
 		// conditions, not command misuse, so do not dump the usage block.
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			paths, err := resolvePaths(home, sourceRoot, stateRoot)
-			if err != nil {
-				return err
-			}
-
-			if !gitrepo.IsRepo(paths.SourceRoot) {
-				return fmt.Errorf("installed repository %s is not a git repository; clone the Source of Truth before updating", paths.SourceRoot)
-			}
-
-			out := cmd.OutOrStdout()
-			var update gitrepo.Update
-			if wantsJSON(cmd) {
-				if dryRun {
-					update, err = gitrepo.Preview(paths.SourceRoot)
-				} else {
-					if !yes {
-						return rejectInteractiveJSON(cmd)
-					}
-					update, err = gitrepo.FastForwardPreservingLocalChanges(paths.SourceRoot)
-				}
-				if errors.Is(err, gitrepo.ErrNotFastForward) {
-					return fmt.Errorf("installed repository %s has diverged from its upstream and cannot be fast-forwarded; resolve it manually with git", paths.SourceRoot)
-				}
-				if err != nil {
-					return err
-				}
-			} else {
-				update, err = refreshRepository(out, paths.SourceRoot, dryRun)
-				if err != nil {
-					return err
-				}
-			}
-
-			// Load the manifest after the fast-forward so a manifest change pulled
-			// from upstream is honored by the recomputed plan. The default
-			// manifest belongs to the Installed Repository, not the caller's cwd;
-			// explicit --file values keep their normal caller-relative behavior.
-			manifestPath := file
-			if !cmd.Flags().Changed("file") {
-				manifestPath = filepath.Join(paths.SourceRoot, file)
-			}
-			m, err := manifest.LoadFile(manifestPath)
-			if err != nil {
-				return err
-			}
-			meta, err := loadInstallationMetadata(paths, stateRoot)
-			if err != nil {
-				return err
-			}
-
-			p, err := plan.Build(*m, plan.Options{
-				Profile:    profile,
-				ExtraTags:  extraTags,
-				OS:         runtime.GOOS,
-				SourceRoot: paths.SourceRoot,
-				Home:       paths.Home,
-				Metadata:   meta,
-			})
-			if err != nil {
-				return err
-			}
-
-			provPlan, err := provision.Build(*m, provision.Options{Profile: profile, ExtraTags: extraTags, OS: runtime.GOOS})
-			if err != nil {
-				return err
-			}
-			if wantsJSON(cmd) {
-				if dryRun {
-					return emitOK(cmd, updateReport{DryRun: true, Update: update, Plan: p, Provisioners: provPlan})
-				}
-			} else {
-				renderPlan(out, p)
-				if err := renderSkippedEntryHint(out, *m, profile, runtime.GOOS); err != nil {
-					return err
-				}
-				renderProvisionPlan(out, provPlan)
-				if err := renderSkippedProvisionerHint(out, *m, profile, runtime.GOOS); err != nil {
-					return err
-				}
-			}
-
-			if dryRun {
-				return nil
-			}
-
-			applied, err := resolveAndApply(cmd, p, paths, yes, noTUI)
-			if err != nil {
-				return err
-			}
-			if !applied {
-				if wantsJSON(cmd) {
-					return emitOK(cmd, updateReport{DryRun: false, Update: update, Plan: p, Provisioners: provPlan})
-				}
-				return nil
-			}
-
-			// Mirror install: managed agent configuration stays aligned with the
-			// Source of Truth only if the same provisioners install runs are
-			// re-applied after an update, not just the file plan.
-			if err := runProvisioners(cmd, *m, profile, extraTags, paths.Home); err != nil {
-				return err
-			}
-			if wantsJSON(cmd) {
-				return emitOK(cmd, updateReport{DryRun: false, Update: update, Plan: p, Provisioners: provPlan})
-			}
-			return nil
+			_, err := runUpdateWorkflow(cmd, updateOptions{file: file, profile: profile, extraTags: extraTags, sourceRoot: sourceRoot, home: home, stateRoot: stateRoot, dryRun: dryRun, yes: yes, noTUI: noTUI}, true)
+			return err
 		},
 	}
 
@@ -210,4 +118,89 @@ func renderUpdate(out io.Writer, upd gitrepo.Update, dryRun bool) {
 		fmt.Fprintln(out, "\n(dry run: working tree and managed files not modified)")
 	}
 	fmt.Fprintln(out)
+}
+
+func runUpdateWorkflow(cmd *cobra.Command, opts updateOptions, emit bool) (updateReport, error) {
+	paths, err := resolvePaths(opts.home, opts.sourceRoot, opts.stateRoot)
+	if err != nil {
+		return updateReport{}, err
+	}
+	if !gitrepo.IsRepo(paths.SourceRoot) {
+		return updateReport{}, fmt.Errorf("installed repository %s is not a git repository; clone the Source of Truth before updating", paths.SourceRoot)
+	}
+	out := cmd.OutOrStdout()
+	var update gitrepo.Update
+	if wantsJSON(cmd) {
+		if opts.dryRun {
+			update, err = gitrepo.Preview(paths.SourceRoot)
+		} else {
+			if !opts.yes {
+				return updateReport{}, rejectInteractiveJSON(cmd)
+			}
+			update, err = gitrepo.FastForwardPreservingLocalChanges(paths.SourceRoot)
+		}
+		if errors.Is(err, gitrepo.ErrNotFastForward) {
+			return updateReport{}, fmt.Errorf("installed repository %s has diverged from its upstream and cannot be fast-forwarded; resolve it manually with git", paths.SourceRoot)
+		}
+		if err != nil {
+			return updateReport{}, err
+		}
+	} else {
+		update, err = refreshRepository(out, paths.SourceRoot, opts.dryRun)
+		if err != nil {
+			return updateReport{}, err
+		}
+	}
+
+	manifestPath := opts.file
+	if !cmd.Flags().Changed("file") {
+		manifestPath = filepath.Join(paths.SourceRoot, opts.file)
+	}
+	m, err := manifest.LoadFile(manifestPath)
+	if err != nil {
+		return updateReport{}, err
+	}
+	meta, err := loadInstallationMetadata(paths, opts.stateRoot)
+	if err != nil {
+		return updateReport{}, err
+	}
+	p, err := plan.Build(*m, plan.Options{Profile: opts.profile, ExtraTags: opts.extraTags, OS: runtime.GOOS, SourceRoot: paths.SourceRoot, Home: paths.Home, Metadata: meta})
+	if err != nil {
+		return updateReport{}, err
+	}
+	provPlan, err := provision.Build(*m, provision.Options{Profile: opts.profile, ExtraTags: opts.extraTags, OS: runtime.GOOS})
+	if err != nil {
+		return updateReport{}, err
+	}
+	report := updateReport{DryRun: opts.dryRun, Update: update, Plan: p, Provisioners: provPlan}
+	if wantsJSON(cmd) {
+		if opts.dryRun && emit {
+			return report, emitOK(cmd, report)
+		}
+	} else {
+		renderPlan(out, p)
+		if err := renderSkippedEntryHint(out, *m, opts.profile, runtime.GOOS); err != nil {
+			return updateReport{}, err
+		}
+		renderProvisionPlan(out, provPlan)
+		if err := renderSkippedProvisionerHint(out, *m, opts.profile, runtime.GOOS); err != nil {
+			return updateReport{}, err
+		}
+	}
+	if opts.dryRun {
+		return report, nil
+	}
+	applied, err := resolveAndApply(cmd, p, paths, opts.yes, opts.noTUI)
+	if err != nil {
+		return updateReport{}, err
+	}
+	if applied {
+		if err := runProvisioners(cmd, *m, opts.profile, opts.extraTags, paths.Home); err != nil {
+			return updateReport{}, err
+		}
+	}
+	if wantsJSON(cmd) && emit {
+		return report, emitOK(cmd, report)
+	}
+	return report, nil
 }

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -1,0 +1,182 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/spf13/cobra"
+	"github.com/yersonargotev/dots/internal/upgrade"
+	"github.com/yersonargotev/dots/internal/version"
+)
+
+var (
+	currentExecutable = os.Executable
+	execBinary        = syscall.Exec
+)
+
+func newUpgradeCommand() *cobra.Command {
+	var (
+		file       string
+		profile    string
+		extraTags  []string
+		sourceRoot string
+		home       string
+		stateRoot  string
+		dryRun     bool
+		yes        bool
+		noTUI      bool
+		continue_  bool
+
+		binaryChannel        string
+		binaryCurrentVersion string
+		binaryLatestVersion  string
+		binaryAction         string
+		binaryExecutable     string
+		binaryArtifact       string
+		binaryChecksum       string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "upgrade",
+		Short: "Upgrade the dots binary and refresh dots-owned configuration",
+		Long: "upgrade updates only dots-owned surfaces: the dots binary, the Installed Repository, " +
+			"Managed Entries, and Provisioners. It never performs a broad system package upgrade.",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts := updateOptions{file: file, profile: profile, extraTags: extraTags, sourceRoot: sourceRoot, home: home, stateRoot: stateRoot, dryRun: dryRun, yes: yes, noTUI: noTUI}
+			if continue_ {
+				updateReport, err := runUpdateWorkflow(cmd, opts, !wantsJSON(cmd))
+				if err != nil {
+					return err
+				}
+				if wantsJSON(cmd) {
+					binPlan := upgrade.Plan{Channel: binaryChannel, CurrentVersion: binaryCurrentVersion, LatestVersion: binaryLatestVersion, Action: binaryAction, Executable: binaryExecutable, Artifact: binaryArtifact, Checksum: binaryChecksum}
+					return emitOK(cmd, upgradeReport{DryRun: false, Binary: binPlan, Update: updateReport.Update, Plan: updateReport.Plan, Provisioners: updateReport.Provisioners})
+				}
+				return nil
+			}
+			if wantsJSON(cmd) && !dryRun && !yes {
+				return rejectInteractiveJSON(cmd)
+			}
+			exe, err := currentExecutable()
+			if err != nil {
+				return err
+			}
+			binOpts := upgrade.Options{CurrentVersion: version.Value, Executable: exe}
+			if dryRun {
+				binPlan, err := upgrade.Preview(cmd.Context(), binOpts)
+				if err != nil {
+					return err
+				}
+				if !wantsJSON(cmd) {
+					renderUpgradeBinary(cmd.OutOrStdout(), binPlan, true)
+				}
+				updateReport, err := runUpdateWorkflow(cmd, opts, false)
+				if err != nil {
+					return err
+				}
+				if wantsJSON(cmd) {
+					return emitOK(cmd, upgradeReport{DryRun: true, Binary: binPlan, Update: updateReport.Update, Plan: updateReport.Plan, Provisioners: updateReport.Provisioners})
+				}
+				return nil
+			}
+
+			binPlan, err := upgrade.Execute(cmd.Context(), binOpts)
+			if err != nil {
+				return err
+			}
+			if !wantsJSON(cmd) {
+				renderUpgradeBinary(cmd.OutOrStdout(), binPlan, false)
+			}
+			if binPlan.Action == upgrade.ActionHomebrewUpgrade || binPlan.Action == upgrade.ActionReplaceBinary {
+				return execBinary(exe, upgradeContinuationArgs(file, cmd.Flags().Changed("file"), profile, extraTags, sourceRoot, home, stateRoot, yes, noTUI, wantsJSON(cmd), binPlan), os.Environ())
+			}
+			updateReport, err := runUpdateWorkflow(cmd, opts, false)
+			if err != nil {
+				return err
+			}
+			if wantsJSON(cmd) {
+				return emitOK(cmd, upgradeReport{DryRun: false, Binary: binPlan, Update: updateReport.Update, Plan: updateReport.Plan, Provisioners: updateReport.Provisioners})
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&file, "file", "f", "dots.yaml", "manifest file to install after upgrading")
+	cmd.Flags().StringVarP(&profile, "profile", "p", "default", "profile to install after upgrading")
+	cmd.Flags().StringArrayVar(&extraTags, "tag", nil, "include an additional manifest tag; repeat to include multiple tags")
+	cmd.Flags().StringVar(&sourceRoot, "source-root", "", "installed repository root to update (default ~/.local/share/dots)")
+	cmd.Flags().StringVar(&home, "home", "", "target home directory to install into (default: the current user's home); use a sandbox path to avoid touching real config")
+	cmd.Flags().StringVar(&stateRoot, "state-root", "", "state directory for Installation Metadata and Backup Sets (default ~/.local/state/dots)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview the binary upgrade and Source of Truth update without modifying either phase")
+	cmd.Flags().BoolVar(&yes, "yes", false, "apply safe install actions without prompting; conflicts default to skip")
+	cmd.Flags().BoolVar(&noTUI, "no-tui", false, "use text prompts instead of the interactive TUI for conflict resolution")
+	cmd.Flags().BoolVar(&continue_, "continue", false, "continue Source of Truth upgrade after binary replacement")
+	cmd.Flags().StringVar(&binaryChannel, "binary-channel", "", "binary phase channel preserved across upgrade continuation")
+	cmd.Flags().StringVar(&binaryCurrentVersion, "binary-current-version", "", "binary phase current version preserved across upgrade continuation")
+	cmd.Flags().StringVar(&binaryLatestVersion, "binary-latest-version", "", "binary phase latest version preserved across upgrade continuation")
+	cmd.Flags().StringVar(&binaryAction, "binary-action", "", "binary phase action preserved across upgrade continuation")
+	cmd.Flags().StringVar(&binaryExecutable, "binary-executable", "", "binary phase executable path preserved across upgrade continuation")
+	cmd.Flags().StringVar(&binaryArtifact, "binary-artifact", "", "binary phase artifact preserved across upgrade continuation")
+	cmd.Flags().StringVar(&binaryChecksum, "binary-checksum", "", "binary phase checksum preserved across upgrade continuation")
+	_ = cmd.Flags().MarkHidden("continue")
+	_ = cmd.Flags().MarkHidden("binary-channel")
+	_ = cmd.Flags().MarkHidden("binary-current-version")
+	_ = cmd.Flags().MarkHidden("binary-latest-version")
+	_ = cmd.Flags().MarkHidden("binary-action")
+	_ = cmd.Flags().MarkHidden("binary-executable")
+	_ = cmd.Flags().MarkHidden("binary-artifact")
+	_ = cmd.Flags().MarkHidden("binary-checksum")
+	return cmd
+}
+
+func upgradeContinuationArgs(file string, fileChanged bool, profile string, extraTags []string, sourceRoot, home, stateRoot string, yes, noTUI, json bool, binPlan upgrade.Plan) []string {
+	args := []string{"dots", "upgrade", "--continue"}
+	if fileChanged {
+		args = append(args, "--file", file)
+	}
+	args = append(args, "--profile", profile)
+	for _, tag := range extraTags {
+		args = append(args, "--tag", tag)
+	}
+	if sourceRoot != "" {
+		args = append(args, "--source-root", sourceRoot)
+	}
+	if home != "" {
+		args = append(args, "--home", home)
+	}
+	if stateRoot != "" {
+		args = append(args, "--state-root", stateRoot)
+	}
+	if yes {
+		args = append(args, "--yes")
+	}
+	if noTUI {
+		args = append(args, "--no-tui")
+	}
+	if json {
+		args = append(args, "--output", "json")
+	}
+	args = append(args,
+		"--binary-channel", binPlan.Channel,
+		"--binary-current-version", binPlan.CurrentVersion,
+		"--binary-latest-version", binPlan.LatestVersion,
+		"--binary-action", binPlan.Action,
+		"--binary-executable", binPlan.Executable,
+		"--binary-artifact", binPlan.Artifact,
+		"--binary-checksum", binPlan.Checksum,
+	)
+	return args
+}
+
+func renderUpgradeBinary(out interface{ Write([]byte) (int, error) }, plan upgrade.Plan, dryRun bool) {
+	prefix := "Binary upgrade"
+	if dryRun {
+		prefix = "Binary upgrade preview"
+	}
+	fmt.Fprintf(out, "%s: channel=%s current=%s", prefix, plan.Channel, plan.CurrentVersion)
+	if plan.LatestVersion != "" {
+		fmt.Fprintf(out, " latest=%s", plan.LatestVersion)
+	}
+	fmt.Fprintf(out, " action=%s\n\n", plan.Action)
+}

--- a/internal/cli/upgrade_internal_test.go
+++ b/internal/cli/upgrade_internal_test.go
@@ -1,0 +1,26 @@
+package cli
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/upgrade"
+)
+
+func TestUpgradeContinuationArgsPreserveUpdateFlags(t *testing.T) {
+	binPlan := upgrade.Plan{Channel: "homebrew", CurrentVersion: "v0.18.0", LatestVersion: "v0.19.0", Action: "homebrew-upgrade", Executable: "/bin/dots", Artifact: "dots_v0.19.0_darwin_arm64", Checksum: "abc123"}
+	got := upgradeContinuationArgs("custom.yaml", true, "work", []string{"core", "desktop"}, "/src", "/home", "/state", true, true, true, binPlan)
+	want := []string{"dots", "upgrade", "--continue", "--file", "custom.yaml", "--profile", "work", "--tag", "core", "--tag", "desktop", "--source-root", "/src", "--home", "/home", "--state-root", "/state", "--yes", "--no-tui", "--output", "json", "--binary-channel", "homebrew", "--binary-current-version", "v0.18.0", "--binary-latest-version", "v0.19.0", "--binary-action", "homebrew-upgrade", "--binary-executable", "/bin/dots", "--binary-artifact", "dots_v0.19.0_darwin_arm64", "--binary-checksum", "abc123"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("args = %#v, want %#v", got, want)
+	}
+}
+
+func TestUpgradeContinuationArgsDoNotMarkDefaultFileChanged(t *testing.T) {
+	got := upgradeContinuationArgs("dots.yaml", false, "default", nil, "/src", "/home", "", true, false, false, upgrade.Plan{})
+	for i, arg := range got {
+		if arg == "--file" || arg == "-f" {
+			t.Fatalf("args[%d] = %q; default manifest must not be forwarded as an explicit --file: %#v", i, arg, got)
+		}
+	}
+}

--- a/internal/cli/upgrade_test.go
+++ b/internal/cli/upgrade_test.go
@@ -1,0 +1,240 @@
+package cli_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/cli"
+)
+
+func TestUpgradeDryRunPreviewsBinaryAndSourceOfTruthWithoutModifying(t *testing.T) {
+	requireGitCLI(t)
+	home := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	origin, sourceRoot := newInstalledRepo(t, map[string]string{
+		"configs/zsh/zshrc": "export A=1\n",
+		"dots.yaml": `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+`,
+	})
+	advanceUpstream(t, origin, "update zsh config", map[string]string{"configs/zsh/zshrc": "export A=2\n"})
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"upgrade", "--dry-run", "--file", filepath.Join(sourceRoot, "dots.yaml"), "--home", home, "--source-root", sourceRoot})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("upgrade --dry-run error = %v\noutput:\n%s", err, out.String())
+	}
+	for _, want := range []string{"Binary upgrade preview", "action=manual-rebuild", "update zsh config", `Plan for profile "default"`} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output missing %q\n%s", want, out.String())
+		}
+	}
+	if _, err := os.Lstat(filepath.Join(home, ".zshrc")); !os.IsNotExist(err) {
+		t.Fatalf("dry-run installed a target; lstat err = %v", err)
+	}
+}
+
+func TestUpgradeJSONRequiresDryRunOrYes(t *testing.T) {
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"upgrade", "--output", "json"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--output json requires --yes or --dry-run") {
+		t.Fatalf("error = %v, want JSON gating error", err)
+	}
+}
+
+func TestUpgradeDevBuildAbortsBeforeSourceOfTruthPhase(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"upgrade", "--home", home, "--source-root", sourceRoot})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "development/local dots build detected") {
+		t.Fatalf("error = %v, want development build rejection", err)
+	}
+	if strings.Contains(err.Error(), "not a git repository") {
+		t.Fatalf("upgrade reached Source of Truth phase after binary rejection: %v", err)
+	}
+	if _, statErr := os.Lstat(filepath.Join(home, ".zshrc")); !os.IsNotExist(statErr) {
+		t.Fatalf("upgrade touched HOME after binary rejection; lstat err = %v", statErr)
+	}
+}
+
+func TestUpgradeContinueReusesUpdateWorkflow(t *testing.T) {
+	requireGitCLI(t)
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	origin, sourceRoot := newInstalledRepo(t, map[string]string{
+		"configs/zsh/zshrc": "export A=1\n",
+		"dots.yaml": `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+`,
+	})
+	advanceUpstream(t, origin, "add tmux config", map[string]string{
+		"configs/tmux/tmux.conf": "set -g mouse on\n",
+		"dots.yaml": `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+  - source: configs/tmux/tmux.conf
+    target: ~/.tmux.conf
+    strategy: symlink
+    tags: [core]
+`,
+	})
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"upgrade", "--continue", "--file", filepath.Join(sourceRoot, "dots.yaml"), "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("upgrade --continue error = %v\noutput:\n%s", err, out.String())
+	}
+	if _, err := os.Readlink(filepath.Join(home, ".tmux.conf")); err != nil {
+		t.Fatalf("continuation did not install updated Managed Entry: %v", err)
+	}
+}
+
+func TestUpgradeContinueJSONEmitsUpgradeReportWithBinaryPhase(t *testing.T) {
+	requireGitCLI(t)
+	home := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	_, sourceRoot := newInstalledRepo(t, map[string]string{
+		"configs/zsh/zshrc": "export A=1\n",
+		"dots.yaml": `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+`,
+	})
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"upgrade", "--continue", "--yes", "--output", "json",
+		"--file", filepath.Join(sourceRoot, "dots.yaml"),
+		"--home", home, "--source-root", sourceRoot,
+		"--binary-channel", "homebrew",
+		"--binary-current-version", "v0.18.0",
+		"--binary-latest-version", "v0.19.0",
+		"--binary-action", "homebrew-upgrade",
+		"--binary-executable", "/opt/homebrew/bin/dots",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("upgrade --continue --output json error = %v\noutput:\n%s", err, out.String())
+	}
+	var env struct {
+		Command string `json:"command"`
+		Status  string `json:"status"`
+		Data    struct {
+			DryRun bool `json:"dry_run"`
+			Binary struct {
+				Channel        string `json:"channel"`
+				CurrentVersion string `json:"current_version"`
+				LatestVersion  string `json:"latest_version"`
+				Action         string `json:"action"`
+			} `json:"binary"`
+			Update struct {
+				OldRev string `json:"old_rev"`
+			} `json:"update"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatalf("invalid JSON envelope: %v\n%s", err, out.String())
+	}
+	if env.Command != "upgrade" || env.Status != "ok" || env.Data.DryRun {
+		t.Fatalf("envelope header = %+v, want upgrade ok real run", env)
+	}
+	if env.Data.Binary.Channel != "homebrew" || env.Data.Binary.CurrentVersion != "v0.18.0" || env.Data.Binary.LatestVersion != "v0.19.0" || env.Data.Binary.Action != "homebrew-upgrade" {
+		t.Fatalf("binary report = %+v, want preserved binary phase", env.Data.Binary)
+	}
+	if env.Data.Update.OldRev == "" {
+		t.Fatalf("upgrade JSON lost Source of Truth update report: %+v", env.Data.Update)
+	}
+}
+
+func TestUpgradeDryRunJSONUsesAgentEnvelope(t *testing.T) {
+	requireGitCLI(t)
+	home := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	_, sourceRoot := newInstalledRepo(t, map[string]string{
+		"configs/zsh/zshrc": "export A=1\n",
+		"dots.yaml": `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+`,
+	})
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"upgrade", "--dry-run", "--output", "json", "--file", filepath.Join(sourceRoot, "dots.yaml"), "--home", home, "--source-root", sourceRoot})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("upgrade --dry-run --output json error = %v\noutput:\n%s", err, out.String())
+	}
+	var env struct {
+		Command string `json:"command"`
+		Status  string `json:"status"`
+		Data    struct {
+			DryRun bool `json:"dry_run"`
+			Binary struct {
+				Channel string `json:"channel"`
+				Action  string `json:"action"`
+			} `json:"binary"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatalf("invalid JSON envelope: %v\n%s", err, out.String())
+	}
+	if env.Command != "upgrade" || env.Status != "ok" || !env.Data.DryRun || env.Data.Binary.Action != "manual-rebuild" {
+		t.Fatalf("envelope = %+v, want upgrade ok dry-run manual rebuild", env)
+	}
+}

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -1,0 +1,351 @@
+package upgrade
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"regexp"
+	"runtime"
+	"strings"
+)
+
+const (
+	ChannelHomebrew    = "homebrew"
+	ChannelRelease     = "release-artifact"
+	ChannelDevelopment = "development"
+
+	ActionHomebrewUpgrade = "homebrew-upgrade"
+	ActionReplaceBinary   = "replace-binary"
+	ActionAlreadyCurrent  = "already-current"
+	ActionManualRebuild   = "manual-rebuild"
+)
+
+const defaultReleaseBaseURL = "https://github.com/yersonargotev/dots/releases/download"
+
+type Runner interface {
+	Run(ctx context.Context, executable string, args ...string) (string, error)
+}
+
+type ExecRunner struct{}
+
+func (ExecRunner) Run(ctx context.Context, executable string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, executable, args...)
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg != "" {
+			return stdout.String(), fmt.Errorf("%s", msg)
+		}
+		return stdout.String(), err
+	}
+	return stdout.String(), nil
+}
+
+type Plan struct {
+	Channel        string `json:"channel"`
+	CurrentVersion string `json:"current_version"`
+	LatestVersion  string `json:"latest_version,omitempty"`
+	Action         string `json:"action"`
+	Executable     string `json:"executable"`
+	Artifact       string `json:"artifact,omitempty"`
+	Checksum       string `json:"checksum,omitempty"`
+}
+
+type Options struct {
+	CurrentVersion string
+	Executable     string
+	GOOS           string
+	GOARCH         string
+	ReleaseBaseURL string
+	HTTPClient     *http.Client
+	Runner         Runner
+}
+
+func (o Options) withDefaults() Options {
+	if o.GOOS == "" {
+		o.GOOS = runtime.GOOS
+	}
+	if o.GOARCH == "" {
+		o.GOARCH = runtime.GOARCH
+	}
+	if o.ReleaseBaseURL == "" {
+		o.ReleaseBaseURL = os.Getenv("DOTS_RELEASE_BASE_URL")
+	}
+	if o.ReleaseBaseURL == "" {
+		o.ReleaseBaseURL = defaultReleaseBaseURL
+	}
+	if o.HTTPClient == nil {
+		o.HTTPClient = http.DefaultClient
+	}
+	if o.Runner == nil {
+		o.Runner = ExecRunner{}
+	}
+	return o
+}
+
+func Preview(ctx context.Context, opts Options) (Plan, error) {
+	opts = opts.withDefaults()
+	channel := detectChannel(ctx, opts)
+	plan := Plan{Channel: channel, CurrentVersion: opts.CurrentVersion, Executable: opts.Executable}
+	switch channel {
+	case ChannelDevelopment:
+		plan.Action = ActionManualRebuild
+		return plan, nil
+	case ChannelHomebrew:
+		latest, err := homebrewLatestVersion(ctx, opts.Runner)
+		if err != nil {
+			return Plan{}, err
+		}
+		plan.Action = ActionHomebrewUpgrade
+		plan.LatestVersion = latest
+		return plan, nil
+	default:
+		asset, err := resolveLatestAsset(ctx, opts)
+		if err != nil {
+			return Plan{}, err
+		}
+		plan.LatestVersion = asset.Version
+		plan.Artifact = asset.Name
+		plan.Checksum = asset.Checksum
+		if opts.CurrentVersion == asset.Version {
+			plan.Action = ActionAlreadyCurrent
+		} else {
+			plan.Action = ActionReplaceBinary
+		}
+		return plan, nil
+	}
+}
+
+func Execute(ctx context.Context, opts Options) (Plan, error) {
+	opts = opts.withDefaults()
+	plan, err := Preview(ctx, opts)
+	if err != nil {
+		return Plan{}, err
+	}
+	switch plan.Action {
+	case ActionManualRebuild:
+		return plan, fmt.Errorf("development/local dots build detected; rebuild manually from the Source of Truth before running dots upgrade")
+	case ActionHomebrewUpgrade:
+		if _, err := opts.Runner.Run(ctx, "brew", "update"); err != nil {
+			return plan, fmt.Errorf("brew update: %w", err)
+		}
+		if _, err := opts.Runner.Run(ctx, "brew", "upgrade", "yersonargotev/tap/dots"); err != nil {
+			return plan, fmt.Errorf("brew upgrade yersonargotev/tap/dots: %w", err)
+		}
+		return plan, nil
+	case ActionAlreadyCurrent:
+		return plan, nil
+	case ActionReplaceBinary:
+		if err := replaceReleaseArtifact(ctx, opts, plan); err != nil {
+			return plan, err
+		}
+		return plan, nil
+	default:
+		return plan, fmt.Errorf("unknown upgrade action %q", plan.Action)
+	}
+}
+
+func detectChannel(ctx context.Context, opts Options) string {
+	if opts.CurrentVersion == "" || opts.CurrentVersion == "dev" {
+		return ChannelDevelopment
+	}
+	if opts.Runner != nil {
+		if _, err := opts.Runner.Run(ctx, "brew", "list", "--formula", "yersonargotev/tap/dots"); err == nil {
+			return ChannelHomebrew
+		}
+	}
+	return ChannelRelease
+}
+
+type homebrewInfo struct {
+	Formulae []struct {
+		Versions struct {
+			Stable string `json:"stable"`
+		} `json:"versions"`
+	} `json:"formulae"`
+}
+
+func homebrewLatestVersion(ctx context.Context, runner Runner) (string, error) {
+	out, err := runner.Run(ctx, "brew", "info", "--json=v2", "yersonargotev/tap/dots")
+	if err != nil {
+		return "", fmt.Errorf("brew info yersonargotev/tap/dots: %w", err)
+	}
+	var info homebrewInfo
+	if err := json.Unmarshal([]byte(out), &info); err != nil {
+		return "", fmt.Errorf("parse brew info yersonargotev/tap/dots: %w", err)
+	}
+	if len(info.Formulae) == 0 || info.Formulae[0].Versions.Stable == "" {
+		return "", fmt.Errorf("brew info yersonargotev/tap/dots did not report a stable version")
+	}
+	stable := info.Formulae[0].Versions.Stable
+	if strings.HasPrefix(stable, "v") {
+		return stable, nil
+	}
+	return "v" + stable, nil
+}
+
+type asset struct {
+	Name     string
+	Version  string
+	Checksum string
+}
+
+func resolveLatestAsset(ctx context.Context, opts Options) (asset, error) {
+	assetBase := assetBaseURL(opts.ReleaseBaseURL)
+	checksums, err := downloadText(ctx, opts.HTTPClient, assetBase+"/checksums.txt")
+	if err != nil {
+		return asset{}, err
+	}
+	return parseAsset(checksums, opts.GOOS, opts.GOARCH)
+}
+
+var artifactRE = regexp.MustCompile(`^dots_(v[^_]+)_([a-z0-9]+)_([a-z0-9]+)$`)
+
+func parseAsset(checksums, goos, goarch string) (asset, error) {
+	for _, line := range strings.Split(checksums, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		m := artifactRE.FindStringSubmatch(fields[1])
+		if len(m) != 4 {
+			continue
+		}
+		if m[2] == goos && m[3] == goarch {
+			return asset{Name: fields[1], Version: m[1], Checksum: fields[0]}, nil
+		}
+	}
+	return asset{}, fmt.Errorf("checksums.txt does not contain a Release Artifact for %s/%s", goos, goarch)
+}
+
+func replaceReleaseArtifact(ctx context.Context, opts Options, plan Plan) error {
+	if opts.Executable == "" {
+		return fmt.Errorf("cannot replace dots binary: executable path is unknown")
+	}
+	tmpPath, err := downloadToTemp(ctx, opts.HTTPClient, assetBaseURL(opts.ReleaseBaseURL)+"/"+plan.Artifact)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmpPath)
+	actual, err := sha256File(tmpPath)
+	if err != nil {
+		return err
+	}
+	if actual != plan.Checksum {
+		return fmt.Errorf("checksum mismatch for %s", plan.Artifact)
+	}
+	newPath := opts.Executable + ".new"
+	oldPath := opts.Executable + ".old"
+	if err := copyFile(tmpPath, newPath, 0o755); err != nil {
+		return err
+	}
+	_ = os.Remove(oldPath)
+	if err := os.Rename(opts.Executable, oldPath); err != nil {
+		_ = os.Remove(newPath)
+		return fmt.Errorf("preserve previous binary as %s: %w", oldPath, err)
+	}
+	if err := os.Rename(newPath, opts.Executable); err != nil {
+		_ = os.Rename(oldPath, opts.Executable)
+		return fmt.Errorf("activate new binary: %w", err)
+	}
+	return nil
+}
+
+func assetBaseURL(releaseBaseURL string) string {
+	base := strings.TrimRight(releaseBaseURL, "/")
+	if base == defaultReleaseBaseURL {
+		return "https://github.com/yersonargotev/dots/releases/latest/download"
+	}
+	return base + "/latest"
+}
+
+func downloadToTemp(ctx context.Context, client *http.Client, url string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("download %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return "", fmt.Errorf("download %s: HTTP %d", url, resp.StatusCode)
+	}
+	tmp, err := os.CreateTemp("", "dots-upgrade-*")
+	if err != nil {
+		return "", fmt.Errorf("create temporary release artifact: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer tmp.Close()
+	if _, err := io.Copy(tmp, resp.Body); err != nil {
+		_ = os.Remove(tmpPath)
+		return "", fmt.Errorf("write temporary release artifact: %w", err)
+	}
+	return tmpPath, nil
+}
+
+func sha256File(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", fmt.Errorf("hash %s: %w", path, err)
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func copyFile(source, target string, mode os.FileMode) error {
+	in, err := os.Open(source)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", source, err)
+	}
+	defer in.Close()
+	out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return fmt.Errorf("write %s: %w", target, err)
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return fmt.Errorf("write %s: %w", target, err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", target, err)
+	}
+	if err := os.Chmod(target, mode); err != nil {
+		return fmt.Errorf("chmod %s: %w", target, err)
+	}
+	return nil
+}
+
+func downloadText(ctx context.Context, client *http.Client, url string) (string, error) {
+	b, err := downloadBytes(ctx, client, url)
+	return string(b), err
+}
+
+func downloadBytes(ctx context.Context, client *http.Client, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("download %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, fmt.Errorf("download %s: HTTP %d", url, resp.StatusCode)
+	}
+	return io.ReadAll(resp.Body)
+}

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -1,0 +1,197 @@
+package upgrade
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type recordingRunner struct {
+	brewInstalled bool
+	calls         []string
+	failAt        string
+	outputs       map[string]string
+}
+
+func (r *recordingRunner) Run(_ context.Context, executable string, args ...string) (string, error) {
+	call := executable + " " + strings.Join(args, " ")
+	r.calls = append(r.calls, call)
+	if call == r.failAt {
+		return "", fmt.Errorf("boom")
+	}
+	if executable == "brew" && strings.Join(args, " ") == "list --formula yersonargotev/tap/dots" {
+		if r.brewInstalled {
+			return "", nil
+		}
+		return "", fmt.Errorf("not installed")
+	}
+	if r.outputs != nil {
+		return r.outputs[call], nil
+	}
+	return "", nil
+}
+
+func TestPreviewRejectsDevelopmentBuilds(t *testing.T) {
+	plan, err := Preview(context.Background(), Options{CurrentVersion: "dev", Runner: &recordingRunner{}})
+	if err != nil {
+		t.Fatalf("Preview() error = %v", err)
+	}
+	if plan.Channel != ChannelDevelopment || plan.Action != ActionManualRebuild {
+		t.Fatalf("plan = %+v, want development manual rebuild", plan)
+	}
+}
+
+func TestPreviewHomebrewReportsStableLatestVersion(t *testing.T) {
+	runner := &recordingRunner{brewInstalled: true, outputs: map[string]string{"brew info --json=v2 yersonargotev/tap/dots": `{"formulae":[{"versions":{"stable":"0.20.0"}}]}`}}
+	plan, err := Preview(context.Background(), Options{CurrentVersion: "v0.19.0", Runner: runner})
+	if err != nil {
+		t.Fatalf("Preview() error = %v", err)
+	}
+	if plan.Channel != ChannelHomebrew || plan.LatestVersion != "v0.20.0" || plan.Action != ActionHomebrewUpgrade {
+		t.Fatalf("plan = %+v, want Homebrew dry-run preview with real latest version", plan)
+	}
+}
+
+func TestExecuteRunsHomebrewUpdateThenFormulaUpgrade(t *testing.T) {
+	runner := &recordingRunner{brewInstalled: true, outputs: map[string]string{"brew info --json=v2 yersonargotev/tap/dots": `{"formulae":[{"versions":{"stable":"0.19.0"}}]}`}}
+	plan, err := Execute(context.Background(), Options{CurrentVersion: "v0.18.0", Runner: runner})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if plan.Channel != ChannelHomebrew || plan.Action != ActionHomebrewUpgrade || plan.LatestVersion != "v0.19.0" {
+		t.Fatalf("plan = %+v, want homebrew upgrade", plan)
+	}
+	want := []string{
+		"brew list --formula yersonargotev/tap/dots",
+		"brew info --json=v2 yersonargotev/tap/dots",
+		"brew update",
+		"brew upgrade yersonargotev/tap/dots",
+	}
+	if !reflect.DeepEqual(runner.calls, want) {
+		t.Fatalf("calls = %#v, want %#v", runner.calls, want)
+	}
+}
+
+func TestReleaseReplacementVerifiesChecksumAndPreservesOldBinary(t *testing.T) {
+	body := []byte("new dots binary")
+	sum := sha256.Sum256(body)
+	checksum := hex.EncodeToString(sum[:])
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/latest/checksums.txt":
+			fmt.Fprintf(w, "%s  dots_v0.19.0_linux_amd64\n", checksum)
+		case "/latest/dots_v0.19.0_linux_amd64":
+			_, _ = w.Write(body)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	exe := filepath.Join(t.TempDir(), "dots")
+	if err := os.WriteFile(exe, []byte("old dots binary"), 0o755); err != nil {
+		t.Fatalf("write executable: %v", err)
+	}
+
+	plan, err := Execute(context.Background(), Options{
+		CurrentVersion: "v0.18.0",
+		Executable:     exe,
+		GOOS:           "linux",
+		GOARCH:         "amd64",
+		ReleaseBaseURL: server.URL,
+		Runner:         &recordingRunner{},
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if plan.Action != ActionReplaceBinary || plan.LatestVersion != "v0.19.0" {
+		t.Fatalf("plan = %+v, want replacement to v0.19.0", plan)
+	}
+	got, err := os.ReadFile(exe)
+	if err != nil {
+		t.Fatalf("read executable: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Fatalf("executable = %q, want new body", got)
+	}
+	old, err := os.ReadFile(exe + ".old")
+	if err != nil {
+		t.Fatalf("read old executable: %v", err)
+	}
+	if string(old) != "old dots binary" {
+		t.Fatalf("old executable = %q, want preserved old body", old)
+	}
+	if _, err := os.Stat(exe + ".new"); !os.IsNotExist(err) {
+		t.Fatalf("temporary .new file remains; stat err = %v", err)
+	}
+}
+
+func TestReleaseReplacementRejectsChecksumMismatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/latest/checksums.txt":
+			fmt.Fprintln(w, "0000  dots_v0.19.0_linux_amd64")
+		case "/latest/dots_v0.19.0_linux_amd64":
+			_, _ = w.Write([]byte("new dots binary"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	exe := filepath.Join(t.TempDir(), "dots")
+	if err := os.WriteFile(exe, []byte("old dots binary"), 0o755); err != nil {
+		t.Fatalf("write executable: %v", err)
+	}
+
+	_, err := Execute(context.Background(), Options{
+		CurrentVersion: "v0.18.0",
+		Executable:     exe,
+		GOOS:           "linux",
+		GOARCH:         "amd64",
+		ReleaseBaseURL: server.URL,
+		Runner:         &recordingRunner{},
+	})
+	if err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("Execute() error = %v, want checksum mismatch", err)
+	}
+	got, err := os.ReadFile(exe)
+	if err != nil {
+		t.Fatalf("read executable: %v", err)
+	}
+	if string(got) != "old dots binary" {
+		t.Fatalf("executable mutated after checksum failure: %q", got)
+	}
+}
+
+func TestDownloadToTempWritesReleaseArtifactToTemporaryFile(t *testing.T) {
+	body := []byte("downloaded release artifact")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer server.Close()
+
+	path, err := downloadToTemp(context.Background(), server.Client(), server.URL+"/dots")
+	if err != nil {
+		t.Fatalf("downloadToTemp() error = %v", err)
+	}
+	defer os.Remove(path)
+	if filepath.Base(path) == "dots.new" {
+		t.Fatalf("download used final .new path instead of temporary artifact path: %s", path)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read temporary artifact: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Fatalf("temporary artifact = %q, want downloaded body", got)
+	}
+}


### PR DESCRIPTION
Closes #163

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds `dots upgrade` to upgrade dots-owned surfaces in a binary-first flow.
- Reuses the existing `dots update` Source of Truth flow through a hidden continuation phase.
- Documents the new command and its safety boundaries.

## Changes

| File | Change |
|------|--------|
| `internal/cli/upgrade.go` | Adds the public `dots upgrade` command, dry-run/JSON handling, hidden `--continue`, and exec handoff. |
| `internal/upgrade/upgrade.go` | Adds binary channel detection plus Homebrew and Release Artifact upgrade behavior. |
| `internal/cli/update.go` | Extracts the update workflow so `upgrade --continue` reuses the same install/provisioner path. |
| `internal/cli/json_reports.go` | Adds the upgrade JSON report payload. |
| `internal/cli/upgrade_test.go`, `internal/cli/upgrade_internal_test.go` | Covers CLI dry-run, JSON gating/envelope, continuation, dev-build abort, and forwarded args. |
| `internal/upgrade/upgrade_test.go` | Covers Homebrew runner behavior, release replacement safety, and checksum mismatch handling. |
| `docs/upgrade.md`, `docs/scope.md` | Documents `dots upgrade` and updates scope boundaries. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp>`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #163`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
