### PR TITLE
fix(cli): scope CodeGraph overlay to tag

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -162,10 +162,7 @@ func runProvisioners(cmd *cobra.Command, m manifest.Manifest, profile string, ex
 	if agents := selectedCodeGraphAgents(selected); len(agents) > 0 {
 		return codexconfig.EnsureCodeGraphMode(home, agents...)
 	}
-	if !selectedProvisionersAffectCodex(selected) {
-		return nil
-	}
-	return codexconfig.EnsureCodeGraphMode(home)
+	return nil
 }
 
 func selectedCodeGraphAgents(selected []manifest.Provisioner) []string {
@@ -184,33 +181,6 @@ func selectedCodeGraphAgents(selected []manifest.Provisioner) []string {
 		}
 	}
 	return agents
-}
-
-func selectedProvisionersAffectCodex(selected []manifest.Provisioner) bool {
-	for _, prov := range selected {
-		if prov.Tool == "codex" {
-			return true
-		}
-		if prov.Tool == "codegraph" && provisionerAgentsInclude(prov, "codex") {
-			return true
-		}
-		if prov.Tool == "gentle-ai" && provisionerAgentsInclude(prov, "codex") {
-			return true
-		}
-		if prov.Tool == "skills" && provisionerAgentsInclude(prov, "codex") {
-			return true
-		}
-	}
-	return false
-}
-
-func provisionerAgentsInclude(prov manifest.Provisioner, want string) bool {
-	for _, agent := range prov.Spec.Agents {
-		if agent == want {
-			return true
-		}
-	}
-	return false
 }
 
 // resolveAndApply resolves the plan's conflicts (via the TUI, text prompts, or

--- a/internal/cli/install_provision_test.go
+++ b/internal/cli/install_provision_test.go
@@ -116,10 +116,10 @@ func TestInstallExecutesProvisionerAfterFilesWithHomeThreaded(t *testing.T) {
 	}
 }
 
-// TestInstallDoesNotWriteCodeGraphOverlayAfterGentleAIProvisioner proves a
+// TestInstallDoesNotWriteCodeGraphInstructionBlockAfterGentleAIProvisioner proves a
 // non-CodeGraph provisioner does not create the dots-owned CodeGraph
-// instruction layer.
-func TestInstallDoesNotWriteCodeGraphOverlayAfterGentleAIProvisioner(t *testing.T) {
+// instruction block.
+func TestInstallDoesNotWriteCodeGraphInstructionBlockAfterGentleAIProvisioner(t *testing.T) {
 	sandboxHome := t.TempDir()
 	sourceRoot := t.TempDir()
 	stateRoot := t.TempDir()
@@ -145,18 +145,18 @@ func TestInstallDoesNotWriteCodeGraphOverlayAfterGentleAIProvisioner(t *testing.
 	}
 
 	if _, err := os.Stat(filepath.Join(sandboxHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
-		t.Fatalf("install with gentle-ai provisioner wrote CodeGraph overlay without the codegraph tag; stat err = %v\noutput:\n%s", err, out.String())
+		t.Fatalf("install with gentle-ai provisioner wrote CodeGraph instruction block without the codegraph tag; stat err = %v\noutput:\n%s", err, out.String())
 	}
 	if _, err := os.Stat(filepath.Join(fakeRealHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
 		t.Fatalf("install wrote Codex AGENTS.md in inherited HOME %q; stat err = %v", fakeRealHome, err)
 	}
 }
 
-// TestInstallDoesNotWriteCodexCodeGraphOverlayWithoutSelectedProvisioners proves
-// the post-provision CodeGraph layer is scoped to the codegraph tag. A
+// TestInstallDoesNotWriteCodexCodeGraphInstructionBlockWithoutSelectedProvisioners proves
+// the post-provision CodeGraph instruction block is scoped to the codegraph tag. A
 // successful install whose active profile selects no provisioners must not
 // create a sandbox Codex AGENTS.md.
-func TestInstallDoesNotWriteCodexCodeGraphOverlayWithoutSelectedProvisioners(t *testing.T) {
+func TestInstallDoesNotWriteCodexCodeGraphInstructionBlockWithoutSelectedProvisioners(t *testing.T) {
 	sandboxHome := t.TempDir()
 	sourceRoot := t.TempDir()
 	stateRoot := t.TempDir()
@@ -203,10 +203,10 @@ provisioners:
 	}
 }
 
-// TestInstallDoesNotWriteCodeGraphOverlayAfterCodexProvisioner proves a Codex
+// TestInstallDoesNotWriteCodeGraphInstructionBlockAfterCodexProvisioner proves a Codex
 // MCP provisioner alone does not create the dots-owned CodeGraph instruction
 // layer.
-func TestInstallDoesNotWriteCodeGraphOverlayAfterCodexProvisioner(t *testing.T) {
+func TestInstallDoesNotWriteCodeGraphInstructionBlockAfterCodexProvisioner(t *testing.T) {
 	sandboxHome := t.TempDir()
 	sourceRoot := t.TempDir()
 	stateRoot := t.TempDir()
@@ -248,17 +248,17 @@ provisioners:
 	}
 
 	if _, err := os.Stat(filepath.Join(sandboxHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
-		t.Fatalf("install with codex provisioner wrote CodeGraph overlay without the codegraph tag; stat err = %v\noutput:\n%s", err, out.String())
+		t.Fatalf("install with codex provisioner wrote CodeGraph instruction block without the codegraph tag; stat err = %v\noutput:\n%s", err, out.String())
 	}
 	if _, err := os.Stat(filepath.Join(fakeRealHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
 		t.Fatalf("install wrote Codex AGENTS.md in inherited HOME %q; stat err = %v", fakeRealHome, err)
 	}
 }
 
-// TestInstallDoesNotWriteCodeGraphOverlayAfterSkillsProvisioner proves a
+// TestInstallDoesNotWriteCodeGraphInstructionBlockAfterSkillsProvisioner proves a
 // skills-only provisioner targeting Codex does not create the dots-owned
-// CodeGraph instruction layer.
-func TestInstallDoesNotWriteCodeGraphOverlayAfterSkillsProvisioner(t *testing.T) {
+// CodeGraph instruction block.
+func TestInstallDoesNotWriteCodeGraphInstructionBlockAfterSkillsProvisioner(t *testing.T) {
 	sandboxHome := t.TempDir()
 	sourceRoot := t.TempDir()
 	stateRoot := t.TempDir()
@@ -300,7 +300,7 @@ provisioners:
 	}
 
 	if _, err := os.Stat(filepath.Join(sandboxHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
-		t.Fatalf("install with skills provisioner wrote CodeGraph overlay without the codegraph tag; stat err = %v\noutput:\n%s", err, out.String())
+		t.Fatalf("install with skills provisioner wrote CodeGraph instruction block without the codegraph tag; stat err = %v\noutput:\n%s", err, out.String())
 	}
 	if _, err := os.Stat(filepath.Join(fakeRealHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
 		t.Fatalf("install wrote Codex AGENTS.md in inherited HOME %q; stat err = %v", fakeRealHome, err)

--- a/internal/cli/install_provision_test.go
+++ b/internal/cli/install_provision_test.go
@@ -116,10 +116,10 @@ func TestInstallExecutesProvisionerAfterFilesWithHomeThreaded(t *testing.T) {
 	}
 }
 
-// TestInstallWritesCodexCodeGraphOverlayAfterProvisioners proves dots adds its
-// own Codex AGENTS.md instruction layer only after a successful provisioner run,
-// under the sandbox HOME threaded through --home.
-func TestInstallWritesCodexCodeGraphOverlayAfterProvisioners(t *testing.T) {
+// TestInstallDoesNotWriteCodeGraphOverlayAfterGentleAIProvisioner proves a
+// non-CodeGraph provisioner does not create the dots-owned CodeGraph
+// instruction layer.
+func TestInstallDoesNotWriteCodeGraphOverlayAfterGentleAIProvisioner(t *testing.T) {
 	sandboxHome := t.TempDir()
 	sourceRoot := t.TempDir()
 	stateRoot := t.TempDir()
@@ -144,21 +144,8 @@ func TestInstallWritesCodexCodeGraphOverlayAfterProvisioners(t *testing.T) {
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
 	}
 
-	got, err := os.ReadFile(filepath.Join(sandboxHome, ".codex", "AGENTS.md"))
-	if err != nil {
-		t.Fatalf("read sandbox Codex AGENTS.md: %v", err)
-	}
-	content := string(got)
-	for _, want := range []string{
-		"<!-- dots:codegraph-mode -->",
-		"CodeGraph Mode: enabled",
-		"Use CodeGraph for architecture questions",
-		"Never use CodeGraph just because `.codegraph/` exists.",
-		"<!-- /dots:codegraph-mode -->",
-	} {
-		if !strings.Contains(content, want) {
-			t.Fatalf("Codex AGENTS.md missing %q\ncontent:\n%s", want, content)
-		}
+	if _, err := os.Stat(filepath.Join(sandboxHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatalf("install with gentle-ai provisioner wrote CodeGraph overlay without the codegraph tag; stat err = %v\noutput:\n%s", err, out.String())
 	}
 	if _, err := os.Stat(filepath.Join(fakeRealHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
 		t.Fatalf("install wrote Codex AGENTS.md in inherited HOME %q; stat err = %v", fakeRealHome, err)
@@ -166,9 +153,9 @@ func TestInstallWritesCodexCodeGraphOverlayAfterProvisioners(t *testing.T) {
 }
 
 // TestInstallDoesNotWriteCodexCodeGraphOverlayWithoutSelectedProvisioners proves
-// the post-provision Codex layer is scoped to selected Codex-related
-// provisioners. A successful install whose active profile selects no
-// provisioners must not create a sandbox Codex AGENTS.md.
+// the post-provision CodeGraph layer is scoped to the codegraph tag. A
+// successful install whose active profile selects no provisioners must not
+// create a sandbox Codex AGENTS.md.
 func TestInstallDoesNotWriteCodexCodeGraphOverlayWithoutSelectedProvisioners(t *testing.T) {
 	sandboxHome := t.TempDir()
 	sourceRoot := t.TempDir()
@@ -216,10 +203,10 @@ provisioners:
 	}
 }
 
-// TestInstallWritesCodexCodeGraphOverlayAfterCodexProvisioner proves a selected
-// Codex MCP provisioner also qualifies for the post-provision Codex layer, not
-// only the gentle-ai provisioner that installs Codex agents.
-func TestInstallWritesCodexCodeGraphOverlayAfterCodexProvisioner(t *testing.T) {
+// TestInstallDoesNotWriteCodeGraphOverlayAfterCodexProvisioner proves a Codex
+// MCP provisioner alone does not create the dots-owned CodeGraph instruction
+// layer.
+func TestInstallDoesNotWriteCodeGraphOverlayAfterCodexProvisioner(t *testing.T) {
 	sandboxHome := t.TempDir()
 	sourceRoot := t.TempDir()
 	stateRoot := t.TempDir()
@@ -260,18 +247,18 @@ provisioners:
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
 	}
 
-	if _, err := os.ReadFile(filepath.Join(sandboxHome, ".codex", "AGENTS.md")); err != nil {
-		t.Fatalf("read sandbox Codex AGENTS.md after codex provisioner: %v\noutput:\n%s", err, out.String())
+	if _, err := os.Stat(filepath.Join(sandboxHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatalf("install with codex provisioner wrote CodeGraph overlay without the codegraph tag; stat err = %v\noutput:\n%s", err, out.String())
 	}
 	if _, err := os.Stat(filepath.Join(fakeRealHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
 		t.Fatalf("install wrote Codex AGENTS.md in inherited HOME %q; stat err = %v", fakeRealHome, err)
 	}
 }
 
-// TestInstallWritesCodexCodeGraphOverlayAfterSkillsProvisioner proves a
-// skills-only provisioner targeting Codex also qualifies for the post-provision
-// Codex layer.
-func TestInstallWritesCodexCodeGraphOverlayAfterSkillsProvisioner(t *testing.T) {
+// TestInstallDoesNotWriteCodeGraphOverlayAfterSkillsProvisioner proves a
+// skills-only provisioner targeting Codex does not create the dots-owned
+// CodeGraph instruction layer.
+func TestInstallDoesNotWriteCodeGraphOverlayAfterSkillsProvisioner(t *testing.T) {
 	sandboxHome := t.TempDir()
 	sourceRoot := t.TempDir()
 	stateRoot := t.TempDir()
@@ -312,8 +299,8 @@ provisioners:
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
 	}
 
-	if _, err := os.ReadFile(filepath.Join(sandboxHome, ".codex", "AGENTS.md")); err != nil {
-		t.Fatalf("read sandbox Codex AGENTS.md after skills provisioner: %v\noutput:\n%s", err, out.String())
+	if _, err := os.Stat(filepath.Join(sandboxHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatalf("install with skills provisioner wrote CodeGraph overlay without the codegraph tag; stat err = %v\noutput:\n%s", err, out.String())
 	}
 	if _, err := os.Stat(filepath.Join(fakeRealHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
 		t.Fatalf("install wrote Codex AGENTS.md in inherited HOME %q; stat err = %v", fakeRealHome, err)

--- a/internal/cli/provision_runner_test.go
+++ b/internal/cli/provision_runner_test.go
@@ -184,7 +184,7 @@ printf '%s\n' "$*" > "$HOME/skills-args"
 		t.Fatalf("skills args = %q, want %q", got, want)
 	}
 	if _, err := os.Stat(filepath.Join(home, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
-		t.Fatalf("skills-only Codex provisioner wrote CodeGraph overlay without the codegraph tag: %v", err)
+		t.Fatalf("skills-only Codex provisioner wrote CodeGraph instruction block without the codegraph tag: %v", err)
 	}
 }
 

--- a/internal/cli/provision_runner_test.go
+++ b/internal/cli/provision_runner_test.go
@@ -183,8 +183,8 @@ printf '%s\n' "$*" > "$HOME/skills-args"
 	if string(got) != want {
 		t.Fatalf("skills args = %q, want %q", got, want)
 	}
-	if _, err := os.ReadFile(filepath.Join(home, ".codex", "AGENTS.md")); err != nil {
-		t.Fatalf("skills-only Codex provisioner did not write Codex overlay: %v", err)
+	if _, err := os.Stat(filepath.Join(home, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatalf("skills-only Codex provisioner wrote CodeGraph overlay without the codegraph tag: %v", err)
 	}
 }
 
@@ -249,58 +249,6 @@ printf '%s\n' "$*" > "$HOME/codegraph-args"
 		if !strings.Contains(string(got), "Do NOT use CodeGraph as proof for runtime behavior.") {
 			t.Fatalf("%s missing runtime-verification guidance\ncontent:\n%s", path, got)
 		}
-	}
-}
-
-func TestSelectedProvisionersAffectCodex(t *testing.T) {
-	tests := []struct {
-		name     string
-		selected []manifest.Provisioner
-		want     bool
-	}{
-		{
-			name: "skills provisioner targeting codex",
-			selected: []manifest.Provisioner{
-				{Tool: "skills", Spec: manifest.ProvisionerSpec{Agents: []string{"codex"}}},
-			},
-			want: true,
-		},
-		{
-			name: "skills provisioner targeting claude only",
-			selected: []manifest.Provisioner{
-				{Tool: "skills", Spec: manifest.ProvisionerSpec{Agents: []string{"claude"}}},
-			},
-			want: false,
-		},
-		{
-			name: "gentle-ai provisioner targeting codex",
-			selected: []manifest.Provisioner{
-				{Tool: "gentle-ai", Spec: manifest.ProvisionerSpec{Agents: []string{"codex"}}},
-			},
-			want: true,
-		},
-		{
-			name: "codex provisioner",
-			selected: []manifest.Provisioner{
-				{Tool: "codex"},
-			},
-			want: true,
-		},
-		{
-			name: "no codex-affecting provisioners",
-			selected: []manifest.Provisioner{
-				{Tool: "claude"},
-			},
-			want: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := selectedProvisionersAffectCodex(tt.selected); got != tt.want {
-				t.Fatalf("selectedProvisionersAffectCodex() = %v, want %v", got, tt.want)
-			}
-		})
 	}
 }
 

--- a/internal/cli/update_provision_test.go
+++ b/internal/cli/update_provision_test.go
@@ -94,10 +94,10 @@ func TestUpdateExecutesProvisionersAfterApply(t *testing.T) {
 	}
 }
 
-// TestUpdateDoesNotWriteCodeGraphOverlayAfterGentleAIProvisioner proves update
-// does not create the dots-owned CodeGraph instruction layer unless the
+// TestUpdateDoesNotWriteCodeGraphInstructionBlockAfterGentleAIProvisioner proves update
+// does not create the dots-owned CodeGraph instruction block unless the
 // CodeGraph provisioner is selected.
-func TestUpdateDoesNotWriteCodeGraphOverlayAfterGentleAIProvisioner(t *testing.T) {
+func TestUpdateDoesNotWriteCodeGraphInstructionBlockAfterGentleAIProvisioner(t *testing.T) {
 	requireGitCLI(t)
 	sandboxHome := t.TempDir()
 	stateRoot := t.TempDir()
@@ -118,17 +118,17 @@ func TestUpdateDoesNotWriteCodeGraphOverlayAfterGentleAIProvisioner(t *testing.T
 		"--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot)
 
 	if _, err := os.Stat(filepath.Join(sandboxHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
-		t.Fatalf("update with gentle-ai provisioner wrote CodeGraph overlay without the codegraph tag; stat err = %v\noutput:\n%s", err, out)
+		t.Fatalf("update with gentle-ai provisioner wrote CodeGraph instruction block without the codegraph tag; stat err = %v\noutput:\n%s", err, out)
 	}
 	if _, err := os.Stat(filepath.Join(fakeRealHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
 		t.Fatalf("update wrote Codex AGENTS.md in inherited HOME %q; stat err = %v", fakeRealHome, err)
 	}
 }
 
-// TestUpdateDoesNotWriteCodeGraphOverlayAfterSkillsProvisioner proves update
-// does not create the dots-owned CodeGraph instruction layer for a skills-only
+// TestUpdateDoesNotWriteCodeGraphInstructionBlockAfterSkillsProvisioner proves update
+// does not create the dots-owned CodeGraph instruction block for a skills-only
 // Codex provisioner.
-func TestUpdateDoesNotWriteCodeGraphOverlayAfterSkillsProvisioner(t *testing.T) {
+func TestUpdateDoesNotWriteCodeGraphInstructionBlockAfterSkillsProvisioner(t *testing.T) {
 	requireGitCLI(t)
 	sandboxHome := t.TempDir()
 	stateRoot := t.TempDir()
@@ -165,7 +165,7 @@ provisioners:
 		"--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot)
 
 	if _, err := os.Stat(filepath.Join(sandboxHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
-		t.Fatalf("update with skills provisioner wrote CodeGraph overlay without the codegraph tag; stat err = %v\noutput:\n%s", err, out)
+		t.Fatalf("update with skills provisioner wrote CodeGraph instruction block without the codegraph tag; stat err = %v\noutput:\n%s", err, out)
 	}
 	if _, err := os.Stat(filepath.Join(fakeRealHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
 		t.Fatalf("update wrote Codex AGENTS.md in inherited HOME %q; stat err = %v", fakeRealHome, err)

--- a/internal/cli/update_provision_test.go
+++ b/internal/cli/update_provision_test.go
@@ -94,10 +94,10 @@ func TestUpdateExecutesProvisionersAfterApply(t *testing.T) {
 	}
 }
 
-// TestUpdateWritesCodexCodeGraphOverlayAfterProvisioners proves update reaches
-// the same post-provision Codex AGENTS.md overlay hook as install, under the
-// sandbox HOME.
-func TestUpdateWritesCodexCodeGraphOverlayAfterProvisioners(t *testing.T) {
+// TestUpdateDoesNotWriteCodeGraphOverlayAfterGentleAIProvisioner proves update
+// does not create the dots-owned CodeGraph instruction layer unless the
+// CodeGraph provisioner is selected.
+func TestUpdateDoesNotWriteCodeGraphOverlayAfterGentleAIProvisioner(t *testing.T) {
 	requireGitCLI(t)
 	sandboxHome := t.TempDir()
 	stateRoot := t.TempDir()
@@ -117,31 +117,18 @@ func TestUpdateWritesCodexCodeGraphOverlayAfterProvisioners(t *testing.T) {
 	out := runUpdate(t, "--yes", "--file", filepath.Join(sourceRoot, "dots.yaml"),
 		"--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot)
 
-	got, err := os.ReadFile(filepath.Join(sandboxHome, ".codex", "AGENTS.md"))
-	if err != nil {
-		t.Fatalf("read sandbox Codex AGENTS.md: %v\noutput:\n%s", err, out)
-	}
-	content := string(got)
-	for _, want := range []string{
-		"<!-- dots:codegraph-mode -->",
-		"CodeGraph Mode: enabled",
-		"Use CodeGraph for architecture questions",
-		"Never use CodeGraph just because `.codegraph/` exists.",
-		"<!-- /dots:codegraph-mode -->",
-	} {
-		if !strings.Contains(content, want) {
-			t.Fatalf("Codex AGENTS.md missing %q\ncontent:\n%s", want, content)
-		}
+	if _, err := os.Stat(filepath.Join(sandboxHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatalf("update with gentle-ai provisioner wrote CodeGraph overlay without the codegraph tag; stat err = %v\noutput:\n%s", err, out)
 	}
 	if _, err := os.Stat(filepath.Join(fakeRealHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
 		t.Fatalf("update wrote Codex AGENTS.md in inherited HOME %q; stat err = %v", fakeRealHome, err)
 	}
 }
 
-// TestUpdateWritesCodexCodeGraphOverlayAfterSkillsProvisioner proves update
-// reaches the post-provision Codex overlay hook for a skills-only Codex
-// provisioner.
-func TestUpdateWritesCodexCodeGraphOverlayAfterSkillsProvisioner(t *testing.T) {
+// TestUpdateDoesNotWriteCodeGraphOverlayAfterSkillsProvisioner proves update
+// does not create the dots-owned CodeGraph instruction layer for a skills-only
+// Codex provisioner.
+func TestUpdateDoesNotWriteCodeGraphOverlayAfterSkillsProvisioner(t *testing.T) {
 	requireGitCLI(t)
 	sandboxHome := t.TempDir()
 	stateRoot := t.TempDir()
@@ -177,8 +164,8 @@ provisioners:
 	out := runUpdate(t, "--yes", "--file", filepath.Join(sourceRoot, "dots.yaml"),
 		"--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot)
 
-	if _, err := os.ReadFile(filepath.Join(sandboxHome, ".codex", "AGENTS.md")); err != nil {
-		t.Fatalf("read sandbox Codex AGENTS.md after skills provisioner: %v\noutput:\n%s", err, out)
+	if _, err := os.Stat(filepath.Join(sandboxHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatalf("update with skills provisioner wrote CodeGraph overlay without the codegraph tag; stat err = %v\noutput:\n%s", err, out)
 	}
 	if _, err := os.Stat(filepath.Join(fakeRealHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
 		t.Fatalf("update wrote Codex AGENTS.md in inherited HOME %q; stat err = %v", fakeRealHome, err)


### PR DESCRIPTION
Closes #171

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Scopes the dots-owned CodeGraph instruction overlay to selected CodeGraph provisioners only.
- Stops Codex-related `gentle-ai`, `codex`, and `skills` provisioners from creating the CodeGraph marker block without `--tag codegraph`.
- Updates install, update, and provision-runner tests for the negative cases.

## Changes

| File | Change |
|------|--------|
| `internal/cli/install.go` | Removed the fallback that injected CodeGraph instructions for non-CodeGraph Codex-related provisioners. |
| `internal/cli/install_provision_test.go` | Updated install tests to assert non-CodeGraph provisioners do not create the CodeGraph overlay. |
| `internal/cli/update_provision_test.go` | Updated update tests to assert non-CodeGraph provisioners do not create the CodeGraph overlay. |
| `internal/cli/provision_runner_test.go` | Updated direct provisioner runner expectations and removed obsolete Codex-affecting helper tests. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [ ] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp>`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #171`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
