### PR TITLE
feat(install): offer macos homebrew setup

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -84,6 +84,10 @@ _Avoid_: package, app, required tool
 The OS-aware installation guidance the Dotfiles CLI produces for missing Dependencies. It is the reviewable intent that `dots deps plan` previews and that `dots deps install` may execute.
 _Avoid_: install script, package install, setup commands
 
+**Package Manager Setup**:
+An explicit, user-confirmed preparation step in `dots install` that installs or activates a supported package manager required to provision selected Dependencies. It is separate from Dependency installation and must not run in non-interactive Confirmed Install mode.
+_Avoid_: bootstrap install, hidden package-manager install, provider magic
+
 **Font Dependency**:
 A Dependency that is a font rather than an executable, such as a Nerd Font required so Starship, tmux, or editor configuration renders its glyphs. Because a font is not on the search path, its presence is detected by scanning the workstation font directories for its installed files, not by a command lookup.
 _Avoid_: typeface, glyph pack, icon font

--- a/docs/adr/0012-macos-homebrew-package-manager-setup.md
+++ b/docs/adr/0012-macos-homebrew-package-manager-setup.md
@@ -1,0 +1,19 @@
+# Offer macOS Homebrew Package Manager Setup from install
+
+`dots install` may offer Package Manager Setup for Homebrew on macOS when `brew` is missing and at least one selected required Dependency needs the Homebrew provider. This keeps fresh macOS setup achievable from the primary install flow while preserving the Bootstrapper boundary: `scripts/install.sh` remains limited to downloading, verifying, and launching the Dotfiles CLI.
+
+Package Manager Setup is explicit and interactive-only. `dots install` must show the exact official Homebrew installer command, ask for user confirmation, execute it with terminal stdio only after acceptance, then re-detect `brew` through PATH or the expected macOS prefixes for the current run; no extra opt-in flag is required because the interactive confirmation is the control point. `--yes` must not install Homebrew, and `--dry-run` only previews that setup would be offered. If the user declines Package Manager Setup, install aborts before touching Managed Configuration because the selected required Dependencies remain unresolved.
+
+**Considered Options**: Installing Homebrew from the shell Bootstrapper was rejected because it gives the curl-compatible entrypoint too much authority and conflicts with the Bootstrapper's minimal responsibility. Always installing Homebrew on macOS was rejected because Package Manager Setup should be justified by selected required Dependencies, not by the absence of `brew` itself. Linuxbrew setup is intentionally out of scope for this decision because Linux already has distro providers and User-Local Providers before Linuxbrew fallback, and Linuxbrew setup carries different PATH and permission concerns.
+
+**Consequences**: This refines ADR 0010: `dots` still does not install Homebrew automatically, but it can offer a transparent, user-confirmed macOS setup step when required Dependencies are otherwise blocked. The dependency gate needs to distinguish Package Manager Setup from normal Dependency installation so Confirmed Install remains conservative and no Managed Configuration is touched when required setup is declined or unavailable.
+
+Package Manager Setup should be represented separately from Dependencies in machine-readable output. Homebrew is provisioning infrastructure, not an Install Manifest Dependency, so JSON reports should expose setup state through a dedicated package-manager setup object rather than rendering `Homebrew` as a normal dependency item.
+
+Package Manager Setup must not execute Homebrew Tap Trust commands. Trusting third-party taps or formulas remains a separate security decision surfaced as guidance by the normal Dependency flow; if missing trust blocks a required formula, install should stop before Managed Configuration changes with the existing trust remediation.
+
+If setup succeeds but the new `brew` is not on the current process PATH, `dots install` may use the discovered macOS Homebrew binary path for the rest of that run and should report PATH repair guidance. Expected macOS locations are `/opt/homebrew/bin/brew` for Apple Silicon and `/usr/local/bin/brew` for Intel; if `brew` cannot be found there or on PATH after setup, Package Manager Setup is unavailable and install stops before Managed Configuration changes.
+
+Implementation should keep this as part of dependency provisioning, not Bootstrapper or filesystem installation. A small dependency-owned package can detect Homebrew, describe the setup command/result, and let `dots install` orchestrate setup before recalculating dependency actions and before building/applying the Managed Configuration Install Plan.
+
+Tests must never execute the real Homebrew installer. Verification should use unit tests for Homebrew detection, expected-prefix lookup, command rendering, and setup-need classification, plus CLI tests with fake runners and sandboxed home/state/source paths for interactive accept, interactive decline, `--yes`, and `--dry-run` behavior.

--- a/docs/agents/output-contract.md
+++ b/docs/agents/output-contract.md
@@ -118,6 +118,11 @@ prose the text surface prints:
   dependency item/action is exposed. Omitted manifest values are normalized to
   `required`; optional unresolved Dependencies remain reportable but do not
   block Managed Configuration during integrated install.
+- `install` reports Package Manager Setup separately from Dependencies under
+  `data.package_manager_setup` when selected required Dependencies need
+  package-manager preparation before they can be provisioned. For example, a
+  macOS Homebrew setup preview or gate is reported there instead of rendering
+  Homebrew as a normal Dependency item.
 - `install --dry-run --output json` includes dependency preflight under
   `data.dependencies.preview` before the file `data.plan`. A confirmed
   `install --yes --output json` includes dependency execution results under

--- a/internal/cli/deps.go
+++ b/internal/cli/deps.go
@@ -284,9 +284,13 @@ type depsExecRunner struct {
 	stderr    io.Writer
 	home      string
 	stateRoot string
+	brewPath  string
 }
 
 func (r depsExecRunner) Run(executable string, args []string) error {
+	if executable == "brew" && r.brewPath != "" {
+		executable = r.brewPath
+	}
 	cmd := exec.CommandContext(r.ctx, executable, args...)
 	cmd.Stdin = r.stdin
 	cmd.Stdout = r.stdout

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"runtime"
 	"strings"
@@ -17,6 +18,7 @@ import (
 	"github.com/yersonargotev/dots/internal/bootstrap"
 	"github.com/yersonargotev/dots/internal/codexconfig"
 	"github.com/yersonargotev/dots/internal/deps"
+	"github.com/yersonargotev/dots/internal/deps/pkgmgr"
 	"github.com/yersonargotev/dots/internal/install"
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/plan"
@@ -24,6 +26,13 @@ import (
 	"github.com/yersonargotev/dots/internal/state"
 	"github.com/yersonargotev/dots/internal/tui"
 	"github.com/yersonargotev/dots/internal/version"
+)
+
+var (
+	installHostOS                           = runtime.GOOS
+	installHostArch                         = runtime.GOARCH
+	packageManagerDetector                  = pkgmgr.Detector{}
+	packageManagerSetupRunner pkgmgr.Runner = pkgmgr.ExecRunner{}
 )
 
 func newInstallCommand() *cobra.Command {
@@ -75,25 +84,34 @@ func newInstallCommand() *cobra.Command {
 				return err
 			}
 
-			depOptions := deps.Options{Profile: profile, ExtraTags: extraTags, OS: runtime.GOOS, Arch: runtime.GOARCH, Home: paths.Home, StateRoot: paths.StateRoot}
-			depTier, err := resolveTier("")
+			hostOS := installHostOS
+			hostArch := installHostArch
+			depOptions := deps.Options{Profile: profile, ExtraTags: extraTags, OS: hostOS, Arch: hostArch, Home: paths.Home, StateRoot: paths.StateRoot}
+			depTier, err := resolveInstallTier(hostOS)
 			if err != nil {
 				return err
 			}
 			var depPreview deps.InstallDryRunReport
 			var depPreviewReport *deps.InstallDryRunReport
+			var packageManagerSetup *pkgmgr.Report
+			brewDetection := packageManagerDetector.DetectHomebrew()
+			depLookup := packageManagerLookup(brewDetection)
 			if !skipDeps {
-				depPreview, err = deps.InstallDryRun(*m, depOptions, lookupCommand, fontInstalled(runtime.GOOS, paths.Home), depTier)
+				depPreview, err = deps.InstallDryRun(*m, depOptions, depLookup, fontInstalled(hostOS, paths.Home), depTier)
 				if err != nil {
 					return err
 				}
 				depPreviewReport = &depPreview
+				setup := pkgmgr.HomebrewSetupNeed(hostOS, depPreview, brewDetection)
+				if setup.Status != pkgmgr.StatusNotNeeded || setup.Detection.NeedsPATH {
+					packageManagerSetup = &setup
+				}
 			}
 
 			p, err := plan.Build(*m, plan.Options{
 				Profile:    profile,
 				ExtraTags:  extraTags,
-				OS:         runtime.GOOS,
+				OS:         hostOS,
 				SourceRoot: paths.SourceRoot,
 				Home:       paths.Home,
 				Metadata:   meta,
@@ -102,7 +120,7 @@ func newInstallCommand() *cobra.Command {
 				return err
 			}
 
-			provPlan, err := provision.Build(*m, provision.Options{Profile: profile, ExtraTags: extraTags, OS: runtime.GOOS})
+			provPlan, err := provision.Build(*m, provision.Options{Profile: profile, ExtraTags: extraTags, OS: hostOS})
 			if err != nil {
 				return err
 			}
@@ -113,12 +131,13 @@ func newInstallCommand() *cobra.Command {
 			}
 			if wantsJSON(cmd) {
 				if dryRun {
-					return emitOK(cmd, installReport{DryRun: true, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan})
+					return emitOK(cmd, installReport{DryRun: true, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan})
 				}
 				if !yes {
 					return rejectInteractiveJSON(cmd)
 				}
 			} else if depPreviewReport != nil {
+				renderPackageManagerSetup(cmd.OutOrStdout(), packageManagerSetup)
 				renderDepsInstallPreview(cmd.OutOrStdout(), *depPreviewReport)
 				fmt.Fprintln(cmd.OutOrStdout())
 			} else if skipDeps {
@@ -136,11 +155,53 @@ func newInstallCommand() *cobra.Command {
 			}
 
 			if !skipDeps {
-				depReport, depsApplied, err := runInstallDependencies(cmd, *m, depOptions, depTier, paths.Home, depPreview, yes)
+				depsConfirmed := yes
+				if packageManagerSetup != nil && packageManagerSetup.Status == pkgmgr.StatusWouldOffer {
+					if yes {
+						packageManagerSetup.Status = pkgmgr.StatusUnavailable
+						err := fmt.Errorf("Homebrew Package Manager Setup requires interactive confirmation; rerun without --yes or install Homebrew manually with %s", packageManagerSetup.Command.Display)
+						if wantsJSON(cmd) {
+							return installDependencyGateError{err: err, report: installReport{DryRun: false, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan}}
+						}
+						return err
+					}
+					confirmed, err := confirmPackageManagerSetup(cmd.InOrStdin(), cmd.OutOrStdout(), *packageManagerSetup)
+					if err != nil {
+						return err
+					}
+					if !confirmed {
+						packageManagerSetup.Status = pkgmgr.StatusDeclined
+						fmt.Fprintln(cmd.OutOrStdout(), "Package Manager Setup declined; install canceled before Managed Configuration.")
+						return nil
+					}
+					if err := pkgmgr.RunHomebrewSetup(cmd.Context(), packageManagerSetupRunner, cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr()); err != nil {
+						packageManagerSetup.Status = pkgmgr.StatusFailed
+						return fmt.Errorf("Homebrew Package Manager Setup failed: %w", err)
+					}
+					brewDetection = packageManagerDetector.DetectHomebrew()
+					packageManagerSetup.Detection = brewDetection
+					if !brewDetection.Found {
+						packageManagerSetup.Status = pkgmgr.StatusUnavailable
+						return fmt.Errorf("Homebrew Package Manager Setup completed but brew was not found on PATH, /opt/homebrew/bin/brew, or /usr/local/bin/brew")
+					}
+					packageManagerSetup.Status = pkgmgr.StatusInstalled
+					if brewDetection.PATHGuidance != "" {
+						fmt.Fprintln(cmd.OutOrStdout(), brewDetection.PATHGuidance)
+					}
+					depLookup = packageManagerLookup(brewDetection)
+					depPreview, err = deps.InstallDryRun(*m, depOptions, depLookup, fontInstalled(hostOS, paths.Home), depTier)
+					if err != nil {
+						return err
+					}
+					dependenciesReport.Preview = &depPreview
+					renderDepsInstallPreview(cmd.OutOrStdout(), depPreview)
+					depsConfirmed = true
+				}
+				depReport, depsApplied, err := runInstallDependencies(cmd, *m, depOptions, depTier, paths.Home, depPreview, depsConfirmed, depLookup, brewDetection.Path)
 				dependenciesReport.Result = &depReport
 				if err != nil {
 					if wantsJSON(cmd) {
-						return installDependencyGateError{err: err, report: installReport{DryRun: false, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan}}
+						return installDependencyGateError{err: err, report: installReport{DryRun: false, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan}}
 					}
 					return err
 				}
@@ -169,7 +230,7 @@ func newInstallCommand() *cobra.Command {
 			}
 			if !applied {
 				if wantsJSON(cmd) {
-					return emitOK(cmd, installReport{DryRun: false, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan})
+					return emitOK(cmd, installReport{DryRun: false, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan})
 				}
 				return nil
 			}
@@ -177,12 +238,12 @@ func newInstallCommand() *cobra.Command {
 			provResult, err := runProvisioners(cmd, *m, profile, extraTags, paths.Home, paths.StateRoot)
 			if err != nil {
 				if wantsJSON(cmd) {
-					return installProvisionerError{err: err, report: installReport{DryRun: false, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan, BackupSets: createdBackups, ProvisionerResults: &provResult}}
+					return installProvisionerError{err: err, report: installReport{DryRun: false, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan, BackupSets: createdBackups, ProvisionerResults: &provResult}}
 				}
 				return err
 			}
 			if wantsJSON(cmd) {
-				return emitOK(cmd, installReport{DryRun: false, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan, BackupSets: createdBackups})
+				return emitOK(cmd, installReport{DryRun: false, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan, BackupSets: createdBackups})
 			}
 			return nil
 		},
@@ -211,6 +272,59 @@ func renderInstallPlanAndProvisioners(cmd *cobra.Command, m manifest.Manifest, p
 	return renderSkippedProvisionerHint(cmd.OutOrStdout(), m, profile, runtime.GOOS)
 }
 
+func resolveInstallTier(goos string) (deps.Tier, error) {
+	if goos == "darwin" {
+		return deps.TierHomebrew, nil
+	}
+	return resolveTier("")
+}
+
+func packageManagerLookup(detection pkgmgr.HomebrewDetection) deps.Lookup {
+	return func(command string) bool {
+		if command == "brew" && detection.Found {
+			return true
+		}
+		return lookupCommand(command)
+	}
+}
+
+func renderPackageManagerSetup(w io.Writer, report *pkgmgr.Report) {
+	if report == nil {
+		return
+	}
+	if report.Status == pkgmgr.StatusWouldOffer {
+		fmt.Fprintf(w, "Package Manager Setup for %s\n\n", report.Manager)
+		fmt.Fprintf(w, "  would-offer %s\n", report.Reason)
+		fmt.Fprintf(w, "  command     %s\n\n", report.Command.Display)
+		return
+	}
+	if report.Detection.PATHGuidance != "" {
+		fmt.Fprintln(w, report.Detection.PATHGuidance)
+		fmt.Fprintln(w)
+	}
+}
+
+func confirmPackageManagerSetup(r io.Reader, w io.Writer, report pkgmgr.Report) (bool, error) {
+	fmt.Fprintf(w, "Run Homebrew Package Manager Setup? This will execute: %s [y/N] ", report.Command.Display)
+	scanner := bufio.NewScanner(r)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return false, fmt.Errorf("read package manager setup confirmation: %w", err)
+		}
+		return false, nil
+	}
+	answer := strings.ToLower(strings.TrimSpace(scanner.Text()))
+	switch answer {
+	case "y", "yes":
+		return true, nil
+	case "", "n", "no":
+		return false, nil
+	default:
+		fmt.Fprintf(w, "Response %q is not yes/y; cancelling.\n", answer)
+		return false, nil
+	}
+}
+
 type installDependencyGateError struct {
 	err    error
 	report installReport
@@ -237,7 +351,7 @@ func (e installProvisionerError) JSONErrorData() any { return e.report }
 // Managed Configuration is applied. Interactive runs reuse the deps confirmation
 // prompt for package-manager execution; manual or unresolved Dependencies abort
 // the install before filesystem targets are touched.
-func runInstallDependencies(cmd *cobra.Command, m manifest.Manifest, options deps.Options, tier deps.Tier, home string, preview deps.InstallDryRunReport, yes bool) (deps.InstallReport, bool, error) {
+func runInstallDependencies(cmd *cobra.Command, m manifest.Manifest, options deps.Options, tier deps.Tier, home string, preview deps.InstallDryRunReport, yes bool, look deps.Lookup, brewPath string) (deps.InstallReport, bool, error) {
 	if !yes {
 		if hasRequiredInstallablePreviewAction(preview) {
 			confirmed, err := confirmDepsInstall(cmd.InOrStdin(), cmd.OutOrStdout())
@@ -261,13 +375,14 @@ func runInstallDependencies(cmd *cobra.Command, m manifest.Manifest, options dep
 	if wantsJSON(cmd) {
 		stdout = cmd.ErrOrStderr()
 	}
-	report, err := deps.Install(m, options, lookupCommand, fontInstalled(runtime.GOOS, home), tier, depsExecRunner{
+	report, err := deps.Install(m, options, look, fontInstalled(options.OS, home), tier, depsExecRunner{
 		ctx:       cmd.Context(),
 		stdin:     cmd.InOrStdin(),
 		stdout:    stdout,
 		stderr:    cmd.ErrOrStderr(),
 		home:      home,
 		stateRoot: options.StateRoot,
+		brewPath:  brewPath,
 	})
 	if !wantsJSON(cmd) && (report.Profile != "" || len(report.Items) > 0) {
 		renderDepsInstall(cmd.OutOrStdout(), report)

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -108,32 +108,12 @@ func newInstallCommand() *cobra.Command {
 				}
 			}
 
-			p, err := plan.Build(*m, plan.Options{
-				Profile:    profile,
-				ExtraTags:  extraTags,
-				OS:         hostOS,
-				SourceRoot: paths.SourceRoot,
-				Home:       paths.Home,
-				Metadata:   meta,
-			})
-			if err != nil {
-				return err
-			}
-
-			provPlan, err := provision.Build(*m, provision.Options{Profile: profile, ExtraTags: extraTags, OS: hostOS})
-			if err != nil {
-				return err
-			}
-
 			var dependenciesReport *installDependenciesReport
 			if depPreviewReport != nil {
 				dependenciesReport = &installDependenciesReport{Preview: depPreviewReport}
 			}
 			if wantsJSON(cmd) {
-				if dryRun {
-					return emitOK(cmd, installReport{DryRun: true, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan})
-				}
-				if !yes {
+				if !dryRun && !yes {
 					return rejectInteractiveJSON(cmd)
 				}
 			} else if depPreviewReport != nil {
@@ -146,13 +126,22 @@ func newInstallCommand() *cobra.Command {
 			}
 
 			if dryRun {
-				if !wantsJSON(cmd) {
-					if err := renderInstallPlanAndProvisioners(cmd, *m, p, provPlan, profile); err != nil {
-						return err
-					}
+				p, provPlan, err := buildInstallPlanAndProvisioners(*m, meta, profile, extraTags, hostOS, paths)
+				if err != nil {
+					return err
+				}
+				if wantsJSON(cmd) {
+					return emitOK(cmd, installReport{DryRun: true, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan})
+				}
+				if err := renderInstallPlanAndProvisioners(cmd, *m, p, provPlan, profile); err != nil {
+					return err
 				}
 				return nil
 			}
+
+			var p plan.Plan
+			var provPlan provision.Plan
+			installPlanReady := false
 
 			if !skipDeps {
 				depsConfirmed := yes
@@ -161,7 +150,7 @@ func newInstallCommand() *cobra.Command {
 						packageManagerSetup.Status = pkgmgr.StatusUnavailable
 						err := fmt.Errorf("Homebrew Package Manager Setup requires interactive confirmation; rerun without --yes or install Homebrew manually with %s", packageManagerSetup.Command.Display)
 						if wantsJSON(cmd) {
-							return installDependencyGateError{err: err, report: installReport{DryRun: false, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan}}
+							return installDependencyGateError{err: err, report: installReport{DryRun: false, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport}}
 						}
 						return err
 					}
@@ -197,6 +186,12 @@ func newInstallCommand() *cobra.Command {
 					renderDepsInstallPreview(cmd.OutOrStdout(), depPreview)
 					depsConfirmed = true
 				}
+				p, provPlan, err = buildInstallPlanAndProvisioners(*m, meta, profile, extraTags, hostOS, paths)
+				if err != nil {
+					return err
+				}
+				installPlanReady = true
+
 				depReport, depsApplied, err := runInstallDependencies(cmd, *m, depOptions, depTier, paths.Home, depPreview, depsConfirmed, depLookup, brewDetection.Path)
 				dependenciesReport.Result = &depReport
 				if err != nil {
@@ -207,6 +202,13 @@ func newInstallCommand() *cobra.Command {
 				}
 				if !depsApplied {
 					return nil
+				}
+			}
+
+			if !installPlanReady {
+				p, provPlan, err = buildInstallPlanAndProvisioners(*m, meta, profile, extraTags, hostOS, paths)
+				if err != nil {
+					return err
 				}
 			}
 
@@ -270,6 +272,26 @@ func renderInstallPlanAndProvisioners(cmd *cobra.Command, m manifest.Manifest, p
 	}
 	renderProvisionPlan(cmd.OutOrStdout(), provPlan)
 	return renderSkippedProvisionerHint(cmd.OutOrStdout(), m, profile, runtime.GOOS)
+}
+
+func buildInstallPlanAndProvisioners(m manifest.Manifest, meta state.Metadata, profile string, extraTags []string, hostOS string, paths resolvedPaths) (plan.Plan, provision.Plan, error) {
+	p, err := plan.Build(m, plan.Options{
+		Profile:    profile,
+		ExtraTags:  extraTags,
+		OS:         hostOS,
+		SourceRoot: paths.SourceRoot,
+		Home:       paths.Home,
+		Metadata:   meta,
+	})
+	if err != nil {
+		return plan.Plan{}, provision.Plan{}, err
+	}
+
+	provPlan, err := provision.Build(m, provision.Options{Profile: profile, ExtraTags: extraTags, OS: hostOS})
+	if err != nil {
+		return plan.Plan{}, provision.Plan{}, err
+	}
+	return p, provPlan, nil
 }
 
 func resolveInstallTier(goos string) (deps.Tier, error) {

--- a/internal/cli/install_deps_test.go
+++ b/internal/cli/install_deps_test.go
@@ -495,10 +495,13 @@ func TestInstallDryRunJSONIncludesDependencyPreviewAndInstallPlan(t *testing.T) 
 	}
 }
 
-func TestInstallDryRunClassifiesMissingFNMToolchainAsManual(t *testing.T) {
+func TestInstallDryRunClassifiesMissingFNMToolchainAsInstallableWhenHomebrewIsAvailable(t *testing.T) {
 	home := t.TempDir()
 	sourceRoot := t.TempDir()
 	binDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(binDir, "brew"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write fake brew: %v", err)
+	}
 	t.Setenv("PATH", binDir)
 	writeCLISource(t, sourceRoot, "configs/zsh/zshrc", "managed\n")
 	manifestPath := writeCLIManifest(t, home, fnmBootstrapCLIManifest)
@@ -513,14 +516,8 @@ func TestInstallDryRunClassifiesMissingFNMToolchainAsManual(t *testing.T) {
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
 	}
 	got := out.String()
-	if strings.Contains(got, "Homebrew was found at") {
-		if !strings.Contains(got, "would-install Node LTS (fnm)") {
-			t.Fatalf("install --dry-run should use detected prefix Homebrew for missing fnm:\n%s", got)
-		}
-		return
-	}
-	if !strings.Contains(got, "manual") || strings.Contains(got, "would-install Node LTS (fnm)") {
-		t.Fatalf("install --dry-run should classify missing fnm bootstrap as manual without Homebrew:\n%s", got)
+	if !strings.Contains(got, "would-install Node LTS (fnm)") || strings.Contains(got, "manual        Node LTS (fnm)") {
+		t.Fatalf("install --dry-run should use sandboxed PATH Homebrew for missing fnm:\n%s", got)
 	}
 }
 

--- a/internal/cli/install_deps_test.go
+++ b/internal/cli/install_deps_test.go
@@ -513,8 +513,14 @@ func TestInstallDryRunClassifiesMissingFNMToolchainAsManual(t *testing.T) {
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
 	}
 	got := out.String()
+	if strings.Contains(got, "Homebrew was found at") {
+		if !strings.Contains(got, "would-install Node LTS (fnm)") {
+			t.Fatalf("install --dry-run should use detected prefix Homebrew for missing fnm:\n%s", got)
+		}
+		return
+	}
 	if !strings.Contains(got, "manual") || strings.Contains(got, "would-install Node LTS (fnm)") {
-		t.Fatalf("install --dry-run should classify missing fnm bootstrap as manual:\n%s", got)
+		t.Fatalf("install --dry-run should classify missing fnm bootstrap as manual without Homebrew:\n%s", got)
 	}
 }
 

--- a/internal/cli/install_pkgmgr_test.go
+++ b/internal/cli/install_pkgmgr_test.go
@@ -1,0 +1,277 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/deps/pkgmgr"
+)
+
+const packageManagerSetupManifest = `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+    dependencies:
+      - name: starship
+        command: starship
+        brew: starship
+`
+
+func withDarwinInstallHost(t *testing.T, detector pkgmgr.Detector, runner pkgmgr.Runner) {
+	t.Helper()
+	oldOS, oldArch := installHostOS, installHostArch
+	oldDetector, oldRunner := packageManagerDetector, packageManagerSetupRunner
+	installHostOS, installHostArch = "darwin", "arm64"
+	packageManagerDetector = detector
+	packageManagerSetupRunner = runner
+	t.Cleanup(func() {
+		installHostOS, installHostArch = oldOS, oldArch
+		packageManagerDetector = oldDetector
+		packageManagerSetupRunner = oldRunner
+	})
+}
+
+func writeInstallFixture(t *testing.T, manifestText string) (home, sourceRoot, stateRoot, manifestPath string) {
+	t.Helper()
+	home = t.TempDir()
+	sourceRoot = t.TempDir()
+	stateRoot = t.TempDir()
+	if err := os.MkdirAll(filepath.Join(sourceRoot, "configs", "zsh"), 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceRoot, "configs", "zsh", "zshrc"), []byte("managed\n"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	manifestPath = filepath.Join(home, "dots.yaml")
+	if err := os.WriteFile(manifestPath, []byte(manifestText), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	return home, sourceRoot, stateRoot, manifestPath
+}
+
+func runInstallCommand(t *testing.T, stdin string, args ...string) (string, error) {
+	t.Helper()
+	cmd := NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	if stdin != "" {
+		cmd.SetIn(strings.NewReader(stdin))
+	}
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+type recordingPkgMgrRunner struct {
+	executable string
+	args       []string
+	onRun      func() error
+}
+
+func (r *recordingPkgMgrRunner) Run(ctx context.Context, executable string, args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) error {
+	r.executable = executable
+	r.args = append([]string(nil), args...)
+	if r.onRun != nil {
+		return r.onRun()
+	}
+	return nil
+}
+
+func TestInstallDryRunJSONReportsHomebrewPackageManagerSetupSeparately(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	home, sourceRoot, _, manifestPath := writeInstallFixture(t, packageManagerSetupManifest)
+	withDarwinInstallHost(t, pkgmgr.Detector{
+		LookPath: func(command string) (string, error) { return "", os.ErrNotExist },
+		Exists:   func(path string) bool { return false },
+	}, &recordingPkgMgrRunner{})
+
+	out, err := runInstallCommand(t, "", "install", "--dry-run", "--output", "json", "--file", manifestPath, "--home", home, "--source-root", sourceRoot)
+	if err != nil {
+		t.Fatalf("install --dry-run error = %v\n%s", err, out)
+	}
+	var env struct {
+		Data struct {
+			PackageManagerSetup *struct {
+				Manager string `json:"manager"`
+				Status  string `json:"status"`
+				Command struct {
+					Display string `json:"display"`
+				} `json:"command"`
+				Dependencies []string `json:"dependencies"`
+			} `json:"package_manager_setup"`
+			Dependencies struct {
+				Preview struct {
+					Items []struct {
+						Dependency string `json:"dependency"`
+					} `json:"items"`
+				} `json:"preview"`
+			} `json:"dependencies"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out)
+	}
+	setup := env.Data.PackageManagerSetup
+	if setup == nil || setup.Manager != "homebrew" || setup.Status != "would-offer" || setup.Command.Display != pkgmgr.OfficialHomebrewInstallerCommand || !reflect.DeepEqual(setup.Dependencies, []string{"starship"}) {
+		t.Fatalf("package_manager_setup = %#v\n%s", setup, out)
+	}
+	if len(env.Data.Dependencies.Preview.Items) != 1 {
+		t.Fatalf("dependency preview should stay under dependencies, got %#v", env.Data.Dependencies)
+	}
+}
+
+func TestInstallYesDoesNotRunHomebrewPackageManagerSetup(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	home, sourceRoot, stateRoot, manifestPath := writeInstallFixture(t, packageManagerSetupManifest)
+	runner := &recordingPkgMgrRunner{}
+	withDarwinInstallHost(t, pkgmgr.Detector{
+		LookPath: func(command string) (string, error) { return "", os.ErrNotExist },
+		Exists:   func(path string) bool { return false },
+	}, runner)
+
+	out, err := runInstallCommand(t, "", "install", "--yes", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot)
+	if err == nil {
+		t.Fatalf("install --yes error = nil, want interactive setup error\n%s", out)
+	}
+	if runner.executable != "" {
+		t.Fatalf("--yes must not run setup, runner = %#v", runner)
+	}
+	if _, statErr := os.Lstat(filepath.Join(home, ".zshrc")); !os.IsNotExist(statErr) {
+		t.Fatalf("--yes setup block must not write managed config; lstat=%v", statErr)
+	}
+}
+
+func TestInstallYesJSONReportsHomebrewPackageManagerSetupGate(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	home, sourceRoot, stateRoot, manifestPath := writeInstallFixture(t, packageManagerSetupManifest)
+	runner := &recordingPkgMgrRunner{}
+	withDarwinInstallHost(t, pkgmgr.Detector{
+		LookPath: func(command string) (string, error) { return "", os.ErrNotExist },
+		Exists:   func(path string) bool { return false },
+	}, runner)
+
+	var out, errOut bytes.Buffer
+	code := Run([]string{"install", "--yes", "--output", "json", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot}, &out, &errOut)
+	if code != ExitError {
+		t.Fatalf("exit code = %d, want %d\nstderr:\n%s\nstdout:\n%s", code, ExitError, errOut.String(), out.String())
+	}
+	if errOut.Len() != 0 {
+		t.Fatalf("Machine Output Mode must keep stderr clean, got:\n%s", errOut.String())
+	}
+	if runner.executable != "" {
+		t.Fatalf("--yes JSON must not run setup, runner = %#v", runner)
+	}
+	if _, statErr := os.Lstat(filepath.Join(home, ".zshrc")); !os.IsNotExist(statErr) {
+		t.Fatalf("--yes setup gate must not write managed config; lstat=%v", statErr)
+	}
+
+	var env struct {
+		Status string `json:"status"`
+		Error  string `json:"error"`
+		Data   struct {
+			PackageManagerSetup *struct {
+				Manager string `json:"manager"`
+				Status  string `json:"status"`
+				Command struct {
+					Display string `json:"display"`
+				} `json:"command"`
+			} `json:"package_manager_setup"`
+			Dependencies struct {
+				Preview *struct {
+					Items []struct {
+						Dependency string `json:"dependency"`
+					} `json:"items"`
+				} `json:"preview"`
+			} `json:"dependencies"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal json: %v\n%s", err, out.String())
+	}
+	setup := env.Data.PackageManagerSetup
+	if env.Status != "error" || !strings.Contains(env.Error, "requires interactive confirmation") {
+		t.Fatalf("error envelope = %#v\n%s", env, out.String())
+	}
+	if setup == nil || setup.Manager != "homebrew" || setup.Status != "unavailable" || setup.Command.Display != pkgmgr.OfficialHomebrewInstallerCommand {
+		t.Fatalf("package_manager_setup = %#v\n%s", setup, out.String())
+	}
+	if env.Data.Dependencies.Preview == nil || len(env.Data.Dependencies.Preview.Items) != 1 {
+		t.Fatalf("dependencies preview missing from gate envelope: %#v\n%s", env.Data.Dependencies, out.String())
+	}
+}
+
+func TestInstallDecliningHomebrewSetupAbortsBeforeManagedConfiguration(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	home, sourceRoot, stateRoot, manifestPath := writeInstallFixture(t, packageManagerSetupManifest)
+	withDarwinInstallHost(t, pkgmgr.Detector{
+		LookPath: func(command string) (string, error) { return "", os.ErrNotExist },
+		Exists:   func(path string) bool { return false },
+	}, &recordingPkgMgrRunner{})
+
+	out, err := runInstallCommand(t, "n\n", "install", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot)
+	if err != nil {
+		t.Fatalf("install decline error = %v\n%s", err, out)
+	}
+	if !strings.Contains(out, pkgmgr.OfficialHomebrewInstallerCommand) || !strings.Contains(out, "Package Manager Setup declined") {
+		t.Fatalf("decline output missing setup details:\n%s", out)
+	}
+	if _, statErr := os.Lstat(filepath.Join(home, ".zshrc")); !os.IsNotExist(statErr) {
+		t.Fatalf("declined setup must not write managed config; lstat=%v", statErr)
+	}
+}
+
+func TestInstallAcceptingHomebrewSetupUsesPrefixBrewForCurrentRun(t *testing.T) {
+	home, sourceRoot, stateRoot, manifestPath := writeInstallFixture(t, packageManagerSetupManifest)
+	binDir := t.TempDir()
+	brewPath := filepath.Join(t.TempDir(), "brew")
+	probe := filepath.Join(binDir, "starship")
+	t.Setenv("PATH", binDir)
+
+	runner := &recordingPkgMgrRunner{onRun: func() error {
+		if err := os.MkdirAll(filepath.Dir(brewPath), 0o755); err != nil {
+			return err
+		}
+		return os.WriteFile(brewPath, []byte("#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$BREW_ARGS\"\nprintf '#!/bin/sh\\n' > \"$STARSHIP_PROBE\"\n/bin/chmod +x \"$STARSHIP_PROBE\"\n"), 0o755)
+	}}
+	t.Setenv("BREW_ARGS", filepath.Join(binDir, "brew-args"))
+	t.Setenv("STARSHIP_PROBE", probe)
+	withDarwinInstallHost(t, pkgmgr.Detector{
+		LookPath: func(command string) (string, error) { return "", os.ErrNotExist },
+		Exists: func(path string) bool {
+			info, err := os.Stat(path)
+			return err == nil && !info.IsDir()
+		},
+		Prefixes: []string{brewPath},
+	}, runner)
+
+	out, err := runInstallCommand(t, "y\ny\n", "install", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot)
+	if err != nil {
+		t.Fatalf("install accept error = %v\n%s", err, out)
+	}
+	if runner.executable != "/bin/bash" || !reflect.DeepEqual(runner.args, []string{"-c", `$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)`}) {
+		t.Fatalf("setup runner = %#v", runner)
+	}
+	args, err := os.ReadFile(filepath.Join(binDir, "brew-args"))
+	if err != nil || string(args) != "install\nstarship\n" {
+		t.Fatalf("brew args = %q, err=%v\noutput:\n%s", string(args), err, out)
+	}
+	if _, err := os.Lstat(filepath.Join(home, ".zshrc")); err != nil {
+		t.Fatalf("managed config not written after setup+deps: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "not on PATH") {
+		t.Fatalf("output should include PATH guidance for prefix brew:\n%s", out)
+	}
+}

--- a/internal/cli/install_pkgmgr_test.go
+++ b/internal/cli/install_pkgmgr_test.go
@@ -261,7 +261,7 @@ func TestInstallAcceptingHomebrewSetupUsesPrefixBrewForCurrentRun(t *testing.T) 
 	if err != nil {
 		t.Fatalf("install accept error = %v\n%s", err, out)
 	}
-	if runner.executable != "/bin/bash" || !reflect.DeepEqual(runner.args, []string{"-c", `$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)`}) {
+	if runner.executable != "/bin/sh" || !reflect.DeepEqual(runner.args, []string{"-c", pkgmgr.OfficialHomebrewInstallerCommand}) {
 		t.Fatalf("setup runner = %#v", runner)
 	}
 	args, err := os.ReadFile(filepath.Join(binDir, "brew-args"))

--- a/internal/cli/json_reports.go
+++ b/internal/cli/json_reports.go
@@ -4,6 +4,7 @@ import (
 	"github.com/yersonargotev/dots/internal/backups"
 	"github.com/yersonargotev/dots/internal/bootstrap"
 	"github.com/yersonargotev/dots/internal/deps"
+	"github.com/yersonargotev/dots/internal/deps/pkgmgr"
 	"github.com/yersonargotev/dots/internal/gitrepo"
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/provision"
@@ -34,12 +35,13 @@ type manifestValidateReport struct {
 }
 
 type installReport struct {
-	DryRun             bool                       `json:"dry_run"`
-	Dependencies       *installDependenciesReport `json:"dependencies,omitempty"`
-	Plan               plan.Plan                  `json:"plan"`
-	Provisioners       provision.Plan             `json:"provisioners"`
-	BackupSets         []installBackupSetReport   `json:"backup_sets,omitempty"`
-	ProvisionerResults *provision.Report          `json:"provisioner_results,omitempty"`
+	DryRun              bool                       `json:"dry_run"`
+	PackageManagerSetup *pkgmgr.Report             `json:"package_manager_setup,omitempty"`
+	Dependencies        *installDependenciesReport `json:"dependencies,omitempty"`
+	Plan                plan.Plan                  `json:"plan"`
+	Provisioners        provision.Plan             `json:"provisioners"`
+	BackupSets          []installBackupSetReport   `json:"backup_sets,omitempty"`
+	ProvisionerResults  *provision.Report          `json:"provisioner_results,omitempty"`
 }
 
 type installDependenciesReport struct {

--- a/internal/cli/output_golden_test.go
+++ b/internal/cli/output_golden_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/yersonargotev/dots/internal/backups"
 	"github.com/yersonargotev/dots/internal/deps"
+	"github.com/yersonargotev/dots/internal/deps/pkgmgr"
 	"github.com/yersonargotev/dots/internal/doctor"
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/provision"
@@ -15,8 +16,8 @@ import (
 // TestEnvelopeGolden locks the full JSON shape of the Agent Output Contract.
 // Any rename, removal, or addition of an exposed domain field changes a golden
 // file and must be a deliberate schema_version bump. The fixtures also prove the
-// machine-local / advisory fields (resolved_source, probe_detail, hint) stay out
-// of the contract.
+// machine-local / advisory fields (resolved_source, probe_detail, hint,
+// package-manager paths/guidance) stay out of the contract.
 func TestEnvelopeGolden(t *testing.T) {
 	installPreview := deps.InstallDryRunReport{Profile: "default", Tier: deps.TierHomebrew, Items: []deps.InstallPreview{
 		{Dependency: "starship", Requirement: "required", Status: deps.InstallPreviewWouldInstall, Provider: deps.TierHomebrew, Package: "starship", Executable: "brew", Args: []string{"install", "starship"}},
@@ -132,6 +133,19 @@ func TestEnvelopeGolden(t *testing.T) {
 				Status:        statusOK,
 				Data: installReport{
 					DryRun: false,
+					PackageManagerSetup: &pkgmgr.Report{
+						Manager: "homebrew",
+						Status:  pkgmgr.StatusInstalled,
+						Command: pkgmgr.HomebrewInstallerCommand(),
+						Detection: pkgmgr.HomebrewDetection{
+							Found:        true,
+							Path:         "/opt/homebrew/bin/brew-MUST-NOT-APPEAR",
+							NeedsPATH:    true,
+							PATHGuidance: "MUST NOT APPEAR",
+						},
+						Reason:       "selected required Dependencies need Homebrew, but brew is not available",
+						Dependencies: []string{"starship"},
+					},
 					Dependencies: &installDependenciesReport{
 						Preview: &installPreview,
 						Result:  &installResult,

--- a/internal/cli/testdata/envelope_install.golden
+++ b/internal/cli/testdata/envelope_install.golden
@@ -4,6 +4,26 @@
   "status": "ok",
   "data": {
     "dry_run": false,
+    "package_manager_setup": {
+      "manager": "homebrew",
+      "status": "installed",
+      "command": {
+        "executable": "/bin/sh",
+        "args": [
+          "-c",
+          "/bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\""
+        ],
+        "display": "/bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\""
+      },
+      "detection": {
+        "found": true,
+        "needs_path": true
+      },
+      "reason": "selected required Dependencies need Homebrew, but brew is not available",
+      "dependencies": [
+        "starship"
+      ]
+    },
     "dependencies": {
       "preview": {
         "profile": "default",

--- a/internal/deps/pkgmgr/homebrew.go
+++ b/internal/deps/pkgmgr/homebrew.go
@@ -1,0 +1,151 @@
+package pkgmgr
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/yersonargotev/dots/internal/deps"
+	"github.com/yersonargotev/dots/internal/manifest"
+)
+
+const OfficialHomebrewInstallerCommand = `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
+const homebrewInstallerScript = `$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)`
+
+var macOSHomebrewPrefixes = []string{"/opt/homebrew/bin/brew", "/usr/local/bin/brew"}
+
+type Command struct {
+	Executable string   `json:"executable"`
+	Args       []string `json:"args,omitempty"`
+	Display    string   `json:"display"`
+}
+
+func HomebrewInstallerCommand() Command {
+	return Command{Executable: "/bin/bash", Args: []string{"-c", homebrewInstallerScript}, Display: OfficialHomebrewInstallerCommand}
+}
+
+type HomebrewDetection struct {
+	Found        bool   `json:"found"`
+	Path         string `json:"path,omitempty"`
+	NeedsPATH    bool   `json:"needs_path,omitempty"`
+	PATHGuidance string `json:"path_guidance,omitempty"`
+}
+
+type Detector struct {
+	LookPath func(string) (string, error)
+	Exists   func(string) bool
+	Prefixes []string
+}
+
+func (d Detector) DetectHomebrew() HomebrewDetection {
+	lookPath := d.LookPath
+	if lookPath == nil {
+		lookPath = exec.LookPath
+	}
+	if path, err := lookPath("brew"); err == nil && path != "" {
+		return HomebrewDetection{Found: true, Path: path}
+	}
+	prefixes := d.Prefixes
+	if len(prefixes) == 0 {
+		prefixes = macOSHomebrewPrefixes
+	}
+	exists := d.Exists
+	if exists == nil {
+		exists = func(path string) bool {
+			info, err := os.Stat(path)
+			return err == nil && !info.IsDir()
+		}
+	}
+	for _, path := range prefixes {
+		if exists(path) {
+			return HomebrewDetection{Found: true, Path: path, NeedsPATH: true, PATHGuidance: fmt.Sprintf("Homebrew was found at %s but is not on PATH; add its bin directory to PATH for future shells.", path)}
+		}
+	}
+	return HomebrewDetection{}
+}
+
+type Status string
+
+const (
+	StatusNotNeeded   Status = "not-needed"
+	StatusWouldOffer  Status = "would-offer"
+	StatusDeclined    Status = "declined"
+	StatusInstalled   Status = "installed"
+	StatusUnavailable Status = "unavailable"
+	StatusFailed      Status = "failed"
+)
+
+type Report struct {
+	Manager      string            `json:"manager"`
+	Status       Status            `json:"status"`
+	Command      Command           `json:"command,omitempty"`
+	Detection    HomebrewDetection `json:"detection,omitempty"`
+	Reason       string            `json:"reason,omitempty"`
+	Dependencies []string          `json:"dependencies,omitempty"`
+}
+
+func HomebrewSetupNeed(goos string, preview deps.InstallDryRunReport, detection HomebrewDetection) Report {
+	report := Report{Manager: "homebrew", Status: StatusNotNeeded, Detection: detection}
+	if goos != "darwin" || detection.Found {
+		return report
+	}
+	for _, item := range preview.Items {
+		if requirementValue(item.Requirement) != manifest.DependencyRequirementRequired {
+			continue
+		}
+		if needsHomebrew(item) {
+			report.Dependencies = append(report.Dependencies, item.Dependency)
+		}
+	}
+	if len(report.Dependencies) == 0 {
+		return report
+	}
+	report.Status = StatusWouldOffer
+	report.Command = HomebrewInstallerCommand()
+	report.Reason = "selected required Dependencies need Homebrew, but brew is not available"
+	return report
+}
+
+func requirementValue(requirement string) string {
+	if requirement == "" {
+		return manifest.DependencyRequirementRequired
+	}
+	return requirement
+}
+
+func needsHomebrew(item deps.InstallPreview) bool {
+	if item.Provider == deps.TierHomebrew || item.Executable == "brew" {
+		return true
+	}
+	for _, candidate := range item.Candidates {
+		if candidate.Provider == deps.TierHomebrew {
+			return true
+		}
+	}
+	return false
+}
+
+type Runner interface {
+	Run(ctx context.Context, executable string, args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) error
+}
+
+type ExecRunner struct{}
+
+func (ExecRunner) Run(ctx context.Context, executable string, args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) error {
+	cmd := exec.CommandContext(ctx, executable, args...)
+	cmd.Stdin = stdin
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	return cmd.Run()
+}
+
+func RunHomebrewSetup(ctx context.Context, runner Runner, stdin io.Reader, stdout io.Writer, stderr io.Writer) error {
+	if runner == nil {
+		return errors.New("homebrew setup runner unavailable")
+	}
+	cmd := HomebrewInstallerCommand()
+	return runner.Run(ctx, cmd.Executable, append([]string(nil), cmd.Args...), stdin, stdout, stderr)
+}

--- a/internal/deps/pkgmgr/homebrew.go
+++ b/internal/deps/pkgmgr/homebrew.go
@@ -2,6 +2,7 @@ package pkgmgr
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -13,7 +14,6 @@ import (
 )
 
 const OfficialHomebrewInstallerCommand = `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
-const homebrewInstallerScript = `$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)`
 
 var macOSHomebrewPrefixes = []string{"/opt/homebrew/bin/brew", "/usr/local/bin/brew"}
 
@@ -24,14 +24,23 @@ type Command struct {
 }
 
 func HomebrewInstallerCommand() Command {
-	return Command{Executable: "/bin/bash", Args: []string{"-c", homebrewInstallerScript}, Display: OfficialHomebrewInstallerCommand}
+	return Command{Executable: "/bin/sh", Args: []string{"-c", OfficialHomebrewInstallerCommand}, Display: OfficialHomebrewInstallerCommand}
 }
 
 type HomebrewDetection struct {
-	Found        bool   `json:"found"`
-	Path         string `json:"path,omitempty"`
-	NeedsPATH    bool   `json:"needs_path,omitempty"`
-	PATHGuidance string `json:"path_guidance,omitempty"`
+	Found        bool
+	Path         string
+	NeedsPATH    bool
+	PATHGuidance string
+}
+
+type homebrewDetectionJSON struct {
+	Found     bool `json:"found"`
+	NeedsPATH bool `json:"needs_path,omitempty"`
+}
+
+func (d HomebrewDetection) MarshalJSON() ([]byte, error) {
+	return json.Marshal(homebrewDetectionJSON{Found: d.Found, NeedsPATH: d.NeedsPATH})
 }
 
 type Detector struct {

--- a/internal/deps/pkgmgr/homebrew_test.go
+++ b/internal/deps/pkgmgr/homebrew_test.go
@@ -1,0 +1,64 @@
+package pkgmgr_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/deps"
+	"github.com/yersonargotev/dots/internal/deps/pkgmgr"
+	"github.com/yersonargotev/dots/internal/manifest"
+)
+
+func TestDetectHomebrewFindsPATHBeforePrefixes(t *testing.T) {
+	d := pkgmgr.Detector{
+		LookPath: func(command string) (string, error) { return "/tmp/bin/brew", nil },
+		Exists:   func(path string) bool { return true },
+		Prefixes: []string{"/opt/homebrew/bin/brew"},
+	}.DetectHomebrew()
+	if !d.Found || d.Path != "/tmp/bin/brew" || d.NeedsPATH {
+		t.Fatalf("DetectHomebrew() = %#v", d)
+	}
+}
+
+func TestDetectHomebrewFindsExpectedPrefixAndReportsPATHGuidance(t *testing.T) {
+	d := pkgmgr.Detector{
+		LookPath: func(command string) (string, error) { return "", execErr{} },
+		Exists:   func(path string) bool { return path == "/opt/homebrew/bin/brew" },
+		Prefixes: []string{"/opt/homebrew/bin/brew", "/usr/local/bin/brew"},
+	}.DetectHomebrew()
+	if !d.Found || d.Path != "/opt/homebrew/bin/brew" || !d.NeedsPATH || d.PATHGuidance == "" {
+		t.Fatalf("DetectHomebrew() = %#v", d)
+	}
+}
+
+type execErr struct{}
+
+func (execErr) Error() string { return "missing" }
+
+func TestHomebrewInstallerCommandIsOfficialCommand(t *testing.T) {
+	cmd := pkgmgr.HomebrewInstallerCommand()
+	if cmd.Display != `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"` {
+		t.Fatalf("Display = %q", cmd.Display)
+	}
+	if cmd.Executable != "/bin/bash" || !reflect.DeepEqual(cmd.Args, []string{"-c", `$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)`}) {
+		t.Fatalf("command = %#v", cmd)
+	}
+}
+
+func TestHomebrewSetupNeedRequiresDarwinMissingBrewAndRequiredHomebrewDependency(t *testing.T) {
+	preview := deps.InstallDryRunReport{Profile: "default", Tier: deps.TierHomebrew, Items: []deps.InstallPreview{{
+		Dependency: "starship", Requirement: manifest.DependencyRequirementRequired, Status: deps.InstallPreviewManual,
+		Candidates: []deps.ProviderCandidate{{Provider: deps.TierHomebrew, Package: "starship"}},
+	}}}
+	report := pkgmgr.HomebrewSetupNeed("darwin", preview, pkgmgr.HomebrewDetection{})
+	if report.Status != pkgmgr.StatusWouldOffer || len(report.Dependencies) != 1 || report.Command.Display == "" {
+		t.Fatalf("HomebrewSetupNeed() = %#v", report)
+	}
+	if got := pkgmgr.HomebrewSetupNeed("linux", preview, pkgmgr.HomebrewDetection{}); got.Status != pkgmgr.StatusNotNeeded {
+		t.Fatalf("linux setup = %#v, want not-needed", got)
+	}
+	preview.Items[0].Requirement = manifest.DependencyRequirementOptional
+	if got := pkgmgr.HomebrewSetupNeed("darwin", preview, pkgmgr.HomebrewDetection{}); got.Status != pkgmgr.StatusNotNeeded {
+		t.Fatalf("optional setup = %#v, want not-needed", got)
+	}
+}

--- a/internal/deps/pkgmgr/homebrew_test.go
+++ b/internal/deps/pkgmgr/homebrew_test.go
@@ -40,7 +40,7 @@ func TestHomebrewInstallerCommandIsOfficialCommand(t *testing.T) {
 	if cmd.Display != `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"` {
 		t.Fatalf("Display = %q", cmd.Display)
 	}
-	if cmd.Executable != "/bin/bash" || !reflect.DeepEqual(cmd.Args, []string{"-c", `$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)`}) {
+	if cmd.Executable != "/bin/sh" || !reflect.DeepEqual(cmd.Args, []string{"-c", pkgmgr.OfficialHomebrewInstallerCommand}) {
 		t.Fatalf("command = %#v", cmd)
 	}
 }


### PR DESCRIPTION
Closes #257

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds macOS-only Homebrew Package Manager Setup as an interactive dependency gate in `dots install`.
- Keeps `--yes` conservative and `--dry-run` preview-only while reporting setup separately in JSON.
- Uses fakeable runners and sandboxed CLI tests so the real Homebrew installer is never executed.

## Changes

| File | Change |
|------|--------|
| `CONTEXT.md` | Defines Package Manager Setup as a separate domain term. |
| `docs/adr/0012-macos-homebrew-package-manager-setup.md` | Records the accepted macOS Homebrew setup decision. |
| `docs/agents/output-contract.md` | Documents `data.package_manager_setup` separately from `data.dependencies`. |
| `internal/deps/pkgmgr/homebrew.go` | Adds Homebrew detection, official setup command rendering, setup-need classification, report states, and runner seam. |
| `internal/cli/install.go` | Orchestrates Package Manager Setup before dependency execution and Managed Configuration. |
| `internal/cli/deps.go` | Lets the current run use an absolute prefix-discovered `brew` path when `brew` is not on PATH. |
| `internal/cli/json_reports.go` | Adds the optional `package_manager_setup` JSON report field. |
| `internal/deps/pkgmgr/homebrew_test.go` | Covers detection, installer command, and setup-need classification. |
| `internal/cli/install_pkgmgr_test.go` | Covers dry-run JSON, `--yes`, `--yes --output json`, decline, and accept/prefix-brew flows with fake runners and sandboxed paths. |
| `internal/cli/install_deps_test.go` | Accounts for macOS prefix Homebrew detection in an existing dry-run expectation. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp>`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #257`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
