### PR TITLE
feat(agents): gate Codex Spark delegation by tag

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -11,10 +11,24 @@
 - Use `grilling` when the plan or decision needs one-question-at-a-time stress testing and codebase exploration cannot answer the question.
 - `grill-with-docs` is skipped only for mechanical or already-aligned work: small fixes, documentation adjustments with no new decision, explicit review follow-ups, or issues already marked `ready-for-agent`.
 - Changes touching domain language, CLI UX, security, installation behavior, release workflow, or architecture go through `grill-with-docs`.
+- Spark subagent delegation is evaluated in every phase of the dots development loop but is not mandatory. The main thread owns requirements, decisions, integration, and final verification.
+- Good Spark slices: independent exploration, impact scans, test/log triage, or disjoint implementation ownership. Bad slices: tiny tasks, single coherent edits, review, real user configuration, or overlapping write scopes.
+- Spark does not mutate GitHub or other external project state in the dots development loop. The main agent owns opening/editing issues, labels, comments, PRs, merges, releases, commits, and final integration.
+- Codex Spark delegation should be opt-in and separately installable, not bundled into the default `agents` profile. Preferred tag name: `codex-spark-delegation`, selected with `dots install --profile agents --tag codex-spark-delegation`, so the user can stop installing it without removing the rest of the agent baseline.
+- Codex Spark delegation needs explicit cleanup because omitting the install tag does not remove an already-written block. Preferred cleanup tag: `without-codex-spark-delegation`, removing only `<!-- dots:codex-spark-delegation -->...<!-- /dots:codex-spark-delegation -->` and preserving `dots:rules`, Engram, CodeGraph, Codex config, and the rest of the agent baseline.
+- If both `codex-spark-delegation` and `without-codex-spark-delegation` are selected, `without-codex-spark-delegation` wins because explicit exclusion expresses the desired final state.
 
 - After `grill-with-docs`, use a human-in-the-loop Alignment Brief before triage. The user would like more automation eventually, but wants to prove the loop first.
 - After triage, use a human-in-the-loop Triage Brief before implementation. It includes issue links, state/labels, research, exact scope, risks, and acceptance criteria.
+- Spark delegation does not add a new checkpoint. Existing briefs include Delegation notes when Spark was used: what was delegated, what came back, what the main agent accepted or rejected, and what the main agent verified directly.
 - Implementation default is changes → local review → PR. PR-before-review is reserved for cases where early GitHub/CI feedback or external visibility materially helps.
-- Mandatory implementation review uses the available `$review` skill only. It reviews Standards and Spec axes. Run it locally before PR readiness, repeat after fixes, and rerun after meaningful PR/CI follow-up commits.
+- Mandatory implementation review uses the available `$review` skill only, not Spark. It reviews Standards and Spec axes. Run it locally before PR readiness, repeat after fixes, and rerun after meaningful PR/CI follow-up commits.
 - A merged PR triggers a dots release when it affects CLI behavior, install/deps behavior, visible output, distributed configuration, operational user documentation, or a user-usable bugfix. Pure internal tooling/tests/agent-only docs do not trigger release.
 - The loop closes with a Release/Closure Brief containing merged PRs, merge commit, tag/release links when applicable, closed issues, validation, user-facing change summary, and follow-ups.
+
+## Pending implementation notes
+
+- Implement `codex-spark-delegation` and `without-codex-spark-delegation` as separate selectable tags.
+- Migrate Codex Spark delegation markers from `argote:subagent-delegation` to `dots:codex-spark-delegation`.
+- Cleanup must remove both current `dots:codex-spark-delegation` markers and legacy `argote:subagent-delegation` markers while preserving `dots:rules`, Engram, CodeGraph, Codex config, and the rest of the agent baseline.
+- Technical implementation direction: keep `dots:rules` on the automatic `agents` convergence path, move Codex Spark delegation into separate `ConvergeCodexSparkDelegation(home)` and `RemoveCodexSparkDelegation(home)` functions, and call them from install/update tag selection. `without-codex-spark-delegation` wins over `codex-spark-delegation`.

--- a/internal/agentinstructions/trigger_rules.go
+++ b/internal/agentinstructions/trigger_rules.go
@@ -11,14 +11,16 @@ import (
 )
 
 const (
-	gentleAITriggerRulesStart = "<!-- gentle-ai:trigger-rules -->"
-	gentleAITriggerRulesEnd   = "<!-- /gentle-ai:trigger-rules -->"
-	gentleAIPersonaStart      = "<!-- gentle-ai:persona -->"
-	gentleAIPersonaEnd        = "<!-- /gentle-ai:persona -->"
-	dotsRulesStart            = "<!-- dots:rules -->"
-	dotsRulesEnd              = "<!-- /dots:rules -->"
-	codexDelegationStart      = "<!-- argote:subagent-delegation -->"
-	codexDelegationEnd        = "<!-- /argote:subagent-delegation -->"
+	gentleAITriggerRulesStart  = "<!-- gentle-ai:trigger-rules -->"
+	gentleAITriggerRulesEnd    = "<!-- /gentle-ai:trigger-rules -->"
+	gentleAIPersonaStart       = "<!-- gentle-ai:persona -->"
+	gentleAIPersonaEnd         = "<!-- /gentle-ai:persona -->"
+	dotsRulesStart             = "<!-- dots:rules -->"
+	dotsRulesEnd               = "<!-- /dots:rules -->"
+	codexDelegationStart       = "<!-- dots:codex-spark-delegation -->"
+	codexDelegationEnd         = "<!-- /dots:codex-spark-delegation -->"
+	legacyCodexDelegationStart = "<!-- argote:subagent-delegation -->"
+	legacyCodexDelegationEnd   = "<!-- /argote:subagent-delegation -->"
 )
 
 const dotsRulesBlock = `## Dots Agent Rules
@@ -40,9 +42,8 @@ Use subagents only when the user explicitly asks for delegation, parallel agents
 | --- | --- |
 | Codebase exploration, impact scans, or test/log triage can run independently | Spawn explorer on gpt-5.3-codex-spark and ask for findings with file refs. |
 | Implementation can be split into disjoint files/modules | Spawn worker on gpt-5.3-codex-spark, assign ownership, and require a changed-file list. |
-| Review needs parallel lenses (bugs, tests, security, maintainability) | Spawn one focused Spark agent per lens; wait before final judgment. |
 
-Avoid delegation when the task is tiny, requires a single coherent edit, touches real user configuration, or would create overlapping write scopes. For write-heavy work, define non-overlapping ownership and remind workers not to revert others' edits. After results return, inspect/integrate the changes yourself, run the relevant verification, close finished agents, and summarize only distilled outcomes.`
+Avoid delegation when the task is tiny, requires a single coherent edit, touches real user configuration, review, or would create overlapping write scopes. For write-heavy work, define non-overlapping ownership and remind workers not to revert others' edits. After results return, inspect/integrate the changes yourself, run the relevant verification, close finished agents, and summarize only distilled outcomes.`
 
 type instructionTarget struct {
 	agent string
@@ -70,13 +71,22 @@ func ConvergeDotsAgentRules(home string, agents ...string) error {
 		if err := convergeDotsRules(target.path); err != nil {
 			return err
 		}
-		if target.agent == "codex" {
-			if err := convergeCodexDelegation(target.path); err != nil {
-				return err
-			}
-		}
 	}
 	return nil
+}
+
+// ConvergeCodexSparkDelegation injects the opt-in Codex Spark delegation
+// guidance into Codex instructions only. Legacy argote-owned marker pairs are
+// migrated to the dots-owned marker pair during the upsert.
+func ConvergeCodexSparkDelegation(home string) error {
+	return convergeCodexDelegation(filepath.Join(home, ".codex", "AGENTS.md"))
+}
+
+// RemoveCodexSparkDelegation removes both current dots-owned and legacy
+// argote-owned Codex Spark delegation blocks without touching the rest of the
+// agent baseline.
+func RemoveCodexSparkDelegation(home string) error {
+	return removeCodexDelegation(filepath.Join(home, ".codex", "AGENTS.md"))
 }
 
 func instructionPaths(home string, agents []string) []string {
@@ -177,9 +187,39 @@ func convergeCodexDelegation(path string) error {
 	if err != nil {
 		return err
 	}
-	updated, err := textblock.Upsert(content, textblock.Markers{Start: codexDelegationStart, End: codexDelegationEnd}, codexDelegationBlock)
+	updated, err := textblock.Upsert(
+		content,
+		textblock.Markers{Start: codexDelegationStart, End: codexDelegationEnd},
+		codexDelegationBlock,
+		textblock.Markers{Start: legacyCodexDelegationStart, End: legacyCodexDelegationEnd},
+	)
 	if err != nil {
 		return fmt.Errorf("upsert Codex delegation guidance in %s: %w", path, err)
+	}
+	if updated == content {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("mkdir agent instructions %s: %w", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(updated), mode); err != nil {
+		return fmt.Errorf("write agent instructions %s: %w", path, err)
+	}
+	return nil
+}
+
+func removeCodexDelegation(path string) error {
+	content, mode, err := readInstructionFile(path)
+	if err != nil {
+		return err
+	}
+	updated, err := textblock.Remove(
+		content,
+		textblock.Markers{Start: codexDelegationStart, End: codexDelegationEnd},
+		textblock.Markers{Start: legacyCodexDelegationStart, End: legacyCodexDelegationEnd},
+	)
+	if err != nil {
+		return fmt.Errorf("remove Codex delegation guidance from %s: %w", path, err)
 	}
 	if updated == content {
 		return nil

--- a/internal/agentinstructions/trigger_rules_test.go
+++ b/internal/agentinstructions/trigger_rules_test.go
@@ -89,17 +89,12 @@ func TestConvergeDotsAgentRulesRemovesPersonaAndInjectsRules(t *testing.T) {
 	if strings.Count(out, dotsRulesStart) != 1 || strings.Count(out, dotsRulesEnd) != 1 {
 		t.Fatalf("dots rules block should be present once\n%s", out)
 	}
-	if strings.Count(out, codexDelegationStart) != 1 || strings.Count(out, codexDelegationEnd) != 1 {
-		t.Fatalf("Codex delegation block should be present once\n%s", out)
+	if strings.Contains(out, codexDelegationStart) || strings.Contains(out, codexDelegationEnd) {
+		t.Fatalf("baseline dots rules should not install Codex Spark delegation\n%s", out)
 	}
 	for _, want := range []string{"Keep diffs surgical", "Choose the simplest change", "Plan before editing", "Verify before declaring success", "Use sandboxed HOME/config paths"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("dots rules missing %q\n%s", want, out)
-		}
-	}
-	for _, want := range []string{"Subagent delegation defaults", "gpt-5.3-codex-spark", "Implementation can be split into disjoint files/modules", "Avoid delegation when the task is tiny"} {
-		if !strings.Contains(out, want) {
-			t.Fatalf("Codex delegation guidance missing %q\n%s", want, out)
 		}
 	}
 	if strings.Contains(out, "Prefer dots JSON output") || strings.Contains(out, "scraping human prose") {
@@ -144,14 +139,17 @@ func TestConvergeDotsAgentRulesPreservesCustomPersonalitySection(t *testing.T) {
 	}
 }
 
-func TestConvergeDotsAgentRulesKeepsSparkDelegationCodexOnly(t *testing.T) {
+func TestConvergeCodexSparkDelegationIsOptInCodexOnly(t *testing.T) {
 	home := t.TempDir()
 
 	if err := ConvergeDotsAgentRules(home, "codex", "claude-code", "opencode", "antigravity", "vscode-copilot"); err != nil {
 		t.Fatalf("ConvergeDotsAgentRules() error = %v", err)
 	}
-	if err := ConvergeDotsAgentRules(home, "codex", "claude-code", "opencode", "antigravity", "vscode-copilot"); err != nil {
-		t.Fatalf("ConvergeDotsAgentRules() second run error = %v", err)
+	if err := ConvergeCodexSparkDelegation(home); err != nil {
+		t.Fatalf("ConvergeCodexSparkDelegation() error = %v", err)
+	}
+	if err := ConvergeCodexSparkDelegation(home); err != nil {
+		t.Fatalf("ConvergeCodexSparkDelegation() second run error = %v", err)
 	}
 
 	codexPath := filepath.Join(home, ".codex", "AGENTS.md")
@@ -165,6 +163,9 @@ func TestConvergeDotsAgentRulesKeepsSparkDelegationCodexOnly(t *testing.T) {
 	}
 	if strings.Count(codexContent, "gpt-5.3-codex-spark") != 2 {
 		t.Fatalf("Codex delegation block should include Spark role guidance exactly twice\n%s", codexContent)
+	}
+	if strings.Contains(codexContent, legacyCodexDelegationStart) || strings.Contains(codexContent, legacyCodexDelegationEnd) {
+		t.Fatalf("Codex delegation block should use dots-owned markers, not legacy markers\n%s", codexContent)
 	}
 
 	nonCodexPaths := []string{
@@ -229,5 +230,74 @@ func TestConvergeDotsAgentRulesRemovesLegacyMarkerlessPersona(t *testing.T) {
 	}
 	if !strings.Contains(out, dotsRulesStart) {
 		t.Fatalf("dots rules not injected\n%s", out)
+	}
+}
+
+func TestConvergeCodexSparkDelegationMigratesLegacyMarkers(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".codex", "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+	content := "before\n\n" + legacyCodexDelegationStart + "\nstale spark guidance\n" + legacyCodexDelegationEnd + "\n\nafter\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+
+	if err := ConvergeCodexSparkDelegation(home); err != nil {
+		t.Fatalf("ConvergeCodexSparkDelegation() error = %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	out := string(got)
+	for _, not := range []string{legacyCodexDelegationStart, legacyCodexDelegationEnd, "stale spark guidance"} {
+		if strings.Contains(out, not) {
+			t.Fatalf("legacy content kept %q\n%s", not, out)
+		}
+	}
+	if strings.Count(out, codexDelegationStart) != 1 || strings.Count(out, codexDelegationEnd) != 1 {
+		t.Fatalf("dots-owned Codex delegation block should be present once\n%s", out)
+	}
+	if !strings.Contains(out, "before") || !strings.Contains(out, "after") {
+		t.Fatalf("surrounding content not preserved\n%s", out)
+	}
+}
+
+func TestRemoveCodexSparkDelegationRemovesCurrentAndLegacyMarkers(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".codex", "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+	content := "before\n\n" +
+		dotsRulesStart + "\n" + dotsRulesBlock + "\n" + dotsRulesEnd + "\n\n" +
+		codexDelegationStart + "\ncurrent\n" + codexDelegationEnd + "\n\n" +
+		legacyCodexDelegationStart + "\nlegacy\n" + legacyCodexDelegationEnd + "\n\nafter\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+
+	if err := RemoveCodexSparkDelegation(home); err != nil {
+		t.Fatalf("RemoveCodexSparkDelegation() error = %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	out := string(got)
+	for _, not := range []string{codexDelegationStart, codexDelegationEnd, legacyCodexDelegationStart, legacyCodexDelegationEnd, "current", "legacy"} {
+		if strings.Contains(out, not) {
+			t.Fatalf("delegation cleanup kept %q\n%s", not, out)
+		}
+	}
+	if !strings.Contains(out, dotsRulesStart) || !strings.Contains(out, "Keep diffs surgical") {
+		t.Fatalf("delegation cleanup removed dots rules\n%s", out)
+	}
+	if !strings.Contains(out, "before") || !strings.Contains(out, "after") {
+		t.Fatalf("surrounding content not preserved\n%s", out)
 	}
 }

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -319,6 +319,16 @@ func runProvisioners(cmd *cobra.Command, m manifest.Manifest, profile string, ex
 			}
 		}
 	}
+	selectedTags := manifest.SelectionTags(m.Profiles[profile], extraTags)
+	if hasTag(selectedTags, "without-codex-spark-delegation") {
+		if cleanupErr := agentinstructions.RemoveCodexSparkDelegation(home); cleanupErr != nil {
+			return report, errors.Join(err, cleanupErr)
+		}
+	} else if hasTag(selectedTags, "codex-spark-delegation") {
+		if cleanupErr := agentinstructions.ConvergeCodexSparkDelegation(home); cleanupErr != nil {
+			return report, errors.Join(err, cleanupErr)
+		}
+	}
 	if err != nil {
 		return report, err
 	}
@@ -326,6 +336,15 @@ func runProvisioners(cmd *cobra.Command, m manifest.Manifest, profile string, ex
 		return report, codexconfig.EnsureCodeGraphMode(home, agents...)
 	}
 	return report, nil
+}
+
+func hasTag(tags []string, want string) bool {
+	for _, tag := range tags {
+		if tag == want {
+			return true
+		}
+	}
+	return false
 }
 
 func gentleAIProvisionerRan(report provision.Report) bool {

--- a/internal/cli/install_provision_test.go
+++ b/internal/cli/install_provision_test.go
@@ -231,6 +231,106 @@ func TestInstallDoesNotWriteCodeGraphInstructionBlockAfterGentleAIProvisioner(t 
 	if !strings.Contains(string(got), "<!-- dots:rules -->") {
 		t.Fatalf("install with gentle-ai provisioner did not write dots rules block\ncontent:\n%s\noutput:\n%s", got, out.String())
 	}
+	if strings.Contains(string(got), "dots:codex-spark-delegation") || strings.Contains(string(got), "argote:subagent-delegation") || strings.Contains(string(got), "gpt-5.3-codex-spark") {
+		t.Fatalf("install without Codex Spark tag wrote delegation guidance\ncontent:\n%s\noutput:\n%s", got, out.String())
+	}
+	if _, err := os.Stat(filepath.Join(fakeRealHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatalf("install wrote Codex AGENTS.md in inherited HOME %q; stat err = %v", fakeRealHome, err)
+	}
+}
+
+func TestInstallCodexSparkDelegationTagInstallsGuidance(t *testing.T) {
+	sandboxHome := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	fakeRealHome := t.TempDir()
+	t.Setenv("HOME", fakeRealHome)
+
+	stubDir := t.TempDir()
+	writeExecStub(t, filepath.Join(stubDir, "gentle-ai"), "#!/bin/sh\nexit 0\n")
+	writeExecStub(t, filepath.Join(stubDir, "engram"), "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	writeCLISource(t, sourceRoot, "configs/zsh/zshrc", "managed\n")
+	manifestPath := writeCLIManifest(t, sandboxHome, provisionerManifest)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"install", "--yes", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot, "--tag", "codex-spark-delegation"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+
+	got, err := os.ReadFile(filepath.Join(sandboxHome, ".codex", "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("install with Codex Spark tag did not write Codex AGENTS.md: %v\noutput:\n%s", err, out.String())
+	}
+	content := string(got)
+	for _, want := range []string{"<!-- dots:rules -->", "<!-- dots:codex-spark-delegation -->", "gpt-5.3-codex-spark"} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("install with Codex Spark tag missing %q\ncontent:\n%s\noutput:\n%s", want, content, out.String())
+		}
+	}
+	if strings.Contains(content, "argote:subagent-delegation") {
+		t.Fatalf("install with Codex Spark tag used legacy markers\ncontent:\n%s", content)
+	}
+	if _, err := os.Stat(filepath.Join(fakeRealHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatalf("install wrote Codex AGENTS.md in inherited HOME %q; stat err = %v", fakeRealHome, err)
+	}
+}
+
+func TestInstallWithoutCodexSparkDelegationTagRemovesCurrentAndLegacyGuidance(t *testing.T) {
+	sandboxHome := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	fakeRealHome := t.TempDir()
+	t.Setenv("HOME", fakeRealHome)
+
+	stubDir := t.TempDir()
+	writeExecStub(t, filepath.Join(stubDir, "gentle-ai"), "#!/bin/sh\nexit 0\n")
+	writeExecStub(t, filepath.Join(stubDir, "engram"), "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	codexPath := filepath.Join(sandboxHome, ".codex", "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(codexPath), 0o755); err != nil {
+		t.Fatalf("mkdir Codex dir: %v", err)
+	}
+	preexisting := "before\n\n<!-- dots:codex-spark-delegation -->\ncurrent\n<!-- /dots:codex-spark-delegation -->\n\n<!-- argote:subagent-delegation -->\nlegacy\n<!-- /argote:subagent-delegation -->\n\nafter\n"
+	if err := os.WriteFile(codexPath, []byte(preexisting), 0o600); err != nil {
+		t.Fatalf("write preexisting Codex instructions: %v", err)
+	}
+
+	writeCLISource(t, sourceRoot, "configs/zsh/zshrc", "managed\n")
+	manifestPath := writeCLIManifest(t, sandboxHome, provisionerManifest)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"install", "--yes", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot, "--tag", "codex-spark-delegation", "--tag", "without-codex-spark-delegation"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+
+	got, err := os.ReadFile(codexPath)
+	if err != nil {
+		t.Fatalf("read Codex instructions: %v", err)
+	}
+	content := string(got)
+	for _, not := range []string{"dots:codex-spark-delegation", "argote:subagent-delegation", "current", "legacy", "gpt-5.3-codex-spark"} {
+		if strings.Contains(content, not) {
+			t.Fatalf("without Codex Spark tag kept %q\ncontent:\n%s\noutput:\n%s", not, content, out.String())
+		}
+	}
+	for _, want := range []string{"<!-- dots:rules -->", "Keep diffs surgical", "before", "after"} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("without Codex Spark tag removed expected %q\ncontent:\n%s", want, content)
+		}
+	}
 	if _, err := os.Stat(filepath.Join(fakeRealHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
 		t.Fatalf("install wrote Codex AGENTS.md in inherited HOME %q; stat err = %v", fakeRealHome, err)
 	}

--- a/internal/cli/update_provision_test.go
+++ b/internal/cli/update_provision_test.go
@@ -127,6 +127,47 @@ func TestUpdateDoesNotWriteCodeGraphInstructionBlockAfterGentleAIProvisioner(t *
 	if !strings.Contains(string(got), "<!-- dots:rules -->") {
 		t.Fatalf("update with gentle-ai provisioner did not write dots rules block\ncontent:\n%s\noutput:\n%s", got, out)
 	}
+	if strings.Contains(string(got), "dots:codex-spark-delegation") || strings.Contains(string(got), "argote:subagent-delegation") || strings.Contains(string(got), "gpt-5.3-codex-spark") {
+		t.Fatalf("update without Codex Spark tag wrote delegation guidance\ncontent:\n%s\noutput:\n%s", got, out)
+	}
+	if _, err := os.Stat(filepath.Join(fakeRealHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatalf("update wrote Codex AGENTS.md in inherited HOME %q; stat err = %v", fakeRealHome, err)
+	}
+}
+
+func TestUpdateCodexSparkDelegationTagInstallsGuidance(t *testing.T) {
+	requireGitCLI(t)
+	sandboxHome := t.TempDir()
+	stateRoot := t.TempDir()
+	fakeRealHome := t.TempDir()
+	t.Setenv("HOME", fakeRealHome)
+
+	stubDir := t.TempDir()
+	writeExecStub(t, filepath.Join(stubDir, "gentle-ai"), "#!/bin/sh\nexit 0\n")
+	writeExecStub(t, filepath.Join(stubDir, "engram"), "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	_, sourceRoot := newInstalledRepo(t, map[string]string{
+		"configs/git/gitconfig": "managed\n",
+		"dots.yaml":             updateProvisionerManifest,
+	})
+
+	out := runUpdate(t, "--yes", "--file", filepath.Join(sourceRoot, "dots.yaml"),
+		"--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot, "--tag", "codex-spark-delegation")
+
+	got, err := os.ReadFile(filepath.Join(sandboxHome, ".codex", "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("update with Codex Spark tag did not write Codex AGENTS.md: %v\noutput:\n%s", err, out)
+	}
+	content := string(got)
+	for _, want := range []string{"<!-- dots:rules -->", "<!-- dots:codex-spark-delegation -->", "gpt-5.3-codex-spark"} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("update with Codex Spark tag missing %q\ncontent:\n%s\noutput:\n%s", want, content, out)
+		}
+	}
+	if strings.Contains(content, "argote:subagent-delegation") {
+		t.Fatalf("update with Codex Spark tag used legacy markers\ncontent:\n%s", content)
+	}
 	if _, err := os.Stat(filepath.Join(fakeRealHome, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
 		t.Fatalf("update wrote Codex AGENTS.md in inherited HOME %q; stat err = %v", fakeRealHome, err)
 	}

--- a/workflows/dots-development-loop.md
+++ b/workflows/dots-development-loop.md
@@ -16,26 +16,47 @@ The workflow starts when the user has an intention of change for the `dots` proj
    - Use `grill-with-docs` when the change needs shared understanding, domain sharpening, ADRs, issue creation, architecture notes, or workflow documentation.
    - Skip `grill-with-docs` only for mechanical or already-aligned work: small fixes, documentation adjustments that introduce no new decision, explicit review follow-ups, or existing issues already marked `ready-for-agent`.
    - Use `grill-with-docs` for any change touching domain language, CLI UX, security, installation behavior, release workflow, or architecture.
+   - Evaluate Spark subagent delegation in every phase, but do not delegate by default. Delegate only when a bounded slice can return compact findings or changes without blurring ownership.
+   - Spark does not mutate GitHub or other external project state. It produces findings, briefs, or local changes for the main agent to inspect.
+   - Codex Spark delegation is an opt-in installable capability, not part of the default `agents` baseline. It should be selected with a dedicated tag such as `codex-spark-delegation` so the user can stop installing it independently from the rest of the agents profile.
+   - Codex Spark delegation also needs a dedicated cleanup path. Removing the install tag from future runs is not enough because an existing `<!-- dots:codex-spark-delegation -->` block remains in `~/.codex/AGENTS.md` until explicitly removed.
 2. Present an Alignment Brief after alignment and wait for the user to approve moving into triage.
    - The brief includes links to ADRs and issues created or changed, decisions made, doubts closed, and the single decision: approve moving to triage.
    - This checkpoint is intentionally human-in-the-loop for now, even though the desired long-term direction is more automation after the loop proves itself.
+   - If Spark was used during alignment, include Delegation notes: what was delegated, what came back, what the main agent accepted or rejected, and what the main agent verified directly.
 3. Triage the resulting issue or issues, including research and further alignment when necessary.
+   - The main agent owns all GitHub actions: opening or editing issues, applying labels, posting comments, opening PRs, merging, and releasing.
 4. Present a Triage Brief and wait for the user to approve moving into implementation.
    - The brief includes issue links, current state and labels, relevant research, exact implementation scope, risks, acceptance criteria, and the single decision: approve moving to implementation.
+   - If Spark was used during triage, include Delegation notes with the same accept/reject/verification shape.
 5. Implement the issue or issues using the repository skills and workflow documentation.
    - Default path: changes → local review → PR.
    - Use PR-before-review only when early GitHub/CI feedback is materially useful or the work needs external visibility before local review is complete.
+   - Delegate implementation to Spark only for disjoint files or modules with explicit ownership, required changed-file reporting, and no permission to revert unrelated edits.
+   - Spark workers may prepare local patches, but the main agent inspects and integrates the result before any commit, PR, or external update.
+   - If a change is needed to the Codex Spark delegation guidance itself, prefer making it separately installable/removable through the `codex-spark-delegation` tag rather than coupling it to the `agents` profile.
+   - Preferred cleanup shape: a declarative tag, `without-codex-spark-delegation`, removes only the `<!-- dots:codex-spark-delegation -->...<!-- /dots:codex-spark-delegation -->` block. It must not remove `dots:rules`, Engram, CodeGraph, Codex config, or any other agent baseline.
+   - If both `codex-spark-delegation` and `without-codex-spark-delegation` are selected, the `without-*` tag wins because explicit exclusion expresses the desired final state.
 6. Review the implementation with `$review` and loop back into implementation for every confirmed finding.
    - `$review` is the mandatory review skill for this loop.
    - Run it locally against the fixed point before opening or marking the PR ready, using the two available axes: Standards and Spec.
    - If review finds issues, fix them and run `$review` again until the confirmed findings are closed.
    - After the PR exists, run `$review` again when PR feedback, CI fixes, or meaningful follow-up commits change the diff.
+   - Do not use Spark for review in this loop. Keep review centralized through `$review` and the main agent's verification.
 7. Merge the PR and release `dots` when the change should ship.
    - Release after merging changes that affect CLI behavior, install/deps behavior, visible output, distributed configuration, operational user documentation, or a user-usable bugfix.
    - Do not release for purely internal tooling, tests, or agent-only documentation that does not change the user experience.
 8. Present a Release/Closure Brief to close the workflow.
    - The brief includes merged PR links, merge commit, tag and release links when applicable, closed issues, final validation evidence, what changed for the user, and any remaining follow-ups.
+   - If Spark was used at any point in the workflow, include final Delegation notes covering the delegated slices, accepted findings or changes, rejected findings or changes, and final verification performed by the main agent.
 
-## Open questions
+## Implementation follow-ups
 
-None.
+- Implement `codex-spark-delegation` and `without-codex-spark-delegation` as separate selectable tags.
+- Migrate the Codex Spark delegation markers from `<!-- argote:subagent-delegation -->...<!-- /argote:subagent-delegation -->` to `<!-- dots:codex-spark-delegation -->...<!-- /dots:codex-spark-delegation -->`.
+- Ensure cleanup removes both the current `dots:codex-spark-delegation` marker pair and the legacy `argote:subagent-delegation` marker pair without touching `dots:rules`, Engram, CodeGraph, Codex config, or any other agent baseline.
+- Keep `dots:rules` coupled to the `agents` profile, but move Codex Spark delegation out of the automatic `ConvergeDotsAgentRules` path.
+- Add separate convergence functions for the opt-in capability:
+  - `ConvergeCodexSparkDelegation(home)` installs or updates only the `dots:codex-spark-delegation` block.
+  - `RemoveCodexSparkDelegation(home)` removes both `dots:codex-spark-delegation` and legacy `argote:subagent-delegation` blocks.
+- Invoke those functions from install/update based on selected tags: `codex-spark-delegation` installs, `without-codex-spark-delegation` removes, and `without-*` wins when both are selected.


### PR DESCRIPTION
Closes #253

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Makes Codex Spark delegation opt-in via `codex-spark-delegation`.
- Adds `without-codex-spark-delegation` cleanup with precedence when both tags are selected.
- Migrates the managed block to `dots:codex-spark-delegation` markers while preserving baseline `dots:rules`.

## Changes

| File | Change |
|------|--------|
| `internal/agentinstructions/trigger_rules.go` | Split baseline dots rules from opt-in Codex Spark delegation, add dots-owned markers, legacy marker migration, and removal helper. |
| `internal/cli/install.go` | Invoke Codex Spark delegation convergence/removal from selected install/update tags, with `without-*` taking precedence. |
| `internal/agentinstructions/trigger_rules_test.go` | Cover baseline-only rules, opt-in Spark block, legacy marker migration, and cleanup preservation. |
| `internal/cli/install_provision_test.go` | Cover sandboxed install behavior for no Spark tag, opt-in tag, and `without-*` precedence/removal. |
| `internal/cli/update_provision_test.go` | Cover sandboxed update behavior for no Spark tag and opt-in tag. |
| `workflows/dots-development-loop.md`, `NOTES.md` | Carry forward the updated loop/spec notes for tag-controlled Spark delegation and no-Spark review. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `SANDBOX=$(mktemp -d); mkdir -p "$SANDBOX/home"; go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home "$SANDBOX/home"`

Note: initial sandboxed plan attempt failed before validation because `$SANDBOX/home` did not exist; reran with `mkdir -p` and it passed.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #253`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
