### PR TITLE
feat(zsh): provision Zim runtime

### DIFF
--- a/configs/zsh/README.md
+++ b/configs/zsh/README.md
@@ -54,17 +54,14 @@ IDE shell integrations live.
 
 ## Zim runtime
 
-Installing Zim itself is out of scope for this slice. If Zim is not present,
-the shell prints a non-destructive notice and runs without modules. To install
-Zim:
+dots provisions the Zim runtime as part of the core install. `~/.zimrc` remains
+the Source of Truth for module selection, and the generated runtime lives under
+`~/.zim/`.
 
-```sh
-curl -fsSL https://raw.githubusercontent.com/zimfw/install/master/install.zsh | zsh
-```
-
-Then restart your shell. The following are intentionally **excluded** from the
-repository: `~/.zim/`, `.zcompdump*`, `.zsh_history`, `.zsh_sessions/`, and any
-generated or backup files.
+If `~/.zim/` is missing, rerun `dots install --profile default` or another
+profile that includes `core`, then restart your shell. The following are
+intentionally **excluded** from the repository: `~/.zim/`, `.zcompdump*`,
+`.zsh_history`, `.zsh_sessions/`, and any generated or backup files.
 
 ## Validation
 

--- a/configs/zsh/zshrc
+++ b/configs/zsh/zshrc
@@ -15,9 +15,8 @@ done
 unset _zrc
 
 # --- Zim Framework ---------------------------------------------------------
-# Installing or bootstrapping Zim is intentionally out of scope for this slice.
-# We only use Zim when it is already present; a missing runtime degrades to a
-# usable, module-less shell instead of breaking the session.
+# dots provisions the Zim runtime during install. The fallback keeps an existing
+# shell usable if the runtime is removed or provisioning was skipped.
 ZIM_HOME="${ZDOTDIR:-${HOME}}/.zim"
 if [[ -e "${ZIM_HOME}/init.zsh" ]]; then
   # Recompile init.zsh when ~/.zimrc is newer than the compiled init.
@@ -27,7 +26,7 @@ if [[ -e "${ZIM_HOME}/init.zsh" ]]; then
   source "${ZIM_HOME}/init.zsh"
 else
   print -u2 "dots: Zim not found at ${ZIM_HOME}; continuing without modules."
-  print -u2 "dots: install it, then restart your shell — see configs/zsh/README.md."
+  print -u2 "dots: rerun dots install for the core profile, then restart your shell."
 fi
 
 # Post-init modular config: PATH, tool integrations, aliases, AI hooks.

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -213,7 +213,7 @@ reuse user-local tools without requiring sudo in non-interactive runs.
 
 | Field | Required | Supported values |
 |-------|----------|------------------|
-| `tool` | Yes | `gentle-ai`, `claude`, `codex`, `codegraph`, or `skills`. |
+| `tool` | Yes | `gentle-ai`, `claude`, `codex`, `codegraph`, `skills`, or `zimfw`. |
 | `tags` | Yes | Non-empty strings matched against the selected Profile. |
 | `os` | No | `darwin`, `linux`; empty means all supported operating systems. |
 | `spec` | Yes | Tool-specific declaration. Each spec must speak exactly one tool dialect. |
@@ -300,10 +300,26 @@ Constraints:
 - Skills specs must not mix gentle-ai scalar/action fields, Claude fields, or
   Codex MCP fields.
 
+### `zimfw` spec
+
+Supported fields: `yes`.
+
+`zimfw` renders one fixed non-interactive `zsh -c` invocation. It ensures
+`~/.zim/zimfw.zsh` exists by downloading the latest ZimFW runtime when missing,
+then runs `zimfw init -q` against the dots-managed `~/.zimrc`. The generated
+runtime stays under `~/.zim/`; `~/.zimrc` remains the managed Source of Truth.
+
+Constraints:
+
+- `yes` is required and must be `true`.
+- ZimFW specs must not mix gentle-ai fields, Claude fields, MCP fields, or
+  skills.sh fields.
+
 Current Provisioners:
 
 | Tool | Tags | OS | Rendered intent | Dependencies |
 |------|------|----|-----------------|--------------|
+| `zimfw` | `core` | all | Install the ZimFW runtime under `~/.zim` when missing and run `zimfw init -q` using the dots-managed `~/.zimrc`. | `zsh`, `git`, `curl` |
 | `gentle-ai` | `agents` | all | Uninstall `sdd` for `codex`, `claude-code`, `opencode`, `antigravity`, and `vscode-copilot` with `--yes`. | `gentle-ai` |
 | `gentle-ai` | `sdd` | all | Install global stable neutral custom SDD setup in multi-agent mode for `codex`, `claude-code`, `opencode`, `antigravity`, and `vscode-copilot`. Select with `--profile agents --tag sdd`. | `gentle-ai` |
 | `gentle-ai` | `agents` | all | Install global stable custom baseline for `codex` with `engram` and `context7`; persona prompt Regenerated Content is not installed by default. | `gentle-ai`, `engram` |

--- a/dots.yaml
+++ b/dots.yaml
@@ -423,6 +423,30 @@ entries:
       - name: opencode
         command: opencode
 provisioners:
+  - tool: zimfw
+    tags:
+      - core
+    spec:
+      yes: true
+    dependencies:
+      - name: zsh
+        command: zsh
+        brew: zsh
+        apt: zsh
+        dnf: zsh
+        pacman: zsh
+      - name: git
+        command: git
+        brew: git
+        apt: git
+        dnf: git
+        pacman: git
+      - name: curl
+        command: curl
+        brew: curl
+        apt: curl
+        dnf: curl
+        pacman: curl
   - tool: gentle-ai
     tags:
       - agents

--- a/internal/cli/install_provision_test.go
+++ b/internal/cli/install_provision_test.go
@@ -116,6 +116,82 @@ func TestInstallExecutesProvisionerAfterFilesWithHomeThreaded(t *testing.T) {
 	}
 }
 
+func TestInstallCoreZimFWProvisionerCreatesRuntimeInSandbox(t *testing.T) {
+	sandboxHome := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	fakeRealHome := t.TempDir()
+	t.Setenv("HOME", fakeRealHome)
+
+	stubDir := t.TempDir()
+	writeExecStub(t, filepath.Join(stubDir, "zsh"), `#!/bin/sh
+printf '%s\n' "$*" > "$HOME/zimfw-args"
+test -e "$HOME/.zimrc" || exit 42
+mkdir -p "$HOME/.zim"
+printf 'zimfw\n' > "$HOME/.zim/zimfw.zsh"
+printf 'init\n' > "$HOME/.zim/init.zsh"
+`)
+	writeExecStub(t, filepath.Join(stubDir, "git"), "#!/bin/sh\nexit 0\n")
+	writeExecStub(t, filepath.Join(stubDir, "curl"), "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	writeCLISource(t, sourceRoot, "configs/zsh/zshrc", "managed zshrc\n")
+	writeCLISource(t, sourceRoot, "configs/zsh/zimrc", "managed zimrc\n")
+	manifestPath := writeCLIManifest(t, sandboxHome, `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+  - source: configs/zsh/zimrc
+    target: ~/.zimrc
+    strategy: symlink
+    tags: [core]
+provisioners:
+  - tool: zimfw
+    tags: [core]
+    spec:
+      yes: true
+    dependencies:
+      - name: zsh
+      - name: git
+      - name: curl
+`)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"install", "--yes", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+
+	if _, err := os.Lstat(filepath.Join(sandboxHome, ".zshrc")); err != nil {
+		t.Fatalf("install did not create .zshrc: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(sandboxHome, ".zimrc")); err != nil {
+		t.Fatalf("install did not create .zimrc before provisioning: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(sandboxHome, ".zim", "init.zsh")); err != nil {
+		t.Fatalf("zimfw provisioner did not create sandbox runtime: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(fakeRealHome, ".zim", "init.zsh")); err == nil {
+		t.Fatalf("zimfw provisioner wrote runtime into inherited HOME %q", fakeRealHome)
+	}
+	args, err := os.ReadFile(filepath.Join(sandboxHome, "zimfw-args"))
+	if err != nil {
+		t.Fatalf("read zimfw args: %v", err)
+	}
+	if !strings.Contains(string(args), "zimfw.zsh") || !strings.Contains(string(args), "init -q") {
+		t.Fatalf("zimfw args did not include fixed init script:\n%s", string(args))
+	}
+}
+
 // TestInstallDoesNotWriteCodeGraphInstructionBlockAfterGentleAIProvisioner proves a
 // non-CodeGraph provisioner does not create the dots-owned CodeGraph
 // instruction block.

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -347,7 +347,7 @@ func (m Manifest) Validate() error {
 			return fmt.Errorf("provisioners[%d].tool is required", i)
 		}
 		if !allowedProvisionerTool(prov.Tool) {
-			return fmt.Errorf("provisioners[%d].tool must be one of claude, codegraph, codex, gentle-ai, skills", i)
+			return fmt.Errorf("provisioners[%d].tool must be one of claude, codegraph, codex, gentle-ai, skills, zimfw", i)
 		}
 		if len(prov.Tags) == 0 {
 			return fmt.Errorf("provisioners[%d].tags is required", i)
@@ -378,6 +378,10 @@ func (m Manifest) Validate() error {
 			}
 		case "skills":
 			if err := validateSkillsSpec(prov.Spec, i); err != nil {
+				return err
+			}
+		case "zimfw":
+			if err := validateZimFWSpec(prov.Spec, i); err != nil {
 				return err
 			}
 		default:
@@ -691,6 +695,36 @@ func validateSkillsSpec(s ProvisionerSpec, i int) error {
 	return nil
 }
 
+// validateZimFWSpec enforces the Zim runtime bootstrap contract: dots owns a
+// single non-interactive install/init invocation for ~/.zim and accepts no
+// user-shaped command fields.
+func validateZimFWSpec(s ProvisionerSpec, i int) error {
+	if s.usesClaudeFields() {
+		return fmt.Errorf("provisioners[%d].spec must not set claude fields (marketplace, plugin, from) for the zimfw tool", i)
+	}
+	if s.usesMCPFields() {
+		return fmt.Errorf("provisioners[%d].spec must not set MCP fields (mcp, command, env) for the zimfw tool", i)
+	}
+	if s.usesSkillsFields() {
+		return fmt.Errorf("provisioners[%d].spec must not set skills.sh fields (package, global, copy) for the zimfw tool", i)
+	}
+	if strings.TrimSpace(s.Action) != "" ||
+		strings.TrimSpace(s.Scope) != "" ||
+		strings.TrimSpace(s.Channel) != "" ||
+		strings.TrimSpace(s.Persona) != "" ||
+		strings.TrimSpace(s.Preset) != "" ||
+		strings.TrimSpace(s.SDDMode) != "" ||
+		hasNonEmptyString(s.Agents) ||
+		hasNonEmptyString(s.Components) ||
+		hasNonEmptyString(s.Skills) {
+		return fmt.Errorf("provisioners[%d].spec must not set gentle-ai fields (action, scope, channel, persona, preset, sdd-mode, agents, components, skills) for the zimfw tool", i)
+	}
+	if !s.Yes {
+		return fmt.Errorf("provisioners[%d].spec.yes must be true for the zimfw tool", i)
+	}
+	return nil
+}
+
 func validateSkillsPackageRef(value, path string) error {
 	value = strings.TrimSpace(value)
 	if strings.HasPrefix(value, "-") {
@@ -830,11 +864,12 @@ func allowedOS(osName string) bool {
 }
 
 // allowedProvisionerTool enforces the provisioner allowlist. dots is never a
-// generic command runner: gentle-ai, claude, codex, codegraph, and skills are the
-// only accepted provisioner tools, each driven through a fixed set of subcommands.
+// generic command runner: gentle-ai, claude, codex, codegraph, skills, and zimfw
+// are the only accepted provisioner tools, each driven through a fixed set of
+// subcommands.
 func allowedProvisionerTool(tool string) bool {
 	switch strings.TrimSpace(tool) {
-	case "gentle-ai", "claude", "codex", "codegraph", "skills":
+	case "gentle-ai", "claude", "codex", "codegraph", "skills", "zimfw":
 		return true
 	default:
 		return false

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -1776,7 +1776,7 @@ provisioners:
     spec:
       scope: global
 `,
-			want: "provisioners[0].tool must be one of claude, codegraph, codex, gentle-ai, skills",
+			want: "provisioners[0].tool must be one of claude, codegraph, codex, gentle-ai, skills, zimfw",
 		},
 		{
 			name: "claude spec sets neither marketplace nor plugin",
@@ -2004,6 +2004,25 @@ provisioners:
       global: true
 `,
 			want: "provisioners[0].spec.package must be an owner/repo package reference with optional path or @ref",
+		},
+		{
+			name: "zimfw spec requires yes",
+			provisioner: `  - tool: zimfw
+    tags: [core]
+    spec:
+      action: install
+`,
+			want: "provisioners[0].spec must not set gentle-ai fields (action, scope, channel, persona, preset, sdd-mode, agents, components, skills) for the zimfw tool",
+		},
+		{
+			name: "zimfw spec rejects mcp fields",
+			provisioner: `  - tool: zimfw
+    tags: [core]
+    spec:
+      yes: true
+      mcp: codegraph
+`,
+			want: "provisioners[0].spec must not set MCP fields (mcp, command, env) for the zimfw tool",
 		},
 		{
 			name: "skills spec requires global true when missing",

--- a/internal/provision/plan.go
+++ b/internal/provision/plan.go
@@ -118,9 +118,10 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 // installed versions and shim under ~/.codegraph and ~/.local/bin, plus MCP
 // config and instructions for the selected agents. skills.sh installs global
 // skills under the user-level agent skill directories selected by its --agent
-// flags. Keep these roots aligned with the pinned skills@1.5.12 agent registry:
-// claude-code writes to ~/.claude/skills; codex, antigravity, opencode, and
-// github-copilot write to ~/.agents/skills.
+// flags. zimfw provisions the generated runtime under ~/.zim while ~/.zimrc
+// remains a Managed Entry. Keep these roots aligned with the pinned skills@1.5.12
+// agent registry: claude-code writes to ~/.claude/skills; codex, antigravity,
+// opencode, and github-copilot write to ~/.agents/skills.
 func managedRoots(prov manifest.Provisioner) []string {
 	switch prov.Tool {
 	case "gentle-ai":
@@ -149,6 +150,8 @@ func managedRoots(prov manifest.Provisioner) []string {
 		return codeGraphRoots(prov.Spec.Agents)
 	case "skills":
 		return skillsRoots(prov.Spec.Agents)
+	case "zimfw":
+		return []string{"~/.zim"}
 	default:
 		return nil
 	}

--- a/internal/provision/plan_test.go
+++ b/internal/provision/plan_test.go
@@ -239,6 +239,30 @@ func TestPlanResolvesCodeGraphProvisioner(t *testing.T) {
 	}
 }
 
+func TestPlanResolvesZimFWProvisioner(t *testing.T) {
+	zimfw := manifest.Provisioner{
+		Tool: "zimfw", Tags: []string{"core"},
+		Spec: manifest.ProvisionerSpec{Yes: true},
+	}
+	m := manifestWithProvisioners(zimfw)
+
+	p, err := provision.Build(m, provision.Options{Profile: "default", OS: "linux"})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if len(p.Steps) != 1 {
+		t.Fatalf("len(Plan.Steps) = %d, want 1", len(p.Steps))
+	}
+
+	step := p.Steps[0]
+	if step.Tool != "zimfw" || step.Executable != "zsh" {
+		t.Fatalf("zimfw step tool/executable = %q/%q, want zimfw/zsh", step.Tool, step.Executable)
+	}
+	if !reflect.DeepEqual(step.Targets, []string{"~/.zim"}) {
+		t.Fatalf("zimfw targets = %#v, want [~/.zim]", step.Targets)
+	}
+}
+
 func TestPlanResolvesClaudeCodeGentleAIProvisioner(t *testing.T) {
 	prov := manifest.Provisioner{
 		Tool: "gentle-ai", Tags: []string{"core"},

--- a/internal/provision/provision.go
+++ b/internal/provision/provision.go
@@ -19,6 +19,18 @@ if ! command -v codegraph >/dev/null 2>&1; then
 fi
 export PATH="$HOME/.local/bin:$PATH"
 codegraph install --target "$1" --location "$2" --yes`
+const zimfwInstallScript = `set -e
+ZDOTDIR="${ZDOTDIR:-${HOME}}"
+ZIM_HOME="${ZIM_HOME:-${ZDOTDIR}/.zim}"
+ZIM_CONFIG_FILE="${ZIM_CONFIG_FILE:-${ZDOTDIR}/.zimrc}"
+export ZDOTDIR ZIM_HOME ZIM_CONFIG_FILE
+
+mkdir -p "${ZIM_HOME}"
+if [[ ! -e "${ZIM_HOME}/zimfw.zsh" ]]; then
+	curl -fsSL -o "${ZIM_HOME}/zimfw.zsh" https://github.com/zimfw/zimfw/releases/latest/download/zimfw.zsh
+fi
+
+source "${ZIM_HOME}/zimfw.zsh" init -q`
 
 // RenderCommand resolves a Provisioner into the exact executable and argv that
 // would run it. It is PURE: it performs no I/O and never invokes the tool, so it
@@ -34,6 +46,8 @@ func RenderCommand(p manifest.Provisioner) (executable string, args []string) {
 		return p.Tool, renderCodexArgs(p.Spec)
 	case "skills":
 		return "npx", renderSkillsArgs(p.Spec)
+	case "zimfw":
+		return "zsh", []string{"-c", zimfwInstallScript}
 	default:
 		return p.Tool, renderGentleAIArgs(p.Spec)
 	}

--- a/internal/provision/provision_test.go
+++ b/internal/provision/provision_test.go
@@ -217,6 +217,18 @@ func TestRenderCommand(t *testing.T) {
 				"--copy",
 			},
 		},
+		{
+			name: "zimfw renders fixed non-interactive runtime bootstrap",
+			prov: manifest.Provisioner{
+				Tool: "zimfw",
+				Spec: manifest.ProvisionerSpec{Yes: true},
+			},
+			wantExec: "zsh",
+			wantArgs: []string{
+				"-c",
+				"set -e\nZDOTDIR=\"${ZDOTDIR:-${HOME}}\"\nZIM_HOME=\"${ZIM_HOME:-${ZDOTDIR}/.zim}\"\nZIM_CONFIG_FILE=\"${ZIM_CONFIG_FILE:-${ZDOTDIR}/.zimrc}\"\nexport ZDOTDIR ZIM_HOME ZIM_CONFIG_FILE\n\nmkdir -p \"${ZIM_HOME}\"\nif [[ ! -e \"${ZIM_HOME}/zimfw.zsh\" ]]; then\n\tcurl -fsSL -o \"${ZIM_HOME}/zimfw.zsh\" https://github.com/zimfw/zimfw/releases/latest/download/zimfw.zsh\nfi\n\nsource \"${ZIM_HOME}/zimfw.zsh\" init -q",
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Closes #209

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds an allowlisted `zimfw` provisioner that installs `~/.zim/zimfw.zsh` when missing and runs `zimfw init -q`.
- Selects the Zim runtime provisioner from the `core` profile so fresh installs no longer leave recurring missing-Zim warnings.
- Updates Zsh/docs to keep `~/.zimrc` as Source of Truth while treating `~/.zim/` as generated runtime state.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Adds the `core` ZimFW provisioner with `zsh`, `git`, and `curl` dependencies. |
| `internal/manifest/*` | Extends the provisioner allowlist and validation for `zimfw`. |
| `internal/provision/*` | Renders the fixed ZimFW bootstrap/init command and reports `~/.zim` as the managed runtime root. |
| `configs/zsh/*` | Reframes missing runtime guidance around rerunning `dots install`. |
| `docs/manifest.md` | Documents the new `zimfw` provisioner contract. |
| `internal/cli/install_provision_test.go` | Proves sandboxed install creates the Zim runtime after `.zimrc` is installed. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp>`

Additional validation:

- [x] `go build ./...`
- [x] `go test ./internal/manifest ./internal/provision ./internal/cli`
- [x] `go run ./cmd/dots install --dry-run --file dots.yaml --home <tmp>/home --source-root "$PWD" --state-root <tmp>/state --skip-deps --no-tui`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #209`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
