### PR TITLE
feat(agents): add opt-in Gentle-AI SDD install tag

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -43,7 +43,7 @@ Current Profiles:
 |---------|------|--------|----------------------|
 | `default` | `core` | Core dotfiles without provisioners. | None |
 | `desktop` | `core`, `desktop` | Desktop dotfiles and desktop-only tool integrations; no gentle-ai agent setup. | `Desktop Nerd Font` via Homebrew cask `font-cascadia-code-nf`, detected with `CascadiaCodeNF*` |
-| `agents` | `core`, `agents` | Core dotfiles plus gentle-ai agent setup/cleanup and shared engineering skills for supported agents. | None |
+| `agents` | `core`, `agents` | Core dotfiles plus gentle-ai agent setup/cleanup and shared engineering skills for supported agents. Add `--tag sdd` to opt into Gentle-AI SDD setup. | None |
 | `web` | `core`, `web` | Optional frontend/browser workbench: web design skills plus Chrome DevTools integrations. | None |
 | `mobile` | `core`, `mobile` | Optional Dart and Flutter mobile development agent skills. | None |
 | `workstation` | `core`, `desktop`, `agents` | Full workstation setup when both desktop integrations and agent setup are desired; web tooling remains explicit opt-in. | `Desktop Nerd Font` via Homebrew cask `font-cascadia-code-nf`, detected with `CascadiaCodeNF*` |
@@ -229,6 +229,7 @@ Current Provisioners:
 | Tool | Tags | OS | Rendered intent | Dependencies |
 |------|------|----|-----------------|--------------|
 | `gentle-ai` | `agents` | all | Uninstall `sdd` for `codex`, `claude-code`, `opencode`, `antigravity`, and `vscode-copilot` with `--yes`. | `gentle-ai` |
+| `gentle-ai` | `sdd` | all | Install global stable neutral custom SDD setup in multi-agent mode for `codex`, `claude-code`, `opencode`, `antigravity`, and `vscode-copilot`. Select with `--profile agents --tag sdd`. | `gentle-ai` |
 | `gentle-ai` | `agents` | all | Install global stable neutral custom setup for `codex` with `engram`, `context7`, and `persona`. | `gentle-ai`, `engram` |
 | `gentle-ai` | `agents` | all | Install global stable neutral custom setup for `claude-code` with `engram`, `context7`, `persona`, and `permissions`. | `gentle-ai`, `engram` |
 | `gentle-ai` | `agents` | all | Install global stable neutral custom setup for `antigravity` with `engram`, `context7`, and `persona` only; no `sdd` or `permissions`. | `gentle-ai`, `engram` |

--- a/dots.yaml
+++ b/dots.yaml
@@ -347,6 +347,27 @@ provisioners:
         brew: gentleman-programming/tap/gentle-ai
   - tool: gentle-ai
     tags:
+      - sdd
+    spec:
+      scope: global
+      channel: stable
+      persona: neutral
+      preset: custom
+      sdd-mode: multi
+      agents:
+        - codex
+        - claude-code
+        - opencode
+        - antigravity
+        - vscode-copilot
+      components:
+        - sdd
+    dependencies:
+      - name: gentle-ai
+        command: gentle-ai
+        brew: gentleman-programming/tap/gentle-ai
+  - tool: gentle-ai
+    tags:
       - agents
     spec:
       scope: global

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -786,7 +786,7 @@ func TestRepositoryManifestIncludesGentleAICleanupBeforeBasicInstall(t *testing.
 		t.Fatalf("LoadFile(%q) error = %v", manifestPath, err)
 	}
 
-	var cleanup, codexInstall, claudeInstall, antigravityInstall, opencodeInstall, copilotInstall *manifest.Provisioner
+	var cleanup, sddInstall, codexInstall, claudeInstall, antigravityInstall, opencodeInstall, copilotInstall *manifest.Provisioner
 	for i := range got.Provisioners {
 		prov := &got.Provisioners[i]
 		if prov.Tool != "gentle-ai" {
@@ -795,6 +795,8 @@ func TestRepositoryManifestIncludesGentleAICleanupBeforeBasicInstall(t *testing.
 		switch {
 		case cleanup == nil && prov.Spec.Action == "uninstall":
 			cleanup = prov
+		case sddInstall == nil && sameStrings(prov.Spec.Components, []string{"sdd"}):
+			sddInstall = prov
 		case codexInstall == nil && sameStrings(prov.Spec.Agents, []string{"codex"}):
 			codexInstall = prov
 		case claudeInstall == nil && sameStrings(prov.Spec.Agents, []string{"claude-code"}):
@@ -810,6 +812,9 @@ func TestRepositoryManifestIncludesGentleAICleanupBeforeBasicInstall(t *testing.
 
 	if cleanup == nil {
 		t.Fatal("repository manifest missing gentle-ai uninstall cleanup provisioner")
+	}
+	if sddInstall == nil {
+		t.Fatal("repository manifest missing opt-in gentle-ai SDD install provisioner")
 	}
 	if codexInstall == nil {
 		t.Fatal("repository manifest missing gentle-ai codex basic install provisioner")
@@ -839,6 +844,15 @@ func TestRepositoryManifestIncludesGentleAICleanupBeforeBasicInstall(t *testing.
 	}
 	if !sameStrings(cleanup.Spec.Components, []string{"sdd"}) {
 		t.Fatalf("gentle-ai cleanup components = %#v, want [sdd]", cleanup.Spec.Components)
+	}
+	if !sameStrings(sddInstall.Tags, []string{"sdd"}) {
+		t.Fatalf("gentle-ai SDD install tags = %#v, want [sdd] so agents profile only installs SDD with --tag sdd", sddInstall.Tags)
+	}
+	if !sameStrings(sddInstall.Spec.Agents, []string{"codex", "claude-code", "opencode", "antigravity", "vscode-copilot"}) {
+		t.Fatalf("gentle-ai SDD install agents = %#v, want [codex claude-code opencode antigravity vscode-copilot]", sddInstall.Spec.Agents)
+	}
+	if sddInstall.Spec.SDDMode != "multi" {
+		t.Fatalf("gentle-ai SDD install mode = %q, want multi", sddInstall.Spec.SDDMode)
 	}
 	if codexInstall.Spec.Preset != "custom" {
 		t.Fatalf("gentle-ai codex install preset = %q, want custom", codexInstall.Spec.Preset)
@@ -877,7 +891,7 @@ func TestRepositoryManifestIncludesGentleAICleanupBeforeBasicInstall(t *testing.
 		if &got.Provisioners[i] == cleanup {
 			break
 		}
-		if &got.Provisioners[i] == codexInstall || &got.Provisioners[i] == claudeInstall || &got.Provisioners[i] == antigravityInstall || &got.Provisioners[i] == opencodeInstall || &got.Provisioners[i] == copilotInstall {
+		if &got.Provisioners[i] == sddInstall || &got.Provisioners[i] == codexInstall || &got.Provisioners[i] == claudeInstall || &got.Provisioners[i] == antigravityInstall || &got.Provisioners[i] == opencodeInstall || &got.Provisioners[i] == copilotInstall {
 			t.Fatal("gentle-ai install provisioner appears before cleanup")
 		}
 	}
@@ -918,6 +932,36 @@ func TestRepositoryManifestDesktopProfileDoesNotSelectGentleAIProvisioners(t *te
 	}
 	if !foundGentleAI {
 		t.Fatal("agents profile did not select gentle-ai provisioners")
+	}
+	wantSDDArgs := []string{
+		"install",
+		"--scope", "global",
+		"--channel", "stable",
+		"--persona", "neutral",
+		"--preset", "custom",
+		"--sdd-mode", "multi",
+		"--agents", "codex,claude-code,opencode,antigravity,vscode-copilot",
+		"--components", "sdd",
+	}
+	for _, step := range agents.Steps {
+		if step.Tool == "gentle-ai" && sameStrings(step.Args, wantSDDArgs) {
+			t.Fatalf("agents profile selected SDD install args %#v; SDD must require --tag sdd", step.Args)
+		}
+	}
+
+	agentsWithSDD, err := provision.Build(*got, provision.Options{Profile: "agents", ExtraTags: []string{"sdd"}, OS: "darwin"})
+	if err != nil {
+		t.Fatalf("provision.Build(agents --tag sdd) error = %v", err)
+	}
+	foundSDDInstall := false
+	for _, step := range agentsWithSDD.Steps {
+		if step.Tool == "gentle-ai" && sameStrings(step.Args, wantSDDArgs) {
+			foundSDDInstall = true
+			break
+		}
+	}
+	if !foundSDDInstall {
+		t.Fatal("agents profile with --tag sdd did not select the Gentle-AI SDD install provisioner")
 	}
 }
 


### PR DESCRIPTION
Closes #165

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds an opt-in `sdd` manifest tag for Gentle-AI SDD installation.
- Keeps plain `dots install --profile agents` on the baseline non-SDD agent setup.
- Verifies the repository manifest shape and cleanup ordering in tests.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Adds a `gentle-ai` provisioner tagged `sdd` that installs component `sdd` with `sdd-mode: multi` for supported agents. |
| `internal/manifest/manifest_test.go` | Asserts the SDD provisioner is opt-in, targets the expected agents, uses multi mode, remains ordered after cleanup, and is selected only with `--tag sdd`. |
| `docs/manifest.md` | Documents `--tag sdd` for the agents profile and the opt-in SDD provisioner row. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots install --profile agents --tag sdd --dry-run --home <tmp> --source-root "$PWD" --state-root <tmp>`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
