### PR TITLE
feat(deps): support official rustup installer

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -59,7 +59,12 @@ their Managed Entries, while common runtimes and package tools are owned by
 Homebrew-provider declarations for `fnm`, `rustup`, `go`, `uv`, `pnpm`, and
 `bun`. Linux Homebrew fallback is explicit with `linux_homebrew: true`; GUI apps and fonts stay manual unless they have validated Linux support. Node and Rust use constrained built-in toolchain bootstrap commands after
 manager installation: `fnm install --lts` for Node LTS and `rustup default
-stable` for Rust stable.
+stable` for Rust stable. On Linux, when `rustup` is absent but `curl`
+and `sh` are available, the Rust toolchain may use the constrained official
+rustup installer flow (`curl --proto '=https' --tlsv1.2 -sSf
+https://sh.rustup.rs | sh -s -- -y --no-modify-path`) before running
+`rustup default stable`. This is a built-in Rust action, not arbitrary shell
+from the manifest.
 
 ## Managed Entries
 

--- a/internal/cli/render_deps.go
+++ b/internal/cli/render_deps.go
@@ -85,8 +85,7 @@ func renderDepsInstallPreviewWithTitle(w io.Writer, title string, report deps.In
 	for _, item := range report.Items {
 		hint := item.Manual
 		if item.Executable != "" {
-			parts := append([]string{item.Executable}, item.Args...)
-			hint = strings.Join(parts, " ")
+			hint = commandHint(item.Executable, item.Args)
 		} else if len(item.Bootstrap) > 0 {
 			hint = "see bootstrap command(s)"
 		}
@@ -174,8 +173,7 @@ func renderDepsInstall(w io.Writer, report deps.InstallReport) {
 	for _, item := range report.Items {
 		hint := item.Manual
 		if item.Executable != "" {
-			parts := append([]string{item.Executable}, item.Args...)
-			hint = strings.Join(parts, " ")
+			hint = commandHint(item.Executable, item.Args)
 		} else if len(item.Bootstrap) > 0 {
 			hint = "see bootstrap command(s)"
 		}
@@ -203,7 +201,25 @@ func renderDepsInstall(w io.Writer, report deps.InstallReport) {
 
 func commandHint(executable string, args []string) string {
 	parts := append([]string{executable}, args...)
+	for i, part := range parts {
+		parts[i] = shellQuoteIfNeeded(part)
+	}
 	return strings.Join(parts, " ")
+}
+
+func shellQuoteIfNeeded(s string) string {
+	if s == "" {
+		return "''"
+	}
+	if strings.IndexFunc(s, func(r rune) bool {
+		return !((r >= 'a' && r <= 'z') ||
+			(r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') ||
+			strings.ContainsRune("_@%+=:,./-", r))
+	}) == -1 {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
 func dependencyRequirementLabel(requirement string) string {

--- a/internal/cli/render_deps_command_test.go
+++ b/internal/cli/render_deps_command_test.go
@@ -1,0 +1,18 @@
+package cli
+
+import "testing"
+
+func TestCommandHintShellQuotesUnsafeArguments(t *testing.T) {
+	got := commandHint("sh", []string{"-c", "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path"})
+	want := "sh -c 'curl --proto '\\''=https'\\'' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path'"
+	if got != want {
+		t.Fatalf("commandHint() = %q, want %q", got, want)
+	}
+}
+
+func TestCommandHintLeavesSafeArgumentsReadable(t *testing.T) {
+	got := commandHint("brew", []string{"install", "starship"})
+	if got != "brew install starship" {
+		t.Fatalf("commandHint() = %q, want brew install starship", got)
+	}
+}

--- a/internal/deps/install_test.go
+++ b/internal/deps/install_test.go
@@ -576,6 +576,14 @@ func TestInstallDryRunReportsOfficialRustupInstaller(t *testing.T) {
 	if item.Status != deps.InstallPreviewWouldInstall || item.Executable != "sh" || len(item.Args) != 2 || !strings.Contains(item.Args[1], "https://sh.rustup.rs") || len(item.Bootstrap) != 1 {
 		t.Fatalf("Rust dry-run item = %#v, want official installer plus bootstrap", item)
 	}
+
+	plan, err := deps.Plan(m, deps.Options{Profile: "default", OS: "linux"}, lookupSet("curl", "sh"), fontLookupSet(), deps.TierGeneric)
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+	if len(plan.Items) != 1 || !strings.Contains(plan.Items[0].Command, "sh -c '") || !strings.Contains(plan.Items[0].Command, `'\''=https'\''`) {
+		t.Fatalf("Rust installer command hint = %#v, want shell-quoted script", plan.Items)
+	}
 }
 
 func TestInstallYesRunsOfficialRustupInstallerBeforeBootstrap(t *testing.T) {

--- a/internal/deps/install_test.go
+++ b/internal/deps/install_test.go
@@ -3,6 +3,7 @@ package deps_test
 import (
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/yersonargotev/dots/internal/deps"
@@ -545,6 +546,83 @@ func TestInstallYesRunsConstrainedToolchainBootstrapBeforeReprobe(t *testing.T) 
 	}
 	if len(report.Items) != 1 || report.Items[0].Status != deps.InstallStatusInstalled || !reflect.DeepEqual(report.Items[0].Bootstrap, []deps.Command{{Executable: "fnm", Args: []string{"install", "--lts"}}}) {
 		t.Fatalf("report items = %#v, want installed item with fnm bootstrap", report.Items)
+	}
+}
+
+func TestInstallDryRunReportsOfficialRustupInstaller(t *testing.T) {
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}},
+		Dependencies: []manifest.DependencySet{{
+			Tags: []string{"core"},
+			Dependencies: []manifest.Dependency{{
+				Name:      "Rust stable (rustup)",
+				Commands:  []string{"rustup", "rustc", "cargo"},
+				Brew:      "rustup",
+				Toolchain: manifest.DependencyToolchainRustStableRustup,
+			}},
+		}},
+		Entries: []manifest.Entry{{Source: "configs/x", Target: "~/.x", Strategy: "symlink", Tags: []string{"core"}}},
+	}
+
+	report, err := deps.InstallDryRun(m, deps.Options{Profile: "default", OS: "linux"}, lookupSet("curl", "sh"), fontLookupSet(), deps.TierGeneric)
+	if err != nil {
+		t.Fatalf("InstallDryRun() error = %v", err)
+	}
+	if len(report.Items) != 1 {
+		t.Fatalf("Items len = %d, want 1 (%#v)", len(report.Items), report.Items)
+	}
+	item := report.Items[0]
+	if item.Status != deps.InstallPreviewWouldInstall || item.Executable != "sh" || len(item.Args) != 2 || !strings.Contains(item.Args[1], "https://sh.rustup.rs") || len(item.Bootstrap) != 1 {
+		t.Fatalf("Rust dry-run item = %#v, want official installer plus bootstrap", item)
+	}
+}
+
+func TestInstallYesRunsOfficialRustupInstallerBeforeBootstrap(t *testing.T) {
+	present := map[string]bool{"curl": true, "sh": true}
+	runner := &recordingRunner{}
+	runner.afterRun = func() {
+		last := runner.calls[len(runner.calls)-1]
+		switch {
+		case last.executable == "sh" && len(last.args) == 2 && strings.Contains(last.args[1], "https://sh.rustup.rs"):
+			present["rustup"] = true
+		case last.executable == "rustup" && reflect.DeepEqual(last.args, []string{"default", "stable"}):
+			present["rustc"] = true
+			present["cargo"] = true
+		}
+	}
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}},
+		Dependencies: []manifest.DependencySet{{
+			Tags: []string{"core"},
+			Dependencies: []manifest.Dependency{{
+				Name:      "Rust stable (rustup)",
+				Commands:  []string{"rustup", "rustc", "cargo"},
+				Brew:      "rustup",
+				Toolchain: manifest.DependencyToolchainRustStableRustup,
+			}},
+		}},
+		Entries: []manifest.Entry{{Source: "configs/x", Target: "~/.x", Strategy: "symlink", Tags: []string{"core"}}},
+	}
+
+	report, err := deps.Install(m, deps.Options{Profile: "default", OS: "linux"}, func(command string) bool {
+		return present[command]
+	}, fontLookupSet(), deps.TierGeneric, runner)
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if len(runner.calls) != 2 {
+		t.Fatalf("runner calls len = %d, want official installer then bootstrap (%#v)", len(runner.calls), runner.calls)
+	}
+	if runner.calls[0].executable != "sh" || !reflect.DeepEqual(runner.calls[0].args[:1], []string{"-c"}) || !strings.Contains(runner.calls[0].args[1], "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path") {
+		t.Fatalf("official installer call = %#v", runner.calls[0])
+	}
+	if runner.calls[1].executable != "rustup" || !reflect.DeepEqual(runner.calls[1].args, []string{"default", "stable"}) {
+		t.Fatalf("bootstrap call = %#v", runner.calls[1])
+	}
+	if len(report.Items) != 1 || report.Items[0].Status != deps.InstallStatusInstalled {
+		t.Fatalf("report items = %#v, want installed Rust item", report.Items)
 	}
 }
 

--- a/internal/deps/plan.go
+++ b/internal/deps/plan.go
@@ -119,6 +119,13 @@ func actionFor(dep manifest.Dependency, opts Options, tier Tier, look Lookup) In
 	probes := dep.Probes()
 	action := InstallAction{Dependency: dep.Name, Requirement: dep.RequirementValue(), Status: InstallActionStatusManual, Probe: dep.Probe(), Probes: probes, FontMatch: fontMatch, FontMatches: fontMatches, Toolchain: strings.TrimSpace(dep.Toolchain), Bootstrap: bootstrapCommands(dep)}
 
+	if officialRustupInstallerRunnable(action, opts, look) {
+		action.Status = InstallActionStatusInstallable
+		action.Executable = "sh"
+		action.Args = []string{"-c", officialRustupInstallerScript}
+		return action
+	}
+
 	for _, candidate := range providerCandidates(dep, opts, tier, look) {
 		action.Candidates = append(action.Candidates, candidate)
 		if !candidate.Available || candidate.Executable == "" {
@@ -148,6 +155,16 @@ func guidanceFor(action InstallAction) Guidance {
 		return Guidance{Name: action.Dependency, Requirement: action.Requirement, Manual: action.Manual, TrustCommand: action.TrustCommand, Action: action}
 	}
 	return Guidance{Name: action.Dependency, Requirement: action.Requirement, Command: action.commandHint(), TrustCommand: action.TrustCommand, Action: action}
+}
+
+const officialRustupInstallerScript = "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path"
+
+func officialRustupInstallerRunnable(action InstallAction, opts Options, look Lookup) bool {
+	return opts.OS == "linux" &&
+		action.Toolchain == manifest.DependencyToolchainRustStableRustup &&
+		!look("rustup") &&
+		look("curl") &&
+		look("sh")
 }
 
 func bootstrapRunnable(commands []Command, look Lookup) bool {

--- a/internal/deps/plan.go
+++ b/internal/deps/plan.go
@@ -181,7 +181,25 @@ func bootstrapRunnable(commands []Command, look Lookup) bool {
 
 func (a InstallAction) commandHint() string {
 	parts := append([]string{a.Executable}, a.Args...)
+	for i, part := range parts {
+		parts[i] = shellQuoteIfNeeded(part)
+	}
 	return strings.Join(parts, " ")
+}
+
+func shellQuoteIfNeeded(s string) string {
+	if s == "" {
+		return "''"
+	}
+	if strings.IndexFunc(s, func(r rune) bool {
+		return !((r >= 'a' && r <= 'z') ||
+			(r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') ||
+			strings.ContainsRune("_@%+=:,./-", r))
+	}) == -1 {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
 func bootstrapCommands(dep manifest.Dependency) []Command {


### PR DESCRIPTION
Closes #204

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds a constrained official rustup installer path for the Rust toolchain on Linux.
- Runs the fixed `curl https://sh.rustup.rs | sh -s -- -y --no-modify-path` flow before `rustup default stable` when `rustup` is absent and `curl`/`sh` are available.
- Keeps this as built-in Rust behavior, not arbitrary shell from `dots.yaml`.

## Changes

| File | Change |
|------|--------|
| `internal/deps/plan.go` | Plans the official rustup installer for `rust-stable-rustup` on Linux when `curl` and `sh` are available. |
| `internal/deps/install_test.go` | Adds dry-run and confirmed install regression coverage for the fresh-machine Rust path. |
| `docs/manifest.md` | Documents the constrained official Rust installer flow. |

## Test Plan

- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `SANDBOX=$(mktemp -d); mkdir -p "$SANDBOX/home"; go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home "$SANDBOX/home"`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #204`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
