### PR TITLE
feat(deps): add starship user-local provider

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -174,7 +174,7 @@ Current dependency package coverage:
 | `Desktop Nerd Font` | Font globs `CascadiaCodeNF*` or `CaskaydiaCoveNerdFont*` | `brew install --cask font-cascadia-code-nf` | Manual | Manual | Manual |
 | `zsh` | `zsh` | `zsh` | `zsh` | `zsh` | `zsh` |
 | `git` | `git` | `git` | `git` | `git` | `git` |
-| `starship` | `starship` | `starship` | `starship` | `starship` | `starship` |
+| `starship` | `starship` | `starship` | User-local / Linuxbrew opt-in/manual | `starship` | `starship` |
 | `tmux` | `tmux` | `tmux` | `tmux` | `tmux` | `tmux` |
 | `zellij` | `zellij` | `zellij` | User-local / Linuxbrew opt-in/manual | `zellij` | `zellij` |
 | `Node LTS (fnm)` | `fnm`, `node`; bootstrap `fnm install --lts` | `fnm` | Linuxbrew opt-in or official fnm installer (`curl`, `bash`, `unzip`) | Linuxbrew opt-in or official fnm installer (`curl`, `bash`, `unzip`) | Linuxbrew opt-in or official fnm installer (`curl`, `bash`, `unzip`) |
@@ -200,7 +200,7 @@ Current dependency package coverage:
 | `npx` | `npx` | Manual | Manual | Manual | Manual |
 
 Reviewed Linuxbrew opt-ins include CLI/runtime tools whose Homebrew formulas are
-expected to work on Linuxbrew: the core runtimes/package tools, GitHub CLI,
+expected to work on Linuxbrew: Starship, the core runtimes/package tools, GitHub CLI,
 Playwright CLI, atuin, gentle-ai, and engram. Brew-only GUI apps such as Ghostty
 and Zed remain manual on Linux.
 

--- a/dots.yaml
+++ b/dots.yaml
@@ -172,6 +172,12 @@ entries:
         linux_homebrew: true
         dnf: starship
         pacman: starship
+        user_local:
+          recipe: starship
+          version: v1.25.1
+          checksums:
+            linux_amd64: 4488c11ca632327d1f1f16fb2f102c0646094c35479cd5435991385da43c61ac
+            linux_arm64: 01517aab398959ea9ea73bdb4f032ea4dbb51dff5c8e5eb05b4a1b9b7ab872b8
   - source: configs/tmux/tmux.conf
     target: ~/.tmux.conf
     strategy: symlink

--- a/internal/deps/plan_test.go
+++ b/internal/deps/plan_test.go
@@ -467,7 +467,18 @@ func TestRepositoryManifestDoesNotAdvertiseUnavailableUbuntuAptPackages(t *testi
 			t.Fatalf("Plan() error = %v", err)
 		}
 
-		for _, name := range []string{"starship", "GitHub CLI"} {
+		githubCLI, ok := findAction(report.Actions, "GitHub CLI")
+		if !ok {
+			t.Fatalf("missing action for GitHub CLI in %#v", report.Actions)
+		}
+		if githubCLI.Provider == deps.TierDebian || githubCLI.Executable == "sudo" {
+			t.Fatalf("GitHub CLI action = %#v, must not advertise unavailable Ubuntu apt package", githubCLI)
+		}
+		if githubCLI.Status != deps.InstallActionStatusInstallable || githubCLI.Provider != deps.TierHomebrew || githubCLI.Executable != "brew" {
+			t.Fatalf("GitHub CLI action = %#v, want installable Homebrew fallback", githubCLI)
+		}
+
+		for _, name := range []string{"starship", "zellij"} {
 			action, ok := findAction(report.Actions, name)
 			if !ok {
 				t.Fatalf("missing action for %q in %#v", name, report.Actions)
@@ -475,16 +486,9 @@ func TestRepositoryManifestDoesNotAdvertiseUnavailableUbuntuAptPackages(t *testi
 			if action.Provider == deps.TierDebian || action.Executable == "sudo" {
 				t.Fatalf("%s action = %#v, must not advertise unavailable Ubuntu apt package", name, action)
 			}
-			if action.Status != deps.InstallActionStatusInstallable || action.Provider != deps.TierHomebrew || action.Executable != "brew" {
-				t.Fatalf("%s action = %#v, want installable Homebrew fallback", name, action)
+			if action.Provider != deps.TierUserLocal || action.UserLocal == nil {
+				t.Fatalf("%s action = %#v, want user-local before Linuxbrew", name, action)
 			}
-		}
-		zellij, ok := findAction(report.Actions, "zellij")
-		if !ok {
-			t.Fatalf("missing action for zellij in %#v", report.Actions)
-		}
-		if zellij.Provider != deps.TierUserLocal || zellij.UserLocal == nil {
-			t.Fatalf("zellij action = %#v, want user-local before Linuxbrew", zellij)
 		}
 	})
 
@@ -494,21 +498,22 @@ func TestRepositoryManifestDoesNotAdvertiseUnavailableUbuntuAptPackages(t *testi
 			t.Fatalf("Plan() error = %v", err)
 		}
 
-		for _, name := range []string{"starship", "GitHub CLI"} {
+		githubCLI, ok := findAction(report.Actions, "GitHub CLI")
+		if !ok {
+			t.Fatalf("missing action for GitHub CLI in %#v", report.Actions)
+		}
+		if githubCLI.Status != deps.InstallActionStatusManual || githubCLI.Provider == deps.TierDebian || githubCLI.Executable == "sudo" || githubCLI.Manual == "" {
+			t.Fatalf("GitHub CLI action = %#v, want manual guidance without Ubuntu apt installability", githubCLI)
+		}
+
+		for _, name := range []string{"starship", "zellij"} {
 			action, ok := findAction(report.Actions, name)
 			if !ok {
 				t.Fatalf("missing action for %q in %#v", name, report.Actions)
 			}
-			if action.Status != deps.InstallActionStatusManual || action.Provider == deps.TierDebian || action.Executable == "sudo" || action.Manual == "" {
-				t.Fatalf("%s action = %#v, want manual guidance without Ubuntu apt installability", name, action)
+			if action.Provider != deps.TierUserLocal || action.UserLocal == nil {
+				t.Fatalf("%s action = %#v, want user-local without Linuxbrew", name, action)
 			}
-		}
-		zellij, ok := findAction(report.Actions, "zellij")
-		if !ok {
-			t.Fatalf("missing action for zellij in %#v", report.Actions)
-		}
-		if zellij.Provider != deps.TierUserLocal || zellij.UserLocal == nil {
-			t.Fatalf("zellij action = %#v, want user-local without Linuxbrew", zellij)
 		}
 	})
 }
@@ -687,6 +692,54 @@ func userLocalProviderManifest() manifest.Manifest {
 				},
 			}},
 		}},
+	}
+}
+
+func TestPlanResolvesStarshipUserLocalArtifact(t *testing.T) {
+	m := userLocalProviderManifest()
+	m.Entries[0].Dependencies[0] = manifest.Dependency{
+		Name:          "starship",
+		Command:       "starship",
+		Brew:          "starship",
+		LinuxHomebrew: true,
+		Dnf:           "starship",
+		Pacman:        "starship",
+		UserLocal: &manifest.UserLocalProvider{
+			Recipe:  "starship",
+			Version: "v1.25.1",
+			Checksums: map[string]string{
+				"linux_amd64": "4488c11ca632327d1f1f16fb2f102c0646094c35479cd5435991385da43c61ac",
+				"linux_arm64": "01517aab398959ea9ea73bdb4f032ea4dbb51dff5c8e5eb05b4a1b9b7ab872b8",
+			},
+		},
+	}
+
+	report, err := deps.Plan(m, deps.Options{Profile: "default", OS: "linux", Arch: "amd64"}, lookupSet("brew"), fontLookupSet(), deps.TierDebian)
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+	action := report.Actions[0]
+	if action.Provider != deps.TierUserLocal || action.UserLocal == nil {
+		t.Fatalf("action = %#v, want starship user-local provider", action)
+	}
+	if action.UserLocal.Recipe != "starship" || action.UserLocal.Layout != "single-binary" || !strings.Contains(action.UserLocal.URL, "starship-x86_64-unknown-linux-gnu.tar.gz") {
+		t.Fatalf("user-local artifact = %#v, want pinned starship linux amd64 artifact", action.UserLocal)
+	}
+
+	report, err = deps.Plan(m, deps.Options{Profile: "default", OS: "linux", Arch: "amd64"}, lookupSet("sudo", "dnf", "brew"), fontLookupSet(), deps.TierFedora)
+	if err != nil {
+		t.Fatalf("Plan() with Fedora tier error = %v", err)
+	}
+	if got := report.Actions[0]; got.Provider != deps.TierFedora || got.UserLocal != nil {
+		t.Fatalf("Fedora action = %#v, want distro provider before user-local", got)
+	}
+
+	report, err = deps.Plan(m, deps.Options{Profile: "default", OS: "linux", Arch: "amd64"}, lookupSet("starship", "brew"), fontLookupSet(), deps.TierDebian)
+	if err != nil {
+		t.Fatalf("Plan() with present starship error = %v", err)
+	}
+	if len(report.Actions) != 0 {
+		t.Fatalf("Actions = %#v, want no install when starship is present", report.Actions)
 	}
 }
 

--- a/internal/deps/user_local.go
+++ b/internal/deps/user_local.go
@@ -87,6 +87,26 @@ var userLocalRecipes = map[string]userLocalRecipe{
 		binaryPath:  func(archive, command string) string { return strings.TrimSuffix(archive, ".zip") + "/" + command },
 		links:       []string{"bun"},
 	},
+	"starship": {
+		archiveName: func(version, goarch string) (string, bool) {
+			switch goarch {
+			case "amd64":
+				return "starship-x86_64-unknown-linux-gnu.tar.gz", true
+			case "arm64":
+				return "starship-aarch64-unknown-linux-musl.tar.gz", true
+			default:
+				return "", false
+			}
+		},
+		url: func(version, archive string) string {
+			return fmt.Sprintf("https://github.com/starship/starship/releases/download/%s/%s", version, archive)
+		},
+		layout:      userLocalLayoutSingle,
+		command:     "starship",
+		archiveType: "tar.gz",
+		binaryPath:  func(_ string, command string) string { return command },
+		links:       []string{"starship"},
+	},
 	"zellij": {
 		archiveName: func(version, goarch string) (string, bool) {
 			switch goarch {

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -756,6 +756,14 @@ func TestRepositoryManifestLinuxHomebrewReviewBoundary(t *testing.T) {
 			if (name == "starship" || name == "zellij") && dep.Apt != "" {
 				t.Fatalf("%s dependency = %#v, want no Ubuntu apt package declaration", name, dep)
 			}
+			if name == "starship" {
+				if dep.UserLocal == nil || dep.UserLocal.Recipe != "starship" || dep.UserLocal.Version == "" {
+					t.Fatalf("starship dependency = %#v, want reviewed user-local policy", dep)
+				}
+				if dep.UserLocal.Checksums["linux_amd64"] == "" || dep.UserLocal.Checksums["linux_arm64"] == "" {
+					t.Fatalf("starship user_local checksums = %#v, want linux amd64 and arm64", dep.UserLocal.Checksums)
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Closes #230

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds an allowlisted Starship User-Local Provider recipe with pinned Linux release artifacts.
- Opts the repository Starship dependency into user-local install after distro providers and before Linuxbrew fallback.
- Documents the Starship user-local path and adds regression coverage for provider priority and absent/present behavior.

## Changes

| File | Change |
|------|--------|
| `internal/deps/user_local.go` | Added the reviewed Starship recipe for Linux amd64/arm64 tarball artifacts. |
| `dots.yaml` | Added pinned Starship `user_local` version/checksum policy. |
| `internal/deps/plan_test.go` | Covered Starship user-local selection, distro priority, and no-op when `starship` is present. |
| `internal/manifest/manifest_test.go` | Asserted repository manifest keeps Starship user-local policy and Linux checksums. |
| `docs/manifest.md` | Distinguished Starship user-local/Linuxbrew/manual Linux handling from distro package installs. |

## Test Plan

- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp>`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #230`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
