### PR TITLE
feat(deps): add Ubuntu Ghostty manual guidance

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -152,6 +152,8 @@ Tag-scoped Dependency Sets use:
 | `name` | Yes | Human-readable dependency name. Also used as the executable probe when `command` is omitted. |
 | `requirement` | No | `required` or `optional`. Omitted means `required`. Required Dependencies gate integrated install; optional Dependencies are reported but do not block Managed Configuration. |
 | `command` | No | Single executable name to probe on `PATH`. |
+| `manual` | No | Dependency-specific remediation for manual-only tools. Use it when generic package-manager guidance would hide required user choices, privileges, or verification steps. |
+| `manual_debian` | No | Debian/Ubuntu-specific manual remediation. Prefer this over `manual` when instructions mention Debian/Ubuntu-only packages, commands, privileges, or verification. |
 | `commands` | No | Multiple executable names that must all be present. Use this for manager-owned toolchains where both the manager and runtime commands matter. |
 | `toolchain` | No | Built-in runtime bootstrap flow. Supported values: `node-lts-fnm`, `rust-stable-rustup`. These values map to fixed argv commands, not arbitrary shell hooks. |
 | `brew` | No | Homebrew formula token. Mutually exclusive with `brew_cask`. |
@@ -191,7 +193,7 @@ Current dependency package coverage:
 | `bun` | `bun` | `bun` | User-local / Linuxbrew opt-in/manual | User-local / Linuxbrew opt-in/manual | User-local / Linuxbrew opt-in/manual |
 | `GitHub CLI` | `gh` | `gh` | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual |
 | `Playwright CLI` | `playwright-cli` | `playwright-cli` | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual |
-| `ghostty` | `ghostty` | `ghostty` | Manual | Manual | Manual |
+| `ghostty` | `ghostty` | `ghostty` | Manual; Ubuntu guidance includes Ghostty upstream binary docs, the community `.deb` installer command, and notes `snap install ghostty --classic` requires sudo/password interactivity | Manual | Manual |
 | `Warp` | `warp-terminal` | Manual | Manual | Manual | Manual |
 | `atuin` | `atuin` | `atuin` | User-local / Linuxbrew opt-in/manual | User-local / Linuxbrew opt-in/manual | User-local / Linuxbrew opt-in/manual |
 | `bat` | `bat` | `bat` | User-local / Linuxbrew opt-in/manual | `bat` | `bat` |

--- a/dots.yaml
+++ b/dots.yaml
@@ -249,6 +249,13 @@ entries:
     dependencies:
       - name: ghostty
         command: ghostty
+        manual_debian: >-
+          Install Ghostty from https://ghostty.org/docs/install/binary. On Ubuntu,
+          use the community .deb installer from ghostty-ubuntu with /bin/bash -c
+          "$(curl -fsSL https://raw.githubusercontent.com/mkasberg/ghostty-ubuntu/HEAD/install.sh)",
+          or run snap install ghostty --classic; this requires sudo/password
+          interactivity. After installation, verify ghostty --version and rerun
+          dots deps check.
         brew: ghostty
   - source: configs/warp/settings.toml
     target: ~/.warp/settings.toml

--- a/internal/deps/plan.go
+++ b/internal/deps/plan.go
@@ -349,6 +349,14 @@ func tierPackage(dep manifest.Dependency, tier Tier) (pkg, executable string, ar
 }
 
 func manualNote(dep manifest.Dependency, opts Options, tier Tier, candidates []ProviderCandidate) string {
+	if tier == TierDebian {
+		if manual := strings.TrimSpace(dep.ManualDebian); manual != "" {
+			return manual
+		}
+	}
+	if manual := strings.TrimSpace(dep.Manual); manual != "" {
+		return manual
+	}
 	if dep.IsFont() && opts.OS == "linux" {
 		name := strings.TrimSpace(dep.Name)
 		matchHint := fontMatchHint(dep.FontMatches())

--- a/internal/deps/plan_test.go
+++ b/internal/deps/plan_test.go
@@ -300,6 +300,8 @@ func TestPlanFallsBackToManualGuidance(t *testing.T) {
 					{Name: "neovim", Command: "nvim"},
 					// Has brew but no apt: manual on debian.
 					{Name: "ripgrep", Command: "rg", Brew: "ripgrep"},
+					// Has explicit manual remediation.
+					{Name: "ghostty", Command: "ghostty", ManualDebian: "Install Ghostty from https://ghostty.org/docs/install/binary, then rerun dots deps check."},
 				},
 			},
 		},
@@ -310,8 +312,8 @@ func TestPlanFallsBackToManualGuidance(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Plan() error = %v", err)
 		}
-		if len(report.Items) != 2 {
-			t.Fatalf("Items len = %d, want 2", len(report.Items))
+		if len(report.Items) != 3 {
+			t.Fatalf("Items len = %d, want 3", len(report.Items))
 		}
 		for _, item := range report.Items {
 			if item.Command != "" {
@@ -337,6 +339,10 @@ func TestPlanFallsBackToManualGuidance(t *testing.T) {
 		}
 		if byName["neovim"].Command != "" || byName["neovim"].Manual == "" {
 			t.Fatalf("neovim guidance = %#v, want manual fallback", byName["neovim"])
+		}
+		wantManual := "Install Ghostty from https://ghostty.org/docs/install/binary, then rerun dots deps check."
+		if byName["ghostty"].Manual != wantManual {
+			t.Fatalf("ghostty Manual = %q, want %q", byName["ghostty"].Manual, wantManual)
 		}
 	})
 }

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -123,7 +123,11 @@ type Dependency struct {
 	Name        string `yaml:"name"`
 	Requirement string `yaml:"requirement,omitempty"`
 	Command     string `yaml:"command,omitempty"`
-	Brew        string `yaml:"brew,omitempty"`
+	// Manual carries dependency-specific remediation for manual-only tools.
+	Manual string `yaml:"manual,omitempty"`
+	// ManualDebian carries Debian/Ubuntu-specific manual remediation.
+	ManualDebian string `yaml:"manual_debian,omitempty"`
+	Brew         string `yaml:"brew,omitempty"`
 	// LinuxHomebrew allows Linux distro tiers to fall back to Homebrew when the
 	// distro package is absent or unavailable. Keep this opt-in so GUI apps and
 	// tools without Linuxbrew support stay manual instead of rendering false
@@ -451,6 +455,12 @@ func validateDependency(dep Dependency, path string) error {
 	}
 	if dep.Command != "" && strings.TrimSpace(dep.Command) == "" {
 		return fmt.Errorf("%s.command must not be empty", path)
+	}
+	if dep.Manual != "" && strings.TrimSpace(dep.Manual) == "" {
+		return fmt.Errorf("%s.manual must not be empty", path)
+	}
+	if dep.ManualDebian != "" && strings.TrimSpace(dep.ManualDebian) == "" {
+		return fmt.Errorf("%s.manual_debian must not be empty", path)
 	}
 	for i, command := range dep.Commands {
 		if strings.TrimSpace(command) == "" {

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -749,6 +749,15 @@ func TestRepositoryManifestLinuxHomebrewReviewBoundary(t *testing.T) {
 			}
 		}
 	}
+	ghosttyManualFound := false
+	for _, dep := range dependencies["ghostty"] {
+		if strings.Contains(dep.ManualDebian, "snap install ghostty --classic") && strings.Contains(dep.ManualDebian, "requires sudo") {
+			ghosttyManualFound = true
+		}
+	}
+	if !ghosttyManualFound {
+		t.Fatalf("ghostty dependency missing explicit Ubuntu manual guidance with snap sudo/interactivity note: %#v", dependencies["ghostty"])
+	}
 
 	for _, name := range []string{"bat", "starship", "zellij", "atuin", "pnpm", "gentle-ai", "engram"} {
 		if len(dependencies[name]) == 0 {
@@ -1682,6 +1691,40 @@ entries:
 			want: `entries[0].dependencies[0].command must not be empty`,
 		},
 		{
+			name: "dependency with whitespace-only manual guidance",
+			content: `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/ghostty/config.ghostty
+    target: ~/.config/ghostty/config.ghostty
+    strategy: symlink
+    tags: [desktop]
+    dependencies:
+      - name: ghostty
+        manual: "  "
+`,
+			want: `entries[0].dependencies[0].manual must not be empty`,
+		},
+		{
+			name: "dependency with whitespace-only Debian manual guidance",
+			content: `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/ghostty/config.ghostty
+    target: ~/.config/ghostty/config.ghostty
+    strategy: symlink
+    tags: [desktop]
+    dependencies:
+      - name: ghostty
+        manual_debian: "  "
+`,
+			want: `entries[0].dependencies[0].manual_debian must not be empty`,
+		},
+		{
 			name: "dependency with whitespace-only brew cask",
 			content: `version: 1
 profiles:
@@ -2276,6 +2319,30 @@ provisioners:
       - brew: gentleman-programming/tap/gentle-ai
 `,
 			want: "provisioners[0].dependencies[0].name is required",
+		},
+		{
+			name: "dependency with whitespace-only manual guidance",
+			provisioner: `  - tool: gentle-ai
+    tags: [core]
+    spec:
+      scope: global
+    dependencies:
+      - name: ghostty
+        manual: "  "
+`,
+			want: "provisioners[0].dependencies[0].manual must not be empty",
+		},
+		{
+			name: "dependency with whitespace-only Debian manual guidance",
+			provisioner: `  - tool: gentle-ai
+    tags: [core]
+    spec:
+      scope: global
+    dependencies:
+      - name: ghostty
+        manual_debian: "  "
+`,
+			want: "provisioners[0].dependencies[0].manual_debian must not be empty",
 		},
 		{
 			name: "dependency with whitespace-only brew cask",


### PR DESCRIPTION
Closes #215

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds explicit Debian/Ubuntu manual remediation for Ghostty instead of generic manual fallback.
- Keeps Ghostty non-installable/non-interactive in `dots deps install` while documenting sudo/password Snap tradeoffs.
- Documents and validates manual remediation manifest fields.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Adds `manual_debian` guidance for Ghostty with upstream binary docs, community `.deb` installer command, Snap sudo/interactivity note, and `ghostty --version` verification. |
| `internal/manifest/manifest.go` | Adds `manual` and `manual_debian` dependency fields with whitespace validation. |
| `internal/deps/plan.go` | Uses Debian/Ubuntu-specific manual remediation before generic manual fallback. |
| `internal/deps/plan_test.go` | Covers explicit manual remediation in dependency planning. |
| `internal/manifest/manifest_test.go` | Covers Ghostty manifest guidance and validation for manual fields. |
| `docs/manifest.md` | Documents manual remediation fields and current Ghostty Ubuntu coverage. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: built a temp `dots` binary and ran Debian/Fedora `deps plan` with temp `--home` and restricted `PATH` to verify Ubuntu guidance is Debian-scoped.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #215`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
