### PR TITLE
fix(upgrade): recover detached Installed Repository

### DIFF
--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -101,6 +101,13 @@ func renderUpdate(out io.Writer, upd gitrepo.Update, dryRun bool) {
 	if upd.PreservedChanges != "" {
 		fmt.Fprintf(out, "Preserved local Installed Repository changes in %s.\n", upd.PreservedChanges)
 	}
+	if upd.AttachedBranch != "" {
+		if dryRun {
+			fmt.Fprintf(out, "Detached Installed Repository would attach to %s.\n", upd.AttachedBranch)
+		} else {
+			fmt.Fprintf(out, "Attached detached Installed Repository to %s.\n", upd.AttachedBranch)
+		}
+	}
 	if !upd.Changed() {
 		fmt.Fprintf(out, "Installed Repository already up to date at %s.\n\n", upd.OldRev)
 		return

--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -26,6 +26,14 @@ type Update struct {
 	NewRev           string   `json:"new_rev"`
 	Incoming         []string `json:"incoming"`
 	PreservedChanges string   `json:"preserved_changes,omitempty"`
+	AttachedBranch   string   `json:"attached_branch,omitempty"`
+}
+
+type upstreamTarget struct {
+	Ref             string
+	Rev             string
+	AttachBranch    string
+	NeedsAttachment bool
 }
 
 // Changed reports whether the update moves (or would move) HEAD.
@@ -80,21 +88,21 @@ func Preview(dir string) (Update, error) {
 	if err := fetch(dir); err != nil {
 		return Update{}, err
 	}
-	upstream, err := upstreamRev(dir)
+	upstream, err := resolveUpstream(dir)
 	if err != nil {
 		return Update{}, err
 	}
-	if old == upstream {
-		return Update{OldRev: old, NewRev: old}, nil
+	if old == upstream.Rev {
+		return Update{OldRev: old, NewRev: old, AttachedBranch: upstream.AttachBranch}, nil
 	}
-	if !canFastForward(dir) {
+	if !canFastForwardTo(dir, upstream.Ref) {
 		return Update{}, ErrNotFastForward
 	}
-	incoming, err := incomingCommits(dir)
+	incoming, err := incomingCommitsFrom(dir, upstream.Ref)
 	if err != nil {
 		return Update{}, err
 	}
-	return Update{OldRev: old, NewRev: upstream, Incoming: incoming}, nil
+	return Update{OldRev: old, NewRev: upstream.Rev, Incoming: incoming, AttachedBranch: upstream.AttachBranch}, nil
 }
 
 // FastForward fetches and advances dir to its upstream via merge --ff-only. It
@@ -108,27 +116,35 @@ func FastForward(dir string) (Update, error) {
 	if err := fetch(dir); err != nil {
 		return Update{}, err
 	}
-	upstream, err := upstreamRev(dir)
+	upstream, err := resolveUpstream(dir)
 	if err != nil {
 		return Update{}, err
 	}
-	if old == upstream {
-		return Update{OldRev: old, NewRev: old}, nil
+	if old == upstream.Rev {
+		return Update{OldRev: old, NewRev: old, AttachedBranch: upstream.AttachBranch}, nil
+	}
+	if upstream.NeedsAttachment && !canAttachBranch(dir, upstream.AttachBranch, upstream.Ref) {
+		return Update{}, ErrNotFastForward
 	}
 	// Capture the incoming commits before merging so the report reflects exactly
 	// what the fast-forward applied.
-	incoming, err := incomingCommits(dir)
+	incoming, err := incomingCommitsFrom(dir, upstream.Ref)
 	if err != nil {
 		return Update{}, err
 	}
-	if _, err := run(dir, "merge", "--ff-only", "@{u}"); err != nil {
+	if upstream.NeedsAttachment {
+		if err := attachBranch(dir, upstream.AttachBranch); err != nil {
+			return Update{}, err
+		}
+	}
+	if _, err := run(dir, "merge", "--ff-only", upstream.Ref); err != nil {
 		return Update{}, ErrNotFastForward
 	}
 	newRev, err := head(dir)
 	if err != nil {
 		return Update{}, err
 	}
-	return Update{OldRev: old, NewRev: newRev, Incoming: incoming}, nil
+	return Update{OldRev: old, NewRev: newRev, Incoming: incoming, AttachedBranch: upstream.AttachBranch}, nil
 }
 
 // FastForwardPreservingLocalChanges verifies that dir can fast-forward before
@@ -143,35 +159,43 @@ func FastForwardPreservingLocalChanges(dir string) (Update, error) {
 	if err := fetch(dir); err != nil {
 		return Update{}, err
 	}
-	upstream, err := upstreamRev(dir)
+	upstream, err := resolveUpstream(dir)
 	if err != nil {
 		return Update{}, err
 	}
-	if old != upstream && !canFastForward(dir) {
+	if old != upstream.Rev && !canFastForwardTo(dir, upstream.Ref) {
 		return Update{}, ErrNotFastForward
 	}
 
 	var incoming []string
-	if old != upstream {
-		incoming, err = incomingCommits(dir)
+	if old != upstream.Rev {
+		incoming, err = incomingCommitsFrom(dir, upstream.Ref)
 		if err != nil {
 			return Update{}, err
 		}
+	}
+	if upstream.NeedsAttachment && !canAttachBranch(dir, upstream.AttachBranch, upstream.Ref) {
+		return Update{}, ErrNotFastForward
 	}
 
 	preserved, stashed, err := PreserveLocalChanges(dir)
 	if err != nil {
 		return Update{}, err
 	}
-	upd := Update{OldRev: old, NewRev: old, Incoming: incoming}
+	upd := Update{OldRev: old, NewRev: old, Incoming: incoming, AttachedBranch: upstream.AttachBranch}
 	if stashed {
 		upd.PreservedChanges = preserved
 	}
-	if old == upstream {
+	if upstream.NeedsAttachment {
+		if err := attachBranch(dir, upstream.AttachBranch); err != nil {
+			return Update{}, err
+		}
+	}
+	if old == upstream.Rev {
 		return upd, nil
 	}
 
-	if _, err := run(dir, "merge", "--ff-only", "@{u}"); err != nil {
+	if _, err := run(dir, "merge", "--ff-only", upstream.Ref); err != nil {
 		return Update{}, ErrNotFastForward
 	}
 	newRev, err := head(dir)
@@ -190,12 +214,93 @@ func head(dir string) (string, error) {
 	return strings.TrimSpace(out), nil
 }
 
-func upstreamRev(dir string) (string, error) {
-	out, err := run(dir, "rev-parse", "--short", "@{u}")
+func resolveUpstream(dir string) (upstreamTarget, error) {
+	ref, err := run(dir, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}")
+	if err == nil {
+		ref = strings.TrimSpace(ref)
+		rev, err := rev(dir, ref)
+		if err != nil {
+			return upstreamTarget{}, err
+		}
+		return upstreamTarget{Ref: ref, Rev: rev}, nil
+	}
+
+	branch, branchErr := run(dir, "rev-parse", "--abbrev-ref", "HEAD")
+	if branchErr != nil || strings.TrimSpace(branch) != "HEAD" {
+		return upstreamTarget{}, fmt.Errorf("resolve upstream for %s: %w", dir, err)
+	}
+
+	ref, attachBranch, fallbackErr := defaultRemoteBranch(dir)
+	if fallbackErr != nil {
+		if fetchErr := fetchOriginBranches(dir); fetchErr != nil {
+			return upstreamTarget{}, fmt.Errorf("resolve upstream for detached Installed Repository %s: %w", dir, fetchErr)
+		}
+		ref, attachBranch, fallbackErr = defaultRemoteBranch(dir)
+		if fallbackErr != nil {
+			return upstreamTarget{}, fmt.Errorf("resolve upstream for detached Installed Repository %s: %w", dir, fallbackErr)
+		}
+	}
+	rev, err := rev(dir, ref)
 	if err != nil {
-		return "", fmt.Errorf("resolve upstream for %s: %w", dir, err)
+		return upstreamTarget{}, err
+	}
+	return upstreamTarget{Ref: ref, Rev: rev, AttachBranch: attachBranch, NeedsAttachment: true}, nil
+}
+
+func rev(dir, ref string) (string, error) {
+	out, err := run(dir, "rev-parse", "--short", ref)
+	if err != nil {
+		return "", fmt.Errorf("resolve %s for %s: %w", ref, dir, err)
 	}
 	return strings.TrimSpace(out), nil
+}
+
+func defaultRemoteBranch(dir string) (ref, branch string, err error) {
+	out, err := run(dir, "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD")
+	if err == nil {
+		ref = strings.TrimSpace(out)
+		return ref, strings.TrimPrefix(ref, "origin/"), nil
+	}
+	for _, candidate := range []string{"origin/main", "origin/master"} {
+		if _, err := rev(dir, candidate); err == nil {
+			return candidate, strings.TrimPrefix(candidate, "origin/"), nil
+		}
+	}
+	return "", "", errors.New("origin default branch is unavailable")
+}
+
+func attachBranch(dir, branch string) error {
+	if strings.TrimSpace(branch) == "" || branch == "HEAD" {
+		return errors.New("default branch is unavailable")
+	}
+	if branchExists(dir, branch) {
+		if _, err := run(dir, "switch", branch); err != nil {
+			return fmt.Errorf("attach Installed Repository to %s: %w", branch, err)
+		}
+		return nil
+	}
+	if _, err := run(dir, "switch", "--create", branch, "origin/"+branch); err != nil {
+		return fmt.Errorf("attach Installed Repository to %s: %w", branch, err)
+	}
+	if _, err := run(dir, "branch", "--set-upstream-to", "origin/"+branch, branch); err != nil {
+		return fmt.Errorf("track Installed Repository branch %s: %w", branch, err)
+	}
+	return nil
+}
+
+func branchExists(dir, branch string) bool {
+	_, err := run(dir, "show-ref", "--verify", "--quiet", "refs/heads/"+branch)
+	return err == nil
+}
+
+func canAttachBranch(dir, branch, upstreamRef string) bool {
+	if strings.TrimSpace(branch) == "" || branch == "HEAD" {
+		return false
+	}
+	if !branchExists(dir, branch) {
+		return true
+	}
+	return canFastForwardRefTo(dir, branch, upstreamRef)
 }
 
 func fetch(dir string) error {
@@ -205,14 +310,28 @@ func fetch(dir string) error {
 	return nil
 }
 
-func canFastForward(dir string) bool {
-	// HEAD must be an ancestor of upstream for a fast-forward to be possible.
-	_, err := run(dir, "merge-base", "--is-ancestor", "HEAD", "@{u}")
+func fetchOriginBranches(dir string) error {
+	if _, err := run(dir, "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"); err != nil {
+		return fmt.Errorf("configure origin branch fetch for %s: %w", dir, err)
+	}
+	if _, err := run(dir, "fetch", "--quiet", "origin", "+refs/heads/*:refs/remotes/origin/*"); err != nil {
+		return fmt.Errorf("fetch origin branches for %s: %w", dir, err)
+	}
+	return nil
+}
+
+func canFastForwardTo(dir, ref string) bool {
+	// HEAD must be an ancestor of the update target for a fast-forward to be possible.
+	return canFastForwardRefTo(dir, "HEAD", ref)
+}
+
+func canFastForwardRefTo(dir, from, to string) bool {
+	_, err := run(dir, "merge-base", "--is-ancestor", from, to)
 	return err == nil
 }
 
-func incomingCommits(dir string) ([]string, error) {
-	out, err := run(dir, "log", "--pretty=%h %s", "HEAD..@{u}")
+func incomingCommitsFrom(dir, ref string) ([]string, error) {
+	out, err := run(dir, "log", "--pretty=%h %s", "HEAD.."+ref)
 	if err != nil {
 		return nil, fmt.Errorf("list incoming commits for %s: %w", dir, err)
 	}

--- a/internal/gitrepo/gitrepo_test.go
+++ b/internal/gitrepo/gitrepo_test.go
@@ -1,6 +1,7 @@
 package gitrepo_test
 
 import (
+	"bytes"
 	"errors"
 	"os"
 	"os/exec"
@@ -127,6 +128,128 @@ func TestPreviewReportsIncomingWithoutModifyingWorkingTree(t *testing.T) {
 	}
 }
 
+func TestPreviewSupportsDetachedInstalledRepositoryAtReleaseTag(t *testing.T) {
+	requireGit(t)
+	origin, clone := setupRemoteAndClone(t)
+	gitExec(t, origin, "tag", "v0.99.0")
+	gitExec(t, clone, "fetch", "--tags")
+	gitExec(t, clone, "switch", "--detach", "v0.99.0")
+
+	writeFile(t, filepath.Join(origin, "configs/git/gitconfig"), "[user]\n")
+	gitExec(t, origin, "add", "-A")
+	gitExec(t, origin, "commit", "-m", "add gitconfig")
+
+	upd, err := gitrepo.Preview(clone)
+	if err != nil {
+		t.Fatalf("Preview() error = %v", err)
+	}
+	if !upd.Changed() {
+		t.Fatalf("Preview() Changed() = false, want true from detached release tag")
+	}
+	if upd.AttachedBranch != "main" {
+		t.Fatalf("Preview() AttachedBranch = %q, want main", upd.AttachedBranch)
+	}
+	if got := gitOutput(t, clone, "rev-parse", "--abbrev-ref", "HEAD"); got != "HEAD" {
+		t.Fatalf("Preview() attached working tree branch %q, want still detached", got)
+	}
+}
+
+func TestFastForwardPreservingLocalChangesAttachesDetachedInstalledRepository(t *testing.T) {
+	requireGit(t)
+	origin, clone := setupRemoteAndClone(t)
+	gitExec(t, origin, "tag", "v0.99.0")
+	gitExec(t, clone, "fetch", "--tags")
+	gitExec(t, clone, "switch", "--detach", "v0.99.0")
+
+	writeFile(t, filepath.Join(clone, "configs/nvim/lazy-lock.json"), "local editor update\n")
+
+	writeFile(t, filepath.Join(origin, "configs/git/gitconfig"), "[user]\n")
+	gitExec(t, origin, "add", "-A")
+	gitExec(t, origin, "commit", "-m", "add gitconfig")
+
+	upd, err := gitrepo.FastForwardPreservingLocalChanges(clone)
+	if err != nil {
+		t.Fatalf("FastForwardPreservingLocalChanges() error = %v", err)
+	}
+	if !upd.Changed() {
+		t.Fatalf("FastForwardPreservingLocalChanges() Changed() = false, want true")
+	}
+	if upd.AttachedBranch != "main" {
+		t.Fatalf("FastForwardPreservingLocalChanges() AttachedBranch = %q, want main", upd.AttachedBranch)
+	}
+	if upd.PreservedChanges == "" {
+		t.Fatal("FastForwardPreservingLocalChanges() did not preserve dirty Installed Repository changes")
+	}
+	if got := gitOutput(t, clone, "rev-parse", "--abbrev-ref", "HEAD"); got != "main" {
+		t.Fatalf("HEAD branch = %q, want main", got)
+	}
+	if _, err := os.Stat(filepath.Join(clone, "configs/git/gitconfig")); err != nil {
+		t.Fatalf("fast-forward did not materialize upstream file: %v", err)
+	}
+	if status := gitOutput(t, clone, "status", "--porcelain"); status != "" {
+		t.Fatalf("working tree status = %q, want clean after preserving changes", status)
+	}
+}
+
+func TestFastForwardPreservingLocalChangesDoesNotResetDivergedLocalBranch(t *testing.T) {
+	requireGit(t)
+	origin, clone := setupRemoteAndClone(t)
+	gitExec(t, origin, "tag", "v0.99.0")
+	gitExec(t, clone, "fetch", "--tags")
+
+	writeFile(t, filepath.Join(clone, "configs/zsh/zshrc"), "local branch change\n")
+	gitExec(t, clone, "add", "-A")
+	gitExec(t, clone, "commit", "-m", "local branch change")
+	localMain := gitOutput(t, clone, "rev-parse", "--short", "main")
+
+	gitExec(t, clone, "switch", "--detach", "v0.99.0")
+	writeFile(t, filepath.Join(clone, "configs/nvim/lazy-lock.json"), "local editor update\n")
+
+	writeFile(t, filepath.Join(origin, "configs/zsh/zshrc"), "upstream branch change\n")
+	gitExec(t, origin, "add", "-A")
+	gitExec(t, origin, "commit", "-m", "upstream branch change")
+
+	_, err := gitrepo.FastForwardPreservingLocalChanges(clone)
+	if !errors.Is(err, gitrepo.ErrNotFastForward) {
+		t.Fatalf("FastForwardPreservingLocalChanges() error = %v, want ErrNotFastForward", err)
+	}
+	if got := gitOutput(t, clone, "rev-parse", "--short", "main"); got != localMain {
+		t.Fatalf("local main was reset: got %s, want %s", got, localMain)
+	}
+	if got := gitOutput(t, clone, "rev-parse", "--abbrev-ref", "HEAD"); got != "HEAD" {
+		t.Fatalf("HEAD branch = %q, want still detached after failed recovery", got)
+	}
+	if status := gitOutput(t, clone, "status", "--porcelain"); status == "" {
+		t.Fatal("local dirty editor change was stashed despite failed recovery")
+	}
+}
+
+func TestFastForwardSupportsShallowTagCloneWithoutRemoteBranches(t *testing.T) {
+	requireGit(t)
+	origin := setupOriginWithReleaseTag(t, "v0.99.0")
+	clone := filepath.Join(t.TempDir(), "clone")
+	gitExec(t, "", "clone", "--depth", "1", "--branch", "v0.99.0", "file://"+origin, clone)
+	configIdentity(t, clone)
+
+	writeFile(t, filepath.Join(origin, "configs/git/gitconfig"), "[user]\n")
+	gitExec(t, origin, "add", "-A")
+	gitExec(t, origin, "commit", "-m", "add gitconfig")
+
+	upd, err := gitrepo.FastForwardPreservingLocalChanges(clone)
+	if err != nil {
+		t.Fatalf("FastForwardPreservingLocalChanges() error = %v", err)
+	}
+	if !upd.Changed() {
+		t.Fatalf("FastForwardPreservingLocalChanges() Changed() = false, want true")
+	}
+	if got := gitOutput(t, clone, "rev-parse", "--abbrev-ref", "HEAD"); got != "main" {
+		t.Fatalf("HEAD branch = %q, want main", got)
+	}
+	if _, err := os.Stat(filepath.Join(clone, "configs/git/gitconfig")); err != nil {
+		t.Fatalf("fast-forward did not materialize upstream file: %v", err)
+	}
+}
+
 func TestFastForwardReturnsErrNotFastForwardOnDivergence(t *testing.T) {
 	requireGit(t)
 	origin, clone := setupRemoteAndClone(t)
@@ -146,6 +269,24 @@ func TestFastForwardReturnsErrNotFastForwardOnDivergence(t *testing.T) {
 	}
 }
 
+func gitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	cmd.Env = append(os.Environ(),
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"GIT_CONFIG_SYSTEM=/dev/null",
+		"GIT_TERMINAL_PROMPT=0",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return string(bytes.TrimSpace(out))
+}
+
 // --- helpers ---
 
 func requireGit(t *testing.T) {
@@ -161,17 +302,26 @@ func requireGit(t *testing.T) {
 // fast-forward path without any network access.
 func setupRemoteAndClone(t *testing.T) (origin, clone string) {
 	t.Helper()
-	origin = t.TempDir()
-	gitExec(t, origin, "init", "-b", "main")
-	configIdentity(t, origin)
-	writeFile(t, filepath.Join(origin, "configs/zsh/zshrc"), "export A=1\n")
-	gitExec(t, origin, "add", "-A")
-	gitExec(t, origin, "commit", "-m", "initial")
+	origin = setupOriginWithReleaseTag(t, "")
 
 	clone = t.TempDir()
 	gitExec(t, "", "clone", origin, clone)
 	configIdentity(t, clone)
 	return origin, clone
+}
+
+func setupOriginWithReleaseTag(t *testing.T, tag string) string {
+	t.Helper()
+	origin := t.TempDir()
+	gitExec(t, origin, "init", "-b", "main")
+	configIdentity(t, origin)
+	writeFile(t, filepath.Join(origin, "configs/zsh/zshrc"), "export A=1\n")
+	gitExec(t, origin, "add", "-A")
+	gitExec(t, origin, "commit", "-m", "initial")
+	if tag != "" {
+		gitExec(t, origin, "tag", tag)
+	}
+	return origin
 }
 
 func configIdentity(t *testing.T, dir string) {


### PR DESCRIPTION
Closes #183

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Recover `dots upgrade` / `dots update` when the Installed Repository is detached at a release tag.
- Preserve local Installed Repository edits before safe fast-forward updates.
- Avoid resetting an existing local default branch during detached recovery.

## Changes

| File | Change |
|------|--------|
| `internal/gitrepo/gitrepo.go` | Resolves detached upstream via the origin default branch, restores shallow tag clone branch fetch config, attaches branches conservatively, and preflights divergent local branches before mutating state. |
| `internal/gitrepo/gitrepo_test.go` | Adds regression coverage for detached tag preview, dirty detached update recovery, shallow tag clones, and divergent local default branches. |
| `internal/cli/update.go` | Reports detached branch attachment separately for dry-run and real update output. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [ ] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp>`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #183`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
