### PR TITLE
fix(agents): remove stale gentle-ai trigger rules

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -362,6 +362,14 @@ Current Provisioners:
 | `codex` | `web` | `darwin`, `linux` | Add MCP server `chrome-devtools` using `npx -y chrome-devtools-mcp@latest --no-performance-crux`. | `codex` |
 | `codegraph` | `codegraph` | `darwin`, `linux` | Reuse `codegraph` when already on `PATH`; otherwise install it with the official curl bootstrap, then run `codegraph install --target codex,claude,antigravity,opencode --location global --yes` so CodeGraph configures MCP plus instructions for Codex, Claude Code, Antigravity, and OpenCode. Select with `--tag codegraph`. | `curl` |
 
+After any `gentle-ai` provisioner runs, `dots` removes the
+`<!-- gentle-ai:trigger-rules -->` marker section from supported agent
+instruction files it can locate. The upstream 4R identifiers referenced by that
+block (`review-readability`, `review-risk`, `review-resilience`, and
+`review-reliability`) are not portable `gentle-ai` skills that the dots-managed
+baseline can install for every supported agent, so keeping the recommendation
+would leave agents pointing at commands that may not exist.
+
 ## Selection rules
 
 1. The chosen Profile provides the base tags.

--- a/internal/agentinstructions/trigger_rules.go
+++ b/internal/agentinstructions/trigger_rules.go
@@ -1,0 +1,82 @@
+package agentinstructions
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/yersonargotev/dots/internal/textblock"
+)
+
+const (
+	gentleAITriggerRulesStart = "<!-- gentle-ai:trigger-rules -->"
+	gentleAITriggerRulesEnd   = "<!-- /gentle-ai:trigger-rules -->"
+)
+
+// RemoveGentleAITriggerRules removes stale gentle-ai trigger recommendations
+// from supported agent instruction files. dots does not install the referenced
+// 4R review agents as portable skills, so the block must not survive the
+// dots-managed agent baseline.
+func RemoveGentleAITriggerRules(home string, agents ...string) error {
+	for _, path := range triggerRuleInstructionPaths(home, agents) {
+		if err := removeTriggerRules(path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func triggerRuleInstructionPaths(home string, agents []string) []string {
+	var paths []string
+	seen := map[string]bool{}
+	add := func(path string) {
+		if seen[path] {
+			return
+		}
+		seen[path] = true
+		paths = append(paths, path)
+	}
+
+	for _, agent := range agents {
+		switch agent {
+		case "codex":
+			add(filepath.Join(home, ".codex", "AGENTS.md"))
+		case "claude", "claude-code":
+			add(filepath.Join(home, ".claude", "CLAUDE.md"))
+		case "opencode":
+			add(filepath.Join(home, ".config", "opencode", "AGENTS.md"))
+		case "antigravity":
+			add(filepath.Join(home, ".gemini", "GEMINI.md"))
+		case "vscode-copilot":
+			add(filepath.Join(home, "Library", "Application Support", "Code", "User", "prompts", "gentle-ai.instructions.md"))
+			add(filepath.Join(home, ".config", "Code", "User", "prompts", "gentle-ai.instructions.md"))
+		}
+	}
+	return paths
+}
+
+func removeTriggerRules(path string) error {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("read agent instructions %s: %w", path, err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat agent instructions %s: %w", path, err)
+	}
+	updated, err := textblock.Remove(string(content), textblock.Markers{Start: gentleAITriggerRulesStart, End: gentleAITriggerRulesEnd})
+	if err != nil {
+		return fmt.Errorf("remove gentle-ai trigger rules from %s: %w", path, err)
+	}
+	if updated == string(content) {
+		return nil
+	}
+	if err := os.WriteFile(path, []byte(updated), info.Mode().Perm()); err != nil {
+		return fmt.Errorf("write agent instructions %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/agentinstructions/trigger_rules_test.go
+++ b/internal/agentinstructions/trigger_rules_test.go
@@ -1,0 +1,49 @@
+package agentinstructions
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRemoveGentleAITriggerRulesRemovesSupportedAgentBlocks(t *testing.T) {
+	home := t.TempDir()
+	paths := []string{
+		filepath.Join(home, ".codex", "AGENTS.md"),
+		filepath.Join(home, ".claude", "CLAUDE.md"),
+		filepath.Join(home, ".config", "opencode", "AGENTS.md"),
+		filepath.Join(home, ".gemini", "GEMINI.md"),
+		filepath.Join(home, "Library", "Application Support", "Code", "User", "prompts", "gentle-ai.instructions.md"),
+		filepath.Join(home, ".config", "Code", "User", "prompts", "gentle-ai.instructions.md"),
+	}
+	for _, path := range paths {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", path, err)
+		}
+		content := "before\n\n" + gentleAITriggerRulesStart + "\nstale review-readability rule\n" + gentleAITriggerRulesEnd + "\n\nafter\n"
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+
+	if err := RemoveGentleAITriggerRules(home, "codex", "claude-code", "opencode", "antigravity", "vscode-copilot"); err != nil {
+		t.Fatalf("RemoveGentleAITriggerRules() error = %v", err)
+	}
+
+	for _, path := range paths {
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		content := string(got)
+		for _, not := range []string{gentleAITriggerRulesStart, gentleAITriggerRulesEnd, "review-readability"} {
+			if strings.Contains(content, not) {
+				t.Fatalf("%s kept %q\ncontent:\n%s", path, not, content)
+			}
+		}
+		if !strings.Contains(content, "before") || !strings.Contains(content, "after") {
+			t.Fatalf("%s did not preserve surrounding content\ncontent:\n%s", path, content)
+		}
+	}
+}

--- a/internal/cli/claude_config_test.go
+++ b/internal/cli/claude_config_test.go
@@ -30,10 +30,28 @@ func TestClaudeAgentsProfileSeedsUserBaselineInSandbox(t *testing.T) {
 	t.Setenv("HOME", realHome)
 
 	// The gentle-ai stub records the argv it received (under the threaded HOME)
-	// so the test can assert the resolved provisioner command, not just the
-	// rendered plan. engram only needs to be present on PATH for the dep check.
+	// and simulates stale trigger-rules output so the test can assert cleanup
+	// across the supported agent instruction files. engram only needs to be
+	// present on PATH for the dep check.
 	stubDir := t.TempDir()
-	writeExecStub(t, filepath.Join(stubDir, "gentle-ai"), "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$HOME/gentle-ai-args\"\n")
+	writeExecStub(t, filepath.Join(stubDir, "gentle-ai"), `#!/bin/sh
+printf '%s\n' "$*" >> "$HOME/gentle-ai-args"
+block='before
+
+<!-- gentle-ai:trigger-rules -->
+stale review-readability rule
+<!-- /gentle-ai:trigger-rules -->
+
+after
+'
+mkdir -p "$HOME/.codex" "$HOME/.claude" "$HOME/.config/opencode" "$HOME/.gemini" "$HOME/Library/Application Support/Code/User/prompts" "$HOME/.config/Code/User/prompts"
+printf '%s' "$block" > "$HOME/.codex/AGENTS.md"
+printf '%s' "$block" > "$HOME/.claude/CLAUDE.md"
+printf '%s' "$block" > "$HOME/.config/opencode/AGENTS.md"
+printf '%s' "$block" > "$HOME/.gemini/GEMINI.md"
+printf '%s' "$block" > "$HOME/Library/Application Support/Code/User/prompts/gentle-ai.instructions.md"
+printf '%s' "$block" > "$HOME/.config/Code/User/prompts/gentle-ai.instructions.md"
+`)
 	writeExecStub(t, filepath.Join(stubDir, "engram"), "#!/bin/sh\nexit 0\n")
 	writeExecStub(t, filepath.Join(stubDir, "codegraph"), "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$HOME/codegraph-args\"\n")
 	writeManifestDependencyStubs(t, stubDir)
@@ -227,6 +245,22 @@ func TestClaudeAgentsProfileSeedsUserBaselineInSandbox(t *testing.T) {
 	}
 	if _, err := os.ReadFile(filepath.Join(home, "codegraph-args")); !os.IsNotExist(err) {
 		t.Fatalf("agents profile should not run CodeGraph without --tag codegraph: %v", err)
+	}
+	for _, path := range []string{
+		filepath.Join(home, ".codex", "AGENTS.md"),
+		filepath.Join(home, ".claude", "CLAUDE.md"),
+		filepath.Join(home, ".config", "opencode", "AGENTS.md"),
+		filepath.Join(home, ".gemini", "GEMINI.md"),
+		filepath.Join(home, "Library", "Application Support", "Code", "User", "prompts", "gentle-ai.instructions.md"),
+		filepath.Join(home, ".config", "Code", "User", "prompts", "gentle-ai.instructions.md"),
+	} {
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read cleaned agent instructions %s: %v", path, err)
+		}
+		if strings.Contains(string(got), "gentle-ai:trigger-rules") || strings.Contains(string(got), "review-readability") {
+			t.Fatalf("agent instructions %s kept stale gentle-ai trigger rules\ncontent:\n%s", path, got)
+		}
 	}
 	// And it must never have escaped into the inherited real HOME.
 	if _, err := os.Stat(filepath.Join(realHome, "gentle-ai-args")); err == nil {

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/yersonargotev/dots/internal/agentinstructions"
 	"github.com/yersonargotev/dots/internal/backups"
 	"github.com/yersonargotev/dots/internal/bootstrap"
 	"github.com/yersonargotev/dots/internal/codexconfig"
@@ -299,17 +300,25 @@ func runProvisioners(cmd *cobra.Command, m manifest.Manifest, profile string, ex
 		stdout: stdout,
 		stderr: cmd.ErrOrStderr(),
 	}
-	report, err := provision.Apply(m, provision.Options{Profile: profile, ExtraTags: extraTags, OS: runtime.GOOS}, lookupCommand, fontInstalled(runtime.GOOS, home), runner)
+	provisionOpts := provision.Options{Profile: profile, ExtraTags: extraTags, OS: runtime.GOOS}
+	selected, selectErr := provision.Select(m, provisionOpts)
+	if selectErr != nil {
+		return provision.Report{}, selectErr
+	}
+	report, err := provision.Apply(m, provisionOpts, lookupCommand, fontInstalled(runtime.GOOS, home), runner)
 	if !wantsJSON(cmd) {
 		renderProvisionReport(cmd.OutOrStdout(), report)
 	}
 	if recordErr := recordProvisionerMetadata(stateRoot, report); recordErr != nil {
 		return report, recordErr
 	}
-	if err != nil {
-		return report, err
+	if gentleAIProvisionerRan(report) {
+		if agents := selectedGentleAIAgents(selected); len(agents) > 0 {
+			if cleanupErr := agentinstructions.RemoveGentleAITriggerRules(home, agents...); cleanupErr != nil {
+				return report, errors.Join(err, cleanupErr)
+			}
+		}
 	}
-	selected, err := provision.Select(m, provision.Options{Profile: profile, ExtraTags: extraTags, OS: runtime.GOOS})
 	if err != nil {
 		return report, err
 	}
@@ -317,6 +326,33 @@ func runProvisioners(cmd *cobra.Command, m manifest.Manifest, profile string, ex
 		return report, codexconfig.EnsureCodeGraphMode(home, agents...)
 	}
 	return report, nil
+}
+
+func gentleAIProvisionerRan(report provision.Report) bool {
+	for _, item := range report.Items {
+		if item.Tool == "gentle-ai" && item.Status != provision.RunStatusMissingDeps {
+			return true
+		}
+	}
+	return false
+}
+
+func selectedGentleAIAgents(selected []manifest.Provisioner) []string {
+	var agents []string
+	seen := map[string]bool{}
+	for _, prov := range selected {
+		if prov.Tool != "gentle-ai" {
+			continue
+		}
+		for _, agent := range prov.Spec.Agents {
+			if seen[agent] {
+				continue
+			}
+			seen[agent] = true
+			agents = append(agents, agent)
+		}
+	}
+	return agents
 }
 
 func selectedCodeGraphAgents(selected []manifest.Provisioner) []string {

--- a/internal/cli/provision_runner_test.go
+++ b/internal/cli/provision_runner_test.go
@@ -179,6 +179,16 @@ if [ -f "$PROVISION_COUNT" ]; then
 fi
 printf first > "$PROVISION_COUNT"
 printf ok > "$HOME/first-attempt"
+mkdir -p "$HOME/.codex"
+cat > "$HOME/.codex/AGENTS.md" <<'EOF'
+before
+
+<!-- gentle-ai:trigger-rules -->
+stale review-readability rule
+<!-- /gentle-ai:trigger-rules -->
+
+after
+EOF
 `
 	if err := os.WriteFile(filepath.Join(stubDir, "gentle-ai"), []byte(script), 0o755); err != nil {
 		t.Fatalf("write gentle-ai stub: %v", err)
@@ -217,6 +227,13 @@ printf ok > "$HOME/first-attempt"
 		if !strings.Contains(got, want) {
 			t.Fatalf("partial report missing %q\noutput:\n%s", want, got)
 		}
+	}
+	instructions, readErr := os.ReadFile(filepath.Join(home, ".codex", "AGENTS.md"))
+	if readErr != nil {
+		t.Fatalf("read cleaned Codex instructions: %v", readErr)
+	}
+	if strings.Contains(string(instructions), "gentle-ai:trigger-rules") || strings.Contains(string(instructions), "review-readability") {
+		t.Fatalf("stale gentle-ai trigger rules survived after a later provisioner failure\ncontent:\n%s", instructions)
 	}
 }
 

--- a/internal/textblock/textblock.go
+++ b/internal/textblock/textblock.go
@@ -49,6 +49,33 @@ func Upsert(content string, primary Markers, block string, legacy ...Markers) (s
 	return b.String(), nil
 }
 
+// Remove deletes every marker-delimited block matching the provided markers.
+func Remove(content string, markers ...Markers) (string, error) {
+	if len(markers) == 0 {
+		return content, nil
+	}
+	ranges, err := findRanges(content, markers)
+	if err != nil {
+		return "", err
+	}
+	if len(ranges) == 0 {
+		return content, nil
+	}
+
+	sort.Slice(ranges, func(i, j int) bool { return ranges[i].start < ranges[j].start })
+	var b strings.Builder
+	cursor := 0
+	for _, r := range ranges {
+		if r.start < cursor {
+			continue
+		}
+		b.WriteString(content[cursor:r.start])
+		cursor = r.end
+	}
+	b.WriteString(content[cursor:])
+	return b.String(), nil
+}
+
 type blockRange struct {
 	start int
 	end   int


### PR DESCRIPTION
Closes #245

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Removes stale `gentle-ai:trigger-rules` blocks from dots-supported agent instruction files after gentle-ai provisioners run.
- Keys cleanup off provisioner execution reports so cleanup still happens when a later provisioner fails.
- Documents why dots strips the upstream 4R trigger recommendations instead of installing unsupported `review-*` skills.

## Changes

| File | Change |
|------|--------|
| `internal/agentinstructions/trigger_rules.go` | Adds supported-agent path mapping and marker-block cleanup for `gentle-ai:trigger-rules`. |
| `internal/textblock/textblock.go` | Adds pure marker-delimited block removal helper. |
| `internal/cli/install.go` | Runs trigger-rules cleanup after executed gentle-ai provisioners, before returning provisioner errors. |
| `internal/cli/*_test.go` | Adds sandboxed regression coverage for normal cleanup and cleanup after later provisioner failure. |
| `docs/manifest.md` | Documents why dots removes the stale upstream trigger-rules block. |

## Test Plan

- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile agents --source-root "$PWD" --home <tmp> --state-root <tmp> --output json`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #245`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
