### PR TITLE
feat(agents): inject dots rules and clean personas

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -45,7 +45,7 @@ Current Profiles:
 |---------|------|--------|----------------------|
 | `default` | `core` | Core dotfiles without provisioners. | Core Development Baseline via the `core` tag-scoped Dependency Set |
 | `desktop` | `core`, `desktop` | Desktop dotfiles and desktop-only tool integrations; no gentle-ai agent setup. | `Desktop Nerd Font` via Homebrew cask `font-cascadia-code-nf`, detected with `CascadiaCodeNF*` or `CaskaydiaCoveNerdFont*` |
-| `agents` | `core`, `agents` | Core dotfiles plus gentle-ai memory/context setup, cleanup, and shared engineering skills for supported agents. Add `--tag persona` for optional persona styling Regenerated Content or `--tag sdd` for Gentle-AI SDD setup. | Core Development Baseline via the `core` tag-scoped Dependency Set; `GitHub CLI` via the `agents` tag-scoped Dependency Set |
+| `agents` | `core`, `agents` | Core dotfiles plus gentle-ai memory/context setup, cleanup, shared engineering skills, and dots-owned global rules for supported agents. Add `--tag sdd` for Gentle-AI SDD setup. gentle-ai persona Regenerated Content is cleaned up, not installed, by this repository. | Core Development Baseline via the `core` tag-scoped Dependency Set; `GitHub CLI` via the `agents` tag-scoped Dependency Set |
 | `web` | `core`, `web` | Optional frontend/browser workbench: web design skills plus Chrome DevTools integrations. | Core Development Baseline via the `core` tag-scoped Dependency Set; `Playwright CLI` via Homebrew formula `playwright-cli` |
 | `mobile` | `core`, `mobile` | Optional Dart and Flutter mobile development agent skills plus Dart/Flutter MCP integration for Claude, Codex, Antigravity, and GitHub Copilot in VS Code. | Core Development Baseline via the `core` tag-scoped Dependency Set |
 | `workstation` | `core`, `desktop`, `agents` | Full workstation setup when both desktop integrations and agent setup are desired; web tooling remains explicit opt-in. | Core Development Baseline via the `core` tag-scoped Dependency Set; `GitHub CLI` via the `agents` tag-scoped Dependency Set; `Desktop Nerd Font` via Homebrew cask `font-cascadia-code-nf`, detected with `CascadiaCodeNF*` or `CaskaydiaCoveNerdFont*` |
@@ -339,14 +339,13 @@ Current Provisioners:
 | Tool | Tags | OS | Rendered intent | Dependencies |
 |------|------|----|-----------------|--------------|
 | `zimfw` | `core` | all | Install the ZimFW runtime under `~/.zim` when missing and run `zimfw init -q` using the dots-managed `~/.zimrc`. | `zsh`, `git`, `curl` |
-| `gentle-ai` | `agents` | all | Uninstall `sdd` for `codex`, `claude-code`, `opencode`, `antigravity`, and `vscode-copilot` with `--yes`. | `gentle-ai` |
-| `gentle-ai` | `sdd` | all | Install global stable neutral custom SDD setup in multi-agent mode for `codex`, `claude-code`, `opencode`, `antigravity`, and `vscode-copilot`. Select with `--profile agents --tag sdd`. | `gentle-ai` |
+| `gentle-ai` | `agents` | all | Uninstall `sdd` and `persona` for `codex`, `claude-code`, `opencode`, `antigravity`, and `vscode-copilot` with `--yes`. | `gentle-ai` |
+| `gentle-ai` | `sdd` | all | Install global stable custom SDD setup in multi-agent mode for `codex`, `claude-code`, `opencode`, `antigravity`, and `vscode-copilot`, without installing persona. Select with `--profile agents --tag sdd`. | `gentle-ai` |
 | `gentle-ai` | `agents` | all | Install global stable custom baseline for `codex` with `engram` and `context7`; persona prompt Regenerated Content is not installed by default. | `gentle-ai`, `engram` |
 | `gentle-ai` | `agents` | all | Install global stable custom baseline for `claude-code` with `engram`, `context7`, and `permissions`; persona prompt Regenerated Content is not installed by default. | `gentle-ai`, `engram` |
 | `gentle-ai` | `agents` | all | Install global stable custom baseline for `antigravity` with `engram` and `context7` only; no `sdd`, `permissions`, or persona prompt Regenerated Content. | `gentle-ai`, `engram` |
 | `gentle-ai` | `agents` | all | Install global stable custom baseline for `opencode` with `engram` and `context7` only; no `sdd`, `permissions`, or persona prompt Regenerated Content. | `gentle-ai`, `engram` |
 | `gentle-ai` | `agents` | all | Install global stable custom baseline for `vscode-copilot` with `engram` and `context7` only; no `sdd`, `permissions`, or persona prompt Regenerated Content. | `gentle-ai`, `engram` |
-| `gentle-ai` | `persona` | all | Install optional neutral persona prompt Regenerated Content for `codex`, `claude-code`, `opencode`, `antigravity`, and `vscode-copilot`. Select with `--profile agents --tag persona`. | `gentle-ai` |
 | `skills` | `web` | all | Install `playwright-cli` from `microsoft/playwright-cli` globally for `codex`, `claude-code`, `antigravity`, `opencode`, and `github-copilot` through pinned `skills@1.5.12`, copying the skill and references into the agent skill roots. | `npx` |
 | `skills` | `web` | all | Install `frontend-design` from `anthropics/skills` globally for `codex`, `claude-code`, `antigravity`, `opencode`, and `github-copilot` through pinned `skills@1.5.12`. | `npx` |
 | `skills` | `web` | all | Install `vercel-react-best-practices`, `vercel-composition-patterns`, `vercel-react-view-transitions`, and `web-design-guidelines` from `vercel-labs/agent-skills` globally for `codex`, `claude-code`, `antigravity`, `opencode`, and `github-copilot` through pinned `skills@1.5.12`. | `npx` |
@@ -362,9 +361,11 @@ Current Provisioners:
 | `codex` | `web` | `darwin`, `linux` | Add MCP server `chrome-devtools` using `npx -y chrome-devtools-mcp@latest --no-performance-crux`. | `codex` |
 | `codegraph` | `codegraph` | `darwin`, `linux` | Reuse `codegraph` when already on `PATH`; otherwise install it with the official curl bootstrap, then run `codegraph install --target codex,claude,antigravity,opencode --location global --yes` so CodeGraph configures MCP plus instructions for Codex, Claude Code, Antigravity, and OpenCode. Select with `--tag codegraph`. | `curl` |
 
-After any `gentle-ai` provisioner runs, `dots` removes the
-`<!-- gentle-ai:trigger-rules -->` marker section from supported agent
-instruction files it can locate. The upstream 4R identifiers referenced by that
+After any `gentle-ai` provisioner runs, `dots` converges supported agent
+instruction files by removing `<!-- gentle-ai:trigger-rules -->` and
+`<!-- gentle-ai:persona -->` marker sections, cleaning known legacy markerless
+persona prose, and upserting a `<!-- dots:rules -->` block with dots-owned
+behavioral rules. The upstream 4R identifiers referenced by the trigger-rules
 block (`review-readability`, `review-risk`, `review-resilience`, and
 `review-reliability`) are not portable `gentle-ai` skills that the dots-managed
 baseline can install for every supported agent, so keeping the recommendation

--- a/docs/update.md
+++ b/docs/update.md
@@ -69,7 +69,7 @@ Because no fast-forward is applied in a dry run, the rendered plan reflects the 
 
 ## Profiles and provisioners
 
-Provisioners are scoped by profile tags, exactly like file entries. The `default` profile selects no provisioners. The `desktop` profile selects desktop configuration and non-web desktop integrations. The `agents` profile selects gentle-ai memory/context setup and cleanup provisioners for Codex, Claude Code, OpenCode, Antigravity, and VS Code Copilot, plus agent settings baselines and shared engineering skills. Persona prompt Regenerated Content is optional and selected with `--tag persona`; SDD remains optional with `--tag sdd`. CodeGraph is independent and selected with `--tag codegraph`; CodeGraph's installer owns generated MCP/instruction setup, while dots owns only the scoped `<!-- dots:codegraph-mode -->` routing and verification policy overlay. The `web` profile selects frontend design skills plus Chrome DevTools for Claude, Codex, and the OpenCode overlay. The `mobile` profile selects Dart and Flutter agent skills plus the Dart and Flutter MCP server for Claude, Codex, Antigravity, and GitHub Copilot in VS Code. Use `workstation` when you explicitly want both desktop integrations and agent setup; web and mobile tooling remain separate opt-ins. This is design-intent: desktop installs should configure desktop tools, not opt into SDD, gentle-dev agent setup, browser/frontend tooling, or mobile-specific skills.
+Provisioners are scoped by profile tags, exactly like file entries. The `default` profile selects no provisioners. The `desktop` profile selects desktop configuration and non-web desktop integrations. The `agents` profile selects gentle-ai memory/context setup and cleanup provisioners for Codex, Claude Code, OpenCode, Antigravity, and VS Code Copilot, plus agent settings baselines, shared engineering skills, and dots-owned global agent rules. gentle-ai persona prompt Regenerated Content is cleaned up rather than installed by this repository; SDD remains optional with `--tag sdd`. CodeGraph is independent and selected with `--tag codegraph`; CodeGraph's installer owns generated MCP/instruction setup, while dots owns only the scoped `<!-- dots:codegraph-mode -->` routing and verification policy overlay. The `web` profile selects frontend design skills plus Chrome DevTools for Claude, Codex, and the OpenCode overlay. The `mobile` profile selects Dart and Flutter agent skills plus the Dart and Flutter MCP server for Claude, Codex, Antigravity, and GitHub Copilot in VS Code. Use `workstation` when you explicitly want both desktop integrations and agent setup; web and mobile tooling remain separate opt-ins. This is design-intent: desktop installs should configure desktop tools, not opt into SDD, gentle-dev agent setup, browser/frontend tooling, or mobile-specific skills.
 
 The gentle-ai provisioner can model cleanup before install by using separate entries in manifest order. Missing `action` still defaults to `install`; `yes` is only valid for `uninstall` because it confirms a cleanup action. Install/update plan output also calls out provisioners that may install or update user-local global tools, such as Claude Code through the npm prefix under `~/.local`:
 
@@ -85,7 +85,7 @@ provisioners:
     spec:
       action: uninstall
       agents: [codex, claude-code, opencode, antigravity, vscode-copilot]
-      components: [sdd]
+      components: [sdd, persona]
       yes: true
   - tool: gentle-ai
     tags: [agents]
@@ -93,13 +93,6 @@ provisioners:
       preset: custom
       agents: [claude-code]
       components: [engram, context7, permissions]
-  - tool: gentle-ai
-    tags: [persona]
-    spec:
-      preset: custom
-      persona: neutral
-      agents: [codex, claude-code, opencode, antigravity, vscode-copilot]
-      components: [persona]
 ```
 
 To keep that requirement discoverable, both `install` and `update` print a one-line hint when the active profile skips provisioners another profile would select on this OS:

--- a/dots.yaml
+++ b/dots.yaml
@@ -537,6 +537,7 @@ provisioners:
         - vscode-copilot
       components:
         - sdd
+        - persona
       yes: true
     dependencies:
       - name: gentle-ai
@@ -555,7 +556,6 @@ provisioners:
     spec:
       scope: global
       channel: stable
-      persona: neutral
       preset: custom
       sdd-mode: multi
       agents:
@@ -743,33 +743,6 @@ provisioners:
           checksums:
             linux_amd64: 16422ec4596ba4007030bd4b589e139d5a3409eb846f2ffb19a147c953f1e0fe
             linux_arm64: 64e1dc3401046078673468fadedbcec5b28056aab29bf02e35774ffb26f8993d
-  - tool: gentle-ai
-    tags:
-      - persona
-    spec:
-      scope: global
-      channel: stable
-      persona: neutral
-      preset: custom
-      agents:
-        - codex
-        - claude-code
-        - opencode
-        - antigravity
-        - vscode-copilot
-      components:
-        - persona
-    dependencies:
-      - name: gentle-ai
-        command: gentle-ai
-        brew: gentleman-programming/tap/gentle-ai
-        linux_homebrew: true
-        user_local:
-          recipe: gentle-ai
-          version: v1.43.2
-          checksums:
-            linux_amd64: 6c957698fd670e04c5124709d2be2ee1582bdd87c3f1fa88b05740e3f1349a65
-            linux_arm64: 62335f70a1aff8b5e54608cf2c895235db83a430bbd5368040c58391dcda4c3a
   - tool: skills
     tags:
       - web

--- a/internal/agentinstructions/trigger_rules.go
+++ b/internal/agentinstructions/trigger_rules.go
@@ -24,6 +24,7 @@ const dotsRulesBlock = `## Dots Agent Rules
 | Boundary | Rule |
 | --- | --- |
 | Always | Keep diffs surgical: every changed line must trace to the user request; mention unrelated issues instead of fixing them silently. |
+| Always | Choose the simplest change that satisfies the request; avoid speculative abstractions, configurability, or features not explicitly needed. |
 | Always | Verify before declaring success: use focused checks while iterating, then run the repo-required checks when the task is complete. |
 | Always | Use sandboxed HOME/config paths for dotfiles behavior; never validate by writing to the operator's real home config. |
 | Always | Prefer dots JSON output and documented exit codes over scraping human prose. |

--- a/internal/agentinstructions/trigger_rules.go
+++ b/internal/agentinstructions/trigger_rules.go
@@ -25,9 +25,9 @@ const dotsRulesBlock = `## Dots Agent Rules
 | --- | --- |
 | Always | Keep diffs surgical: every changed line must trace to the user request; mention unrelated issues instead of fixing them silently. |
 | Always | Choose the simplest change that satisfies the request; avoid speculative abstractions, configurability, or features not explicitly needed. |
+| Always | Plan before editing: think through the target behavior, inspect existing patterns, and state the smallest intended change before coding. |
 | Always | Verify before declaring success: use focused checks while iterating, then run the repo-required checks when the task is complete. |
 | Always | Use sandboxed HOME/config paths for dotfiles behavior; never validate by writing to the operator's real home config. |
-| Always | Prefer dots JSON output and documented exit codes over scraping human prose. |
 | Ask first | Stop when the safe path is unclear, the scope would broaden, or an action could mutate real user configuration. |`
 
 // RemoveGentleAITriggerRules removes stale gentle-ai trigger recommendations
@@ -183,6 +183,9 @@ func removeLegacyMarkerlessPersona(content string) string {
 			end = start + idx
 		}
 	}
+	if !isKnownLegacyMarkerlessPersona(content[start:end]) {
+		return content
+	}
 
 	updated := strings.TrimRight(content[:start], "\n")
 	if suffix := strings.TrimLeft(content[end:], "\n"); suffix != "" {
@@ -194,6 +197,35 @@ func removeLegacyMarkerlessPersona(content string) string {
 		updated += "\n"
 	}
 	return updated
+}
+
+func isKnownLegacyMarkerlessPersona(block string) bool {
+	requiredHeadings := []string{
+		"## Personality",
+		"## Persona Scope",
+		"## Language",
+		"## Tone",
+		"## Philosophy",
+		"## Expertise",
+		"## Behavior",
+	}
+	for _, heading := range requiredHeadings {
+		if !strings.Contains(block, heading) {
+			return false
+		}
+	}
+
+	for _, phrase := range []string{
+		"Senior Architect, 15+ years experience, GDE & MVP",
+		"The persona styles HOW YOU TALK",
+		"Match the user's current language in your REPLY ONLY",
+		"CONCEPTS > CODE",
+	} {
+		if strings.Contains(block, phrase) {
+			return true
+		}
+	}
+	return false
 }
 
 func nextHeadingAfterBehavior(content string) int {

--- a/internal/agentinstructions/trigger_rules.go
+++ b/internal/agentinstructions/trigger_rules.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/yersonargotev/dots/internal/textblock"
 )
@@ -12,14 +13,28 @@ import (
 const (
 	gentleAITriggerRulesStart = "<!-- gentle-ai:trigger-rules -->"
 	gentleAITriggerRulesEnd   = "<!-- /gentle-ai:trigger-rules -->"
+	gentleAIPersonaStart      = "<!-- gentle-ai:persona -->"
+	gentleAIPersonaEnd        = "<!-- /gentle-ai:persona -->"
+	dotsRulesStart            = "<!-- dots:rules -->"
+	dotsRulesEnd              = "<!-- /dots:rules -->"
 )
+
+const dotsRulesBlock = `## Dots Agent Rules
+
+| Boundary | Rule |
+| --- | --- |
+| Always | Keep diffs surgical: every changed line must trace to the user request; mention unrelated issues instead of fixing them silently. |
+| Always | Verify before declaring success: use focused checks while iterating, then run the repo-required checks when the task is complete. |
+| Always | Use sandboxed HOME/config paths for dotfiles behavior; never validate by writing to the operator's real home config. |
+| Always | Prefer dots JSON output and documented exit codes over scraping human prose. |
+| Ask first | Stop when the safe path is unclear, the scope would broaden, or an action could mutate real user configuration. |`
 
 // RemoveGentleAITriggerRules removes stale gentle-ai trigger recommendations
 // from supported agent instruction files. dots does not install the referenced
 // 4R review agents as portable skills, so the block must not survive the
 // dots-managed agent baseline.
 func RemoveGentleAITriggerRules(home string, agents ...string) error {
-	for _, path := range triggerRuleInstructionPaths(home, agents) {
+	for _, path := range instructionPaths(home, agents) {
 		if err := removeTriggerRules(path); err != nil {
 			return err
 		}
@@ -27,7 +42,19 @@ func RemoveGentleAITriggerRules(home string, agents ...string) error {
 	return nil
 }
 
-func triggerRuleInstructionPaths(home string, agents []string) []string {
+// ConvergeDotsAgentRules removes gentle-ai rules/persona blocks that conflict
+// with the dots-managed baseline and injects the portable dots rules block into
+// supported global agent instruction files.
+func ConvergeDotsAgentRules(home string, agents ...string) error {
+	for _, path := range instructionPaths(home, agents) {
+		if err := convergeDotsRules(path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func instructionPaths(home string, agents []string) []string {
 	var paths []string
 	seen := map[string]bool{}
 	add := func(path string) {
@@ -79,4 +106,104 @@ func removeTriggerRules(path string) error {
 		return fmt.Errorf("write agent instructions %s: %w", path, err)
 	}
 	return nil
+}
+
+func convergeDotsRules(path string) error {
+	content, mode, err := readInstructionFile(path)
+	if err != nil {
+		return err
+	}
+	updated, err := textblock.Remove(
+		content,
+		textblock.Markers{Start: gentleAITriggerRulesStart, End: gentleAITriggerRulesEnd},
+		textblock.Markers{Start: gentleAIPersonaStart, End: gentleAIPersonaEnd},
+	)
+	if err != nil {
+		return fmt.Errorf("remove gentle-ai managed blocks from %s: %w", path, err)
+	}
+	updated = removeLegacyMarkerlessPersona(updated)
+	updated, err = textblock.Upsert(updated, textblock.Markers{Start: dotsRulesStart, End: dotsRulesEnd}, dotsRulesBlock)
+	if err != nil {
+		return fmt.Errorf("upsert dots rules in %s: %w", path, err)
+	}
+	if updated == content {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("mkdir agent instructions %s: %w", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(updated), mode); err != nil {
+		return fmt.Errorf("write agent instructions %s: %w", path, err)
+	}
+	return nil
+}
+
+func readInstructionFile(path string) (string, os.FileMode, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", 0o600, nil
+		}
+		return "", 0, fmt.Errorf("read agent instructions %s: %w", path, err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", 0, fmt.Errorf("stat agent instructions %s: %w", path, err)
+	}
+	return string(content), info.Mode().Perm(), nil
+}
+
+func removeLegacyMarkerlessPersona(content string) string {
+	start := strings.Index(content, "\n## Personality")
+	if start >= 0 {
+		start++
+	} else if strings.HasPrefix(content, "## Personality") {
+		start = 0
+	} else {
+		return content
+	}
+
+	end := len(content)
+	for _, heading := range []string{
+		"\n## Contextual Skill Loading",
+		"\n<!-- gentle-ai:engram-protocol -->",
+		"\n<!-- dots:",
+		"\n<!-- CODEGRAPH_START -->",
+	} {
+		if idx := strings.Index(content[start+len("## Personality"):], heading); idx >= 0 {
+			candidate := start + len("## Personality") + idx + 1
+			if candidate < end {
+				end = candidate
+			}
+		}
+	}
+	if end == len(content) {
+		if idx := nextHeadingAfterBehavior(content[start:]); idx >= 0 {
+			end = start + idx
+		}
+	}
+
+	updated := strings.TrimRight(content[:start], "\n")
+	if suffix := strings.TrimLeft(content[end:], "\n"); suffix != "" {
+		if updated != "" {
+			updated += "\n\n"
+		}
+		updated += suffix
+	} else if updated != "" {
+		updated += "\n"
+	}
+	return updated
+}
+
+func nextHeadingAfterBehavior(content string) int {
+	behavior := strings.Index(content, "\n## Behavior")
+	if behavior < 0 {
+		return -1
+	}
+	searchFrom := behavior + len("\n## Behavior")
+	next := strings.Index(content[searchFrom:], "\n## ")
+	if next < 0 {
+		return len(content)
+	}
+	return searchFrom + next + 1
 }

--- a/internal/agentinstructions/trigger_rules_test.go
+++ b/internal/agentinstructions/trigger_rules_test.go
@@ -47,3 +47,95 @@ func TestRemoveGentleAITriggerRulesRemovesSupportedAgentBlocks(t *testing.T) {
 		}
 	}
 }
+
+func TestConvergeDotsAgentRulesRemovesPersonaAndInjectsRules(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".codex", "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+	content := "before\n\n" +
+		gentleAIPersonaStart + "\n## Personality\nSenior Architect, 15+ years experience, GDE & MVP.\n" + gentleAIPersonaEnd + "\n\n" +
+		gentleAITriggerRulesStart + "\nstale review-readability rule\n" + gentleAITriggerRulesEnd + "\n\n" +
+		"after\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+
+	if err := ConvergeDotsAgentRules(home, "codex"); err != nil {
+		t.Fatalf("ConvergeDotsAgentRules() error = %v", err)
+	}
+	if err := ConvergeDotsAgentRules(home, "codex"); err != nil {
+		t.Fatalf("ConvergeDotsAgentRules() second run error = %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	out := string(got)
+	for _, not := range []string{
+		gentleAIPersonaStart,
+		gentleAIPersonaEnd,
+		gentleAITriggerRulesStart,
+		gentleAITriggerRulesEnd,
+		"Senior Architect",
+		"review-readability",
+	} {
+		if strings.Contains(out, not) {
+			t.Fatalf("content kept %q\n%s", not, out)
+		}
+	}
+	if strings.Count(out, dotsRulesStart) != 1 || strings.Count(out, dotsRulesEnd) != 1 {
+		t.Fatalf("dots rules block should be present once\n%s", out)
+	}
+	for _, want := range []string{"Keep diffs surgical", "Verify before declaring success", "Use sandboxed HOME/config paths"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("dots rules missing %q\n%s", want, out)
+		}
+	}
+	if !strings.Contains(out, "before") || !strings.Contains(out, "after") {
+		t.Fatalf("surrounding content not preserved\n%s", out)
+	}
+}
+
+func TestConvergeDotsAgentRulesRemovesLegacyMarkerlessPersona(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".claude", "CLAUDE.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+	content := "prefix\n\n" +
+		"## Personality\n\nSenior Architect, 15+ years experience, GDE & MVP.\n\n" +
+		"## Persona Scope (CRITICAL — read this first)\n\nThe persona styles HOW YOU TALK, not WHAT YOU BUILD.\n\n" +
+		"## Language\n\n- Match the user's current language in your REPLY ONLY (see Persona Scope above).\n\n" +
+		"## Tone\n\nPassionate and direct, but from a place of CARING.\n\n" +
+		"## Philosophy\n\n- CONCEPTS > CODE\n\n" +
+		"## Expertise\n\nClean/Hexagonal/Screaming Architecture.\n\n" +
+		"## Behavior\n\n- Correct errors ruthlessly but explain WHY technically\n\n" +
+		"## Existing Section\n\nkeep me\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+
+	if err := ConvergeDotsAgentRules(home, "claude-code"); err != nil {
+		t.Fatalf("ConvergeDotsAgentRules() error = %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	out := string(got)
+	for _, not := range []string{"## Personality", "Senior Architect", "## Persona Scope", "## Language", "## Tone", "## Philosophy", "## Expertise", "## Behavior"} {
+		if strings.Contains(out, not) {
+			t.Fatalf("legacy persona cleanup kept %q\n%s", not, out)
+		}
+	}
+	if !strings.Contains(out, "## Existing Section\n\nkeep me") {
+		t.Fatalf("legacy persona cleanup removed unrelated section\n%s", out)
+	}
+	if !strings.Contains(out, dotsRulesStart) {
+		t.Fatalf("dots rules not injected\n%s", out)
+	}
+}

--- a/internal/agentinstructions/trigger_rules_test.go
+++ b/internal/agentinstructions/trigger_rules_test.go
@@ -89,7 +89,7 @@ func TestConvergeDotsAgentRulesRemovesPersonaAndInjectsRules(t *testing.T) {
 	if strings.Count(out, dotsRulesStart) != 1 || strings.Count(out, dotsRulesEnd) != 1 {
 		t.Fatalf("dots rules block should be present once\n%s", out)
 	}
-	for _, want := range []string{"Keep diffs surgical", "Verify before declaring success", "Use sandboxed HOME/config paths"} {
+	for _, want := range []string{"Keep diffs surgical", "Choose the simplest change", "Verify before declaring success", "Use sandboxed HOME/config paths"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("dots rules missing %q\n%s", want, out)
 		}

--- a/internal/agentinstructions/trigger_rules_test.go
+++ b/internal/agentinstructions/trigger_rules_test.go
@@ -89,13 +89,50 @@ func TestConvergeDotsAgentRulesRemovesPersonaAndInjectsRules(t *testing.T) {
 	if strings.Count(out, dotsRulesStart) != 1 || strings.Count(out, dotsRulesEnd) != 1 {
 		t.Fatalf("dots rules block should be present once\n%s", out)
 	}
-	for _, want := range []string{"Keep diffs surgical", "Choose the simplest change", "Verify before declaring success", "Use sandboxed HOME/config paths"} {
+	for _, want := range []string{"Keep diffs surgical", "Choose the simplest change", "Plan before editing", "Verify before declaring success", "Use sandboxed HOME/config paths"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("dots rules missing %q\n%s", want, out)
 		}
 	}
+	if strings.Contains(out, "Prefer dots JSON output") || strings.Contains(out, "scraping human prose") {
+		t.Fatalf("dots rules kept JSON-output scope creep\n%s", out)
+	}
 	if !strings.Contains(out, "before") || !strings.Contains(out, "after") {
 		t.Fatalf("surrounding content not preserved\n%s", out)
+	}
+}
+
+func TestConvergeDotsAgentRulesPreservesCustomPersonalitySection(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".codex", "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+	content := "# Local Agent Guide\n\n" +
+		"## Personality\n\n" +
+		"Be concise, skeptical, and protect production data.\n\n" +
+		"## Project Workflow\n\n" +
+		"Keep this user-owned workflow section.\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+
+	if err := ConvergeDotsAgentRules(home, "codex"); err != nil {
+		t.Fatalf("ConvergeDotsAgentRules() error = %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	out := string(got)
+	for _, want := range []string{"## Personality", "Be concise, skeptical, and protect production data.", "## Project Workflow", "Keep this user-owned workflow section."} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("custom content missing %q\n%s", want, out)
+		}
+	}
+	if !strings.Contains(out, dotsRulesStart) {
+		t.Fatalf("dots rules not injected\n%s", out)
 	}
 }
 

--- a/internal/cli/claude_config_test.go
+++ b/internal/cli/claude_config_test.go
@@ -38,6 +38,11 @@ func TestClaudeAgentsProfileSeedsUserBaselineInSandbox(t *testing.T) {
 printf '%s\n' "$*" >> "$HOME/gentle-ai-args"
 block='before
 
+<!-- gentle-ai:persona -->
+## Personality
+Senior Architect, 15+ years experience, GDE & MVP.
+<!-- /gentle-ai:persona -->
+
 <!-- gentle-ai:trigger-rules -->
 stale review-readability rule
 <!-- /gentle-ai:trigger-rules -->
@@ -199,8 +204,8 @@ printf '%s' "$block" > "$HOME/.config/Code/User/prompts/gentle-ai.instructions.m
 	if err != nil {
 		t.Fatalf("provisioner did not run under the sandbox HOME %q: %v", home, err)
 	}
-	if !strings.Contains(string(gotArgs), "uninstall --agents codex,claude-code,opencode,antigravity,vscode-copilot --components sdd --yes") {
-		t.Fatalf("provisioner argv = %q, want it to cleanup legacy SDD for codex,claude-code,opencode,antigravity,vscode-copilot before install", gotArgs)
+	if !strings.Contains(string(gotArgs), "uninstall --agents codex,claude-code,opencode,antigravity,vscode-copilot --components sdd,persona --yes") {
+		t.Fatalf("provisioner argv = %q, want it to cleanup legacy SDD and persona for codex,claude-code,opencode,antigravity,vscode-copilot before install", gotArgs)
 	}
 	if !strings.Contains(string(gotArgs), "install --scope global --channel stable --preset custom --agents codex --components engram,context7") {
 		t.Fatalf("provisioner argv = %q, want codex install without permissions", gotArgs)
@@ -258,8 +263,15 @@ printf '%s' "$block" > "$HOME/.config/Code/User/prompts/gentle-ai.instructions.m
 		if err != nil {
 			t.Fatalf("read cleaned agent instructions %s: %v", path, err)
 		}
-		if strings.Contains(string(got), "gentle-ai:trigger-rules") || strings.Contains(string(got), "review-readability") {
-			t.Fatalf("agent instructions %s kept stale gentle-ai trigger rules\ncontent:\n%s", path, got)
+		for _, forbidden := range []string{"gentle-ai:trigger-rules", "review-readability", "gentle-ai:persona", "Senior Architect"} {
+			if strings.Contains(string(got), forbidden) {
+				t.Fatalf("agent instructions %s kept stale gentle-ai content %q\ncontent:\n%s", path, forbidden, got)
+			}
+		}
+		for _, want := range []string{"<!-- dots:rules -->", "Keep diffs surgical", "Verify before declaring success", "Use sandboxed HOME/config paths"} {
+			if !strings.Contains(string(got), want) {
+				t.Fatalf("agent instructions %s missing dots rules content %q\ncontent:\n%s", path, want, got)
+			}
 		}
 	}
 	// And it must never have escaped into the inherited real HOME.
@@ -292,10 +304,10 @@ printf '%s' "$block" > "$HOME/.config/Code/User/prompts/gentle-ai.instructions.m
 	}
 }
 
-// TestClaudeAgentsPersonaTagRunsInSandbox proves that the explicit persona
-// opt-in path executes under the threaded sandbox HOME, not just in the
-// provisioner rendering layer.
-func TestClaudeAgentsPersonaTagRunsInSandbox(t *testing.T) {
+// TestClaudeAgentsPersonaTagDoesNotInstallPersona proves that the manifest
+// schema still accepts the persona tag, but the repository no longer uses it to
+// install gentle-ai persona content.
+func TestClaudeAgentsPersonaTagDoesNotInstallPersona(t *testing.T) {
 	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
 	if err != nil {
 		t.Fatalf("resolve repo root: %v", err)
@@ -333,11 +345,11 @@ func TestClaudeAgentsPersonaTagRunsInSandbox(t *testing.T) {
 
 	gotArgs, err := os.ReadFile(filepath.Join(home, "gentle-ai-args"))
 	if err != nil {
-		t.Fatalf("persona provisioner did not run under the sandbox HOME %q: %v", home, err)
+		t.Fatalf("gentle-ai provisioner did not run under the sandbox HOME %q: %v", home, err)
 	}
 	wantPersona := "install --scope global --channel stable --persona neutral --preset custom --agents codex,claude-code,opencode,antigravity,vscode-copilot --components persona"
-	if !strings.Contains(string(gotArgs), wantPersona) {
-		t.Fatalf("provisioner argv = %q, want persona opt-in command %q", gotArgs, wantPersona)
+	if strings.Contains(string(gotArgs), wantPersona) || strings.Contains(string(gotArgs), "--components persona") && strings.Contains(string(gotArgs), "install ") {
+		t.Fatalf("provisioner argv = %q, repository must not install persona even with --tag persona", gotArgs)
 	}
 	if _, err := os.Stat(filepath.Join(realHome, "gentle-ai-args")); err == nil {
 		t.Fatalf("persona provisioner wrote into the inherited HOME %q instead of the sandbox", realHome)

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -314,7 +314,7 @@ func runProvisioners(cmd *cobra.Command, m manifest.Manifest, profile string, ex
 	}
 	if gentleAIProvisionerRan(report) {
 		if agents := selectedGentleAIAgents(selected); len(agents) > 0 {
-			if cleanupErr := agentinstructions.RemoveGentleAITriggerRules(home, agents...); cleanupErr != nil {
+			if cleanupErr := agentinstructions.ConvergeDotsAgentRules(home, agents...); cleanupErr != nil {
 				return report, errors.Join(err, cleanupErr)
 			}
 		}

--- a/internal/cli/install_provision_test.go
+++ b/internal/cli/install_provision_test.go
@@ -221,8 +221,15 @@ func TestInstallDoesNotWriteCodeGraphInstructionBlockAfterGentleAIProvisioner(t 
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
 	}
 
-	if _, err := os.Stat(filepath.Join(sandboxHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
-		t.Fatalf("install with gentle-ai provisioner wrote CodeGraph instruction block without the codegraph tag; stat err = %v\noutput:\n%s", err, out.String())
+	got, err := os.ReadFile(filepath.Join(sandboxHome, ".codex", "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("install with gentle-ai provisioner did not write dots rules block: %v\noutput:\n%s", err, out.String())
+	}
+	if strings.Contains(string(got), "dots:codegraph-mode") {
+		t.Fatalf("install with gentle-ai provisioner wrote CodeGraph instruction block without the codegraph tag\ncontent:\n%s\noutput:\n%s", got, out.String())
+	}
+	if !strings.Contains(string(got), "<!-- dots:rules -->") {
+		t.Fatalf("install with gentle-ai provisioner did not write dots rules block\ncontent:\n%s\noutput:\n%s", got, out.String())
 	}
 	if _, err := os.Stat(filepath.Join(fakeRealHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
 		t.Fatalf("install wrote Codex AGENTS.md in inherited HOME %q; stat err = %v", fakeRealHome, err)

--- a/internal/cli/update_provision_test.go
+++ b/internal/cli/update_provision_test.go
@@ -117,8 +117,15 @@ func TestUpdateDoesNotWriteCodeGraphInstructionBlockAfterGentleAIProvisioner(t *
 	out := runUpdate(t, "--yes", "--file", filepath.Join(sourceRoot, "dots.yaml"),
 		"--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot)
 
-	if _, err := os.Stat(filepath.Join(sandboxHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
-		t.Fatalf("update with gentle-ai provisioner wrote CodeGraph instruction block without the codegraph tag; stat err = %v\noutput:\n%s", err, out)
+	got, err := os.ReadFile(filepath.Join(sandboxHome, ".codex", "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("update with gentle-ai provisioner did not write dots rules block: %v\noutput:\n%s", err, out)
+	}
+	if strings.Contains(string(got), "dots:codegraph-mode") {
+		t.Fatalf("update with gentle-ai provisioner wrote CodeGraph instruction block without the codegraph tag\ncontent:\n%s\noutput:\n%s", got, out)
+	}
+	if !strings.Contains(string(got), "<!-- dots:rules -->") {
+		t.Fatalf("update with gentle-ai provisioner did not write dots rules block\ncontent:\n%s\noutput:\n%s", got, out)
 	}
 	if _, err := os.Stat(filepath.Join(fakeRealHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
 		t.Fatalf("update wrote Codex AGENTS.md in inherited HOME %q; stat err = %v", fakeRealHome, err)

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -1084,9 +1084,6 @@ func TestRepositoryManifestIncludesGentleAICleanupBeforeBasicInstall(t *testing.
 	if codexInstall == nil {
 		t.Fatal("repository manifest missing gentle-ai codex basic install provisioner")
 	}
-	if personaInstall == nil {
-		t.Fatal("repository manifest missing opt-in gentle-ai persona install provisioner")
-	}
 	if claudeInstall == nil {
 		t.Fatal("repository manifest missing gentle-ai claude basic install provisioner")
 	}
@@ -1110,14 +1107,14 @@ func TestRepositoryManifestIncludesGentleAICleanupBeforeBasicInstall(t *testing.
 	if !sameStrings(cleanup.Spec.Agents, []string{"codex", "claude-code", "opencode", "antigravity", "vscode-copilot"}) {
 		t.Fatalf("gentle-ai cleanup agents = %#v, want [codex claude-code opencode antigravity vscode-copilot]", cleanup.Spec.Agents)
 	}
-	if !sameStrings(cleanup.Spec.Components, []string{"sdd"}) {
-		t.Fatalf("gentle-ai cleanup components = %#v, want [sdd]", cleanup.Spec.Components)
+	if !sameStrings(cleanup.Spec.Components, []string{"sdd", "persona"}) {
+		t.Fatalf("gentle-ai cleanup components = %#v, want [sdd persona]", cleanup.Spec.Components)
 	}
 	if !sameStrings(sddInstall.Tags, []string{"sdd"}) {
 		t.Fatalf("gentle-ai SDD install tags = %#v, want [sdd] so agents profile only installs SDD with --tag sdd", sddInstall.Tags)
 	}
-	if !sameStrings(personaInstall.Tags, []string{"persona"}) {
-		t.Fatalf("gentle-ai persona install tags = %#v, want [persona] so agents profile only installs persona with --tag persona", personaInstall.Tags)
+	if personaInstall != nil {
+		t.Fatalf("repository manifest must not install gentle-ai persona; found tags %#v spec %#v", personaInstall.Tags, personaInstall.Spec)
 	}
 	if !sameStrings(sddInstall.Spec.Agents, []string{"codex", "claude-code", "opencode", "antigravity", "vscode-copilot"}) {
 		t.Fatalf("gentle-ai SDD install agents = %#v, want [codex claude-code opencode antigravity vscode-copilot]", sddInstall.Spec.Agents)
@@ -1157,9 +1154,6 @@ func TestRepositoryManifestIncludesGentleAICleanupBeforeBasicInstall(t *testing.
 	}
 	if hasString(copilotInstall.Spec.Components, "sdd") || hasString(copilotInstall.Spec.Components, "permissions") {
 		t.Fatalf("gentle-ai vscode-copilot install components = %#v, must not include sdd or permissions", copilotInstall.Spec.Components)
-	}
-	if !sameStrings(personaInstall.Spec.Agents, []string{"codex", "claude-code", "opencode", "antigravity", "vscode-copilot"}) {
-		t.Fatalf("gentle-ai persona install agents = %#v, want all supported gentle-ai agent targets", personaInstall.Spec.Agents)
 	}
 	for i := range got.Provisioners {
 		if &got.Provisioners[i] == cleanup {
@@ -1211,7 +1205,6 @@ func TestRepositoryManifestDesktopProfileDoesNotSelectGentleAIProvisioners(t *te
 		"install",
 		"--scope", "global",
 		"--channel", "stable",
-		"--persona", "neutral",
 		"--preset", "custom",
 		"--sdd-mode", "multi",
 		"--agents", "codex,claude-code,opencode,antigravity,vscode-copilot",
@@ -1257,15 +1250,10 @@ func TestRepositoryManifestDesktopProfileDoesNotSelectGentleAIProvisioners(t *te
 	if err != nil {
 		t.Fatalf("provision.Build(agents --tag persona) error = %v", err)
 	}
-	foundPersonaInstall := false
 	for _, step := range agentsWithPersona.Steps {
 		if step.Tool == "gentle-ai" && sameStrings(step.Args, wantPersonaArgs) {
-			foundPersonaInstall = true
-			break
+			t.Fatalf("agents profile with --tag persona selected persona install args %#v; repository manifest must not install persona", step.Args)
 		}
-	}
-	if !foundPersonaInstall {
-		t.Fatal("agents profile with --tag persona did not select the Gentle-AI persona install provisioner")
 	}
 }
 


### PR DESCRIPTION
Closes #247

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds a dots-owned global `<!-- dots:rules -->` block for supported agent instruction files.
- Stops the repository manifest from installing gentle-ai persona content while keeping persona schema support intact.
- Cleans gentle-ai trigger-rules, persona marker blocks, and known legacy markerless persona prose after gentle-ai provisioning.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Adds persona to the agents cleanup provisioner, removes the repo persona install provisioner, and removes persona from SDD install flags. |
| `internal/agentinstructions/trigger_rules.go` | Adds `ConvergeDotsAgentRules` to remove gentle-ai stale blocks and upsert dots-owned rules. |
| `internal/cli/install.go` | Runs the broader agent-instruction convergence after successful gentle-ai provisioning. |
| `internal/*_test.go` | Covers persona cleanup, rules injection, manifest selection, and sandboxed install/update behavior. |
| `docs/manifest.md`, `docs/update.md` | Documents persona cleanup and dots-owned global rules. |

## Test Plan

- [x] `go test ./internal/agentinstructions ./internal/manifest ./internal/cli ./internal/provision`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `gofmt -l .`
- [x] Sandboxed plan: `SANDBOX=$(mktemp -d); go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home "$SANDBOX"`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #247`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
