### PR TITLE
feat(agents): add GitHub CLI dependency

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -12,6 +12,7 @@ This repository tracks work in GitHub Issues.
 - Product requirements and implementation-ready work should be published as GitHub Issues.
 - PRD issues should use the `ready-for-agent` label once they are sufficiently specified for an agent to implement without additional human context.
 - Use the GitHub CLI (`gh`) when creating or updating issues from automation.
+- Authenticate before agent work that touches GitHub: run `gh auth login` for an interactive workstation, or export `GH_TOKEN`/`GITHUB_TOKEN` in non-interactive environments.
 
 ## Notes
 

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -45,10 +45,10 @@ Current Profiles:
 |---------|------|--------|----------------------|
 | `default` | `core` | Core dotfiles without provisioners. | Core Development Baseline via the `core` tag-scoped Dependency Set |
 | `desktop` | `core`, `desktop` | Desktop dotfiles and desktop-only tool integrations; no gentle-ai agent setup. | `Desktop Nerd Font` via Homebrew cask `font-cascadia-code-nf`, detected with `CascadiaCodeNF*` or `CaskaydiaCoveNerdFont*` |
-| `agents` | `core`, `agents` | Core dotfiles plus gentle-ai memory/context setup, cleanup, and shared engineering skills for supported agents. Add `--tag persona` for optional persona styling Regenerated Content or `--tag sdd` for Gentle-AI SDD setup. | Core Development Baseline via the `core` tag-scoped Dependency Set |
+| `agents` | `core`, `agents` | Core dotfiles plus gentle-ai memory/context setup, cleanup, and shared engineering skills for supported agents. Add `--tag persona` for optional persona styling Regenerated Content or `--tag sdd` for Gentle-AI SDD setup. | Core Development Baseline via the `core` tag-scoped Dependency Set; `GitHub CLI` via the `agents` tag-scoped Dependency Set |
 | `web` | `core`, `web` | Optional frontend/browser workbench: web design skills plus Chrome DevTools integrations. | Core Development Baseline via the `core` tag-scoped Dependency Set; `Playwright CLI` via Homebrew formula `playwright-cli` |
 | `mobile` | `core`, `mobile` | Optional Dart and Flutter mobile development agent skills plus Dart/Flutter MCP integration for Claude, Codex, Antigravity, and GitHub Copilot in VS Code. | Core Development Baseline via the `core` tag-scoped Dependency Set |
-| `workstation` | `core`, `desktop`, `agents` | Full workstation setup when both desktop integrations and agent setup are desired; web tooling remains explicit opt-in. | Core Development Baseline via the `core` tag-scoped Dependency Set; `Desktop Nerd Font` via Homebrew cask `font-cascadia-code-nf`, detected with `CascadiaCodeNF*` or `CaskaydiaCoveNerdFont*` |
+| `workstation` | `core`, `desktop`, `agents` | Full workstation setup when both desktop integrations and agent setup are desired; web tooling remains explicit opt-in. | Core Development Baseline via the `core` tag-scoped Dependency Set; `GitHub CLI` via the `agents` tag-scoped Dependency Set; `Desktop Nerd Font` via Homebrew cask `font-cascadia-code-nf`, detected with `CascadiaCodeNF*` or `CaskaydiaCoveNerdFont*` |
 
 ## Tag-scoped Dependency Sets
 
@@ -57,11 +57,14 @@ before Managed Entry and Provisioner Dependencies. The current `core` set is the
 Core Development Baseline from ADR 0010: shell/terminal foundations remain on
 their Managed Entries, while common runtimes and package tools are owned by
 Homebrew-provider declarations for `fnm`, `rustup`, `go`, `uv`, `pnpm`, and
-`bun`. Linux Homebrew fallback is explicit with `linux_homebrew: true`; GUI apps and fonts stay manual unless they have validated Linux support. Node and Rust use constrained built-in toolchain bootstrap commands after
-manager installation: `fnm install --lts` for Node LTS and `rustup default
-stable` for Rust stable. Bootstrap declarations do not make an action executable
-by themselves: the manager executable must already be on `PATH` or a concrete
-installer/provider must run first.
+`bun`. The `agents` set adds `GitHub CLI` (`gh`) for issue and PR automation.
+Linux Homebrew fallback is explicit with `linux_homebrew: true`; GUI apps and
+fonts stay manual unless they have validated Linux support. Node and Rust use
+constrained built-in toolchain bootstrap commands after manager installation:
+`fnm install --lts` for Node LTS and `rustup default stable` for Rust stable.
+Bootstrap declarations do not make an action executable by themselves: the
+manager executable must already be on `PATH` or a concrete installer/provider
+must run first.
 
 On Linux, when `fnm` is absent, no executable package provider is available, and
 `curl`, `bash`, and `unzip` are present, Node may use the constrained official
@@ -176,6 +179,7 @@ Current dependency package coverage:
 | `uv` | `uv` | `uv` | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual |
 | `pnpm` | `pnpm` | `pnpm` | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual |
 | `bun` | `bun` | `bun` | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual |
+| `GitHub CLI` | `gh` | `gh` | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual |
 | `Playwright CLI` | `playwright-cli` | `playwright-cli` | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual |
 | `ghostty` | `ghostty` | `ghostty` | Manual | Manual | Manual |
 | `Warp` | `warp-terminal` | Manual | Manual | Manual | Manual |
@@ -192,9 +196,9 @@ Current dependency package coverage:
 | `npx` | `npx` | Manual | Manual | Manual | Manual |
 
 Reviewed Linuxbrew opt-ins include CLI/runtime tools whose Homebrew formulas are
-expected to work on Linuxbrew: the core runtimes/package tools, Playwright CLI,
-atuin, gentle-ai, and engram. Brew-only GUI apps such as Ghostty and Zed remain
-manual on Linux.
+expected to work on Linuxbrew: the core runtimes/package tools, GitHub CLI,
+Playwright CLI, atuin, gentle-ai, and engram. Brew-only GUI apps such as Ghostty
+and Zed remain manual on Linux.
 
 Homebrew dependencies declared with a fully-qualified tap formula such as
 `gentleman-programming/tap/gentle-ai` may require explicit Homebrew Tap Trust on

--- a/dots.yaml
+++ b/dots.yaml
@@ -79,6 +79,16 @@ dependencies:
         command: bun
         brew: bun
         linux_homebrew: true
+  - tags:
+      - agents
+    os:
+      - darwin
+      - linux
+    dependencies:
+      - name: GitHub CLI
+        command: gh
+        brew: gh
+        linux_homebrew: true
 entries:
   - source: configs/zsh/zshrc
     target: ~/.zshrc

--- a/internal/deps/plan_test.go
+++ b/internal/deps/plan_test.go
@@ -466,7 +466,7 @@ func TestRepositoryManifestDoesNotAdvertiseUnavailableUbuntuAptPackages(t *testi
 			t.Fatalf("Plan() error = %v", err)
 		}
 
-		for _, name := range []string{"starship", "zellij"} {
+		for _, name := range []string{"starship", "zellij", "GitHub CLI"} {
 			action, ok := findAction(report.Actions, name)
 			if !ok {
 				t.Fatalf("missing action for %q in %#v", name, report.Actions)
@@ -486,7 +486,7 @@ func TestRepositoryManifestDoesNotAdvertiseUnavailableUbuntuAptPackages(t *testi
 			t.Fatalf("Plan() error = %v", err)
 		}
 
-		for _, name := range []string{"starship", "zellij"} {
+		for _, name := range []string{"starship", "zellij", "GitHub CLI"} {
 			action, ok := findAction(report.Actions, name)
 			if !ok {
 				t.Fatalf("missing action for %q in %#v", name, report.Actions)

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -668,6 +668,49 @@ func TestRepositoryManifestWebProfileIncludesPlaywrightCLI(t *testing.T) {
 	}
 }
 
+func TestRepositoryManifestAgentsProfileIncludesGitHubCLI(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", ".."))
+	manifestPath := filepath.Join(root, "dots.yaml")
+
+	got, err := manifest.LoadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("LoadFile(%q) error = %v", manifestPath, err)
+	}
+
+	var agents *manifest.DependencySet
+	for i := range got.Dependencies {
+		candidate := &got.Dependencies[i]
+		if hasString(candidate.Tags, "agents") {
+			agents = candidate
+			break
+		}
+	}
+	if agents == nil {
+		t.Fatal("repository manifest missing agents dependency set")
+	}
+	if !sameStrings(agents.OS, []string{"darwin", "linux"}) {
+		t.Fatalf("agents dependency set OS = %#v, want [darwin linux]", agents.OS)
+	}
+
+	var dep *manifest.Dependency
+	for i := range agents.Dependencies {
+		candidate := &agents.Dependencies[i]
+		if candidate.Name == "GitHub CLI" {
+			dep = candidate
+			break
+		}
+	}
+	if dep == nil {
+		t.Fatalf("agents dependency set missing GitHub CLI: %#v", agents.Dependencies)
+	}
+	if dep.Command != "gh" || dep.Brew != "gh" || !dep.LinuxHomebrew {
+		t.Fatalf("GitHub CLI dependency = %#v, want command/brew gh with linux_homebrew", *dep)
+	}
+	if dep.Apt != "" || dep.Dnf != "" || dep.Pacman != "" {
+		t.Fatalf("GitHub CLI dependency = %#v, want Homebrew/manual Linux handling until distro setup is modeled", *dep)
+	}
+}
+
 func TestRepositoryManifestLinuxHomebrewReviewBoundary(t *testing.T) {
 	root := filepath.Clean(filepath.Join("..", ".."))
 	manifestPath := filepath.Join(root, "dots.yaml")


### PR DESCRIPTION
Closes #216

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds GitHub CLI (`gh`) to the `agents` tag-scoped dependency set.
- Keeps Ubuntu honest: no fake apt mapping; Linux uses reviewed Homebrew fallback or manual guidance.
- Documents `gh` authentication for agent issue/PR workflows.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Adds `GitHub CLI` as an `agents` dependency with `command: gh`, `brew: gh`, and Linux Homebrew fallback. |
| `docs/manifest.md` | Documents the new agents dependency and package coverage. |
| `docs/agents/issue-tracker.md` | Documents `gh auth login` and token-based authentication requirements. |
| `internal/manifest/manifest_test.go` | Covers the repository manifest's `agents` dependency set for `GitHub CLI`. |
| `internal/deps/plan_test.go` | Verifies Ubuntu does not advertise unsupported apt installability for `GitHub CLI`. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed dependency check: `go run ./cmd/dots deps check --profile agents --file dots.yaml --home <tmp> --output json`
- [x] Sandboxed plan: `go run ./cmd/dots plan --file dots.yaml --profile agents --source-root "$PWD" --home <tmp> --state-root <tmp>`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #216`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
