### PR TITLE
feat(deps): add neovim user-local provider

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -169,6 +169,8 @@ User-Local Providers are not system packages. They are reviewed, allowlisted Go 
 
 `pnpm` is intentionally installed from the pinned standalone `@pnpm/linux-*` executable artifacts instead of through Corepack. Node remains part of the Core Development Baseline through `Node LTS (fnm)`, but the pnpm provider does not enable Corepack, create Corepack shims, run global `npm install -g`, or mutate shell configuration.
 
+`neovim` uses the upstream multi-file Linux tarball through its User-Local Provider. The bundle is extracted under `~/.local/opt/nvim/<version>` and `~/.local/bin/nvim` points at the bundled executable.
+
 Current dependency package coverage:
 
 | Dependency | Detection | macOS/Homebrew | Debian/Ubuntu | Fedora | Arch |
@@ -191,7 +193,7 @@ Current dependency package coverage:
 | `Warp` | `warp-terminal` | Manual | Manual | Manual | Manual |
 | `atuin` | `atuin` | `atuin` | User-local / Linuxbrew opt-in/manual | User-local / Linuxbrew opt-in/manual | User-local / Linuxbrew opt-in/manual |
 | `bat` | `bat` | `bat` | User-local / Linuxbrew opt-in/manual | `bat` | `bat` |
-| `neovim` | `nvim` | `neovim` | `neovim` | `neovim` | `neovim` |
+| `neovim` | `nvim` | `neovim` | User-local / Linuxbrew opt-in/manual | `neovim` | `neovim` |
 | `zed` | `zed` | `zed` | Manual | Manual | Manual |
 | `opencode` | `opencode` | Manual | Manual | Manual | Manual |
 | `gentle-ai` | `gentle-ai` | `gentleman-programming/tap/gentle-ai` | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual |

--- a/dots.yaml
+++ b/dots.yaml
@@ -355,9 +355,15 @@ entries:
       - name: neovim
         command: nvim
         brew: neovim
-        apt: neovim
+        linux_homebrew: true
         dnf: neovim
         pacman: neovim
+        user_local:
+          recipe: nvim
+          version: v0.12.3
+          checksums:
+            linux_amd64: c441b547142860bf01bcce39e36cbed185c41112813e15443b16e5237750724d
+            linux_arm64: e055af73fa9c72b37456da8d204fa5c09850bc07e80e9176fe3b87d4afb7a3fc
   - source: configs/zed/settings.json
     target: ~/.config/zed/settings.json
     strategy: symlink

--- a/internal/deps/plan_test.go
+++ b/internal/deps/plan_test.go
@@ -878,6 +878,54 @@ func TestPlanResolvesStarshipUserLocalArtifact(t *testing.T) {
 	}
 }
 
+func TestPlanResolvesNeovimUserLocalArtifact(t *testing.T) {
+	m := userLocalProviderManifest()
+	m.Entries[0].Dependencies[0] = manifest.Dependency{
+		Name:          "neovim",
+		Command:       "nvim",
+		Brew:          "neovim",
+		LinuxHomebrew: true,
+		Dnf:           "neovim",
+		Pacman:        "neovim",
+		UserLocal: &manifest.UserLocalProvider{
+			Recipe:  "nvim",
+			Version: "v0.12.3",
+			Checksums: map[string]string{
+				"linux_amd64": "c441b547142860bf01bcce39e36cbed185c41112813e15443b16e5237750724d",
+				"linux_arm64": "e055af73fa9c72b37456da8d204fa5c09850bc07e80e9176fe3b87d4afb7a3fc",
+			},
+		},
+	}
+
+	report, err := deps.Plan(m, deps.Options{Profile: "default", OS: "linux", Arch: "amd64"}, lookupSet("brew"), fontLookupSet(), deps.TierDebian)
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+	action := report.Actions[0]
+	if action.Provider != deps.TierUserLocal || action.UserLocal == nil {
+		t.Fatalf("action = %#v, want neovim user-local provider", action)
+	}
+	if action.UserLocal.Recipe != "nvim" || action.UserLocal.Command != "nvim" || action.UserLocal.Layout != "bundle" || action.UserLocal.URL != "https://github.com/neovim/neovim/releases/download/v0.12.3/nvim-linux-x86_64.tar.gz" {
+		t.Fatalf("user-local artifact = %#v, want pinned Neovim linux amd64 bundle", action.UserLocal)
+	}
+
+	report, err = deps.Plan(m, deps.Options{Profile: "default", OS: "linux", Arch: "amd64"}, lookupSet("sudo", "dnf", "brew"), fontLookupSet(), deps.TierFedora)
+	if err != nil {
+		t.Fatalf("Plan() with Fedora tier error = %v", err)
+	}
+	if got := report.Actions[0]; got.Provider != deps.TierFedora || got.UserLocal != nil {
+		t.Fatalf("Fedora action = %#v, want distro provider before user-local", got)
+	}
+
+	report, err = deps.Plan(m, deps.Options{Profile: "default", OS: "linux", Arch: "amd64"}, lookupSet("nvim", "brew"), fontLookupSet(), deps.TierDebian)
+	if err != nil {
+		t.Fatalf("Plan() with present nvim error = %v", err)
+	}
+	if len(report.Actions) != 0 {
+		t.Fatalf("Actions = %#v, want no install when nvim is present", report.Actions)
+	}
+}
+
 func TestPlanRejectsInvalidUserLocalOptIn(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/deps/user_local.go
+++ b/internal/deps/user_local.go
@@ -88,6 +88,28 @@ var userLocalRecipes = map[string]userLocalRecipe{
 		binaryPath:  func(_ string, command string) string { return "package/" + command },
 		links:       []string{"pnpm"},
 	},
+	"nvim": {
+		archiveName: func(version, goarch string) (string, bool) {
+			switch goarch {
+			case "amd64":
+				return "nvim-linux-x86_64.tar.gz", true
+			case "arm64":
+				return "nvim-linux-arm64.tar.gz", true
+			default:
+				return "", false
+			}
+		},
+		url: func(version, archive string) string {
+			return fmt.Sprintf("https://github.com/neovim/neovim/releases/download/%s/%s", version, archive)
+		},
+		layout:      userLocalLayoutBundle,
+		command:     "nvim",
+		archiveType: "tar.gz",
+		binaryPath: func(archive, command string) string {
+			return strings.TrimSuffix(archive, ".tar.gz") + "/bin/" + command
+		},
+		links: []string{"nvim"},
+	},
 	"bun": {
 		archiveName: func(version, goarch string) (string, bool) {
 			switch goarch {
@@ -259,7 +281,7 @@ func InstallUserLocal(home string, action InstallAction) error {
 		return fmt.Errorf("unknown user-local recipe %q", artifact.Recipe)
 	}
 
-	data, err := downloadAndVerify(artifact.URL, artifact.Checksum)
+	data, err := downloadUserLocalArtifact(artifact.URL, artifact.Checksum)
 	if err != nil {
 		return err
 	}
@@ -310,6 +332,8 @@ func InstallUserLocal(home string, action InstallAction) error {
 
 	return nil
 }
+
+var downloadUserLocalArtifact = downloadAndVerify
 
 func downloadAndVerify(url, checksum string) ([]byte, error) {
 	client := http.Client{Timeout: 5 * time.Minute}

--- a/internal/deps/user_local_test.go
+++ b/internal/deps/user_local_test.go
@@ -1,0 +1,105 @@
+package deps
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInstallUserLocalInstallsNeovimBundleInSandboxHome(t *testing.T) {
+	home := t.TempDir()
+	artifactData := tarGz(t, map[string]string{
+		"nvim-linux-x86_64/bin/nvim":          "#!/bin/sh\necho nvim\n",
+		"nvim-linux-x86_64/share/nvim/readme": "runtime files\n",
+	})
+
+	oldDownload := downloadUserLocalArtifact
+	downloadUserLocalArtifact = func(url, checksum string) ([]byte, error) {
+		if url != "https://github.com/neovim/neovim/releases/download/v0.12.3/nvim-linux-x86_64.tar.gz" {
+			t.Fatalf("download url = %q, want Neovim linux amd64 artifact", url)
+		}
+		return artifactData, nil
+	}
+	t.Cleanup(func() { downloadUserLocalArtifact = oldDownload })
+
+	action := InstallAction{UserLocal: &UserLocalArtifact{
+		Recipe:   "nvim",
+		Version:  "v0.12.3",
+		URL:      "https://github.com/neovim/neovim/releases/download/v0.12.3/nvim-linux-x86_64.tar.gz",
+		Checksum: "test-checksum",
+		Layout:   userLocalLayoutBundle,
+		Command:  "nvim",
+	}}
+
+	if err := InstallUserLocal(home, action); err != nil {
+		t.Fatalf("InstallUserLocal() error = %v", err)
+	}
+
+	binary := filepath.Join(home, ".local", "opt", "nvim", "v0.12.3", "nvim-linux-x86_64", "bin", "nvim")
+	if info, err := os.Stat(binary); err != nil || info.Mode()&0o111 == 0 {
+		t.Fatalf("installed binary stat = (%v, %v), want executable under sandbox opt", info, err)
+	}
+	shim := filepath.Join(home, ".local", "bin", "nvim")
+	if target, err := os.Readlink(shim); err != nil || target != binary {
+		t.Fatalf("nvim shim = (%q, %v), want symlink to %q", target, err, binary)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".local", "opt", "nvim", "v0.12.3", "nvim-linux-x86_64", "share", "nvim", "readme")); err != nil {
+		t.Fatalf("runtime file missing from bundle: %v", err)
+	}
+}
+
+func TestRecordDependencyInstallationUsesSandboxStateAndHome(t *testing.T) {
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	action := InstallAction{
+		Dependency: "neovim",
+		UserLocal: &UserLocalArtifact{
+			Recipe:   "nvim",
+			Version:  "v0.12.3",
+			Checksum: "c441b547142860bf01bcce39e36cbed185c41112813e15443b16e5237750724d",
+			Command:  "nvim",
+		},
+	}
+
+	if err := RecordDependencyInstallation(stateRoot, home, action); err != nil {
+		t.Fatalf("RecordDependencyInstallation() error = %v", err)
+	}
+
+	meta, err := LoadDependencyMetadata(DependencyMetadataPath(stateRoot))
+	if err != nil {
+		t.Fatalf("LoadDependencyMetadata() error = %v", err)
+	}
+	if len(meta.Dependencies) != 1 {
+		t.Fatalf("dependencies = %#v, want one record", meta.Dependencies)
+	}
+	record := meta.Dependencies[0]
+	if record.Dependency != "neovim" || record.Provider != string(TierUserLocal) || record.Path != filepath.Join(home, ".local", "bin", "nvim") {
+		t.Fatalf("dependency record = %#v, want sandboxed home/state record", record)
+	}
+}
+
+func tarGz(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for name, body := range files {
+		hdr := &tar.Header{Name: name, Mode: 0o644, Size: int64(len(body))}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("write tar header: %v", err)
+		}
+		if _, err := tw.Write([]byte(body)); err != nil {
+			t.Fatalf("write tar body: %v", err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+	return buf.Bytes()
+}


### PR DESCRIPTION
Closes #233

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds a reviewed Neovim User-Local Provider recipe for Linux.
- Pins upstream Neovim v0.12.3 Linux tarballs with per-arch SHA-256 checksums.
- Documents the multi-file bundle layout under `~/.local/opt/nvim/<version>` with `~/.local/bin/nvim` symlink exposure.

## Changes

| File | Change |
|------|--------|
| `internal/deps/user_local.go` | Adds the allowlisted `nvim` bundle recipe and injectable artifact download seam for sandboxed tests. |
| `dots.yaml` | Switches Debian/Ubuntu Neovim convergence from apt to user-local, with Linuxbrew/manual fallback. |
| `internal/deps/plan_test.go` | Verifies planning picks user-local only when `nvim` is absent and keeps distro providers first where declared. |
| `internal/deps/user_local_test.go` | Verifies sandboxed bundle extraction, shim creation, and dependency metadata home/state paths. |
| `docs/manifest.md` | Updates dependency coverage and documents Neovim bundle behavior. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots deps plan --file dots.yaml --profile default --tier debian --home <tmp>`

Additional validation:

- [x] `go build ./...`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #233`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
