### PR TITLE
feat(status): report provisioner state

### DIFF
--- a/docs/agents/output-contract.md
+++ b/docs/agents/output-contract.md
@@ -37,7 +37,7 @@ state.
 
 ```json
 {
-  "schema_version": "4",
+  "schema_version": "5",
   "command": "doctor",
   "status": "ok",
   "data": { "...": "command-specific report" }
@@ -58,7 +58,7 @@ Schema version `3` introduced this partial-error report allowance:
 
 ```json
 {
-  "schema_version": "4",
+  "schema_version": "5",
   "command": "doctor",
   "status": "error",
   "error": "read manifest: open dots.yaml: no such file or directory"
@@ -99,11 +99,11 @@ esac
 The envelope carries the machine-meaningful report, not every piece of human
 prose the text surface prints:
 
-- `status` includes selected Provisioner commands as read-only context under
-  `data.provisioners`, but these do not affect the status finding decision.
-  Provisioner steps may include `global_tools` when the invocation can install
-  or update user-local tools such as `claude` under `~/.local/bin`. Read
-  dependency readiness for those commands from `doctor`.
+- `status` includes selected Provisioner completion state under
+  `data.provisioners.summary` and per-command state under
+  `data.provisioners.items`. Pending or failed Provisioners are findings so
+  agents can distinguish aligned Managed Entries from an incomplete full-profile
+  setup. Read dependency readiness for those commands from `doctor`.
 - `plan`'s `resolved_source` (a per-machine absolute path) and `deps`'s
   `probe_detail`/`hint` (unstable human prose) are excluded. Agents key on the
   portable, structured fields (`source`, `present`, `warning`, and the

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/yersonargotev/dots/internal/bootstrap"
@@ -18,6 +19,7 @@ import (
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/provision"
+	"github.com/yersonargotev/dots/internal/state"
 	"github.com/yersonargotev/dots/internal/tui"
 	"github.com/yersonargotev/dots/internal/version"
 )
@@ -158,7 +160,11 @@ func newInstallCommand() *cobra.Command {
 				return nil
 			}
 
-			if err := runProvisioners(cmd, *m, profile, extraTags, paths.Home); err != nil {
+			provResult, err := runProvisioners(cmd, *m, profile, extraTags, paths.Home, paths.StateRoot)
+			if err != nil {
+				if wantsJSON(cmd) {
+					return installProvisionerError{err: err, report: installReport{DryRun: false, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan, ProvisionerResults: &provResult}}
+				}
 				return err
 			}
 			if wantsJSON(cmd) {
@@ -200,6 +206,17 @@ func (e installDependencyGateError) Error() string { return e.err.Error() }
 func (e installDependencyGateError) Unwrap() error { return e.err }
 
 func (e installDependencyGateError) JSONErrorData() any { return e.report }
+
+type installProvisionerError struct {
+	err    error
+	report installReport
+}
+
+func (e installProvisionerError) Error() string { return e.err.Error() }
+
+func (e installProvisionerError) Unwrap() error { return e.err }
+
+func (e installProvisionerError) JSONErrorData() any { return e.report }
 
 // runInstallDependencies executes the dependency gate for dots install before any
 // Managed Configuration is applied. Interactive runs reuse the deps confirmation
@@ -250,7 +267,7 @@ func runInstallDependencies(cmd *cobra.Command, m manifest.Manifest, options dep
 // temporary home. Apply stops at the first failing provisioner and returns the
 // error, which the caller surfaces; the tool's own stdout/stderr are streamed
 // through so its progress is visible.
-func runProvisioners(cmd *cobra.Command, m manifest.Manifest, profile string, extraTags []string, home string) error {
+func runProvisioners(cmd *cobra.Command, m manifest.Manifest, profile string, extraTags []string, home string, stateRoot string) (provision.Report, error) {
 	ctx := cmd.Context()
 	if ctx == nil {
 		ctx = context.Background()
@@ -270,17 +287,20 @@ func runProvisioners(cmd *cobra.Command, m manifest.Manifest, profile string, ex
 	if !wantsJSON(cmd) {
 		renderProvisionReport(cmd.OutOrStdout(), report)
 	}
+	if recordErr := recordProvisionerMetadata(stateRoot, report); recordErr != nil {
+		return report, recordErr
+	}
 	if err != nil {
-		return err
+		return report, err
 	}
 	selected, err := provision.Select(m, provision.Options{Profile: profile, ExtraTags: extraTags, OS: runtime.GOOS})
 	if err != nil {
-		return err
+		return report, err
 	}
 	if agents := selectedCodeGraphAgents(selected); len(agents) > 0 {
-		return codexconfig.EnsureCodeGraphMode(home, agents...)
+		return report, codexconfig.EnsureCodeGraphMode(home, agents...)
 	}
-	return nil
+	return report, nil
 }
 
 func selectedCodeGraphAgents(selected []manifest.Provisioner) []string {
@@ -472,4 +492,31 @@ func writeFileForPromptDiff(w interface{ Write([]byte) (int, error) }, path, lab
 		data = append(data, '\n')
 	}
 	_, _ = w.Write(data)
+}
+
+func recordProvisionerMetadata(stateRoot string, report provision.Report) error {
+	if stateRoot == "" || len(report.Items) == 0 {
+		return nil
+	}
+	path := state.Path(stateRoot)
+	meta, err := state.Load(path)
+	if err != nil {
+		return err
+	}
+	if meta.Version == 0 {
+		meta.Version = 1
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	for _, item := range report.Items {
+		meta.UpsertProvisioner(state.ProvisionerRecord{
+			Profile:    report.Profile,
+			Tool:       item.Tool,
+			Executable: item.Executable,
+			Args:       append([]string(nil), item.Args...),
+			Status:     string(item.Status),
+			Missing:    append([]string(nil), item.Missing...),
+			LastRunAt:  now,
+		})
+	}
+	return state.Save(path, meta)
 }

--- a/internal/cli/install_provision_test.go
+++ b/internal/cli/install_provision_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/yersonargotev/dots/internal/cli"
+	"github.com/yersonargotev/dots/internal/state"
 )
 
 const provisionerManifest = `version: 1
@@ -613,5 +614,60 @@ provisioners:
 	}
 	if !strings.Contains(out.String(), "Conflict resolution canceled; no changes applied.") {
 		t.Fatalf("cancel output missing abort message\noutput:\n%s", out.String())
+	}
+}
+
+func TestInstallPersistsFailedProvisionerForStatusResumeGuidance(t *testing.T) {
+	sandboxHome := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	fakeRealHome := t.TempDir()
+	t.Setenv("HOME", fakeRealHome)
+
+	stubDir := t.TempDir()
+	writeExecStub(t, filepath.Join(stubDir, "gentle-ai"), "#!/bin/sh\nexit 7\n")
+	writeExecStub(t, filepath.Join(stubDir, "engram"), "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	writeCLISource(t, sourceRoot, "configs/zsh/zshrc", "managed\n")
+	manifestPath := writeCLIManifest(t, sandboxHome, provisionerManifest)
+
+	installCmd := cli.NewRootCommand()
+	var installOut bytes.Buffer
+	installCmd.SetOut(&installOut)
+	installCmd.SetErr(&installOut)
+	installCmd.SetArgs([]string{"install", "--yes", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot})
+
+	if err := installCmd.Execute(); err == nil {
+		t.Fatalf("install error = nil, want failing provisioner\noutput:\n%s", installOut.String())
+	}
+
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	rec, ok := meta.FindProvisioner("default", "gentle-ai", "gentle-ai", []string{"install", "--scope", "global", "--persona", "neutral", "--agents", "codex"})
+	if !ok {
+		t.Fatalf("failed provisioner was not persisted: %+v", meta.Provisioners)
+	}
+	if rec.Status != "failed" {
+		t.Fatalf("provisioner status = %q, want failed", rec.Status)
+	}
+
+	statusCmd := cli.NewRootCommand()
+	var statusOut bytes.Buffer
+	statusCmd.SetOut(&statusOut)
+	statusCmd.SetErr(&statusOut)
+	statusCmd.SetArgs([]string{"status", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot})
+	requireFindings(t, statusCmd.Execute())
+	got := statusOut.String()
+	for _, want := range []string{
+		`Declared provisioners for profile "default" — failed`,
+		"failed               gentle-ai install --scope global --persona neutral --agents codex",
+		"resume: run dots install again after addressing failed or missing provisioners.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("status output missing %q\noutput:\n%s", want, got)
+		}
 	}
 }

--- a/internal/cli/json_reports.go
+++ b/internal/cli/json_reports.go
@@ -15,13 +15,13 @@ import (
 type initReport bootstrap.Result
 
 type statusReport struct {
-	Profile      string         `json:"profile"`
-	Entries      []status.Entry `json:"entries"`
-	Provisioners provision.Plan `json:"provisioners"`
+	Profile      string                 `json:"profile"`
+	Entries      []status.Entry         `json:"entries"`
+	Provisioners provision.StatusReport `json:"provisioners"`
 }
 
 func (r statusReport) HasFindings() bool {
-	return status.Report{Profile: r.Profile, Entries: r.Entries}.HasFindings()
+	return status.Report{Profile: r.Profile, Entries: r.Entries}.HasFindings() || r.Provisioners.HasFindings()
 }
 
 type versionReport struct {
@@ -34,10 +34,11 @@ type manifestValidateReport struct {
 }
 
 type installReport struct {
-	DryRun       bool                       `json:"dry_run"`
-	Dependencies *installDependenciesReport `json:"dependencies,omitempty"`
-	Plan         plan.Plan                  `json:"plan"`
-	Provisioners provision.Plan             `json:"provisioners"`
+	DryRun             bool                       `json:"dry_run"`
+	Dependencies       *installDependenciesReport `json:"dependencies,omitempty"`
+	Plan               plan.Plan                  `json:"plan"`
+	Provisioners       provision.Plan             `json:"provisioners"`
+	ProvisionerResults *provision.Report          `json:"provisioner_results,omitempty"`
 }
 
 type installDependenciesReport struct {

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -22,7 +22,7 @@ const (
 // binary. Renaming, removing, or repurposing a field in any command's JSON
 // `data` is a breaking change to the Agent Output Contract and must bump this
 // value.
-const schemaVersion = "4"
+const schemaVersion = "5"
 
 // Envelope statuses. They mirror the semantic exit codes: ok->0, findings->2,
 // error->1.

--- a/internal/cli/output_golden_test.go
+++ b/internal/cli/output_golden_test.go
@@ -40,10 +40,11 @@ func TestEnvelopeGolden(t *testing.T) {
 						{Source: "configs/zsh/zshrc", Target: "/home/user/.zshrc", Strategy: "symlink", State: status.StateOK},
 						{Source: "configs/git/config", Target: "/home/user/.gitconfig", Strategy: "copy", State: status.StateMissing},
 					},
-					Provisioners: provision.Plan{
+					Provisioners: provision.StatusReport{
 						Profile: "default",
-						Steps: []provision.Step{
-							{Tool: "gentle-ai", Executable: "gentle-ai", Args: []string{"install", "--scope", "global", "--agents", "claude-code"}, Targets: []string{"~/.claude", "~/.gentle-ai"}, GlobalTools: []string{"claude (~/.local/bin via npm prefix)"}},
+						Summary: provision.StatusSummary{State: provision.SummaryStatePending, Pending: 1},
+						Items: []provision.StatusItem{
+							{Tool: "gentle-ai", Executable: "gentle-ai", Args: []string{"install", "--scope", "global", "--agents", "claude-code"}, Targets: []string{"~/.claude", "~/.gentle-ai"}, Status: provision.StatusStatePending},
 						},
 					},
 				},

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -26,7 +26,7 @@ func decodeEnvelope(t *testing.T, out string) testEnvelope {
 	if err := json.Unmarshal([]byte(out), &env); err != nil {
 		t.Fatalf("stdout is not a JSON envelope: %v\noutput:\n%s", err, out)
 	}
-	if env.SchemaVersion != "4" {
+	if env.SchemaVersion != "5" {
 		t.Fatalf("schema_version = %q, want \"4\"", env.SchemaVersion)
 	}
 	if env.Command != "status" {
@@ -41,7 +41,7 @@ func decodeEnvelopeForCommand(t *testing.T, out string, command string) testEnve
 	if err := json.Unmarshal([]byte(out), &env); err != nil {
 		t.Fatalf("stdout is not a JSON envelope: %v\noutput:\n%s", err, out)
 	}
-	if env.SchemaVersion != "4" {
+	if env.SchemaVersion != "5" {
 		t.Fatalf("schema_version = %q, want \"4\"", env.SchemaVersion)
 	}
 	if env.Command != command {

--- a/internal/cli/provision_runner_test.go
+++ b/internal/cli/provision_runner_test.go
@@ -153,7 +153,7 @@ printf 'npm-local' > "$HOME/gentle-ai-npm-mode"
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
 
-	if err := runProvisioners(cmd, m, "workstation", nil, home); err != nil {
+	if _, err := runProvisioners(cmd, m, "workstation", nil, home, t.TempDir()); err != nil {
 		t.Fatalf("runProvisioners() error = %v\noutput:\n%s", err, out.String())
 	}
 	got, err := os.ReadFile(filepath.Join(home, "gentle-ai-npm-mode"))
@@ -203,7 +203,7 @@ printf ok > "$HOME/first-attempt"
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
 
-	err := runProvisioners(cmd, m, "default", nil, home)
+	_, err := runProvisioners(cmd, m, "default", nil, home, t.TempDir())
 	if err == nil {
 		t.Fatal("runProvisioners() error = nil, want second provisioner failure")
 	}
@@ -261,7 +261,7 @@ printf '%s\n' "$*" > "$HOME/skills-args"
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
 
-	if err := runProvisioners(cmd, m, "default", nil, home); err != nil {
+	if _, err := runProvisioners(cmd, m, "default", nil, home, t.TempDir()); err != nil {
 		t.Fatalf("runProvisioners() error = %v\noutput:\n%s", err, out.String())
 	}
 
@@ -323,7 +323,7 @@ done
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
 
-	if err := runProvisioners(cmd, m, "default", []string{"codegraph"}, home); err != nil {
+	if _, err := runProvisioners(cmd, m, "default", []string{"codegraph"}, home, t.TempDir()); err != nil {
 		t.Fatalf("runProvisioners() error = %v\noutput:\n%s", err, out.String())
 	}
 

--- a/internal/cli/render_status.go
+++ b/internal/cli/render_status.go
@@ -52,20 +52,24 @@ func renderStatus(w io.Writer, report status.Report) {
 	}
 }
 
-// renderStatusProvisioners lists the provisioners declared for the profile as
-// read-only, informational context. It deliberately makes no alignment claim:
-// whether a provisioner has actually been applied is verified by the tool
-// itself, not by dots. It renders nothing when no provisioner is declared.
-func renderStatusProvisioners(w io.Writer, p provision.Plan) {
-	if len(p.Steps) == 0 {
+// renderStatusProvisioners lists the selected Provisioners with their persisted
+// completion state. It renders nothing when no Provisioner is declared.
+func renderStatusProvisioners(w io.Writer, r provision.StatusReport) {
+	if len(r.Items) == 0 {
 		return
 	}
 
-	fmt.Fprintf(w, "\nDeclared provisioners for profile %q\n\n", p.Profile)
-	for _, step := range p.Steps {
-		fmt.Fprintf(w, "  %s %s\n", step.Executable, strings.Join(step.Args, " "))
-		if len(step.Targets) > 0 {
-			fmt.Fprintf(w, "    affects: %s\n", strings.Join(step.Targets, ", "))
+	fmt.Fprintf(w, "\nDeclared provisioners for profile %q — %s\n\n", r.Profile, r.Summary.State)
+	for _, item := range r.Items {
+		fmt.Fprintf(w, "  %-20s %s %s\n", item.Status, item.Executable, strings.Join(item.Args, " "))
+		if len(item.Targets) > 0 {
+			fmt.Fprintf(w, "    affects: %s\n", strings.Join(item.Targets, ", "))
 		}
+		if len(item.Missing) > 0 {
+			fmt.Fprintf(w, "    missing: %s\n", strings.Join(item.Missing, ", "))
+		}
+	}
+	if r.Summary.State == provision.SummaryStatePending || r.Summary.State == provision.SummaryStateFailed {
+		fmt.Fprintln(w, "    resume: run dots install again after addressing failed or missing provisioners.")
 	}
 }

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -70,15 +70,14 @@ func newStatusCommand() *cobra.Command {
 			fullReport := statusReport{
 				Profile:      report.Profile,
 				Entries:      report.Entries,
-				Provisioners: provPlan,
+				Provisioners: provision.BuildStatus(provPlan, meta),
 			}
 
-			// Declared provisioners make no alignment claim, so only the Dotfiles
-			// Status entries decide findings; both text and JSON still include the
-			// resolved provisioner commands as read-only context.
+			// Provisioner completion is now part of status because a profile can have
+			// aligned Managed Entries while provisioning is still pending or failed.
 			return renderOrEmit(cmd, fullReport, func() error {
 				renderStatus(cmd.OutOrStdout(), report)
-				renderStatusProvisioners(cmd.OutOrStdout(), provPlan)
+				renderStatusProvisioners(cmd.OutOrStdout(), provision.BuildStatus(provPlan, meta))
 				return nil
 			})
 		},

--- a/internal/cli/testdata/envelope_deps_check.golden
+++ b/internal/cli/testdata/envelope_deps_check.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "4",
+  "schema_version": "5",
   "command": "deps check",
   "status": "findings",
   "data": {

--- a/internal/cli/testdata/envelope_deps_plan.golden
+++ b/internal/cli/testdata/envelope_deps_plan.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "4",
+  "schema_version": "5",
   "command": "deps plan",
   "status": "findings",
   "data": {

--- a/internal/cli/testdata/envelope_doctor.golden
+++ b/internal/cli/testdata/envelope_doctor.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "4",
+  "schema_version": "5",
   "command": "doctor",
   "status": "findings",
   "data": {

--- a/internal/cli/testdata/envelope_install.golden
+++ b/internal/cli/testdata/envelope_install.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "4",
+  "schema_version": "5",
   "command": "install",
   "status": "ok",
   "data": {

--- a/internal/cli/testdata/envelope_plan.golden
+++ b/internal/cli/testdata/envelope_plan.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "4",
+  "schema_version": "5",
   "command": "plan",
   "status": "findings",
   "data": {

--- a/internal/cli/testdata/envelope_status.golden
+++ b/internal/cli/testdata/envelope_status.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "4",
+  "schema_version": "5",
   "command": "status",
   "status": "findings",
   "data": {
@@ -20,7 +20,13 @@
     ],
     "provisioners": {
       "profile": "default",
-      "steps": [
+      "summary": {
+        "state": "pending",
+        "completed": 0,
+        "pending": 1,
+        "failed": 0
+      },
+      "items": [
         {
           "tool": "gentle-ai",
           "executable": "gentle-ai",
@@ -35,9 +41,7 @@
             "~/.claude",
             "~/.gentle-ai"
           ],
-          "global_tools": [
-            "claude (~/.local/bin via npm prefix)"
-          ]
+          "status": "pending"
         }
       ]
     }

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -202,7 +202,7 @@ func runUpdateWorkflow(cmd *cobra.Command, opts updateOptions, emit bool) (updat
 		return updateReport{}, err
 	}
 	if applied {
-		if err := runProvisioners(cmd, *m, opts.profile, opts.extraTags, paths.Home); err != nil {
+		if _, err := runProvisioners(cmd, *m, opts.profile, opts.extraTags, paths.Home, paths.StateRoot); err != nil {
 			return updateReport{}, err
 		}
 	}

--- a/internal/provision/status.go
+++ b/internal/provision/status.go
@@ -1,0 +1,102 @@
+package provision
+
+import "github.com/yersonargotev/dots/internal/state"
+
+// StatusState summarizes the last known provisioning outcome for one selected
+// Provisioner.
+type StatusState string
+
+const (
+	StatusStatePending             StatusState = "pending"
+	StatusStateProvisioned         StatusState = "provisioned"
+	StatusStateFailed              StatusState = "failed"
+	StatusStateMissingDependencies StatusState = "missing-dependencies"
+)
+
+// SummaryState summarizes the selected Provisioners for a profile.
+type SummaryState string
+
+const (
+	SummaryStateNone      SummaryState = "none"
+	SummaryStatePending   SummaryState = "pending"
+	SummaryStateCompleted SummaryState = "completed"
+	SummaryStateFailed    SummaryState = "failed"
+)
+
+// StatusSummary is the profile-level Provisioner completion state surfaced by
+// diagnostics.
+type StatusSummary struct {
+	State     SummaryState `json:"state"`
+	Completed int          `json:"completed"`
+	Pending   int          `json:"pending"`
+	Failed    int          `json:"failed"`
+}
+
+// StatusItem combines the resolved Provisioner command with its last persisted
+// run result, if any.
+type StatusItem struct {
+	Tool       string      `json:"tool"`
+	Executable string      `json:"executable"`
+	Args       []string    `json:"args"`
+	Targets    []string    `json:"targets,omitempty"`
+	Status     StatusState `json:"status"`
+	LastRunAt  string      `json:"last_run_at,omitempty"`
+	Missing    []string    `json:"missing,omitempty"`
+}
+
+// StatusReport is the read-only diagnostic view of Provisioner completion.
+type StatusReport struct {
+	Profile string        `json:"profile"`
+	Summary StatusSummary `json:"summary"`
+	Items   []StatusItem  `json:"items"`
+}
+
+// HasFindings reports whether Provisioners are pending or failed for the active
+// profile. A profile with no selected Provisioners is not a finding.
+func (r StatusReport) HasFindings() bool {
+	return r.Summary.State == SummaryStatePending || r.Summary.State == SummaryStateFailed
+}
+
+// BuildStatus joins the selected Provisioner plan with persisted Installation
+// Metadata to expose whether Provisioners are pending, failed, or completed.
+func BuildStatus(p Plan, meta state.Metadata) StatusReport {
+	report := StatusReport{Profile: p.Profile}
+	if len(p.Steps) == 0 {
+		report.Summary.State = SummaryStateNone
+		return report
+	}
+
+	for _, step := range p.Steps {
+		item := StatusItem{
+			Tool:       step.Tool,
+			Executable: step.Executable,
+			Args:       append([]string(nil), step.Args...),
+			Targets:    append([]string(nil), step.Targets...),
+			Status:     StatusStatePending,
+		}
+		if rec, ok := meta.FindProvisioner(p.Profile, step.Tool, step.Executable, step.Args); ok {
+			item.Status = StatusState(rec.Status)
+			item.LastRunAt = rec.LastRunAt
+			item.Missing = append([]string(nil), rec.Missing...)
+		}
+		report.Items = append(report.Items, item)
+		switch item.Status {
+		case StatusStateProvisioned:
+			report.Summary.Completed++
+		case StatusStateFailed, StatusStateMissingDependencies:
+			report.Summary.Failed++
+		default:
+			report.Summary.Pending++
+		}
+	}
+
+	switch {
+	case report.Summary.Failed > 0:
+		report.Summary.State = SummaryStateFailed
+	case report.Summary.Pending > 0:
+		report.Summary.State = SummaryStatePending
+	default:
+		report.Summary.State = SummaryStateCompleted
+	}
+	return report
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -16,8 +16,9 @@ import (
 
 // Metadata is the machine-readable record of installed managed targets.
 type Metadata struct {
-	Version int      `json:"version"`
-	Entries []Record `json:"entries"`
+	Version      int                 `json:"version"`
+	Entries      []Record            `json:"entries"`
+	Provisioners []ProvisionerRecord `json:"provisioners,omitempty"`
 }
 
 // Record describes a single managed target the CLI installed. Copy-like
@@ -29,6 +30,18 @@ type Record struct {
 	Strategy    string `json:"strategy"`
 	Hash        string `json:"hash"`
 	InstalledAt string `json:"installedAt"`
+}
+
+// ProvisionerRecord describes the last known result for one selected
+// Provisioner command in a profile.
+type ProvisionerRecord struct {
+	Profile    string   `json:"profile"`
+	Tool       string   `json:"tool"`
+	Executable string   `json:"executable"`
+	Args       []string `json:"args"`
+	Status     string   `json:"status"`
+	Missing    []string `json:"missing,omitempty"`
+	LastRunAt  string   `json:"lastRunAt"`
 }
 
 // Path returns the location of installed.json under a state root.
@@ -80,6 +93,39 @@ func (m Metadata) FindByTarget(target string) (Record, bool) {
 		}
 	}
 	return Record{}, false
+}
+
+// FindProvisioner returns the last result for a selected Provisioner command.
+func (m Metadata) FindProvisioner(profile, tool, executable string, args []string) (ProvisionerRecord, bool) {
+	for _, r := range m.Provisioners {
+		if r.Profile == profile && r.Tool == tool && r.Executable == executable && stringSlicesEqual(r.Args, args) {
+			return r, true
+		}
+	}
+	return ProvisionerRecord{}, false
+}
+
+// UpsertProvisioner records the latest outcome for a selected Provisioner.
+func (m *Metadata) UpsertProvisioner(rec ProvisionerRecord) {
+	for i := range m.Provisioners {
+		if m.Provisioners[i].Profile == rec.Profile && m.Provisioners[i].Tool == rec.Tool && m.Provisioners[i].Executable == rec.Executable && stringSlicesEqual(m.Provisioners[i].Args, rec.Args) {
+			m.Provisioners[i] = rec
+			return
+		}
+	}
+	m.Provisioners = append(m.Provisioners, rec)
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // Remove returns a copy of the Metadata with every record whose Target appears


### PR DESCRIPTION
Closes #214

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Persist selected Provisioner run outcomes in Installation Metadata.
- Report Provisioner completion state from `dots status --output json` and text status.
- Bump the agent output contract schema to `5` because the status Provisioner JSON shape changed.

## Changes

| File | Change |
|------|--------|
| `internal/state/state.go` | Adds persisted Provisioner records keyed by profile/tool/command. |
| `internal/provision/status.go` | Builds pending/completed/failed Provisioner status summaries from plan + metadata. |
| `internal/cli/status.go` / `internal/cli/render_status.go` | Surfaces Provisioner completion state and resume guidance in status output. |
| `internal/cli/install.go` | Records Provisioner successes, missing dependencies, and failures after install/update provisioning. |
| `internal/cli/output.go` / `internal/cli/testdata/*.golden` | Bumps schema version to `5` and locks the new JSON shape. |
| `docs/agents/output-contract.md` | Documents Provisioner status findings in the agent output contract. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp> --state-root <tmp>`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #214`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
