### PR TITLE
fix(deps): explain unresolved rustup probes

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -59,7 +59,10 @@ their Managed Entries, while common runtimes and package tools are owned by
 Homebrew-provider declarations for `fnm`, `rustup`, `go`, `uv`, `pnpm`, and
 `bun`. Linux Homebrew fallback is explicit with `linux_homebrew: true`; GUI apps and fonts stay manual unless they have validated Linux support. Node and Rust use constrained built-in toolchain bootstrap commands after
 manager installation: `fnm install --lts` for Node LTS and `rustup default
-stable` for Rust stable.
+stable` for Rust stable. When Rust bootstrap succeeds but `rustc` or `cargo`
+still are not available on `PATH`, the install result includes repair guidance
+for the rustup proxy/PATH surface instead of only reporting a generic unresolved
+Dependency.
 
 ## Managed Entries
 

--- a/internal/cli/deps_install_test.go
+++ b/internal/cli/deps_install_test.go
@@ -303,6 +303,65 @@ entries:
 	}
 }
 
+func TestDepsInstallExplainsRustupToolchainWhenProbesRemainMissing(t *testing.T) {
+	binDir := t.TempDir()
+	runLog := binDir + "/rustup-args"
+	rustup := binDir + "/rustup"
+	script := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$@\" > %q\nexit 0\n", runLog)
+	if err := os.WriteFile(rustup, []byte(script), 0o700); err != nil {
+		t.Fatalf("write fake rustup: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+
+	manifestPath := writeDepsInstallManifest(t, `version: 1
+profiles:
+  default:
+    tags: [core]
+dependencies:
+  - tags: [core]
+    dependencies:
+      - name: Rust stable (rustup)
+        commands: [rustup, rustc, cargo]
+        toolchain: rust-stable-rustup
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+`)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"deps", "install", "--yes", "--file", manifestPath, "--tier", "generic"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("Execute() error = nil, want unresolved Rust dependency error\noutput:\n%s", out.String())
+	}
+	args, readErr := os.ReadFile(runLog)
+	if readErr != nil {
+		t.Fatalf("read rustup args: %v", readErr)
+	}
+	if string(args) != "default\nstable\n" {
+		t.Fatalf("rustup args = %q, want default/stable", string(args))
+	}
+	got := out.String()
+	for _, want := range []string{
+		"unresolved Rust stable (rustup)",
+		"repair",
+		"rustc, cargo are not available on PATH",
+		"~/.cargo/bin",
+		"rustup which rustc",
+		"rustup which cargo",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Rust unresolved output missing %q\noutput:\n%s", want, got)
+		}
+	}
+}
+
 func TestDepsInstallDryRunRendersPreview(t *testing.T) {
 	binDir := t.TempDir()
 	brew := binDir + "/brew"

--- a/internal/cli/render_deps.go
+++ b/internal/cli/render_deps.go
@@ -186,6 +186,9 @@ func renderDepsInstall(w io.Writer, report deps.InstallReport) {
 		if item.TrustCommand != "" {
 			fmt.Fprintf(w, "  %-10s %-24s %s\n", "trust", item.Dependency, item.TrustCommand)
 		}
+		if item.Status == deps.InstallStatusUnresolved && item.Manual != "" {
+			fmt.Fprintf(w, "  %-10s %-24s %s\n", "repair", item.Dependency, item.Manual)
+		}
 		switch item.Status {
 		case deps.InstallStatusInstalled:
 			installed++

--- a/internal/deps/install.go
+++ b/internal/deps/install.go
@@ -3,6 +3,7 @@ package deps
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/yersonargotev/dots/internal/manifest"
 )
@@ -172,6 +173,7 @@ func Install(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup
 			return report, fmt.Errorf("bootstrap %q: %w", action.Dependency, err)
 		}
 		if !actionPresent(action, look, fontLook) {
+			manual := unresolvedToolchainRemediation(action, look)
 			if action.Requirement == manifest.DependencyRequirementRequired {
 				requiredUnresolved = true
 			}
@@ -184,6 +186,7 @@ func Install(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup
 				Executable:   action.Executable,
 				Args:         args,
 				Bootstrap:    append([]Command(nil), action.Bootstrap...),
+				Manual:       manual,
 				TrustCommand: action.TrustCommand,
 				Candidates:   action.Candidates,
 			})
@@ -209,6 +212,33 @@ func Install(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup
 		return report, errors.New("unresolved required dependencies remain after install")
 	}
 	return report, nil
+}
+
+func unresolvedToolchainRemediation(action InstallAction, look Lookup) string {
+	if action.Toolchain != manifest.DependencyToolchainRustStableRustup {
+		return ""
+	}
+	missing := missingCommandProbes(action.Probes, look)
+	if len(missing) == 0 {
+		return ""
+	}
+	verb := "are"
+	if len(missing) == 1 {
+		verb = "is"
+	}
+	return fmt.Sprintf("Rust stable is selected in rustup, but %s %s not available on PATH; ensure rustup exposes its proxies (usually by adding ~/.cargo/bin to PATH), then verify with `rustup which rustc` and `rustup which cargo`", strings.Join(missing, ", "), verb)
+}
+
+func missingCommandProbes(probes []string, look Lookup) []string {
+	missing := make([]string, 0, len(probes))
+	for _, probe := range probes {
+		probe = strings.TrimSpace(probe)
+		if probe == "" || look(probe) {
+			continue
+		}
+		missing = append(missing, probe)
+	}
+	return missing
 }
 
 func actionExecutable(action InstallAction) bool {

--- a/internal/deps/install_test.go
+++ b/internal/deps/install_test.go
@@ -3,6 +3,7 @@ package deps_test
 import (
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/yersonargotev/dots/internal/deps"
@@ -545,6 +546,45 @@ func TestInstallYesRunsConstrainedToolchainBootstrapBeforeReprobe(t *testing.T) 
 	}
 	if len(report.Items) != 1 || report.Items[0].Status != deps.InstallStatusInstalled || !reflect.DeepEqual(report.Items[0].Bootstrap, []deps.Command{{Executable: "fnm", Args: []string{"install", "--lts"}}}) {
 		t.Fatalf("report items = %#v, want installed item with fnm bootstrap", report.Items)
+	}
+}
+
+func TestInstallYesExplainsRustupToolchainWhenProbesRemainMissing(t *testing.T) {
+	present := map[string]bool{"rustup": true}
+	runner := &recordingRunner{}
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}},
+		Dependencies: []manifest.DependencySet{{
+			Tags: []string{"core"},
+			Dependencies: []manifest.Dependency{{
+				Name:      "Rust stable (rustup)",
+				Commands:  []string{"rustup", "rustc", "cargo"},
+				Brew:      "rustup",
+				Toolchain: manifest.DependencyToolchainRustStableRustup,
+			}},
+		}},
+		Entries: []manifest.Entry{{Source: "configs/x", Target: "~/.x", Strategy: "symlink", Tags: []string{"core"}}},
+	}
+
+	report, err := deps.Install(m, deps.Options{Profile: "default", OS: "linux"}, func(command string) bool {
+		return present[command]
+	}, fontLookupSet(), deps.TierGeneric, runner)
+	if err == nil {
+		t.Fatalf("Install() error = nil, want unresolved rust toolchain error")
+	}
+	wantCalls := []runnerCall{{executable: "rustup", args: []string{"default", "stable"}}}
+	if !reflect.DeepEqual(runner.calls, wantCalls) {
+		t.Fatalf("runner calls = %#v, want %#v", runner.calls, wantCalls)
+	}
+	if len(report.Items) != 1 || report.Items[0].Status != deps.InstallStatusUnresolved {
+		t.Fatalf("report items = %#v, want one unresolved Rust item", report.Items)
+	}
+	manual := report.Items[0].Manual
+	for _, want := range []string{"rustc", "cargo", "~/.cargo/bin", "rustup which rustc", "rustup which cargo"} {
+		if !strings.Contains(manual, want) {
+			t.Fatalf("Rust remediation missing %q: %q", want, manual)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #202

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds Rust-specific remediation when `rustup default stable` succeeds but required probes remain unresolved.
- Renders a `repair` line naming missing commands and pointing users at `~/.cargo/bin` / `rustup which` checks.
- Covers the regression through deps-layer and CLI output tests.

## Changes

| File | Change |
|------|--------|
| `internal/deps/install.go` | Adds post-bootstrap Rust toolchain remediation for missing command probes. |
| `internal/cli/render_deps.go` | Renders unresolved remediation as a `repair` line in dependency install output. |
| `internal/deps/install_test.go` | Adds regression coverage for `rustup` present while `rustc`/`cargo` remain absent. |
| `internal/cli/deps_install_test.go` | Verifies CLI output includes actionable Rust repair guidance. |
| `docs/manifest.md` | Documents Rust post-bootstrap unresolved guidance. |

## Test Plan

- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `SANDBOX=$(mktemp -d); mkdir -p "$SANDBOX/home"; go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home "$SANDBOX/home"`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #202`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
