### PR TITLE
feat(deps): add agent tool user-local providers

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -171,6 +171,8 @@ User-Local Providers are not system packages. They are reviewed, allowlisted Go 
 
 `neovim` uses the upstream multi-file Linux tarball through its User-Local Provider. The bundle is extracted under `~/.local/opt/nvim/<version>` and `~/.local/bin/nvim` points at the bundled executable.
 
+`gentle-ai` and `engram` use pinned upstream GitHub release tarballs through their User-Local Providers. They are Dependency providers only: they make the reviewed executables available for later probes, while Provisioners still own agent configuration changes. These providers do not run `npm install -g`, use `npx`, require `sudo`, or execute arbitrary package scripts.
+
 Current dependency package coverage:
 
 | Dependency | Detection | macOS/Homebrew | Debian/Ubuntu | Fedora | Arch |
@@ -196,8 +198,8 @@ Current dependency package coverage:
 | `neovim` | `nvim` | `neovim` | User-local / Linuxbrew opt-in/manual | `neovim` | `neovim` |
 | `zed` | `zed` | `zed` | Manual | Manual | Manual |
 | `opencode` | `opencode` | Manual | Manual | Manual | Manual |
-| `gentle-ai` | `gentle-ai` | `gentleman-programming/tap/gentle-ai` | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual |
-| `engram` | `engram` | `gentleman-programming/tap/engram` | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual |
+| `gentle-ai` | `gentle-ai` | `gentleman-programming/tap/gentle-ai` | User-local / Linuxbrew opt-in/manual | User-local / Linuxbrew opt-in/manual | User-local / Linuxbrew opt-in/manual |
+| `engram` | `engram` | `gentleman-programming/tap/engram` | User-local / Linuxbrew opt-in/manual | User-local / Linuxbrew opt-in/manual | User-local / Linuxbrew opt-in/manual |
 | `claude` | `claude` | Manual | Manual | Manual | Manual |
 | `codex` | `codex` | Manual | Manual | Manual | Manual |
 | `curl` | `curl` | `curl` | `curl` | `curl` | `curl` |
@@ -205,8 +207,10 @@ Current dependency package coverage:
 
 Reviewed Linuxbrew opt-ins include CLI/runtime tools whose Homebrew formulas are
 expected to work on Linuxbrew: Starship, the core runtimes/package tools, GitHub CLI,
-Playwright CLI, atuin, gentle-ai, and engram. Brew-only GUI apps such as Ghostty
-and Zed remain manual on Linux.
+Playwright CLI, atuin, gentle-ai, and engram. On Linux, gentle-ai and engram also
+have reviewed User-Local Providers from pinned release tarballs, so Linuxbrew is
+only a fallback when that opt-in is absent or unavailable. Brew-only GUI apps such
+as Ghostty and Zed remain manual on Linux.
 
 Homebrew dependencies declared with a fully-qualified tap formula such as
 `gentleman-programming/tap/gentle-ai` may require explicit Homebrew Tap Trust on

--- a/docs/update.md
+++ b/docs/update.md
@@ -73,6 +73,11 @@ Provisioners are scoped by profile tags, exactly like file entries. The `default
 
 The gentle-ai provisioner can model cleanup before install by using separate entries in manifest order. Missing `action` still defaults to `install`; `yes` is only valid for `uninstall` because it confirms a cleanup action. Install/update plan output also calls out provisioners that may install or update user-local global tools, such as Claude Code through the npm prefix under `~/.local`:
 
+The `gentle-ai` and `engram` executables themselves are still Dependencies, not
+Provisioner side effects. On Linux their reviewed User-Local Providers install
+pinned release tarballs only when the executable probe is missing; the later
+Provisioner step only runs after those probes pass.
+
 ```yaml
 provisioners:
   - tool: gentle-ai

--- a/dots.yaml
+++ b/dots.yaml
@@ -536,6 +536,12 @@ provisioners:
         command: gentle-ai
         brew: gentleman-programming/tap/gentle-ai
         linux_homebrew: true
+        user_local:
+          recipe: gentle-ai
+          version: v1.43.2
+          checksums:
+            linux_amd64: 6c957698fd670e04c5124709d2be2ee1582bdd87c3f1fa88b05740e3f1349a65
+            linux_arm64: 62335f70a1aff8b5e54608cf2c895235db83a430bbd5368040c58391dcda4c3a
   - tool: gentle-ai
     tags:
       - sdd
@@ -558,6 +564,12 @@ provisioners:
         command: gentle-ai
         brew: gentleman-programming/tap/gentle-ai
         linux_homebrew: true
+        user_local:
+          recipe: gentle-ai
+          version: v1.43.2
+          checksums:
+            linux_amd64: 6c957698fd670e04c5124709d2be2ee1582bdd87c3f1fa88b05740e3f1349a65
+            linux_arm64: 62335f70a1aff8b5e54608cf2c895235db83a430bbd5368040c58391dcda4c3a
   - tool: gentle-ai
     tags:
       - agents
@@ -575,10 +587,22 @@ provisioners:
         command: gentle-ai
         brew: gentleman-programming/tap/gentle-ai
         linux_homebrew: true
+        user_local:
+          recipe: gentle-ai
+          version: v1.43.2
+          checksums:
+            linux_amd64: 6c957698fd670e04c5124709d2be2ee1582bdd87c3f1fa88b05740e3f1349a65
+            linux_arm64: 62335f70a1aff8b5e54608cf2c895235db83a430bbd5368040c58391dcda4c3a
       - name: engram
         command: engram
         brew: gentleman-programming/tap/engram
         linux_homebrew: true
+        user_local:
+          recipe: engram
+          version: v1.17.0
+          checksums:
+            linux_amd64: 16422ec4596ba4007030bd4b589e139d5a3409eb846f2ffb19a147c953f1e0fe
+            linux_arm64: 64e1dc3401046078673468fadedbcec5b28056aab29bf02e35774ffb26f8993d
   - tool: gentle-ai
     tags:
       - agents
@@ -597,10 +621,22 @@ provisioners:
         command: gentle-ai
         brew: gentleman-programming/tap/gentle-ai
         linux_homebrew: true
+        user_local:
+          recipe: gentle-ai
+          version: v1.43.2
+          checksums:
+            linux_amd64: 6c957698fd670e04c5124709d2be2ee1582bdd87c3f1fa88b05740e3f1349a65
+            linux_arm64: 62335f70a1aff8b5e54608cf2c895235db83a430bbd5368040c58391dcda4c3a
       - name: engram
         command: engram
         brew: gentleman-programming/tap/engram
         linux_homebrew: true
+        user_local:
+          recipe: engram
+          version: v1.17.0
+          checksums:
+            linux_amd64: 16422ec4596ba4007030bd4b589e139d5a3409eb846f2ffb19a147c953f1e0fe
+            linux_arm64: 64e1dc3401046078673468fadedbcec5b28056aab29bf02e35774ffb26f8993d
   - tool: gentle-ai
     tags:
       - agents
@@ -618,10 +654,22 @@ provisioners:
         command: gentle-ai
         brew: gentleman-programming/tap/gentle-ai
         linux_homebrew: true
+        user_local:
+          recipe: gentle-ai
+          version: v1.43.2
+          checksums:
+            linux_amd64: 6c957698fd670e04c5124709d2be2ee1582bdd87c3f1fa88b05740e3f1349a65
+            linux_arm64: 62335f70a1aff8b5e54608cf2c895235db83a430bbd5368040c58391dcda4c3a
       - name: engram
         command: engram
         brew: gentleman-programming/tap/engram
         linux_homebrew: true
+        user_local:
+          recipe: engram
+          version: v1.17.0
+          checksums:
+            linux_amd64: 16422ec4596ba4007030bd4b589e139d5a3409eb846f2ffb19a147c953f1e0fe
+            linux_arm64: 64e1dc3401046078673468fadedbcec5b28056aab29bf02e35774ffb26f8993d
   - tool: gentle-ai
     tags:
       - agents
@@ -639,10 +687,22 @@ provisioners:
         command: gentle-ai
         brew: gentleman-programming/tap/gentle-ai
         linux_homebrew: true
+        user_local:
+          recipe: gentle-ai
+          version: v1.43.2
+          checksums:
+            linux_amd64: 6c957698fd670e04c5124709d2be2ee1582bdd87c3f1fa88b05740e3f1349a65
+            linux_arm64: 62335f70a1aff8b5e54608cf2c895235db83a430bbd5368040c58391dcda4c3a
       - name: engram
         command: engram
         brew: gentleman-programming/tap/engram
         linux_homebrew: true
+        user_local:
+          recipe: engram
+          version: v1.17.0
+          checksums:
+            linux_amd64: 16422ec4596ba4007030bd4b589e139d5a3409eb846f2ffb19a147c953f1e0fe
+            linux_arm64: 64e1dc3401046078673468fadedbcec5b28056aab29bf02e35774ffb26f8993d
   - tool: gentle-ai
     tags:
       - agents
@@ -660,10 +720,22 @@ provisioners:
         command: gentle-ai
         brew: gentleman-programming/tap/gentle-ai
         linux_homebrew: true
+        user_local:
+          recipe: gentle-ai
+          version: v1.43.2
+          checksums:
+            linux_amd64: 6c957698fd670e04c5124709d2be2ee1582bdd87c3f1fa88b05740e3f1349a65
+            linux_arm64: 62335f70a1aff8b5e54608cf2c895235db83a430bbd5368040c58391dcda4c3a
       - name: engram
         command: engram
         brew: gentleman-programming/tap/engram
         linux_homebrew: true
+        user_local:
+          recipe: engram
+          version: v1.17.0
+          checksums:
+            linux_amd64: 16422ec4596ba4007030bd4b589e139d5a3409eb846f2ffb19a147c953f1e0fe
+            linux_arm64: 64e1dc3401046078673468fadedbcec5b28056aab29bf02e35774ffb26f8993d
   - tool: gentle-ai
     tags:
       - persona
@@ -685,6 +757,12 @@ provisioners:
         command: gentle-ai
         brew: gentleman-programming/tap/gentle-ai
         linux_homebrew: true
+        user_local:
+          recipe: gentle-ai
+          version: v1.43.2
+          checksums:
+            linux_amd64: 6c957698fd670e04c5124709d2be2ee1582bdd87c3f1fa88b05740e3f1349a65
+            linux_arm64: 62335f70a1aff8b5e54608cf2c895235db83a430bbd5368040c58391dcda4c3a
   - tool: skills
     tags:
       - web

--- a/internal/deps/plan_test.go
+++ b/internal/deps/plan_test.go
@@ -527,7 +527,7 @@ func TestRepositoryManifestDoesNotAdvertiseUnavailableUbuntuAptPackages(t *testi
 			t.Fatalf("GitHub CLI action = %#v, want installable Homebrew fallback", githubCLI)
 		}
 
-		for _, name := range []string{"bat", "starship", "zellij", "pnpm"} {
+		for _, name := range []string{"bat", "starship", "zellij", "pnpm", "gentle-ai", "engram"} {
 			action, ok := findAction(report.Actions, name)
 			if !ok {
 				t.Fatalf("missing action for %q in %#v", name, report.Actions)
@@ -555,7 +555,7 @@ func TestRepositoryManifestDoesNotAdvertiseUnavailableUbuntuAptPackages(t *testi
 			t.Fatalf("GitHub CLI action = %#v, want manual guidance without Ubuntu apt installability", githubCLI)
 		}
 
-		for _, name := range []string{"bat", "starship", "zellij", "pnpm"} {
+		for _, name := range []string{"bat", "starship", "zellij", "pnpm", "gentle-ai", "engram"} {
 			action, ok := findAction(report.Actions, name)
 			if !ok {
 				t.Fatalf("missing action for %q in %#v", name, report.Actions)
@@ -923,6 +923,84 @@ func TestPlanResolvesNeovimUserLocalArtifact(t *testing.T) {
 	}
 	if len(report.Actions) != 0 {
 		t.Fatalf("Actions = %#v, want no install when nvim is present", report.Actions)
+	}
+}
+
+func TestPlanResolvesAgentToolUserLocalArtifacts(t *testing.T) {
+	tests := []struct {
+		name       string
+		dep        manifest.Dependency
+		wantURL    string
+		wantRecipe string
+		wantCmd    string
+	}{
+		{
+			name: "gentle-ai",
+			dep: manifest.Dependency{
+				Name:          "gentle-ai",
+				Command:       "gentle-ai",
+				Brew:          "gentleman-programming/tap/gentle-ai",
+				LinuxHomebrew: true,
+				UserLocal: &manifest.UserLocalProvider{
+					Recipe:  "gentle-ai",
+					Version: "v1.43.2",
+					Checksums: map[string]string{
+						"linux_amd64": "6c957698fd670e04c5124709d2be2ee1582bdd87c3f1fa88b05740e3f1349a65",
+						"linux_arm64": "62335f70a1aff8b5e54608cf2c895235db83a430bbd5368040c58391dcda4c3a",
+					},
+				},
+			},
+			wantURL:    "https://github.com/Gentleman-Programming/gentle-ai/releases/download/v1.43.2/gentle-ai_1.43.2_linux_amd64.tar.gz",
+			wantRecipe: "gentle-ai",
+			wantCmd:    "gentle-ai",
+		},
+		{
+			name: "engram",
+			dep: manifest.Dependency{
+				Name:          "engram",
+				Command:       "engram",
+				Brew:          "gentleman-programming/tap/engram",
+				LinuxHomebrew: true,
+				UserLocal: &manifest.UserLocalProvider{
+					Recipe:  "engram",
+					Version: "v1.17.0",
+					Checksums: map[string]string{
+						"linux_amd64": "16422ec4596ba4007030bd4b589e139d5a3409eb846f2ffb19a147c953f1e0fe",
+						"linux_arm64": "64e1dc3401046078673468fadedbcec5b28056aab29bf02e35774ffb26f8993d",
+					},
+				},
+			},
+			wantURL:    "https://github.com/Gentleman-Programming/engram/releases/download/v1.17.0/engram_1.17.0_linux_amd64.tar.gz",
+			wantRecipe: "engram",
+			wantCmd:    "engram",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := userLocalProviderManifest()
+			m.Entries[0].Dependencies[0] = tt.dep
+
+			report, err := deps.Plan(m, deps.Options{Profile: "default", OS: "linux", Arch: "amd64"}, lookupSet("brew"), fontLookupSet(), deps.TierDebian)
+			if err != nil {
+				t.Fatalf("Plan() error = %v", err)
+			}
+			action := report.Actions[0]
+			if action.Provider != deps.TierUserLocal || action.UserLocal == nil {
+				t.Fatalf("action = %#v, want user-local provider", action)
+			}
+			if action.UserLocal.Recipe != tt.wantRecipe || action.UserLocal.Command != tt.wantCmd || action.UserLocal.Layout != "single-binary" || action.UserLocal.URL != tt.wantURL {
+				t.Fatalf("user-local artifact = %#v, want pinned %s linux amd64 artifact", action.UserLocal, tt.name)
+			}
+
+			report, err = deps.Plan(m, deps.Options{Profile: "default", OS: "linux", Arch: "amd64"}, lookupSet(tt.wantCmd, "brew"), fontLookupSet(), deps.TierDebian)
+			if err != nil {
+				t.Fatalf("Plan() with present %s error = %v", tt.wantCmd, err)
+			}
+			if len(report.Actions) != 0 {
+				t.Fatalf("Actions = %#v, want no install when %s is present", report.Actions, tt.wantCmd)
+			}
+		})
 	}
 }
 

--- a/internal/deps/user_local.go
+++ b/internal/deps/user_local.go
@@ -110,6 +110,42 @@ var userLocalRecipes = map[string]userLocalRecipe{
 		},
 		links: []string{"nvim"},
 	},
+	"gentle-ai": {
+		archiveName: func(version, goarch string) (string, bool) {
+			switch goarch {
+			case "amd64", "arm64":
+				return fmt.Sprintf("gentle-ai_%s_linux_%s.tar.gz", strings.TrimPrefix(version, "v"), goarch), true
+			default:
+				return "", false
+			}
+		},
+		url: func(version, archive string) string {
+			return fmt.Sprintf("https://github.com/Gentleman-Programming/gentle-ai/releases/download/%s/%s", version, archive)
+		},
+		layout:      userLocalLayoutSingle,
+		command:     "gentle-ai",
+		archiveType: "tar.gz",
+		binaryPath:  func(_ string, command string) string { return command },
+		links:       []string{"gentle-ai"},
+	},
+	"engram": {
+		archiveName: func(version, goarch string) (string, bool) {
+			switch goarch {
+			case "amd64", "arm64":
+				return fmt.Sprintf("engram_%s_linux_%s.tar.gz", strings.TrimPrefix(version, "v"), goarch), true
+			default:
+				return "", false
+			}
+		},
+		url: func(version, archive string) string {
+			return fmt.Sprintf("https://github.com/Gentleman-Programming/engram/releases/download/%s/%s", version, archive)
+		},
+		layout:      userLocalLayoutSingle,
+		command:     "engram",
+		archiveType: "tar.gz",
+		binaryPath:  func(_ string, command string) string { return command },
+		links:       []string{"engram"},
+	},
 	"bun": {
 		archiveName: func(version, goarch string) (string, bool) {
 			switch goarch {


### PR DESCRIPTION
Closes #235

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds reviewed Linux User-Local Provider recipes for `gentle-ai` and `engram`.
- Pins upstream GitHub release tarballs and SHA-256 checksums; no sudo-backed npm global install, `npx`, or arbitrary shell execution.
- Documents the Dependency/Provisioner split for agent tooling.

## Changes

| File | Change |
|------|--------|
| `internal/deps/user_local.go` | Adds allowlisted single-binary recipes for `gentle-ai` and `engram` GitHub release artifacts. |
| `dots.yaml` | Enables `user_local` policy for selected gentle-ai/engram provisioner Dependencies. |
| `internal/deps/plan_test.go` | Verifies agent tool artifacts resolve to pinned user-local providers and skip install actions when probes are present. |
| `docs/manifest.md` | Documents provider ownership, supply-chain boundary, and package coverage. |
| `docs/update.md` | Documents that executables are Dependencies while Provisioners own agent config execution. |

## Test Plan

- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `SANDBOX=$(mktemp -d); mkdir -p "$SANDBOX/home"; go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home "$SANDBOX/home"`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #235`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
