### PR TITLE
feat(deps): add bat user-local provider

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -188,7 +188,7 @@ Current dependency package coverage:
 | `ghostty` | `ghostty` | `ghostty` | Manual | Manual | Manual |
 | `Warp` | `warp-terminal` | Manual | Manual | Manual | Manual |
 | `atuin` | `atuin` | `atuin` | User-local / Linuxbrew opt-in/manual | User-local / Linuxbrew opt-in/manual | User-local / Linuxbrew opt-in/manual |
-| `bat` | `bat` | `bat` | `bat` | `bat` | `bat` |
+| `bat` | `bat` | `bat` | User-local / Linuxbrew opt-in/manual | `bat` | `bat` |
 | `neovim` | `nvim` | `neovim` | `neovim` | `neovim` | `neovim` |
 | `zed` | `zed` | `zed` | Manual | Manual | Manual |
 | `opencode` | `opencode` | Manual | Manual | Manual | Manual |

--- a/dots.yaml
+++ b/dots.yaml
@@ -328,9 +328,15 @@ entries:
       - name: bat
         command: bat
         brew: bat
-        apt: bat
+        linux_homebrew: true
         dnf: bat
         pacman: bat
+        user_local:
+          recipe: bat
+          version: v0.26.1
+          checksums:
+            linux_amd64: 726f04c8f576a7fd18b7634f1bbf2f915c43494c1c0f013baa3287edb0d5a2a3
+            linux_arm64: 422eb73e11c854fddd99f5ca8461c2f1d6e6dce0a2a8c3d5daade5ffcb6564aa
   - source: configs/nvim
     target: ~/.config/nvim
     strategy: symlink

--- a/internal/deps/plan_test.go
+++ b/internal/deps/plan_test.go
@@ -527,7 +527,7 @@ func TestRepositoryManifestDoesNotAdvertiseUnavailableUbuntuAptPackages(t *testi
 			t.Fatalf("GitHub CLI action = %#v, want installable Homebrew fallback", githubCLI)
 		}
 
-		for _, name := range []string{"starship", "zellij"} {
+		for _, name := range []string{"bat", "starship", "zellij"} {
 			action, ok := findAction(report.Actions, name)
 			if !ok {
 				t.Fatalf("missing action for %q in %#v", name, report.Actions)
@@ -555,7 +555,7 @@ func TestRepositoryManifestDoesNotAdvertiseUnavailableUbuntuAptPackages(t *testi
 			t.Fatalf("GitHub CLI action = %#v, want manual guidance without Ubuntu apt installability", githubCLI)
 		}
 
-		for _, name := range []string{"starship", "zellij"} {
+		for _, name := range []string{"bat", "starship", "zellij"} {
 			action, ok := findAction(report.Actions, name)
 			if !ok {
 				t.Fatalf("missing action for %q in %#v", name, report.Actions)
@@ -741,6 +741,54 @@ func userLocalProviderManifest() manifest.Manifest {
 				},
 			}},
 		}},
+	}
+}
+
+func TestPlanResolvesBatUserLocalArtifact(t *testing.T) {
+	m := userLocalProviderManifest()
+	m.Entries[0].Dependencies[0] = manifest.Dependency{
+		Name:          "bat",
+		Command:       "bat",
+		Brew:          "bat",
+		LinuxHomebrew: true,
+		Dnf:           "bat",
+		Pacman:        "bat",
+		UserLocal: &manifest.UserLocalProvider{
+			Recipe:  "bat",
+			Version: "v0.26.1",
+			Checksums: map[string]string{
+				"linux_amd64": "726f04c8f576a7fd18b7634f1bbf2f915c43494c1c0f013baa3287edb0d5a2a3",
+				"linux_arm64": "422eb73e11c854fddd99f5ca8461c2f1d6e6dce0a2a8c3d5daade5ffcb6564aa",
+			},
+		},
+	}
+
+	report, err := deps.Plan(m, deps.Options{Profile: "default", OS: "linux", Arch: "amd64"}, lookupSet("brew"), fontLookupSet(), deps.TierDebian)
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+	action := report.Actions[0]
+	if action.Provider != deps.TierUserLocal || action.UserLocal == nil {
+		t.Fatalf("action = %#v, want bat user-local provider", action)
+	}
+	if action.UserLocal.Recipe != "bat" || action.UserLocal.Command != "bat" || action.UserLocal.Layout != "single-binary" || !strings.Contains(action.UserLocal.URL, "bat-v0.26.1-x86_64-unknown-linux-gnu.tar.gz") {
+		t.Fatalf("user-local artifact = %#v, want pinned bat linux amd64 artifact", action.UserLocal)
+	}
+
+	report, err = deps.Plan(m, deps.Options{Profile: "default", OS: "linux", Arch: "amd64"}, lookupSet("sudo", "dnf", "brew"), fontLookupSet(), deps.TierFedora)
+	if err != nil {
+		t.Fatalf("Plan() with Fedora tier error = %v", err)
+	}
+	if got := report.Actions[0]; got.Provider != deps.TierFedora || got.UserLocal != nil {
+		t.Fatalf("Fedora action = %#v, want distro provider before user-local", got)
+	}
+
+	report, err = deps.Plan(m, deps.Options{Profile: "default", OS: "linux", Arch: "amd64"}, lookupSet("bat", "brew"), fontLookupSet(), deps.TierDebian)
+	if err != nil {
+		t.Fatalf("Plan() with present bat error = %v", err)
+	}
+	if len(report.Actions) != 0 {
+		t.Fatalf("Actions = %#v, want no install when bat is present", report.Actions)
 	}
 }
 

--- a/internal/deps/user_local.go
+++ b/internal/deps/user_local.go
@@ -87,6 +87,26 @@ var userLocalRecipes = map[string]userLocalRecipe{
 		binaryPath:  func(archive, command string) string { return strings.TrimSuffix(archive, ".zip") + "/" + command },
 		links:       []string{"bun"},
 	},
+	"bat": {
+		archiveName: func(version, goarch string) (string, bool) {
+			switch goarch {
+			case "amd64":
+				return fmt.Sprintf("bat-%s-x86_64-unknown-linux-gnu.tar.gz", version), true
+			case "arm64":
+				return fmt.Sprintf("bat-%s-aarch64-unknown-linux-gnu.tar.gz", version), true
+			default:
+				return "", false
+			}
+		},
+		url: func(version, archive string) string {
+			return fmt.Sprintf("https://github.com/sharkdp/bat/releases/download/%s/%s", version, archive)
+		},
+		layout:      userLocalLayoutSingle,
+		command:     "bat",
+		archiveType: "tar.gz",
+		binaryPath:  func(archive, command string) string { return strings.TrimSuffix(archive, ".tar.gz") + "/" + command },
+		links:       []string{"bat"},
+	},
 	"atuin": {
 		archiveName: func(version, goarch string) (string, bool) {
 			switch goarch {

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -745,7 +745,7 @@ func TestRepositoryManifestLinuxHomebrewReviewBoundary(t *testing.T) {
 		}
 	}
 
-	for _, name := range []string{"starship", "zellij", "atuin", "gentle-ai", "engram"} {
+	for _, name := range []string{"bat", "starship", "zellij", "atuin", "gentle-ai", "engram"} {
 		if len(dependencies[name]) == 0 {
 			t.Fatalf("repository manifest missing %s dependency", name)
 		}
@@ -753,10 +753,10 @@ func TestRepositoryManifestLinuxHomebrewReviewBoundary(t *testing.T) {
 			if !dep.LinuxHomebrew {
 				t.Fatalf("%s dependency = %#v, want reviewed Linuxbrew opt-in", name, dep)
 			}
-			if (name == "starship" || name == "zellij" || name == "atuin") && dep.Apt != "" {
+			if (name == "bat" || name == "starship" || name == "zellij" || name == "atuin") && dep.Apt != "" {
 				t.Fatalf("%s dependency = %#v, want no Ubuntu apt package declaration", name, dep)
 			}
-			if name == "starship" || name == "atuin" {
+			if name == "bat" || name == "starship" || name == "atuin" {
 				if dep.UserLocal == nil || dep.UserLocal.Recipe != name || dep.UserLocal.Version == "" {
 					t.Fatalf("%s dependency = %#v, want reviewed user-local policy", name, dep)
 				}


### PR DESCRIPTION
Closes #231

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds a reviewed `bat` User-Local Provider for Linux.
- Removes the Debian/Ubuntu `apt` package declaration so Ubuntu-family systems do not advertise a provider that may fail the required `bat` executable probe.
- Pins bat v0.26.1 Linux amd64/arm64 artifacts and documents the updated package coverage.

## Changes

| File | Change |
|------|--------|
| `internal/deps/user_local.go` | Adds the allowlisted `bat` recipe using upstream Linux tarballs and the `bat` binary inside the archive directory. |
| `dots.yaml` | Adds explicit `user_local` policy and Linuxbrew opt-in for `bat`; preserves Fedora/Arch distro providers. |
| `internal/deps/plan_test.go` | Covers Debian fallback to user-local, distro precedence on Fedora, and no install when the `bat` probe is already present. |
| `internal/manifest/manifest_test.go` | Enforces reviewed Linux policy for `bat` and prevents reintroducing an Ubuntu apt declaration. |
| `docs/manifest.md` | Updates dependency package coverage for `bat`. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `SANDBOX=$(mktemp -d); mkdir -p "$SANDBOX/home"; go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home "$SANDBOX/home"`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #231`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
