### PR TITLE
docs(agent): document development loop

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,18 @@
+# Notes
+
+## Project loops
+
+- Canonical trigger: a `dots` development loop starts when the user has an intention of change for the `dots` project, before an issue necessarily exists.
+- The loop may span multiple sessions and can produce ADRs, GitHub issues, PRs, reviews, merges, and dots releases.
+
+## Workflow conventions
+
+- `grill-with-docs` is skipped only for mechanical or already-aligned work: small fixes, documentation adjustments with no new decision, explicit review follow-ups, or issues already marked `ready-for-agent`.
+- Changes touching domain language, CLI UX, security, installation behavior, release workflow, or architecture go through `grill-with-docs`.
+
+- After `grill-with-docs`, use a human-in-the-loop Alignment Brief before triage. The user would like more automation eventually, but wants to prove the loop first.
+- After triage, use a human-in-the-loop Triage Brief before implementation. It includes issue links, state/labels, research, exact scope, risks, and acceptance criteria.
+- Implementation default is changes → local review → PR. PR-before-review is reserved for cases where early GitHub/CI feedback or external visibility materially helps.
+- Mandatory implementation review uses the available `$review` skill only. It reviews Standards and Spec axes. Run it locally before PR readiness, repeat after fixes, and rerun after meaningful PR/CI follow-up commits.
+- A merged PR triggers a dots release when it affects CLI behavior, install/deps behavior, visible output, distributed configuration, operational user documentation, or a user-usable bugfix. Pure internal tooling/tests/agent-only docs do not trigger release.
+- The loop closes with a Release/Closure Brief containing merged PRs, merge commit, tag/release links when applicable, closed issues, validation, user-facing change summary, and follow-ups.

--- a/workflows/dots-development-loop.md
+++ b/workflows/dots-development-loop.md
@@ -1,0 +1,38 @@
+# dots development loop
+
+## Purpose
+
+Turn a `dots` change intention into aligned design artifacts, triaged work, implemented changes, reviewed PRs, merged code, and a dots release when appropriate.
+
+## Trigger
+
+The workflow starts when the user has an intention of change for the `dots` project, before an issue necessarily exists.
+
+## Current shape
+
+1. Align with `grill-with-docs` when the change needs shared understanding, domain sharpening, ADRs, or issue creation.
+   - Skip `grill-with-docs` only for mechanical or already-aligned work: small fixes, documentation adjustments that introduce no new decision, explicit review follow-ups, or existing issues already marked `ready-for-agent`.
+   - Use `grill-with-docs` for any change touching domain language, CLI UX, security, installation behavior, release workflow, or architecture.
+2. Present an Alignment Brief after `grill-with-docs` and wait for the user to approve moving into triage.
+   - The brief includes links to ADRs and issues created or changed, decisions made, doubts closed, and the single decision: approve moving to triage.
+   - This checkpoint is intentionally human-in-the-loop for now, even though the desired long-term direction is more automation after the loop proves itself.
+3. Triage the resulting issue or issues, including research and further alignment when necessary.
+4. Present a Triage Brief and wait for the user to approve moving into implementation.
+   - The brief includes issue links, current state and labels, relevant research, exact implementation scope, risks, acceptance criteria, and the single decision: approve moving to implementation.
+5. Implement the issue or issues using the repository skills and workflow documentation.
+   - Default path: changes → local review → PR.
+   - Use PR-before-review only when early GitHub/CI feedback is materially useful or the work needs external visibility before local review is complete.
+6. Review the implementation with `$review` and loop back into implementation for every confirmed finding.
+   - `$review` is the mandatory review skill for this loop.
+   - Run it locally against the fixed point before opening or marking the PR ready, using the two available axes: Standards and Spec.
+   - If review finds issues, fix them and run `$review` again until the confirmed findings are closed.
+   - After the PR exists, run `$review` again when PR feedback, CI fixes, or meaningful follow-up commits change the diff.
+7. Merge the PR and release `dots` when the change should ship.
+   - Release after merging changes that affect CLI behavior, install/deps behavior, visible output, distributed configuration, operational user documentation, or a user-usable bugfix.
+   - Do not release for purely internal tooling, tests, or agent-only documentation that does not change the user experience.
+8. Present a Release/Closure Brief to close the workflow.
+   - The brief includes merged PR links, merge commit, tag and release links when applicable, closed issues, final validation evidence, what changed for the user, and any remaining follow-ups.
+
+## Open questions
+
+None.


### PR DESCRIPTION
Closes #220

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [x] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Documents the recurring dots development loop from change intention to closure.
- Captures the human-in-the-loop Alignment, Triage, and Release/Closure briefs.
- Records the workflow conventions in `NOTES.md` for future workflow refinement.

## Changes

| File | Change |
|------|--------|
| `workflows/dots-development-loop.md` | Adds the source-of-truth workflow spec for alignment, triage, implementation, review, PR, merge, release, and closure. |
| `NOTES.md` | Adds canonical notes and conventions learned while defining the loop. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [ ] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: not applicable; documentation-only change.

Validation evidence:

```text
gofmt -l .        # ok, no files printed
go vet ./...      # pass
go build ./...    # pass
go test ./...     # pass
```

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #220`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
