### PR TITLE
fix(deps): surface Homebrew tap trust guidance

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -140,6 +140,13 @@ Current dependency package coverage:
 | `curl` | `curl` | `curl` | `curl` | `curl` | `curl` |
 | `npx` | `npx` | Manual | Manual | Manual | Manual |
 
+Homebrew dependencies declared with a fully-qualified tap formula such as
+`gentleman-programming/tap/gentle-ai` may require explicit Homebrew Tap Trust on
+fresh macOS machines. `dots deps plan` and `dots deps install --dry-run` surface
+the formula-level trust command, for example
+`brew trust --formula gentleman-programming/tap/gentle-ai`, but `dots` does not
+run trust commands automatically.
+
 ## Provisioners
 
 Provisioners are a closed allowlist. They run after selected Managed Entries are

--- a/internal/cli/render_deps.go
+++ b/internal/cli/render_deps.go
@@ -49,6 +49,9 @@ func renderDepsPlan(w io.Writer, report deps.PlanReport) {
 			hint = item.Manual
 		}
 		fmt.Fprintf(w, "  %-12s %s\n", item.Name, hint)
+		if item.TrustCommand != "" {
+			fmt.Fprintf(w, "  %-12s %s\n", "trust", item.TrustCommand)
+		}
 	}
 
 	fmt.Fprintf(w, "\nSummary: %s\n", pluralizeDeps(len(report.Items)))
@@ -86,6 +89,9 @@ func renderDepsInstallPreviewWithTitle(w io.Writer, title string, report deps.In
 			hint = strings.Join(parts, " ")
 		}
 		fmt.Fprintf(w, "  %-13s %-24s %s\n", item.Status, item.Dependency, hint)
+		if item.TrustCommand != "" {
+			fmt.Fprintf(w, "  %-13s %-24s %s\n", "trust", item.Dependency, item.TrustCommand)
+		}
 	}
 
 	installable, manual := countInstallPreviewActions(report)
@@ -126,6 +132,9 @@ func renderDepsInstall(w io.Writer, report deps.InstallReport) {
 			hint = strings.Join(parts, " ")
 		}
 		fmt.Fprintf(w, "  %-10s %-24s %s\n", item.Status, item.Dependency, hint)
+		if item.TrustCommand != "" {
+			fmt.Fprintf(w, "  %-10s %-24s %s\n", "trust", item.Dependency, item.TrustCommand)
+		}
 		switch item.Status {
 		case deps.InstallStatusInstalled:
 			installed++

--- a/internal/cli/render_deps_golden_test.go
+++ b/internal/cli/render_deps_golden_test.go
@@ -62,6 +62,17 @@ func TestRenderDepsPlanGolden(t *testing.T) {
 			golden: "deps_plan_mixed.golden",
 		},
 		{
+			name: "homebrew tap trust guidance",
+			report: deps.PlanReport{
+				Profile: "agents",
+				Tier:    deps.TierHomebrew,
+				Items: []deps.Guidance{
+					{Name: "gentle-ai", Command: "brew install gentleman-programming/tap/gentle-ai", TrustCommand: "brew trust --formula gentleman-programming/tap/gentle-ai"},
+				},
+			},
+			golden: "deps_plan_tap_trust.golden",
+		},
+		{
 			name:   "nothing to install",
 			report: deps.PlanReport{Profile: "default", Tier: deps.TierHomebrew},
 			golden: "deps_plan_empty.golden",
@@ -94,6 +105,17 @@ func TestRenderDepsInstallDryRunGolden(t *testing.T) {
 				},
 			},
 			golden: "deps_install_dry_run_mixed.golden",
+		},
+		{
+			name: "homebrew tap trust preview",
+			report: deps.InstallDryRunReport{
+				Profile: "agents",
+				Tier:    deps.TierHomebrew,
+				Items: []deps.InstallPreview{
+					{Dependency: "gentle-ai", Status: deps.InstallPreviewWouldInstall, Package: "gentleman-programming/tap/gentle-ai", Executable: "brew", Args: []string{"install", "gentleman-programming/tap/gentle-ai"}, TrustCommand: "brew trust --formula gentleman-programming/tap/gentle-ai"},
+				},
+			},
+			golden: "deps_install_dry_run_tap_trust.golden",
 		},
 		{
 			name:   "nothing to install",

--- a/internal/cli/testdata/deps_install_dry_run_tap_trust.golden
+++ b/internal/cli/testdata/deps_install_dry_run_tap_trust.golden
@@ -1,0 +1,6 @@
+Dependency install dry-run for profile "agents" (homebrew)
+
+  would-install gentle-ai                brew install gentleman-programming/tap/gentle-ai
+  trust         gentle-ai                brew trust --formula gentleman-programming/tap/gentle-ai
+
+Summary: 1 installable, 0 manual

--- a/internal/cli/testdata/deps_plan_tap_trust.golden
+++ b/internal/cli/testdata/deps_plan_tap_trust.golden
@@ -1,0 +1,6 @@
+Dependency plan for profile "agents" (homebrew)
+
+  gentle-ai    brew install gentleman-programming/tap/gentle-ai
+  trust        brew trust --formula gentleman-programming/tap/gentle-ai
+
+Summary: 1 dependency to install

--- a/internal/deps/install.go
+++ b/internal/deps/install.go
@@ -18,12 +18,13 @@ const (
 
 // InstallPreview is one dry-run installation preview item.
 type InstallPreview struct {
-	Dependency string               `json:"dependency"`
-	Status     InstallPreviewStatus `json:"status"`
-	Package    string               `json:"package,omitempty"`
-	Executable string               `json:"executable,omitempty"`
-	Args       []string             `json:"args,omitempty"`
-	Manual     string               `json:"manual,omitempty"`
+	Dependency   string               `json:"dependency"`
+	Status       InstallPreviewStatus `json:"status"`
+	Package      string               `json:"package,omitempty"`
+	Executable   string               `json:"executable,omitempty"`
+	Args         []string             `json:"args,omitempty"`
+	Manual       string               `json:"manual,omitempty"`
+	TrustCommand string               `json:"trust_command,omitempty"`
 }
 
 // InstallDryRunReport previews the install actions for a Profile without
@@ -51,12 +52,13 @@ const (
 
 // InstallItem is the result of one attempted dependency installation.
 type InstallItem struct {
-	Dependency string        `json:"dependency"`
-	Status     InstallStatus `json:"status"`
-	Package    string        `json:"package,omitempty"`
-	Executable string        `json:"executable,omitempty"`
-	Args       []string      `json:"args,omitempty"`
-	Manual     string        `json:"manual,omitempty"`
+	Dependency   string        `json:"dependency"`
+	Status       InstallStatus `json:"status"`
+	Package      string        `json:"package,omitempty"`
+	Executable   string        `json:"executable,omitempty"`
+	Args         []string      `json:"args,omitempty"`
+	Manual       string        `json:"manual,omitempty"`
+	TrustCommand string        `json:"trust_command,omitempty"`
 }
 
 // InstallReport records the stable dots summary for a real install run.
@@ -81,12 +83,13 @@ func InstallDryRun(m manifest.Manifest, opts Options, look Lookup, fontLook Font
 			status = InstallPreviewManual
 		}
 		report.Items = append(report.Items, InstallPreview{
-			Dependency: action.Dependency,
-			Status:     status,
-			Package:    action.Package,
-			Executable: action.Executable,
-			Args:       action.Args,
-			Manual:     action.Manual,
+			Dependency:   action.Dependency,
+			Status:       status,
+			Package:      action.Package,
+			Executable:   action.Executable,
+			Args:         action.Args,
+			Manual:       action.Manual,
+			TrustCommand: action.TrustCommand,
 		})
 	}
 	return report, nil
@@ -106,40 +109,44 @@ func Install(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup
 		if action.Executable == "" {
 			unresolved = true
 			report.Items = append(report.Items, InstallItem{
-				Dependency: action.Dependency,
-				Status:     InstallStatusManual,
-				Manual:     action.Manual,
+				Dependency:   action.Dependency,
+				Status:       InstallStatusManual,
+				Manual:       action.Manual,
+				TrustCommand: action.TrustCommand,
 			})
 			continue
 		}
 		args := installArgsWithConfirmation(action, tier)
 		if err := runner.Run(action.Executable, args); err != nil {
 			report.Items = append(report.Items, InstallItem{
-				Dependency: action.Dependency,
-				Status:     InstallStatusFailed,
-				Package:    action.Package,
-				Executable: action.Executable,
-				Args:       args,
+				Dependency:   action.Dependency,
+				Status:       InstallStatusFailed,
+				Package:      action.Package,
+				Executable:   action.Executable,
+				Args:         args,
+				TrustCommand: action.TrustCommand,
 			})
 			return report, fmt.Errorf("install %q: %w", action.Dependency, err)
 		}
 		if !actionPresent(action, look, fontLook) {
 			unresolved = true
 			report.Items = append(report.Items, InstallItem{
-				Dependency: action.Dependency,
-				Status:     InstallStatusUnresolved,
-				Package:    action.Package,
-				Executable: action.Executable,
-				Args:       args,
+				Dependency:   action.Dependency,
+				Status:       InstallStatusUnresolved,
+				Package:      action.Package,
+				Executable:   action.Executable,
+				Args:         args,
+				TrustCommand: action.TrustCommand,
 			})
 			return report, errors.New("unresolved dependencies remain after install")
 		}
 		report.Items = append(report.Items, InstallItem{
-			Dependency: action.Dependency,
-			Status:     InstallStatusInstalled,
-			Package:    action.Package,
-			Executable: action.Executable,
-			Args:       args,
+			Dependency:   action.Dependency,
+			Status:       InstallStatusInstalled,
+			Package:      action.Package,
+			Executable:   action.Executable,
+			Args:         args,
+			TrustCommand: action.TrustCommand,
 		})
 	}
 	if unresolved {

--- a/internal/deps/install_test.go
+++ b/internal/deps/install_test.go
@@ -446,4 +446,7 @@ func TestInstallDryRunIncludesSelectedProvisionerDependencies(t *testing.T) {
 	if item.Package != "gentleman-programming/tap/gentle-ai" {
 		t.Fatalf("Items[0].Package = %q, want tap package", item.Package)
 	}
+	if item.TrustCommand != "brew trust --formula gentleman-programming/tap/gentle-ai" {
+		t.Fatalf("Items[0].TrustCommand = %q, want formula trust guidance", item.TrustCommand)
+	}
 }

--- a/internal/deps/plan.go
+++ b/internal/deps/plan.go
@@ -12,14 +12,15 @@ import (
 // Manual is set when the dependency has no executable package-manager action for
 // the active Tier.
 type InstallAction struct {
-	Dependency  string   `json:"dependency"`
-	Probe       string   `json:"probe,omitempty"`
-	FontMatch   string   `json:"font_match,omitempty"`
-	FontMatches []string `json:"font_matches,omitempty"`
-	Package     string   `json:"package,omitempty"`
-	Executable  string   `json:"executable,omitempty"`
-	Args        []string `json:"args,omitempty"`
-	Manual      string   `json:"manual,omitempty"`
+	Dependency   string   `json:"dependency"`
+	Probe        string   `json:"probe,omitempty"`
+	FontMatch    string   `json:"font_match,omitempty"`
+	FontMatches  []string `json:"font_matches,omitempty"`
+	Package      string   `json:"package,omitempty"`
+	Executable   string   `json:"executable,omitempty"`
+	Args         []string `json:"args,omitempty"`
+	Manual       string   `json:"manual,omitempty"`
+	TrustCommand string   `json:"trust_command,omitempty"`
 }
 
 // Guidance is the advisory installation hint for one missing Dependency. Command
@@ -27,10 +28,11 @@ type InstallAction struct {
 // for the active Tier; otherwise Manual carries a fallback note and Command is
 // empty. Action carries the structured model that Command renders from.
 type Guidance struct {
-	Name    string        `json:"name"`
-	Command string        `json:"command,omitempty"`
-	Manual  string        `json:"manual,omitempty"`
-	Action  InstallAction `json:"action"`
+	Name         string        `json:"name"`
+	Command      string        `json:"command,omitempty"`
+	Manual       string        `json:"manual,omitempty"`
+	TrustCommand string        `json:"trust_command,omitempty"`
+	Action       InstallAction `json:"action"`
 }
 
 // PlanReport is the Dependency Plan for a Profile: OS-aware guidance for the
@@ -82,27 +84,39 @@ func actionFor(dep manifest.Dependency, tier Tier) InstallAction {
 		return InstallAction{Dependency: dep.Name, Probe: dep.Probe(), FontMatch: fontMatch, FontMatches: fontMatches, Manual: manualNote(dep, tier)}
 	}
 	return InstallAction{
-		Dependency:  dep.Name,
-		Probe:       dep.Probe(),
-		FontMatch:   fontMatch,
-		FontMatches: fontMatches,
-		Package:     pkg,
-		Executable:  executable,
-		Args:        append(args, pkg),
+		Dependency:   dep.Name,
+		Probe:        dep.Probe(),
+		FontMatch:    fontMatch,
+		FontMatches:  fontMatches,
+		Package:      pkg,
+		Executable:   executable,
+		Args:         append(args, pkg),
+		TrustCommand: homebrewTapTrustCommand(dep, tier),
 	}
 }
 
 // guidanceFor renders advisory compatibility fields from the structured action.
 func guidanceFor(action InstallAction) Guidance {
 	if action.Executable == "" {
-		return Guidance{Name: action.Dependency, Manual: action.Manual, Action: action}
+		return Guidance{Name: action.Dependency, Manual: action.Manual, TrustCommand: action.TrustCommand, Action: action}
 	}
-	return Guidance{Name: action.Dependency, Command: action.commandHint(), Action: action}
+	return Guidance{Name: action.Dependency, Command: action.commandHint(), TrustCommand: action.TrustCommand, Action: action}
 }
 
 func (a InstallAction) commandHint() string {
 	parts := append([]string{a.Executable}, a.Args...)
 	return strings.Join(parts, " ")
+}
+
+func homebrewTapTrustCommand(dep manifest.Dependency, tier Tier) string {
+	if tier != TierHomebrew || strings.TrimSpace(dep.BrewCask) != "" {
+		return ""
+	}
+	formula := strings.TrimSpace(dep.Brew)
+	if strings.Count(formula, "/") < 2 {
+		return ""
+	}
+	return "brew trust --formula " + formula
 }
 
 // tierPackage returns the package identifier and argv prefix for a Dependency

--- a/internal/deps/plan_test.go
+++ b/internal/deps/plan_test.go
@@ -407,4 +407,23 @@ func TestPlanIncludesSelectedProvisionerDependencies(t *testing.T) {
 	if action.Package != "gentleman-programming/tap/gentle-ai" {
 		t.Fatalf("Actions[0].Package = %q, want tap package", action.Package)
 	}
+	if action.TrustCommand != "brew trust --formula gentleman-programming/tap/gentle-ai" {
+		t.Fatalf("Actions[0].TrustCommand = %q, want formula trust guidance", action.TrustCommand)
+	}
+	if report.Items[0].TrustCommand != action.TrustCommand {
+		t.Fatalf("Items[0].TrustCommand = %q, want %q", report.Items[0].TrustCommand, action.TrustCommand)
+	}
+}
+
+func TestPlanDoesNotAddTapTrustGuidanceForCoreHomebrewFormula(t *testing.T) {
+	report, err := deps.Plan(planManifest(), deps.Options{Profile: "default", OS: "darwin"}, lookupSet("tmux"), fontLookupSet(), deps.TierHomebrew)
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+	if len(report.Actions) != 1 {
+		t.Fatalf("Actions len = %d, want 1 (%#v)", len(report.Actions), report.Actions)
+	}
+	if report.Actions[0].TrustCommand != "" {
+		t.Fatalf("TrustCommand = %q, want empty for core formula", report.Actions[0].TrustCommand)
+	}
 }


### PR DESCRIPTION
Closes #181

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Surface formula-level Homebrew Tap Trust guidance for fully-qualified tap dependencies.
- Keep `brew install ...` as the executable action; trust remains advisory and user-controlled.
- Document the fresh macOS Tap Trust prerequisite for tap-backed dependencies.

## Changes

| File | Change |
|------|--------|
| `internal/deps/plan.go` | Adds `trust_command` guidance for qualified Homebrew formula dependencies. |
| `internal/deps/install.go` | Carries trust guidance through install dry-run and install result reports. |
| `internal/cli/render_deps.go` | Renders advisory trust commands in deps plan/install output. |
| `internal/cli/*test*` | Adds coverage and golden output for Tap Trust guidance. |
| `docs/manifest.md` | Documents that `dots` surfaces but does not execute trust commands. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed/fixture CLI validation: built `/tmp/dots-tap-trust` and ran `deps plan` against a temporary manifest with `PATH=/usr/bin:/bin`.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #181`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
