### PR TITLE
chore(zsh): start copilot in autopilot mode

### DIFF
--- a/configs/zsh/README.md
+++ b/configs/zsh/README.md
@@ -33,7 +33,7 @@ configs/zsh/
 │       ├── 30-path.zsh    # portable PATH additions (guarded)
 │       ├── 40-tools.zsh   # zoxide/starship/atuin/fnm (guarded)
 │       ├── 50-aliases.zsh # eza-backed ls (guarded)
-│       └── 60-ai.zsh      # Claude/Engram knobs (no secrets)
+│       └── 60-ai.zsh      # Claude/Engram/Copilot knobs (no secrets)
 └── zshrc.local.example    # template for machine-specific values + secrets
 ```
 

--- a/configs/zsh/rc.d/post/60-ai.zsh
+++ b/configs/zsh/rc.d/post/60-ai.zsh
@@ -8,3 +8,10 @@ export CLAUDE_CODE_NO_FLICKER=1
 
 # Engram: opt into tool-search behavior.
 export ENABLE_TOOL_SEARCH=true
+
+# GitHub Copilot CLI: start interactive sessions in Autopilot mode by default.
+if [[ -o interactive ]] && command -v copilot >/dev/null 2>&1; then
+  copilot() {
+    command copilot --mode autopilot "$@"
+  }
+fi


### PR DESCRIPTION
Closes #177

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [x] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Starts GitHub Copilot CLI in Autopilot mode from the managed interactive Zsh config.
- Keeps the wrapper guarded behind interactive shells and `command -v copilot`.
- Updates the Zsh README layout description for the Copilot shell knob.

## Changes

| File | Change |
|------|--------|
| `configs/zsh/rc.d/post/60-ai.zsh` | Adds an interactive `copilot()` wrapper that invokes `command copilot --mode autopilot "$@"`. |
| `configs/zsh/README.md` | Documents Copilot alongside the managed AI shell knobs. |

## Test Plan

- [x] `zsh -n configs/zsh/rc.d/post/60-ai.zsh`
- [x] isolated Zsh wrapper stub confirms `--mode autopilot` is prepended
- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp> --state-root <tmp>`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #177`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [ ] Did not add `Co-Authored-By` or AI attribution trailers.

## Validation Evidence

- `zsh -n configs/zsh/rc.d/post/60-ai.zsh`
- isolated Zsh wrapper stub confirms `--mode autopilot` is prepended
- `gofmt -l .`
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- `go run ./cmd/dots manifest validate --file dots.yaml`
- sandboxed `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp> --state-root <tmp>`

## Commit History

- `chore(zsh): start copilot in autopilot mode`
