### PR TITLE
fix(cli): initialize installed repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,21 @@ Verify the binary is available:
 dots --version
 ```
 
+Homebrew installs only the released binary. Initialize the default Installed
+Repository before running read-only diagnostics or install previews:
+
+```bash
+dots init
+```
+
+For released binaries, `dots init` clones the matching release tag by default.
+Use `--repository-ref` only when you intentionally want a different Source of
+Truth ref.
+
 ## Quickstart
 
-Start with a dry run. The CLI should show the Install Plan without writing files:
+Start with a dry run. If you installed through Homebrew, run `dots init` first.
+The CLI should show the Install Plan without writing files:
 
 ```bash
 dots install --dry-run

--- a/docs/release.md
+++ b/docs/release.md
@@ -124,7 +124,7 @@ DOTS_VERSION=v0.5.1 DOTS_SOURCE_ROOT="$PWD" bash scripts/install.sh
 | Artifacts | Raw `dots` binaries named `dots_<version>_<goos>_<goarch>`. |
 | Platforms | `darwin/amd64`, `darwin/arm64`, `linux/amd64`, and `linux/arm64`. |
 | Checksums | One `checksums.txt` file covers every Release Artifact. |
-| Homebrew Distribution | `scripts/generate-homebrew-formula.sh` generates `Formula/dots.rb` from the release tag and `checksums.txt`; the workflow locally prepares the tap commit, dry-run proves that prepared state can be pushed, then pushes it to `yersonargotev/homebrew-tap` with `HOMEBREW_TAP_TOKEN` after release assets upload. Users should prefer formula-level Tap Trust through `brew install yersonargotev/tap/dots`, `brew trust --formula yersonargotev/tap/dots`, or Brewfile `trusted: true`. |
+| Homebrew Distribution | `scripts/generate-homebrew-formula.sh` generates `Formula/dots.rb` from the release tag and `checksums.txt`; the workflow locally prepares the tap commit, dry-run proves that prepared state can be pushed, then pushes it to `yersonargotev/homebrew-tap` with `HOMEBREW_TAP_TOKEN` after release assets upload. Users should prefer formula-level Tap Trust through `brew install yersonargotev/tap/dots`, `brew trust --formula yersonargotev/tap/dots`, or Brewfile `trusted: true`. Homebrew installs only the binary, so first-run package-manager installs must run `dots init` to clone the default Installed Repository before `dots status`, `dots doctor`, or `dots install --dry-run`. |
 
 ## First v0.x checklist
 
@@ -134,6 +134,7 @@ DOTS_VERSION=v0.5.1 DOTS_SOURCE_ROOT="$PWD" bash scripts/install.sh
 - [ ] `checksums.txt` contains one SHA-256 entry for each artifact.
 - [ ] The Bootstrapper maps its detected `goos/goarch` to the matching artifact name.
 - [ ] `dots --version` and `dots version` both report the release tag.
+- [ ] A Homebrew-installed binary can run `dots init` and then read the default Installed Repository manifest.
 - [ ] `Formula/dots.rb` in `yersonargotev/homebrew-tap` points at the same tag and checksums.
 - [ ] A Tap Trust install path has been checked with `HOMEBREW_REQUIRE_TAP_TRUST=1` using the fully-qualified formula or formula-level trust.
 - [ ] `HOMEBREW_TAP_TOKEN` is configured before relying on automatic tap updates.

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -1,0 +1,109 @@
+package bootstrap
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const DefaultRepositoryURL = "https://github.com/yersonargotev/dots.git"
+
+type Options struct {
+	SourceRoot    string
+	RepositoryURL string
+	RepositoryRef string
+}
+
+type Result struct {
+	SourceRoot string `json:"source_root"`
+	Cloned     bool   `json:"cloned"`
+}
+
+func Ensure(opts Options) (Result, error) {
+	if strings.TrimSpace(opts.SourceRoot) == "" {
+		return Result{}, errors.New("source root is required")
+	}
+	if strings.TrimSpace(opts.RepositoryURL) == "" {
+		opts.RepositoryURL = DefaultRepositoryURL
+	}
+
+	result := Result{SourceRoot: opts.SourceRoot}
+	if validSourceRoot(opts.SourceRoot) {
+		return result, nil
+	}
+
+	info, err := os.Stat(opts.SourceRoot)
+	switch {
+	case err == nil && !info.IsDir():
+		return Result{}, fmt.Errorf("Installed Repository path exists but is not a directory: %s", opts.SourceRoot)
+	case err == nil:
+		empty, err := dirEmpty(opts.SourceRoot)
+		if err != nil {
+			return Result{}, err
+		}
+		if !empty {
+			return Result{}, fmt.Errorf("Installed Repository path exists but does not contain a valid dots.yaml: %s. Move it aside or pass --source-root", opts.SourceRoot)
+		}
+		if err := os.Remove(opts.SourceRoot); err != nil {
+			return Result{}, fmt.Errorf("remove empty Installed Repository directory: %w", err)
+		}
+	case !os.IsNotExist(err):
+		return Result{}, fmt.Errorf("inspect Installed Repository: %w", err)
+	}
+
+	if _, err := exec.LookPath("git"); err != nil {
+		return Result{}, fmt.Errorf("git is required to clone the Source of Truth into %s", opts.SourceRoot)
+	}
+	if err := clone(opts); err != nil {
+		return Result{}, err
+	}
+	result.Cloned = true
+	return result, nil
+}
+
+func validSourceRoot(dir string) bool {
+	info, err := os.Stat(filepath.Join(dir, "dots.yaml"))
+	return err == nil && !info.IsDir() && info.Size() > 0
+}
+
+func dirEmpty(dir string) (bool, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false, fmt.Errorf("read Installed Repository directory: %w", err)
+	}
+	return len(entries) == 0, nil
+}
+
+func clone(opts Options) error {
+	parent := filepath.Dir(opts.SourceRoot)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return fmt.Errorf("create Installed Repository parent: %w", err)
+	}
+	tmp, err := os.MkdirTemp(parent, ".dots-clone.*")
+	if err != nil {
+		return fmt.Errorf("create temporary clone directory: %w", err)
+	}
+	defer os.RemoveAll(tmp)
+
+	args := []string{"clone", "--depth", "1"}
+	if strings.TrimSpace(opts.RepositoryRef) != "" {
+		args = append(args, "--branch", opts.RepositoryRef)
+	}
+	args = append(args, opts.RepositoryURL, tmp)
+	cmd := exec.Command("git", args...)
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("clone Source of Truth: %w\n%s", err, strings.TrimSpace(string(output)))
+	}
+	if !validSourceRoot(tmp) {
+		return errors.New("cloned Source of Truth does not contain a valid dots.yaml at repository root")
+	}
+	if err := os.Rename(tmp, opts.SourceRoot); err != nil {
+		return fmt.Errorf("install cloned Source of Truth: %w", err)
+	}
+	return nil
+}

--- a/internal/bootstrap/bootstrap_cli_test.go
+++ b/internal/bootstrap/bootstrap_cli_test.go
@@ -1,0 +1,55 @@
+package bootstrap_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/bootstrap"
+)
+
+func TestEnsureClonesMissingInstalledRepository(t *testing.T) {
+	sourceRepo := newBootstrapSourceRepo(t)
+	sourceRoot := filepath.Join(t.TempDir(), ".local", "share", "dots")
+
+	result, err := bootstrap.Ensure(bootstrap.Options{
+		SourceRoot:    sourceRoot,
+		RepositoryURL: sourceRepo,
+		RepositoryRef: "v0.99.0",
+	})
+	if err != nil {
+		t.Fatalf("Ensure() error = %v", err)
+	}
+	if !result.Cloned {
+		t.Fatal("Ensure() should report that it cloned the Installed Repository")
+	}
+	if _, err := os.Stat(filepath.Join(sourceRoot, "dots.yaml")); err != nil {
+		t.Fatalf("expected cloned dots.yaml: %v", err)
+	}
+}
+
+func TestEnsureAcceptsExistingInstalledRepository(t *testing.T) {
+	sourceRoot := t.TempDir()
+	writeFile(t, filepath.Join(sourceRoot, "dots.yaml"), "version: 1\n", 0o600)
+
+	result, err := bootstrap.Ensure(bootstrap.Options{SourceRoot: sourceRoot})
+	if err != nil {
+		t.Fatalf("Ensure() error = %v", err)
+	}
+	if result.Cloned {
+		t.Fatal("Ensure() should not clone over a valid Installed Repository")
+	}
+}
+
+func TestEnsureRejectsNonEmptyInvalidInstalledRepository(t *testing.T) {
+	sourceRoot := t.TempDir()
+	writeFile(t, filepath.Join(sourceRoot, "partial.txt"), "partial clone\n", 0o600)
+
+	_, err := bootstrap.Ensure(bootstrap.Options{
+		SourceRoot:    sourceRoot,
+		RepositoryURL: newBootstrapSourceRepo(t),
+	})
+	if err == nil {
+		t.Fatal("Ensure() should reject a non-empty invalid Installed Repository")
+	}
+}

--- a/internal/cli/deps.go
+++ b/internal/cli/deps.go
@@ -207,7 +207,7 @@ func newDepsInstallCommand(profile *string, extraTags *[]string) *cobra.Command 
 }
 
 func loadDepsManifest(cmd *cobra.Command, file, home string) (*manifest.Manifest, error) {
-	return manifest.LoadFile(resolveManifestPath(cmd, file, defaultSourceRoot(home)))
+	return loadManifestForCommand(cmd, file, defaultSourceRoot(home))
 }
 
 func runDepsInstall(cmd *cobra.Command, m manifest.Manifest, options deps.Options, tier deps.Tier) error {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/yersonargotev/dots/internal/doctor"
-	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/state"
 )
@@ -33,7 +32,7 @@ func newDoctorCommand() *cobra.Command {
 				return err
 			}
 
-			m, err := manifest.LoadFile(resolveManifestPath(cmd, file, paths.SourceRoot))
+			m, err := loadManifestForCommand(cmd, file, paths.SourceRoot)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -1,0 +1,65 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/yersonargotev/dots/internal/bootstrap"
+	"github.com/yersonargotev/dots/internal/version"
+)
+
+func newInitCommand() *cobra.Command {
+	var (
+		sourceRoot    string
+		home          string
+		repositoryURL string
+		repositoryRef string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Initialize the default Installed Repository",
+		Long:  "init clones the Source of Truth into the Installed Repository so package-manager installs have the manifest and managed configuration available.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			paths, err := resolvePaths(home, sourceRoot, "")
+			if err != nil {
+				return err
+			}
+			result, err := bootstrap.Ensure(bootstrap.Options{
+				SourceRoot:    paths.SourceRoot,
+				RepositoryURL: repositoryURL,
+				RepositoryRef: defaultInitRepositoryRef(repositoryRef, version.Value),
+			})
+			if err != nil {
+				return err
+			}
+			if wantsJSON(cmd) {
+				return emitOK(cmd, initReport(result))
+			}
+			if result.Cloned {
+				fmt.Fprintf(cmd.OutOrStdout(), "Initialized Installed Repository at %s\n", result.SourceRoot)
+				return nil
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Installed Repository already initialized at %s\n", result.SourceRoot)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&sourceRoot, "source-root", "", "installed repository root (default ~/.local/share/dots)")
+	cmd.Flags().StringVar(&home, "home", "", "home directory used to resolve the default Installed Repository")
+	cmd.Flags().StringVar(&repositoryURL, "repository-url", bootstrap.DefaultRepositoryURL, "Source of Truth Git URL")
+	cmd.Flags().StringVar(&repositoryRef, "repository-ref", "", "optional Source of Truth Git ref to clone")
+	return cmd
+}
+
+func defaultInitRepositoryRef(explicitRef, currentVersion string) string {
+	if strings.TrimSpace(explicitRef) != "" {
+		return explicitRef
+	}
+	if strings.HasPrefix(currentVersion, "v") {
+		return currentVersion
+	}
+	return ""
+}

--- a/internal/cli/init_internal_test.go
+++ b/internal/cli/init_internal_test.go
@@ -1,0 +1,21 @@
+package cli
+
+import "testing"
+
+func TestDefaultInitRepositoryRefPinsReleasedBinary(t *testing.T) {
+	if got, want := defaultInitRepositoryRef("", "v0.22.0"), "v0.22.0"; got != want {
+		t.Fatalf("defaultInitRepositoryRef() = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultInitRepositoryRefLeavesDevelopmentBuildOnDefaultBranch(t *testing.T) {
+	if got := defaultInitRepositoryRef("", "dev"); got != "" {
+		t.Fatalf("defaultInitRepositoryRef() = %q, want empty ref for dev build", got)
+	}
+}
+
+func TestDefaultInitRepositoryRefHonorsExplicitRef(t *testing.T) {
+	if got, want := defaultInitRepositoryRef("main", "v0.22.0"), "main"; got != want {
+		t.Fatalf("defaultInitRepositoryRef() = %q, want %q", got, want)
+	}
+}

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -1,0 +1,108 @@
+package cli_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/cli"
+)
+
+func TestInitCommandClonesInstalledRepository(t *testing.T) {
+	sourceRepo := newCLISourceRepo(t)
+	home := t.TempDir()
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"init",
+		"--home", home,
+		"--repository-url", sourceRepo,
+		"--repository-ref", "v0.99.0",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+
+	sourceRoot := filepath.Join(home, ".local", "share", "dots")
+	if _, err := os.Stat(filepath.Join(sourceRoot, "dots.yaml")); err != nil {
+		t.Fatalf("expected cloned Installed Repository manifest: %v", err)
+	}
+	if !strings.Contains(out.String(), "Initialized Installed Repository at "+sourceRoot) {
+		t.Fatalf("init output should report source root, got:\n%s", out.String())
+	}
+}
+
+func TestDefaultManifestErrorSuggestsInit(t *testing.T) {
+	home := t.TempDir()
+	var out, errOut bytes.Buffer
+	code := cli.Run([]string{"status", "--home", home}, &out, &errOut)
+
+	if code != 1 {
+		t.Fatalf("status without Installed Repository exit code = %d, want 1", code)
+	}
+	for _, want := range []string{
+		"Installed Repository not found or missing dots.yaml",
+		"Run `dots init`",
+		"retry `dots status`",
+	} {
+		if !strings.Contains(errOut.String(), want) {
+			t.Fatalf("missing %q in error:\n%s", want, errOut.String())
+		}
+	}
+}
+
+func newCLISourceRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required for CLI init tests")
+	}
+	repo := t.TempDir()
+	runCLIGit(t, repo, "init", "-b", "main")
+	runCLIGit(t, repo, "config", "user.email", "dots@test.local")
+	runCLIGit(t, repo, "config", "user.name", "dots test")
+	writeCLISourceFile(t, filepath.Join(repo, "dots.yaml"), `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+`)
+	writeCLISourceFile(t, filepath.Join(repo, "configs", "zsh", "zshrc"), "export A=1\n")
+	runCLIGit(t, repo, "add", ".")
+	runCLIGit(t, repo, "commit", "-m", "initial")
+	runCLIGit(t, repo, "tag", "v0.99.0")
+	return repo
+}
+
+func runCLIGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_CONFIG_GLOBAL="+os.DevNull,
+		"GIT_CONFIG_NOSYSTEM=1",
+	)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, output)
+	}
+}
+
+func writeCLISourceFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -11,12 +11,14 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/yersonargotev/dots/internal/bootstrap"
 	"github.com/yersonargotev/dots/internal/codexconfig"
 	"github.com/yersonargotev/dots/internal/install"
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/provision"
 	"github.com/yersonargotev/dots/internal/tui"
+	"github.com/yersonargotev/dots/internal/version"
 )
 
 func newInstallCommand() *cobra.Command {
@@ -44,7 +46,16 @@ func newInstallCommand() *cobra.Command {
 				return err
 			}
 
-			m, err := manifest.LoadFile(resolveManifestPath(cmd, file, paths.SourceRoot))
+			if !dryRun && !cmd.Flags().Changed("file") && !cmd.Flags().Changed("source-root") {
+				if _, err := bootstrap.Ensure(bootstrap.Options{
+					SourceRoot:    paths.SourceRoot,
+					RepositoryRef: defaultInitRepositoryRef("", version.Value),
+				}); err != nil {
+					return err
+				}
+			}
+
+			m, err := loadManifestForCommand(cmd, file, paths.SourceRoot)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/json_reports.go
+++ b/internal/cli/json_reports.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"github.com/yersonargotev/dots/internal/backups"
+	"github.com/yersonargotev/dots/internal/bootstrap"
 	"github.com/yersonargotev/dots/internal/deps"
 	"github.com/yersonargotev/dots/internal/gitrepo"
 	"github.com/yersonargotev/dots/internal/plan"
@@ -10,6 +11,8 @@ import (
 	"github.com/yersonargotev/dots/internal/uninstall"
 	"github.com/yersonargotev/dots/internal/upgrade"
 )
+
+type initReport bootstrap.Result
 
 type statusReport struct {
 	Profile      string         `json:"profile"`

--- a/internal/cli/paths.go
+++ b/internal/cli/paths.go
@@ -1,11 +1,13 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
+	"github.com/yersonargotev/dots/internal/manifest"
 )
 
 type resolvedPaths struct {
@@ -56,4 +58,19 @@ func resolveManifestPath(cmd *cobra.Command, file, sourceRoot string) string {
 		return file
 	}
 	return filepath.Join(sourceRoot, file)
+}
+
+func loadManifestForCommand(cmd *cobra.Command, file, sourceRoot string) (*manifest.Manifest, error) {
+	m, err := manifest.LoadFile(resolveManifestPath(cmd, file, sourceRoot))
+	if err != nil {
+		return nil, manifestErrorWithInitHint(cmd, sourceRoot, err)
+	}
+	return m, nil
+}
+
+func manifestErrorWithInitHint(cmd *cobra.Command, sourceRoot string, err error) error {
+	if cmd.Flags().Changed("file") || !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return fmt.Errorf("%w\nInstalled Repository not found or missing dots.yaml at %s.\nRun `dots init`, then retry `dots %s`.", err, sourceRoot, commandName(cmd))
 }

--- a/internal/cli/plan.go
+++ b/internal/cli/plan.go
@@ -4,7 +4,6 @@ import (
 	"runtime"
 
 	"github.com/spf13/cobra"
-	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/plan"
 )
 
@@ -31,7 +30,7 @@ func newPlanCommand() *cobra.Command {
 				return err
 			}
 
-			m, err := manifest.LoadFile(resolveManifestPath(cmd, file, paths.SourceRoot))
+			m, err := loadManifestForCommand(cmd, file, paths.SourceRoot)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -51,6 +51,7 @@ func NewRootCommand() *cobra.Command {
 	}
 
 	root.AddCommand(newVersionCommand())
+	root.AddCommand(newInitCommand())
 	root.AddCommand(newManifestCommand())
 	root.AddCommand(newPlanCommand())
 	root.AddCommand(newInstallCommand())

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -4,7 +4,6 @@ import (
 	"runtime"
 
 	"github.com/spf13/cobra"
-	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/provision"
 	"github.com/yersonargotev/dots/internal/state"
@@ -34,7 +33,7 @@ func newStatusCommand() *cobra.Command {
 				return err
 			}
 
-			m, err := manifest.LoadFile(resolveManifestPath(cmd, file, paths.SourceRoot))
+			m, err := loadManifestForCommand(cmd, file, paths.SourceRoot)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Closes #179

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds `dots init` so package-manager installs can initialize the default Installed Repository.
- Adds actionable recovery guidance when default manifest loading fails.
- Pins release-build initialization to the matching release tag by default to avoid manifest/binary skew.

## Changes

| File | Change |
|------|--------|
| `internal/bootstrap/bootstrap.go` | Adds shared Installed Repository initialization and clone validation. |
| `internal/cli/init.go` | Adds `dots init` with repository URL/ref overrides and JSON output support. |
| `internal/cli/paths.go` | Centralizes manifest loading and adds `dots init` recovery hints for default manifest misses. |
| `internal/cli/install.go` | Lets real `dots install` initialize the default Installed Repository before loading the manifest. |
| `internal/cli/*_test.go`, `internal/bootstrap/*_test.go` | Covers clone, existing repo, invalid repo, release-ref selection, and missing-manifest guidance. |
| `README.md`, `docs/release.md` | Documents Homebrew first-run initialization and release validation expectations. |

## Test Plan

- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp> --state-root <tmp>`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #179`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
