### PR TITLE
feat(deps): add Atuin user-local provider

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -187,7 +187,7 @@ Current dependency package coverage:
 | `Playwright CLI` | `playwright-cli` | `playwright-cli` | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual |
 | `ghostty` | `ghostty` | `ghostty` | Manual | Manual | Manual |
 | `Warp` | `warp-terminal` | Manual | Manual | Manual | Manual |
-| `atuin` | `atuin` | `atuin` | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual |
+| `atuin` | `atuin` | `atuin` | User-local / Linuxbrew opt-in/manual | User-local / Linuxbrew opt-in/manual | User-local / Linuxbrew opt-in/manual |
 | `bat` | `bat` | `bat` | `bat` | `bat` | `bat` |
 | `neovim` | `nvim` | `neovim` | `neovim` | `neovim` | `neovim` |
 | `zed` | `zed` | `zed` | Manual | Manual | Manual |

--- a/dots.yaml
+++ b/dots.yaml
@@ -291,6 +291,12 @@ entries:
         command: atuin
         brew: atuin
         linux_homebrew: true
+        user_local:
+          recipe: atuin
+          version: v18.16.1
+          checksums:
+            linux_amd64: 5c41e20c0130ac84fa4bfa42c19bb55a07855838506063caad0d2922593b39be
+            linux_arm64: 9b2b7b41c3587533964ec5ab204b5116200bda39d534619387bcf4f197739b47
   - source: configs/atuin/themes/catppuccin-mocha.toml
     target: ~/.config/atuin/themes/catppuccin-mocha.toml
     strategy: symlink
@@ -304,6 +310,12 @@ entries:
         command: atuin
         brew: atuin
         linux_homebrew: true
+        user_local:
+          recipe: atuin
+          version: v18.16.1
+          checksums:
+            linux_amd64: 5c41e20c0130ac84fa4bfa42c19bb55a07855838506063caad0d2922593b39be
+            linux_arm64: 9b2b7b41c3587533964ec5ab204b5116200bda39d534619387bcf4f197739b47
   - source: configs/bat/config
     target: ~/.config/bat/config
     strategy: symlink

--- a/internal/deps/plan_test.go
+++ b/internal/deps/plan_test.go
@@ -68,6 +68,55 @@ func TestPlanProducesStructuredInstallActionsForMappedPackages(t *testing.T) {
 	}
 }
 
+func TestPlanUsesAtuinUserLocalProviderOnLinuxWhenDistroProviderUnavailable(t *testing.T) {
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}},
+		Entries: []manifest.Entry{{
+			Source: "configs/atuin/config.toml", Target: "~/.config/atuin/config.toml", Strategy: "symlink", Tags: []string{"core"},
+			Dependencies: []manifest.Dependency{{
+				Name:          "atuin",
+				Command:       "atuin",
+				Brew:          "atuin",
+				LinuxHomebrew: true,
+				UserLocal: &manifest.UserLocalProvider{
+					Recipe:  "atuin",
+					Version: "v18.16.1",
+					Checksums: map[string]string{
+						"linux_amd64": "5c41e20c0130ac84fa4bfa42c19bb55a07855838506063caad0d2922593b39be",
+					},
+				},
+			}},
+		}},
+	}
+
+	installedReport, err := deps.Plan(m, deps.Options{Profile: "default", OS: "linux", Arch: "amd64"}, lookupSet("atuin"), fontLookupSet(), deps.TierDebian)
+	if err != nil {
+		t.Fatalf("Plan() with installed atuin error = %v", err)
+	}
+	if len(installedReport.Actions) != 0 {
+		t.Fatalf("installed Actions len = %d, want 0 (%#v)", len(installedReport.Actions), installedReport.Actions)
+	}
+
+	report, err := deps.Plan(m, deps.Options{Profile: "default", OS: "linux", Arch: "amd64"}, lookupSet(), fontLookupSet(), deps.TierDebian)
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+	if len(report.Actions) != 1 {
+		t.Fatalf("Actions len = %d, want 1 (%#v)", len(report.Actions), report.Actions)
+	}
+	action := report.Actions[0]
+	if action.Provider != deps.TierUserLocal || action.UserLocal == nil {
+		t.Fatalf("action = %#v, want Atuin user-local provider", action)
+	}
+	if action.UserLocal.Recipe != "atuin" || action.UserLocal.Command != "atuin" || action.UserLocal.Layout != "bundle" {
+		t.Fatalf("UserLocal = %#v, want atuin bundle recipe", action.UserLocal)
+	}
+	if action.UserLocal.URL != "https://github.com/atuinsh/atuin/releases/download/v18.16.1/atuin-x86_64-unknown-linux-gnu.tar.gz" {
+		t.Fatalf("UserLocal.URL = %q", action.UserLocal.URL)
+	}
+}
+
 func TestPlanReportsDependencyRequirement(t *testing.T) {
 	m := manifest.Manifest{
 		Version: 1,

--- a/internal/deps/user_local.go
+++ b/internal/deps/user_local.go
@@ -87,6 +87,26 @@ var userLocalRecipes = map[string]userLocalRecipe{
 		binaryPath:  func(archive, command string) string { return strings.TrimSuffix(archive, ".zip") + "/" + command },
 		links:       []string{"bun"},
 	},
+	"atuin": {
+		archiveName: func(version, goarch string) (string, bool) {
+			switch goarch {
+			case "amd64":
+				return "atuin-x86_64-unknown-linux-gnu.tar.gz", true
+			case "arm64":
+				return "atuin-aarch64-unknown-linux-gnu.tar.gz", true
+			default:
+				return "", false
+			}
+		},
+		url: func(version, archive string) string {
+			return fmt.Sprintf("https://github.com/atuinsh/atuin/releases/download/%s/%s", version, archive)
+		},
+		layout:      userLocalLayoutBundle,
+		command:     "atuin",
+		archiveType: "tar.gz",
+		binaryPath:  func(archive, command string) string { return strings.TrimSuffix(archive, ".tar.gz") + "/" + command },
+		links:       []string{"atuin"},
+	},
 	"starship": {
 		archiveName: func(version, goarch string) (string, bool) {
 			switch goarch {

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -745,7 +745,7 @@ func TestRepositoryManifestLinuxHomebrewReviewBoundary(t *testing.T) {
 		}
 	}
 
-	for _, name := range []string{"starship", "zellij", "gentle-ai", "engram"} {
+	for _, name := range []string{"starship", "zellij", "atuin", "gentle-ai", "engram"} {
 		if len(dependencies[name]) == 0 {
 			t.Fatalf("repository manifest missing %s dependency", name)
 		}
@@ -753,15 +753,15 @@ func TestRepositoryManifestLinuxHomebrewReviewBoundary(t *testing.T) {
 			if !dep.LinuxHomebrew {
 				t.Fatalf("%s dependency = %#v, want reviewed Linuxbrew opt-in", name, dep)
 			}
-			if (name == "starship" || name == "zellij") && dep.Apt != "" {
+			if (name == "starship" || name == "zellij" || name == "atuin") && dep.Apt != "" {
 				t.Fatalf("%s dependency = %#v, want no Ubuntu apt package declaration", name, dep)
 			}
-			if name == "starship" {
-				if dep.UserLocal == nil || dep.UserLocal.Recipe != "starship" || dep.UserLocal.Version == "" {
-					t.Fatalf("starship dependency = %#v, want reviewed user-local policy", dep)
+			if name == "starship" || name == "atuin" {
+				if dep.UserLocal == nil || dep.UserLocal.Recipe != name || dep.UserLocal.Version == "" {
+					t.Fatalf("%s dependency = %#v, want reviewed user-local policy", name, dep)
 				}
 				if dep.UserLocal.Checksums["linux_amd64"] == "" || dep.UserLocal.Checksums["linux_arm64"] == "" {
-					t.Fatalf("starship user_local checksums = %#v, want linux amd64 and arm64", dep.UserLocal.Checksums)
+					t.Fatalf("%s user_local checksums = %#v, want linux amd64 and arm64", name, dep.UserLocal.Checksums)
 				}
 			}
 		}


### PR DESCRIPTION
Closes #229

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds Atuin to the reviewed Linux User-Local Provider allowlist.
- Opts the Atuin manifest entries into the pinned v18.16.1 user-local artifact with Linux amd64/arm64 checksums.
- Updates provider docs and tests for Atuin planning/manifest policy.

## Changes

| File | Change |
|------|--------|
| `internal/deps/user_local.go` | Added the Atuin bundle recipe and GitHub release artifact mapping. |
| `dots.yaml` | Added explicit Atuin `user_local` policy to both Atuin managed entries. |
| `internal/deps/plan_test.go` | Covered Atuin user-local selection only when the `atuin` probe is absent. |
| `internal/manifest/manifest_test.go` | Required repository Atuin dependencies to keep reviewed Linux fallback and user-local policy. |
| `docs/manifest.md` | Documented Atuin as user-local capable on Linux tiers. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp>`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
