### PR TITLE
feat(deps): add guarded fnm installer fallback

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -59,15 +59,25 @@ their Managed Entries, while common runtimes and package tools are owned by
 Homebrew-provider declarations for `fnm`, `rustup`, `go`, `uv`, `pnpm`, and
 `bun`. Linux Homebrew fallback is explicit with `linux_homebrew: true`; GUI apps and fonts stay manual unless they have validated Linux support. Node and Rust use constrained built-in toolchain bootstrap commands after
 manager installation: `fnm install --lts` for Node LTS and `rustup default
-stable` for Rust stable. On Linux, when `rustup` is absent but `curl`
-and `sh` are available, the Rust toolchain may use the constrained official
-rustup installer flow (`curl --proto '=https' --tlsv1.2 -sSf
-https://sh.rustup.rs | sh -s -- -y --no-modify-path`) before running
-`rustup default stable`. This is a built-in Rust action, not arbitrary shell
-from the manifest. When Rust bootstrap succeeds but `rustc` or `cargo` still are
-not available on `PATH`, the install result includes repair guidance for the
-rustup proxy/PATH surface instead of only reporting a generic unresolved
-Dependency.
+stable` for Rust stable. Bootstrap declarations do not make an action executable
+by themselves: the manager executable must already be on `PATH` or a concrete
+installer/provider must run first.
+
+On Linux, when `fnm` is absent, no executable package provider is available, and
+`curl`, `bash`, and `unzip` are present, Node may use the constrained official
+fnm installer flow (`curl -fsSL https://fnm.vercel.app/install | bash -s --
+--skip-shell`) before running `fnm install --lts`. The `--skip-shell` flag is
+required because dots owns shell activation through the managed zsh integration,
+not the upstream installer.
+
+On Linux, when `rustup` is absent but `curl` and `sh` are available, the Rust
+toolchain may use the constrained official rustup installer flow (`curl --proto
+'=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path`)
+before running `rustup default stable`. These are built-in runtime actions, not
+arbitrary shell from the manifest. When Rust bootstrap succeeds but `rustc` or
+`cargo` still are not available on `PATH`, the install result includes repair
+guidance for the rustup proxy/PATH surface instead of only reporting a generic
+unresolved Dependency.
 
 ## Managed Entries
 
@@ -160,7 +170,7 @@ Current dependency package coverage:
 | `starship` | `starship` | `starship` | `starship` | `starship` | `starship` |
 | `tmux` | `tmux` | `tmux` | `tmux` | `tmux` | `tmux` |
 | `zellij` | `zellij` | `zellij` | `zellij` | `zellij` | `zellij` |
-| `Node LTS (fnm)` | `fnm`, `node`; bootstrap `fnm install --lts` | `fnm` | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual |
+| `Node LTS (fnm)` | `fnm`, `node`; bootstrap `fnm install --lts` | `fnm` | Linuxbrew opt-in or official fnm installer (`curl`, `bash`, `unzip`) | Linuxbrew opt-in or official fnm installer (`curl`, `bash`, `unzip`) | Linuxbrew opt-in or official fnm installer (`curl`, `bash`, `unzip`) |
 | `Rust stable (rustup)` | `rustup`, `rustc`, `cargo`; bootstrap `rustup default stable` | `rustup` | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual |
 | `go` | `go` | `go` | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual |
 | `uv` | `uv` | `uv` | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual |

--- a/internal/cli/deps_install_test.go
+++ b/internal/cli/deps_install_test.go
@@ -605,8 +605,8 @@ func TestDepsInstallYesDoesNotRunFNMBootstrapWhenFNMIsMissing(t *testing.T) {
 	cmd.SetErr(&out)
 	cmd.SetArgs([]string{"deps", "install", "--yes", "--file", manifestPath, "--tier", "generic"})
 
-	if err := cmd.Execute(); err == nil {
-		t.Fatalf("Execute() error = nil, want unresolved required dependency\noutput:\n%s", out.String())
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v, want missing fnm to remain a non-executed manual action\noutput:\n%s", err, out.String())
 	}
 	got := out.String()
 	if !strings.Contains(got, "manual") || strings.Contains(got, `exec: "fnm"`) {

--- a/internal/cli/deps_install_test.go
+++ b/internal/cli/deps_install_test.go
@@ -562,6 +562,77 @@ entries:
 	}
 }
 
+func TestDepsInstallDryRunClassifiesMissingFNMToolchainLikePlan(t *testing.T) {
+	binDir := t.TempDir()
+	t.Setenv("PATH", binDir)
+	manifestPath := writeDepsInstallManifest(t, fnmBootstrapDepsManifest)
+
+	planCmd := cli.NewRootCommand()
+	var planOut bytes.Buffer
+	planCmd.SetOut(&planOut)
+	planCmd.SetErr(&planOut)
+	planCmd.SetArgs([]string{"deps", "plan", "--file", manifestPath, "--tier", "generic"})
+	if err := planCmd.Execute(); err == nil {
+		t.Fatalf("deps plan error = nil, want findings exit")
+	}
+
+	installCmd := cli.NewRootCommand()
+	var installOut bytes.Buffer
+	installCmd.SetOut(&installOut)
+	installCmd.SetErr(&installOut)
+	installCmd.SetArgs([]string{"deps", "install", "--dry-run", "--file", manifestPath, "--tier", "generic"})
+	if err := installCmd.Execute(); err != nil {
+		t.Fatalf("deps install --dry-run error = %v\noutput:\n%s", err, installOut.String())
+	}
+
+	if strings.Contains(planOut.String(), "would-install") || strings.Contains(planOut.String(), "fnm install --lts") {
+		t.Fatalf("deps plan should not classify missing fnm bootstrap as executable:\n%s", planOut.String())
+	}
+	got := installOut.String()
+	if !strings.Contains(got, "manual") || strings.Contains(got, "would-install Node LTS (fnm)") {
+		t.Fatalf("deps install --dry-run should match deps plan manual classification:\n%s", got)
+	}
+}
+
+func TestDepsInstallYesDoesNotRunFNMBootstrapWhenFNMIsMissing(t *testing.T) {
+	binDir := t.TempDir()
+	t.Setenv("PATH", binDir)
+	manifestPath := writeDepsInstallManifest(t, fnmBootstrapDepsManifest)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"deps", "install", "--yes", "--file", manifestPath, "--tier", "generic"})
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("Execute() error = nil, want unresolved required dependency\noutput:\n%s", out.String())
+	}
+	got := out.String()
+	if !strings.Contains(got, "manual") || strings.Contains(got, `exec: "fnm"`) {
+		t.Fatalf("deps install --yes should not execute missing fnm bootstrap:\n%s", got)
+	}
+}
+
+const fnmBootstrapDepsManifest = `version: 1
+profiles:
+  default:
+    tags: [core]
+dependencies:
+  - tags: [core]
+    dependencies:
+      - name: Node LTS (fnm)
+        commands: [fnm, node]
+        brew: fnm
+        linux_homebrew: true
+        toolchain: node-lts-fnm
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+`
+
 func writeDepsInstallManifest(t *testing.T, content string) string {
 	t.Helper()
 	path := t.TempDir() + "/dots.yaml"

--- a/internal/cli/install_deps_test.go
+++ b/internal/cli/install_deps_test.go
@@ -300,6 +300,48 @@ func TestInstallDryRunJSONIncludesDependencyPreviewAndInstallPlan(t *testing.T) 
 	}
 }
 
+func TestInstallDryRunClassifiesMissingFNMToolchainAsManual(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	binDir := t.TempDir()
+	t.Setenv("PATH", binDir)
+	writeCLISource(t, sourceRoot, "configs/zsh/zshrc", "managed\n")
+	manifestPath := writeCLIManifest(t, home, fnmBootstrapCLIManifest)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"install", "--dry-run", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+	got := out.String()
+	if !strings.Contains(got, "manual") || strings.Contains(got, "would-install Node LTS (fnm)") {
+		t.Fatalf("install --dry-run should classify missing fnm bootstrap as manual:\n%s", got)
+	}
+}
+
+const fnmBootstrapCLIManifest = `version: 1
+profiles:
+  default:
+    tags: [core]
+dependencies:
+  - tags: [core]
+    dependencies:
+      - name: Node LTS (fnm)
+        commands: [fnm, node]
+        brew: fnm
+        linux_homebrew: true
+        toolchain: node-lts-fnm
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+`
+
 func TestInstallJSONDependencyFailureIncludesResultAndInstallPlan(t *testing.T) {
 	home := t.TempDir()
 	sourceRoot := t.TempDir()

--- a/internal/cli/render_deps.go
+++ b/internal/cli/render_deps.go
@@ -84,9 +84,9 @@ func renderDepsInstallPreviewWithTitle(w io.Writer, title string, report deps.In
 
 	for _, item := range report.Items {
 		hint := item.Manual
-		if item.Executable != "" {
+		if item.Status == deps.InstallPreviewWouldInstall && item.Executable != "" {
 			hint = commandHint(item.Executable, item.Args)
-		} else if len(item.Bootstrap) > 0 {
+		} else if item.Status == deps.InstallPreviewWouldInstall && len(item.Bootstrap) > 0 {
 			hint = "see bootstrap command(s)"
 		}
 		fmt.Fprintf(w, "  %-13s %-24s %s (%s)\n", item.Status, item.Dependency, hint, dependencyRequirementLabel(item.Requirement))
@@ -109,7 +109,7 @@ func hasInstallablePreviewAction(report deps.InstallDryRunReport) bool {
 
 func hasRequiredInstallablePreviewAction(report deps.InstallDryRunReport) bool {
 	for _, item := range report.Items {
-		if (item.Executable != "" || len(item.Bootstrap) > 0) && dependencyRequirementLabel(item.Requirement) == "required" {
+		if item.Status == deps.InstallPreviewWouldInstall && dependencyRequirementLabel(item.Requirement) == "required" {
 			return true
 		}
 	}
@@ -121,7 +121,7 @@ func unresolvedInstallReportFromPreview(preview deps.InstallDryRunReport) (deps.
 	requiredUnresolved := false
 	for _, item := range preview.Items {
 		status := deps.InstallStatusUnresolved
-		if item.Executable == "" && len(item.Bootstrap) == 0 {
+		if item.Status == deps.InstallPreviewManual {
 			status = deps.InstallStatusManual
 		}
 		requirement := dependencyRequirementLabel(item.Requirement)
@@ -150,11 +150,12 @@ func unresolvedInstallReportFromPreview(preview deps.InstallDryRunReport) (deps.
 
 func countInstallPreviewActions(report deps.InstallDryRunReport) (installable int, manual int) {
 	for _, item := range report.Items {
-		if item.Executable == "" && len(item.Bootstrap) == 0 {
+		switch item.Status {
+		case deps.InstallPreviewWouldInstall:
+			installable++
+		case deps.InstallPreviewManual:
 			manual++
-			continue
 		}
-		installable++
 	}
 	return installable, manual
 }

--- a/internal/deps/install.go
+++ b/internal/deps/install.go
@@ -154,6 +154,28 @@ func Install(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup
 				return report, fmt.Errorf("install %q: %w", action.Dependency, err)
 			}
 		}
+		if len(action.Bootstrap) > 0 && !bootstrapRunnable(action.Bootstrap, look) {
+			if action.Requirement == manifest.DependencyRequirementRequired {
+				requiredUnresolved = true
+			}
+			report.Items = append(report.Items, InstallItem{
+				Dependency:   action.Dependency,
+				Requirement:  action.Requirement,
+				Status:       InstallStatusUnresolved,
+				Provider:     action.Provider,
+				Package:      action.Package,
+				Executable:   action.Executable,
+				Args:         args,
+				Bootstrap:    append([]Command(nil), action.Bootstrap...),
+				Manual:       unresolvedToolchainRemediation(action, look),
+				TrustCommand: action.TrustCommand,
+				Candidates:   action.Candidates,
+			})
+			if action.Requirement == manifest.DependencyRequirementRequired {
+				return report, errors.New("unresolved required dependencies remain after install")
+			}
+			continue
+		}
 		if err := runBootstrap(action, runner); err != nil {
 			report.Items = append(report.Items, InstallItem{
 				Dependency:   action.Dependency,
@@ -242,7 +264,7 @@ func missingCommandProbes(probes []string, look Lookup) []string {
 }
 
 func actionExecutable(action InstallAction) bool {
-	return action.Executable != "" || len(action.Bootstrap) > 0
+	return action.Status == InstallActionStatusInstallable
 }
 
 func runBootstrap(action InstallAction, runner Runner) error {

--- a/internal/deps/install_test.go
+++ b/internal/deps/install_test.go
@@ -502,6 +502,118 @@ func TestInstallDryRunIncludesSelectedProvisionerDependencies(t *testing.T) {
 	}
 }
 
+func TestInstallDryRunReportsMissingBootstrapManagerAsManual(t *testing.T) {
+	report, err := deps.InstallDryRun(nodeToolchainManifest(), deps.Options{Profile: "default", OS: "linux"}, noProviderLookup(), fontLookupSet(), deps.TierGeneric)
+	if err != nil {
+		t.Fatalf("InstallDryRun() error = %v", err)
+	}
+	if len(report.Items) != 1 {
+		t.Fatalf("Items len = %d, want 1 (%#v)", len(report.Items), report.Items)
+	}
+	item := report.Items[0]
+	if item.Status != deps.InstallPreviewManual || item.Executable != "" || len(item.Bootstrap) != 1 || item.Manual == "" {
+		t.Fatalf("Node dry-run item = %#v, want manual item that records non-runnable bootstrap", item)
+	}
+}
+
+func TestInstallYesDoesNotRunBootstrapWhenManagerIsMissing(t *testing.T) {
+	runner := &recordingRunner{}
+
+	report, err := deps.Install(nodeToolchainManifest(), deps.Options{Profile: "default", OS: "linux"}, noProviderLookup(), fontLookupSet(), deps.TierGeneric, runner)
+	if err == nil {
+		t.Fatalf("Install() error = nil, want unresolved required dependency")
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runner calls = %#v, want no fnm bootstrap when fnm is missing", runner.calls)
+	}
+	if len(report.Items) != 1 || report.Items[0].Status != deps.InstallStatusManual {
+		t.Fatalf("report items = %#v, want one manual Node item", report.Items)
+	}
+}
+
+func TestInstallDryRunReportsOfficialFNMInstallerOnLinuxWithoutProvider(t *testing.T) {
+	report, err := deps.InstallDryRun(nodeToolchainManifest(), deps.Options{Profile: "default", OS: "linux"}, noProviderLookup("curl", "bash", "unzip"), fontLookupSet(), deps.TierGeneric)
+	if err != nil {
+		t.Fatalf("InstallDryRun() error = %v", err)
+	}
+	if len(report.Items) != 1 {
+		t.Fatalf("Items len = %d, want 1 (%#v)", len(report.Items), report.Items)
+	}
+	item := report.Items[0]
+	if item.Status != deps.InstallPreviewWouldInstall || item.Executable != "bash" || len(item.Args) != 2 || !strings.Contains(item.Args[1], "https://fnm.vercel.app/install") || !strings.Contains(item.Args[1], "--skip-shell") || len(item.Bootstrap) != 1 {
+		t.Fatalf("Node dry-run item = %#v, want official fnm installer plus bootstrap", item)
+	}
+}
+
+func TestInstallYesRunsOfficialFNMInstallerBeforeBootstrap(t *testing.T) {
+	present := map[string]bool{"curl": true, "bash": true, "unzip": true}
+	runner := &recordingRunner{}
+	runner.afterRun = func() {
+		last := runner.calls[len(runner.calls)-1]
+		switch {
+		case last.executable == "bash" && len(last.args) == 2 && strings.Contains(last.args[1], "https://fnm.vercel.app/install"):
+			present["fnm"] = true
+		case last.executable == "fnm" && reflect.DeepEqual(last.args, []string{"install", "--lts"}):
+			present["node"] = true
+		}
+	}
+
+	report, err := deps.Install(nodeToolchainManifest(), deps.Options{Profile: "default", OS: "linux"}, func(command string) bool {
+		return present[command]
+	}, fontLookupSet(), deps.TierGeneric, runner)
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if len(runner.calls) != 2 {
+		t.Fatalf("runner calls len = %d, want official installer then bootstrap (%#v)", len(runner.calls), runner.calls)
+	}
+	if runner.calls[0].executable != "bash" || !reflect.DeepEqual(runner.calls[0].args[:1], []string{"-c"}) || !strings.Contains(runner.calls[0].args[1], "curl -fsSL https://fnm.vercel.app/install | bash -s -- --skip-shell") {
+		t.Fatalf("official fnm installer call = %#v", runner.calls[0])
+	}
+	if runner.calls[1].executable != "fnm" || !reflect.DeepEqual(runner.calls[1].args, []string{"install", "--lts"}) {
+		t.Fatalf("bootstrap call = %#v", runner.calls[1])
+	}
+	if len(report.Items) != 1 || report.Items[0].Status != deps.InstallStatusInstalled {
+		t.Fatalf("report items = %#v, want installed Node item", report.Items)
+	}
+}
+
+func TestInstallYesDoesNotRunFNMBootstrapWhenOfficialInstallerDoesNotExposeFNM(t *testing.T) {
+	present := map[string]bool{"curl": true, "bash": true, "unzip": true}
+	runner := &recordingRunner{}
+
+	report, err := deps.Install(nodeToolchainManifest(), deps.Options{Profile: "default", OS: "linux"}, func(command string) bool {
+		return present[command]
+	}, fontLookupSet(), deps.TierGeneric, runner)
+	if err == nil {
+		t.Fatalf("Install() error = nil, want unresolved required dependency")
+	}
+	if len(runner.calls) != 1 || runner.calls[0].executable != "bash" {
+		t.Fatalf("runner calls = %#v, want only official fnm installer", runner.calls)
+	}
+	if len(report.Items) != 1 || report.Items[0].Status != deps.InstallStatusUnresolved {
+		t.Fatalf("report items = %#v, want unresolved Node item", report.Items)
+	}
+}
+
+func nodeToolchainManifest() manifest.Manifest {
+	return manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}},
+		Dependencies: []manifest.DependencySet{{
+			Tags: []string{"core"},
+			Dependencies: []manifest.Dependency{{
+				Name:          "Node LTS (fnm)",
+				Commands:      []string{"fnm", "node"},
+				Brew:          "fnm",
+				LinuxHomebrew: true,
+				Toolchain:     manifest.DependencyToolchainNodeLTSFNM,
+			}},
+		}},
+		Entries: []manifest.Entry{{Source: "configs/x", Target: "~/.x", Strategy: "symlink", Tags: []string{"core"}}},
+	}
+}
+
 func TestInstallYesRunsConstrainedToolchainBootstrapBeforeReprobe(t *testing.T) {
 	present := map[string]bool{"brew": true}
 	runner := &recordingRunner{}

--- a/internal/deps/install_test.go
+++ b/internal/deps/install_test.go
@@ -545,6 +545,35 @@ func TestInstallDryRunReportsOfficialFNMInstallerOnLinuxWithoutProvider(t *testi
 	}
 }
 
+func TestInstallDryRunKeepsFNMManualWhenInstallerPrerequisiteIsMissing(t *testing.T) {
+	report, err := deps.InstallDryRun(nodeToolchainManifest(), deps.Options{Profile: "default", OS: "linux"}, noProviderLookup("curl", "bash"), fontLookupSet(), deps.TierGeneric)
+	if err != nil {
+		t.Fatalf("InstallDryRun() error = %v", err)
+	}
+	if len(report.Items) != 1 {
+		t.Fatalf("Items len = %d, want 1 (%#v)", len(report.Items), report.Items)
+	}
+	item := report.Items[0]
+	if item.Status != deps.InstallPreviewManual || item.Executable != "" || len(item.Args) != 0 || item.Manual == "" {
+		t.Fatalf("Node dry-run item = %#v, want manual when unzip prerequisite is missing", item)
+	}
+}
+
+func TestInstallYesDoesNotRunFNMInstallerOrBootstrapWhenPrerequisiteIsMissing(t *testing.T) {
+	runner := &recordingRunner{}
+
+	report, err := deps.Install(nodeToolchainManifest(), deps.Options{Profile: "default", OS: "linux"}, noProviderLookup("curl", "bash"), fontLookupSet(), deps.TierGeneric, runner)
+	if err == nil {
+		t.Fatalf("Install() error = nil, want unresolved required dependency")
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runner calls = %#v, want no installer or bootstrap when unzip prerequisite is missing", runner.calls)
+	}
+	if len(report.Items) != 1 || report.Items[0].Status != deps.InstallStatusManual {
+		t.Fatalf("report items = %#v, want one manual Node item", report.Items)
+	}
+}
+
 func TestInstallYesRunsOfficialFNMInstallerBeforeBootstrap(t *testing.T) {
 	present := map[string]bool{"curl": true, "bash": true, "unzip": true}
 	runner := &recordingRunner{}

--- a/internal/deps/plan.go
+++ b/internal/deps/plan.go
@@ -126,7 +126,16 @@ func actionFor(dep manifest.Dependency, opts Options, tier Tier, look Lookup) In
 		return action
 	}
 
-	for _, candidate := range providerCandidates(dep, opts, tier, look) {
+	candidates := providerCandidates(dep, opts, tier, look)
+	if officialFNMInstallerRunnable(action, opts, look, candidates) {
+		action.Status = InstallActionStatusInstallable
+		action.Executable = "bash"
+		action.Args = []string{"-c", officialFNMInstallerScript}
+		action.Candidates = append(action.Candidates, candidates...)
+		return action
+	}
+
+	for _, candidate := range candidates {
 		action.Candidates = append(action.Candidates, candidate)
 		if !candidate.Available || candidate.Executable == "" {
 			continue
@@ -158,6 +167,7 @@ func guidanceFor(action InstallAction) Guidance {
 }
 
 const officialRustupInstallerScript = "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path"
+const officialFNMInstallerScript = "curl -fsSL https://fnm.vercel.app/install | bash -s -- --skip-shell"
 
 func officialRustupInstallerRunnable(action InstallAction, opts Options, look Lookup) bool {
 	return opts.OS == "linux" &&
@@ -165,6 +175,23 @@ func officialRustupInstallerRunnable(action InstallAction, opts Options, look Lo
 		!look("rustup") &&
 		look("curl") &&
 		look("sh")
+}
+
+func officialFNMInstallerRunnable(action InstallAction, opts Options, look Lookup, candidates []ProviderCandidate) bool {
+	if opts.OS != "linux" ||
+		action.Toolchain != manifest.DependencyToolchainNodeLTSFNM ||
+		look("fnm") ||
+		!look("curl") ||
+		!look("bash") ||
+		!look("unzip") {
+		return false
+	}
+	for _, candidate := range candidates {
+		if candidate.Available && candidate.Executable != "" {
+			return false
+		}
+	}
+	return true
 }
 
 func bootstrapRunnable(commands []Command, look Lookup) bool {


### PR DESCRIPTION
Closes #206
Closes #218

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Keeps bootstrap declarations from making dependency actions executable when the bootstrap executable is absent.
- Adds the official Linux `fnm` installer fallback with `--skip-shell` when no executable provider is available.
- Re-checks bootstrap executables after installer/provider execution before running toolchain bootstrap commands.

## Changes

| File | Change |
|------|--------|
| `internal/deps/plan.go` | Adds official Linux `fnm` installer planning guarded by `curl`, `bash`, `unzip`, no `fnm`, and no available provider. |
| `internal/deps/install.go` | Makes action status the installability source of truth and skips bootstrap execution when the manager still does not resolve. |
| `internal/deps/install_test.go` | Covers missing `fnm` guardrail, official `fnm` fallback, post-installer bootstrap gating, and existing Rust behavior. |
| `internal/cli/deps_install_test.go` | Covers `deps plan`, `deps install --dry-run`, and `deps install --yes` consistency for missing `fnm`. |
| `internal/cli/install_deps_test.go` | Covers `install --dry-run` classification for missing `fnm`. |
| `docs/manifest.md` | Documents the guarded bootstrap rule and the official `fnm` installer with shell mutation disabled. |

## Test Plan

- [x] `go test ./internal/deps ./internal/cli ./internal/manifest`
- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [ ] Sandboxed plan only when dotfiles behavior changes: not run; this change was validated through dependency/install dry-run tests with temporary homes and fake executables.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
