### PR TITLE
feat(install): add backup-and-replace mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,14 @@ dots --version
 dots install
 ```
 
+Non-interactive installs stay conservative: `dots install --yes` skips Conflicts. To explicitly adopt an existing machine by backing up and replacing every Conflict, use:
+
+```bash
+dots install --yes --backup-and-replace
+```
+
+That mode creates Backup Sets before replacement, reports them in JSON as `data.backup_sets`, and still runs selected Provisioners after Managed Configuration is applied.
+
 To reverse an install, `dots uninstall` removes only the symlinks and copied files `dots` recorded it owns, previewing first and skipping anything that drifted:
 
 ```bash

--- a/docs/agents/output-contract.md
+++ b/docs/agents/output-contract.md
@@ -127,7 +127,10 @@ prose the text surface prints:
   still includes this partial install report so agents can inspect the failed
   Dependency result and prove Managed Configuration was not applied.
   `data.dependencies` is optional and omitted when dependency provisioning is
-  intentionally bypassed with `install --skip-deps`.
+  intentionally bypassed with `install --skip-deps`. When
+  `install --yes --backup-and-replace --output json` replaces Conflicts,
+  `data.backup_sets` lists the Backup Sets created by that run, including each
+  set ID, target list, and state-root path.
 
 The domain reports' `json:` field names are part of the public contract.
 Renaming, removing, or changing the meaning of an existing field is a

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -4,7 +4,7 @@
 
 ## `dots backups list`
 
-`list` reports each recorded Backup Set: when it was created, why the backup was taken, and which targets it protected.
+`list` reports each recorded Backup Set: when it was created, why the backup was taken, and which targets it protected. `dots install --yes --backup-and-replace` records the same Backup Metadata as an interactive `replace`, so backups created by that non-interactive adoption flow appear here too.
 
 ```
 Backup Sets

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/yersonargotev/dots/internal/backups"
 	"github.com/yersonargotev/dots/internal/bootstrap"
 	"github.com/yersonargotev/dots/internal/codexconfig"
 	"github.com/yersonargotev/dots/internal/deps"
@@ -26,16 +27,17 @@ import (
 
 func newInstallCommand() *cobra.Command {
 	var (
-		file       string
-		profile    string
-		extraTags  []string
-		sourceRoot string
-		home       string
-		stateRoot  string
-		dryRun     bool
-		yes        bool
-		noTUI      bool
-		skipDeps   bool
+		file             string
+		profile          string
+		extraTags        []string
+		sourceRoot       string
+		home             string
+		stateRoot        string
+		dryRun           bool
+		yes              bool
+		noTUI            bool
+		skipDeps         bool
+		backupAndReplace bool
 	)
 
 	cmd := &cobra.Command{
@@ -48,6 +50,9 @@ func newInstallCommand() *cobra.Command {
 			paths, err := resolvePaths(home, sourceRoot, stateRoot)
 			if err != nil {
 				return err
+			}
+			if backupAndReplace && !dryRun && !yes {
+				return fmt.Errorf("--backup-and-replace requires --yes for non-interactive conflict replacement")
 			}
 
 			if !dryRun && !cmd.Flags().Changed("file") && !cmd.Flags().Changed("source-root") {
@@ -149,7 +154,15 @@ func newInstallCommand() *cobra.Command {
 				}
 			}
 
-			applied, err := resolveAndApply(cmd, p, paths, yes, noTUI)
+			beforeBackups, err := backups.Load(backups.Path(paths.StateRoot))
+			if err != nil {
+				return err
+			}
+			applied, err := resolveAndApply(cmd, p, paths, yes, noTUI, backupAndReplace)
+			if err != nil {
+				return err
+			}
+			createdBackups, err := createdBackupSetReports(paths.StateRoot, beforeBackups)
 			if err != nil {
 				return err
 			}
@@ -163,12 +176,12 @@ func newInstallCommand() *cobra.Command {
 			provResult, err := runProvisioners(cmd, *m, profile, extraTags, paths.Home, paths.StateRoot)
 			if err != nil {
 				if wantsJSON(cmd) {
-					return installProvisionerError{err: err, report: installReport{DryRun: false, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan, ProvisionerResults: &provResult}}
+					return installProvisionerError{err: err, report: installReport{DryRun: false, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan, BackupSets: createdBackups, ProvisionerResults: &provResult}}
 				}
 				return err
 			}
 			if wantsJSON(cmd) {
-				return emitOK(cmd, installReport{DryRun: false, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan})
+				return emitOK(cmd, installReport{DryRun: false, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan, BackupSets: createdBackups})
 			}
 			return nil
 		},
@@ -184,6 +197,7 @@ func newInstallCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&yes, "yes", false, "apply safe install actions without prompting; conflicts default to skip")
 	cmd.Flags().BoolVar(&noTUI, "no-tui", false, "use text prompts instead of the interactive TUI for conflict resolution")
 	cmd.Flags().BoolVar(&skipDeps, "skip-deps", false, "skip dependency provisioning before applying managed configuration")
+	cmd.Flags().BoolVar(&backupAndReplace, "backup-and-replace", false, "with --yes, replace every conflict after creating Backup Sets")
 	return cmd
 }
 
@@ -325,14 +339,17 @@ func selectedCodeGraphAgents(selected []manifest.Provisioner) []string {
 // the conservative --yes default) and applies it with Backup Set protection. It
 // is shared by install and update so post-update installation reuses identical
 // Conflict Resolution and filesystem machinery instead of reimplementing it.
-func resolveAndApply(cmd *cobra.Command, p plan.Plan, paths resolvedPaths, yes, noTUI bool) (bool, error) {
+func resolveAndApply(cmd *cobra.Command, p plan.Plan, paths resolvedPaths, yes, noTUI, backupAndReplace bool) (bool, error) {
 	var (
 		decisions map[string]install.ConflictDecision
 		err       error
 	)
 	switch {
 	case yes:
-		// Non-interactive: conflicts deliberately default to skip.
+		if backupAndReplace {
+			decisions = replaceAllConflictDecisions(p)
+		}
+		// Non-interactive default: conflicts deliberately default to skip.
 	case noTUI:
 		decisions, err = promptConflictDecisions(cmd, p, paths.Home, paths.SourceRoot)
 		if err != nil {
@@ -350,6 +367,33 @@ func resolveAndApply(cmd *cobra.Command, p plan.Plan, paths resolvedPaths, yes, 
 	}
 
 	return true, install.Apply(p, install.Options{SourceRoot: paths.SourceRoot, Home: paths.Home, StateRoot: paths.StateRoot, ConflictDecisions: decisions})
+}
+
+func replaceAllConflictDecisions(p plan.Plan) map[string]install.ConflictDecision {
+	decisions := map[string]install.ConflictDecision{}
+	for _, action := range conflictActions(p) {
+		decisions[action.Target] = install.DecisionReplace
+	}
+	return decisions
+}
+
+func createdBackupSetReports(stateRoot string, before backups.Metadata) ([]installBackupSetReport, error) {
+	after, err := backups.Load(backups.Path(stateRoot))
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string]bool{}
+	for _, set := range before.Sets {
+		seen[set.ID] = true
+	}
+	var created []installBackupSetReport
+	for _, set := range after.Sets {
+		if seen[set.ID] {
+			continue
+		}
+		created = append(created, installBackupSetReport{BackupSet: set, Path: backups.SetDir(stateRoot, set.ID)})
+	}
+	return created, nil
 }
 
 // resolveConflictsTUI launches the Bubble Tea conflict resolver for the plan's

--- a/internal/cli/install_deps_test.go
+++ b/internal/cli/install_deps_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/yersonargotev/dots/internal/backups"
 	"github.com/yersonargotev/dots/internal/cli"
 )
 
@@ -157,6 +158,200 @@ entries:
 	}
 	if !strings.Contains(out.String(), "Dependency provisioning skipped (--skip-deps).") {
 		t.Fatalf("skip-deps should make the bypass visible:\n%s", out.String())
+	}
+}
+
+func TestInstallYesSkipsConflictByDefault(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	writeCLISource(t, sourceRoot, "configs/git/gitconfig", "managed\n")
+	if err := os.WriteFile(filepath.Join(home, ".gitconfig"), []byte("local\n"), 0o600); err != nil {
+		t.Fatalf("write local target: %v", err)
+	}
+	manifestPath := writeCLIManifest(t, home, `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/git/gitconfig
+    target: ~/.gitconfig
+    strategy: copy
+    tags: [core]
+`)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"install", "--skip-deps", "--yes", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+	got, err := os.ReadFile(filepath.Join(home, ".gitconfig"))
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(got) != "local\n" {
+		t.Fatalf("--yes without --backup-and-replace changed conflict target to %q", got)
+	}
+	meta, err := backups.Load(backups.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load backups: %v", err)
+	}
+	if len(meta.Sets) != 0 {
+		t.Fatalf("--yes default created %d Backup Sets, want 0", len(meta.Sets))
+	}
+}
+
+func TestInstallBackupAndReplaceCreatesBackupSetAndRunsProvisioner(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	fakeRealHome := t.TempDir()
+	t.Setenv("HOME", fakeRealHome)
+
+	stubDir := t.TempDir()
+	writeExecStub(t, filepath.Join(stubDir, "gentle-ai"), "#!/bin/sh\nprintf 'ran' > \"$HOME/gentle-ai-ran\"\n")
+	writeExecStub(t, filepath.Join(stubDir, "engram"), "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	writeCLISource(t, sourceRoot, "configs/git/gitconfig", "managed\n")
+	if err := os.WriteFile(filepath.Join(home, ".gitconfig"), []byte("local\n"), 0o600); err != nil {
+		t.Fatalf("write local target: %v", err)
+	}
+	manifestPath := writeCLIManifest(t, home, `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/git/gitconfig
+    target: ~/.gitconfig
+    strategy: copy
+    tags: [core]
+provisioners:
+  - tool: gentle-ai
+    tags: [core]
+    spec:
+      scope: global
+      persona: neutral
+      agents: [codex]
+    dependencies:
+      - name: gentle-ai
+      - name: engram
+`)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"install", "--yes", "--backup-and-replace", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+	got, err := os.ReadFile(filepath.Join(home, ".gitconfig"))
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(got) != "managed\n" {
+		t.Fatalf("target contents = %q, want managed source after backup-and-replace", got)
+	}
+	meta, err := backups.Load(backups.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load backups: %v", err)
+	}
+	if len(meta.Sets) != 1 {
+		t.Fatalf("Backup Sets = %d, want 1", len(meta.Sets))
+	}
+	preserved, err := os.ReadFile(backups.FilePath(stateRoot, meta.Sets[0].ID, 1, filepath.Join(home, ".gitconfig")))
+	if err != nil {
+		t.Fatalf("read preserved target: %v", err)
+	}
+	if string(preserved) != "local\n" {
+		t.Fatalf("preserved backup = %q, want local content", preserved)
+	}
+	if _, err := os.Stat(filepath.Join(home, "gentle-ai-ran")); err != nil {
+		t.Fatalf("provisioner did not run in sandbox HOME after backup-and-replace: %v", err)
+	}
+}
+
+func TestInstallBackupAndReplaceJSONReportsCreatedBackupSetLocation(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	writeCLISource(t, sourceRoot, "configs/git/gitconfig", "managed\n")
+	if err := os.WriteFile(filepath.Join(home, ".gitconfig"), []byte("local\n"), 0o600); err != nil {
+		t.Fatalf("write local target: %v", err)
+	}
+	manifestPath := writeCLIManifest(t, home, `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/git/gitconfig
+    target: ~/.gitconfig
+    strategy: copy
+    tags: [core]
+`)
+
+	var out, errOut bytes.Buffer
+	code := cli.Run([]string{"install", "--skip-deps", "--yes", "--backup-and-replace", "--output", "json", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot}, &out, &errOut)
+	if code != cli.ExitOK {
+		t.Fatalf("exit code = %d, want 0\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
+	}
+
+	var envelope struct {
+		Data struct {
+			BackupSets []struct {
+				ID      string   `json:"id"`
+				Path    string   `json:"path"`
+				Targets []string `json:"targets"`
+			} `json:"backup_sets"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &envelope); err != nil {
+		t.Fatalf("unmarshal JSON output: %v\n%s", err, out.String())
+	}
+	if len(envelope.Data.BackupSets) != 1 {
+		t.Fatalf("backup_sets length = %d, want 1\n%s", len(envelope.Data.BackupSets), out.String())
+	}
+	set := envelope.Data.BackupSets[0]
+	if set.ID == "" {
+		t.Fatalf("backup set id is empty\n%s", out.String())
+	}
+	if set.Path != backups.SetDir(stateRoot, set.ID) {
+		t.Fatalf("backup set path = %q, want %q", set.Path, backups.SetDir(stateRoot, set.ID))
+	}
+	if len(set.Targets) != 1 || set.Targets[0] != filepath.Join(home, ".gitconfig") {
+		t.Fatalf("backup set targets = %#v, want gitconfig target", set.Targets)
+	}
+}
+
+func TestInstallBackupAndReplaceRequiresYes(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	writeCLISource(t, sourceRoot, "configs/git/gitconfig", "managed\n")
+	manifestPath := writeCLIManifest(t, home, `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/git/gitconfig
+    target: ~/.gitconfig
+    strategy: copy
+    tags: [core]
+`)
+
+	var out, errOut bytes.Buffer
+	code := cli.Run([]string{"install", "--skip-deps", "--backup-and-replace", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot}, &out, &errOut)
+	if code != cli.ExitError {
+		t.Fatalf("exit code = %d, want 1\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "--backup-and-replace requires --yes") {
+		t.Fatalf("stderr missing --yes requirement:\n%s", errOut.String())
 	}
 }
 

--- a/internal/cli/json_reports.go
+++ b/internal/cli/json_reports.go
@@ -38,12 +38,18 @@ type installReport struct {
 	Dependencies       *installDependenciesReport `json:"dependencies,omitempty"`
 	Plan               plan.Plan                  `json:"plan"`
 	Provisioners       provision.Plan             `json:"provisioners"`
+	BackupSets         []installBackupSetReport   `json:"backup_sets,omitempty"`
 	ProvisionerResults *provision.Report          `json:"provisioner_results,omitempty"`
 }
 
 type installDependenciesReport struct {
 	Preview *deps.InstallDryRunReport `json:"preview,omitempty"`
 	Result  *deps.InstallReport       `json:"result,omitempty"`
+}
+
+type installBackupSetReport struct {
+	backups.BackupSet
+	Path string `json:"path"`
 }
 
 type updateReport struct {

--- a/internal/cli/output_golden_test.go
+++ b/internal/cli/output_golden_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/yersonargotev/dots/internal/backups"
 	"github.com/yersonargotev/dots/internal/deps"
 	"github.com/yersonargotev/dots/internal/doctor"
 	"github.com/yersonargotev/dots/internal/plan"
@@ -140,6 +141,10 @@ func TestEnvelopeGolden(t *testing.T) {
 					}},
 					Provisioners: provision.Plan{Profile: "default", Steps: []provision.Step{
 						{Tool: "gentle-ai", Executable: "gentle-ai", Args: []string{"install", "--scope", "global", "--agents", "claude-code"}, Targets: []string{"~/.claude", "~/.gentle-ai"}, GlobalTools: []string{"claude (~/.local/bin via npm prefix)"}},
+					}},
+					BackupSets: []installBackupSetReport{{
+						BackupSet: backups.BackupSet{ID: "backup-20260627T140000.000000000Z", CreatedAt: "2026-06-27T14:00:00Z", Reason: "pre-install conflict protection", Targets: []string{"/home/user/.gitconfig"}},
+						Path:      "/home/user/.local/state/dots/backups/backup-20260627T140000.000000000Z",
 					}},
 				},
 			},

--- a/internal/cli/testdata/envelope_install.golden
+++ b/internal/cli/testdata/envelope_install.golden
@@ -75,6 +75,17 @@
           ]
         }
       ]
-    }
+    },
+    "backup_sets": [
+      {
+        "id": "backup-20260627T140000.000000000Z",
+        "createdAt": "2026-06-27T14:00:00Z",
+        "reason": "pre-install conflict protection",
+        "targets": [
+          "/home/user/.gitconfig"
+        ],
+        "path": "/home/user/.local/state/dots/backups/backup-20260627T140000.000000000Z"
+      }
+    ]
   }
 }

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -197,7 +197,7 @@ func runUpdateWorkflow(cmd *cobra.Command, opts updateOptions, emit bool) (updat
 	if opts.dryRun {
 		return report, nil
 	}
-	applied, err := resolveAndApply(cmd, p, paths, opts.yes, opts.noTUI)
+	applied, err := resolveAndApply(cmd, p, paths, opts.yes, opts.noTUI, false)
 	if err != nil {
 		return updateReport{}, err
 	}


### PR DESCRIPTION
Closes #212

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds explicit `dots install --yes --backup-and-replace` conflict replacement mode.
- Keeps plain `dots install --yes` conservative: conflicts still skip by default.
- Reports created Backup Sets in JSON output and documents the flow.

## Changes

| File | Change |
|------|--------|
| `internal/cli/install.go` | Adds `--backup-and-replace`, maps conflicts to replace only with explicit `--yes`, and reports Backup Sets created during apply. |
| `internal/cli/json_reports.go` | Adds optional `data.backup_sets` install report records with Backup Set metadata and path. |
| `internal/cli/install_deps_test.go` | Covers conservative `--yes`, backup-and-replace, JSON reporting, and `--yes` requirement. |
| `internal/cli/output_golden_test.go` / `internal/cli/testdata/envelope_install.golden` | Locks the new JSON shape. |
| `internal/cli/update.go` | Preserves existing update behavior by opting out of the new install-only mode. |
| `README.md`, `docs/backups.md`, `docs/agents/output-contract.md` | Documents the new non-interactive adoption flow and JSON field. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp>`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
