### PR TITLE
fix(deps): recognize current Cascadia font files

### DIFF
--- a/configs/ghostty/README.md
+++ b/configs/ghostty/README.md
@@ -15,7 +15,8 @@ outside version control.
   infrastructure. Ghostty consumes this shared requirement for the managed
   `font-family` baseline (`Cascadia Code NF`). The primary macOS package is the
   Homebrew cask `font-cascadia-code-nf`, detected through `CascadiaCodeNF*` font
-  files.
+  files. Compatible current Nerd Fonts files such as
+  `CaskaydiaCoveNerdFont*` also satisfy the dependency.
 
 `dots install` does not install packages. `dots deps plan` and the explicit
 `dots deps install` workflow can report/use Homebrew guidance where available;

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -44,11 +44,11 @@ Current Profiles:
 | Profile | Tags | Intent | Profile Dependencies |
 |---------|------|--------|----------------------|
 | `default` | `core` | Core dotfiles without provisioners. | Core Development Baseline via the `core` tag-scoped Dependency Set |
-| `desktop` | `core`, `desktop` | Desktop dotfiles and desktop-only tool integrations; no gentle-ai agent setup. | `Desktop Nerd Font` via Homebrew cask `font-cascadia-code-nf`, detected with `CascadiaCodeNF*` |
+| `desktop` | `core`, `desktop` | Desktop dotfiles and desktop-only tool integrations; no gentle-ai agent setup. | `Desktop Nerd Font` via Homebrew cask `font-cascadia-code-nf`, detected with `CascadiaCodeNF*` or `CaskaydiaCoveNerdFont*` |
 | `agents` | `core`, `agents` | Core dotfiles plus gentle-ai memory/context setup, cleanup, and shared engineering skills for supported agents. Add `--tag persona` for optional persona styling Regenerated Content or `--tag sdd` for Gentle-AI SDD setup. | Core Development Baseline via the `core` tag-scoped Dependency Set |
 | `web` | `core`, `web` | Optional frontend/browser workbench: web design skills plus Chrome DevTools integrations. | Core Development Baseline via the `core` tag-scoped Dependency Set; `Playwright CLI` via Homebrew formula `playwright-cli` |
 | `mobile` | `core`, `mobile` | Optional Dart and Flutter mobile development agent skills plus Dart/Flutter MCP integration for Claude, Codex, Antigravity, and GitHub Copilot in VS Code. | Core Development Baseline via the `core` tag-scoped Dependency Set |
-| `workstation` | `core`, `desktop`, `agents` | Full workstation setup when both desktop integrations and agent setup are desired; web tooling remains explicit opt-in. | Core Development Baseline via the `core` tag-scoped Dependency Set; `Desktop Nerd Font` via Homebrew cask `font-cascadia-code-nf`, detected with `CascadiaCodeNF*` |
+| `workstation` | `core`, `desktop`, `agents` | Full workstation setup when both desktop integrations and agent setup are desired; web tooling remains explicit opt-in. | Core Development Baseline via the `core` tag-scoped Dependency Set; `Desktop Nerd Font` via Homebrew cask `font-cascadia-code-nf`, detected with `CascadiaCodeNF*` or `CaskaydiaCoveNerdFont*` |
 
 ## Tag-scoped Dependency Sets
 
@@ -164,7 +164,7 @@ Current dependency package coverage:
 
 | Dependency | Detection | macOS/Homebrew | Debian/Ubuntu | Fedora | Arch |
 |------------|-----------|----------------|---------------|--------|------|
-| `Desktop Nerd Font` | Font glob `CascadiaCodeNF*` | `brew install --cask font-cascadia-code-nf` | Manual | Manual | Manual |
+| `Desktop Nerd Font` | Font globs `CascadiaCodeNF*` or `CaskaydiaCoveNerdFont*` | `brew install --cask font-cascadia-code-nf` | Manual | Manual | Manual |
 | `zsh` | `zsh` | `zsh` | `zsh` | `zsh` | `zsh` |
 | `git` | `git` | `git` | `git` | `git` | `git` |
 | `starship` | `starship` | `starship` | `starship` | `starship` | `starship` |

--- a/dots.yaml
+++ b/dots.yaml
@@ -11,6 +11,8 @@ profiles:
       - name: Desktop Nerd Font
         brew_cask: font-cascadia-code-nf
         font_match: "CascadiaCodeNF*"
+        font_fallback_matches:
+          - "CaskaydiaCoveNerdFont*"
   agents:
     tags:
       - core
@@ -37,6 +39,8 @@ profiles:
       - name: Desktop Nerd Font
         brew_cask: font-cascadia-code-nf
         font_match: "CascadiaCodeNF*"
+        font_fallback_matches:
+          - "CaskaydiaCoveNerdFont*"
 dependencies:
   - tags:
       - core

--- a/internal/cli/ghostty_config_test.go
+++ b/internal/cli/ghostty_config_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -94,13 +95,15 @@ func TestGhosttyDesktopProfileInstallsAndReportsAlignedInSandbox(t *testing.T) {
 	}
 	foundDesktopFontDependency := false
 	for _, dep := range desktopProfile.Dependencies {
-		if dep.BrewCask == "font-cascadia-code-nf" && dep.FontMatch == "CascadiaCodeNF*" {
+		if dep.BrewCask == "font-cascadia-code-nf" &&
+			dep.FontMatch == "CascadiaCodeNF*" &&
+			slices.Equal(dep.FontFallbackMatches, []string{"CaskaydiaCoveNerdFont*"}) {
 			foundDesktopFontDependency = true
 			break
 		}
 	}
 	if !foundDesktopFontDependency {
-		t.Fatalf("desktop profile dependencies = %#v, want font-cascadia-code-nf with CascadiaCodeNF*", desktopProfile.Dependencies)
+		t.Fatalf("desktop profile dependencies = %#v, want font-cascadia-code-nf with CascadiaCodeNF* and Caskaydia fallback", desktopProfile.Dependencies)
 	}
 
 	localExample := filepath.Join(repoRoot, "configs", "ghostty", "config.local.ghostty.example")

--- a/internal/deps/deps_test.go
+++ b/internal/deps/deps_test.go
@@ -101,6 +101,33 @@ func TestCheckDetectsFontDependencyByFallbackMatch(t *testing.T) {
 	}
 }
 
+func TestRepositoryManifestDesktopFontAcceptsCurrentCaskaydiaName(t *testing.T) {
+	m, err := manifest.LoadFile("../../dots.yaml")
+	if err != nil {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+
+	for _, profile := range []string{"desktop", "workstation"} {
+		t.Run(profile, func(t *testing.T) {
+			report, err := deps.Check(*m, deps.Options{Profile: profile, OS: "linux"},
+				lookupSet(), fontLookupSet("CaskaydiaCoveNerdFont*"))
+			if err != nil {
+				t.Fatalf("Check() error = %v", err)
+			}
+
+			for _, result := range report.Results {
+				if result.Name == "Desktop Nerd Font" {
+					if !result.Present {
+						t.Fatalf("Desktop Nerd Font result = %#v, want present via Caskaydia fallback", result)
+					}
+					return
+				}
+			}
+			t.Fatalf("Desktop Nerd Font result missing from %#v", report.Results)
+		})
+	}
+}
+
 func TestCheckIncludesProfileDependenciesBeforeEntryDependencies(t *testing.T) {
 	m := manifest.Manifest{
 		Version: 1,


### PR DESCRIPTION
Closes #208

## PR Type

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Recognizes current Cascadia Nerd Font filenames for the Desktop Nerd Font dependency.
- Keeps the existing `CascadiaCodeNF*` detection while accepting `CaskaydiaCoveNerdFont*` as compatible.
- Updates manifest docs and desktop config guidance.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Adds `CaskaydiaCoveNerdFont*` to `font_fallback_matches` for `desktop` and `workstation`. |
| `docs/manifest.md` | Documents both accepted Desktop Nerd Font filename globs. |
| `configs/ghostty/README.md` | References current Nerd Fonts files in desktop guidance. |
| `internal/deps/deps_test.go` | Adds real-manifest regression coverage for `desktop` and `workstation`. |
| `internal/cli/ghostty_config_test.go` | Keeps Ghostty manifest coverage aligned with the fallback requirement. |

## Test Plan

- [x] `go test ./internal/deps/... ./internal/cli/...`
- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed font check with temp `--home` and `CaskaydiaCoveNerdFont-Regular.ttf`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #208`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
