### PR TITLE
fix(deps): stop advertising unavailable Ubuntu packages

### DIFF
--- a/dots.yaml
+++ b/dots.yaml
@@ -143,7 +143,7 @@ entries:
     dependencies:
       - name: starship
         brew: starship
-        apt: starship
+        linux_homebrew: true
         dnf: starship
         pacman: starship
   - source: configs/tmux/tmux.conf
@@ -171,7 +171,7 @@ entries:
     dependencies:
       - name: zellij
         brew: zellij
-        apt: zellij
+        linux_homebrew: true
         dnf: zellij
         pacman: zellij
   - source: configs/zellij/layouts/default.kdl
@@ -185,7 +185,7 @@ entries:
     dependencies:
       - name: zellij
         brew: zellij
-        apt: zellij
+        linux_homebrew: true
         dnf: zellij
         pacman: zellij
   - source: configs/ghostty/config.ghostty

--- a/internal/deps/plan_test.go
+++ b/internal/deps/plan_test.go
@@ -454,6 +454,59 @@ func TestPlanReportsManualWhenNoProviderCandidateIsExecutable(t *testing.T) {
 	}
 }
 
+func TestRepositoryManifestDoesNotAdvertiseUnavailableUbuntuAptPackages(t *testing.T) {
+	m, err := manifest.LoadFile("../../dots.yaml")
+	if err != nil {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+
+	t.Run("uses Homebrew fallback when available", func(t *testing.T) {
+		report, err := deps.Plan(*m, deps.Options{Profile: "workstation", OS: "linux"}, noProviderLookup("sudo", "apt-get", "brew"), fontLookupSet(), deps.TierDebian)
+		if err != nil {
+			t.Fatalf("Plan() error = %v", err)
+		}
+
+		for _, name := range []string{"starship", "zellij"} {
+			action, ok := findAction(report.Actions, name)
+			if !ok {
+				t.Fatalf("missing action for %q in %#v", name, report.Actions)
+			}
+			if action.Provider == deps.TierDebian || action.Executable == "sudo" {
+				t.Fatalf("%s action = %#v, must not advertise unavailable Ubuntu apt package", name, action)
+			}
+			if action.Status != deps.InstallActionStatusInstallable || action.Provider != deps.TierHomebrew || action.Executable != "brew" {
+				t.Fatalf("%s action = %#v, want installable Homebrew fallback", name, action)
+			}
+		}
+	})
+
+	t.Run("stays manual when Homebrew is unavailable", func(t *testing.T) {
+		report, err := deps.Plan(*m, deps.Options{Profile: "workstation", OS: "linux"}, noProviderLookup("sudo", "apt-get"), fontLookupSet(), deps.TierDebian)
+		if err != nil {
+			t.Fatalf("Plan() error = %v", err)
+		}
+
+		for _, name := range []string{"starship", "zellij"} {
+			action, ok := findAction(report.Actions, name)
+			if !ok {
+				t.Fatalf("missing action for %q in %#v", name, report.Actions)
+			}
+			if action.Status != deps.InstallActionStatusManual || action.Provider == deps.TierDebian || action.Executable == "sudo" || action.Manual == "" {
+				t.Fatalf("%s action = %#v, want manual guidance without Ubuntu apt installability", name, action)
+			}
+		}
+	})
+}
+
+func findAction(actions []deps.InstallAction, name string) (deps.InstallAction, bool) {
+	for _, action := range actions {
+		if action.Dependency == name {
+			return action, true
+		}
+	}
+	return deps.InstallAction{}, false
+}
+
 func TestPlanActionsUseManifestOrderAndSkipPresentDependencies(t *testing.T) {
 	m := manifest.Manifest{
 		Version:  1,

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -702,13 +702,16 @@ func TestRepositoryManifestLinuxHomebrewReviewBoundary(t *testing.T) {
 		}
 	}
 
-	for _, name := range []string{"gentle-ai", "engram"} {
+	for _, name := range []string{"starship", "zellij", "gentle-ai", "engram"} {
 		if len(dependencies[name]) == 0 {
 			t.Fatalf("repository manifest missing %s dependency", name)
 		}
 		for _, dep := range dependencies[name] {
 			if !dep.LinuxHomebrew {
 				t.Fatalf("%s dependency = %#v, want reviewed Linuxbrew opt-in", name, dep)
+			}
+			if (name == "starship" || name == "zellij") && dep.Apt != "" {
+				t.Fatalf("%s dependency = %#v, want no Ubuntu apt package declaration", name, dep)
 			}
 		}
 	}


### PR DESCRIPTION
Closes #207

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Stops advertising unavailable Ubuntu apt packages for `starship` and `zellij`.
- Routes those tools through reviewed Linux Homebrew fallback when `brew` is available.
- Adds repository-manifest regression coverage for Debian/Ubuntu dependency planning.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Removes `apt` declarations for `starship` and `zellij`; opts both into `linux_homebrew`. |
| `internal/deps/plan_test.go` | Adds a regression test proving Ubuntu/Debian planning avoids apt false positives and falls back to Homebrew/manual. |
| `internal/manifest/manifest_test.go` | Expands the Linux Homebrew review boundary to include `starship` and `zellij`, and asserts they do not declare apt packages. |

## Test Plan

- [x] `go test ./internal/deps -run TestRepositoryManifestDoesNotAdvertiseUnavailableUbuntuAptPackages -count=1`
- [x] `go test ./internal/deps ./internal/cli -count=1`
- [x] `go test ./internal/deps ./internal/manifest ./internal/cli -count=1`
- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp> --state-root <tmp> --output json`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #207`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
