### PR TITLE
feat(config): align Zellij with tmux workflow

### DIFF
--- a/configs/zellij/README.md
+++ b/configs/zellij/README.md
@@ -5,6 +5,12 @@ installed as `~/.config/zellij/config.kdl` (symlink strategy, `core` tag,
 `darwin`+`linux`). `configs/zellij/layouts/default.kdl` is installed as
 `~/.config/zellij/layouts/default.kdl` and selected by `default_layout "default"`.
 
+The Zellij UX intentionally follows the repository-managed tmux configuration
+where Zellij has practical equivalents: `C-a` is the primary multiplexer prefix,
+common pane/tab actions keep tmux-like keys, and the status bar uses a
+Catppuccin `zjstatus` layout at the top of the screen. `Ctrl+g` remains as a
+compatibility entry point for the classic Zellij command flow.
+
 The Source of Truth is this repository. The installed files are links to these
 tracked sources; runtime state and downloaded plugins stay outside version
 control.
@@ -17,9 +23,10 @@ control.
   not a managed Zellij dependency in this slice.
 - **`zjstatus`** — optional/manual prerequisite for the default layout status
   bar. Place the plugin binary at `~/.config/zellij/plugins/zjstatus.wasm` on
-  machines that want this layout exactly. The `.wasm` binary is intentionally
-  not committed; it is a future vendoring candidate only if the repository gets
-  a deliberate plugin-binary policy.
+  machines that want the tmux-like status layout exactly. The `.wasm` binary is
+  intentionally not committed, downloaded, or provisioned by this repository;
+  it is a future vendoring candidate only if the repository gets a deliberate
+  plugin-binary policy.
 
 ## Portability classification
 
@@ -27,7 +34,7 @@ The live `~/.config/zellij` directory was classified before adoption:
 
 | Category | Examples | Repository decision |
 | --- | --- | --- |
-| **Portable** | locked-by-default mode, `Ctrl+g` command flow, pane/tab/resize/move/scroll keybindings, Alt navigation shortcuts, Catppuccin Mocha theme, rounded pane frames, mouse mode, scroll buffer size, Neovim scrollback editor, built-in plugin aliases, default layout selection, and the personal status bar layout | Managed in `configs/zellij/config.kdl` and `configs/zellij/layouts/default.kdl`. |
+| **Portable** | locked-by-default mode, tmux-like `C-a` prefix, `Ctrl+g` compatibility command flow, pane/tab/resize/move/scroll keybindings, Alt navigation shortcuts, Catppuccin Mocha theme, rounded pane frames, mouse mode, scroll buffer size, Neovim scrollback editor, built-in plugin aliases, default layout selection, and the tmux-like personal `zjstatus` status bar layout | Managed in `configs/zellij/config.kdl` and `configs/zellij/layouts/default.kdl`. |
 | **Machine-specific** | absolute user paths, hostnames, machine IDs, per-host overrides | **Excluded.** Use a separate config file or config directory through real Zellij mechanisms when a host needs divergence. |
 | **Generated** | downloaded `.wasm` plugin binaries, `plugexit`, plugin-manager output, caches, logs, sessions, serialized runtime state, backup files such as `config.kdl.bak-*` | **Never committed.** Runtime files live under the user's Zellij data/config locations. |
 | **Private** | secrets, tokens, local-only paths, private command wiring | **Excluded.** Keep them outside the managed files. |
@@ -36,14 +43,46 @@ The live `~/.config/zellij` directory was classified before adoption:
 
 - Zellij starts in `default_mode "locked"` so Neovim/LazyVim receives normal
   bindings without terminal multiplexer interference.
-- `Ctrl+g` moves from locked mode into Zellij normal mode; `Ctrl+g`, `Esc`, or
-  completing most commands returns to locked mode.
+- `C-a` is the primary tmux-like multiplexer prefix. From locked or normal mode
+  it enters Zellij's `tmux` mode for one command, then most commands return to
+  locked mode.
+- `Ctrl+g` remains as the compatibility entry point for the classic Zellij
+  command flow: from locked mode it enters normal mode, and from active command
+  modes it returns to locked mode.
 - The UI uses the built-in `catppuccin-mocha` theme, rounded pane frames,
   `mouse_mode true`, and `scroll_buffer_size 10000`.
 - Scrollback opens in Neovim via `scrollback_editor "nvim"`.
-- The default layout includes a `zjstatus` status bar with the intentional
-  personal timezone preference `America/Bogota`. That timezone is portable
-  because it is an explicit preference, not host detection.
+- The default layout includes a top `zjstatus` status bar with an intentional
+  tmux-like left/center/right shape: mode and session on the left, tabs in the
+  center, and git branch plus `America/Bogota` time on the right. That timezone
+  is portable because it is an explicit preference, not host detection.
+
+## Tmux-like keybinding map
+
+These bindings intentionally mirror `configs/tmux/tmux.conf` where Zellij has a
+matching concept. Zellij is still modal, so this is practical parity rather than
+exact emulation.
+
+| tmux habit | Zellij binding | Zellij action | Notes |
+| --- | --- | --- | --- |
+| Prefix | `C-a` | enter `tmux` mode | Primary path for tmux-like commands. |
+| Classic Zellij command flow | `Ctrl+g` | enter/leave normal command mode | Compatibility path for existing Zellij muscle memory. |
+| Horizontal/right split | `C-a v` or `C-a %` | `NewPane "right"` | `v` matches this repo's tmux config; `%` matches stock tmux. |
+| Vertical/down split | `C-a d` or `C-a "` | `NewPane "down"` | `d` matches this repo's tmux config; `"` matches stock tmux. |
+| Detach | `C-a D` | `Detach` | Matches this repo's tmux `D` binding. |
+| New tab/window | `C-a c` | `NewTab` | Zellij tabs are the closest equivalent to tmux windows. |
+| Rename tab/window | `C-a ,` | rename tab | Mirrors tmux rename-window habit. |
+| Previous/next tab | `C-a p` / `C-a n` | previous/next tab | Zellij tab navigation equivalent. |
+| Focus pane | `C-a h/j/k/l` | move focus | Zellij pane focus equivalent. |
+| Resize pane | `C-a H/J/K/L` | resize focused pane | Zellij resize actions use directional growth/shrink semantics. |
+| Fullscreen/zoom | `C-a z` | toggle fullscreen | Closest equivalent to tmux zoom. |
+| Close focused pane | `C-a x` | close focus | Zellij close equivalent. |
+| Scrollback | `C-a [` | scroll mode | Mirrors tmux copy-mode entry habit. |
+| Tab selection | `C-a 1` … `C-a 9` | go to tab | Uses Zellij's 1-based tab selection. |
+
+Unavoidable differences: Zellij tabs are not tmux windows, Zellij modes remain
+visible in the status bar, and plugin binaries such as `zjstatus.wasm` are
+runtime files rather than TPM-style plugin declarations managed by this repo.
 
 ## Local/private overrides
 

--- a/configs/zellij/config.kdl
+++ b/configs/zellij/config.kdl
@@ -1,14 +1,52 @@
 // Zellij configuration - portable defaults for Neovim/LazyVim workflows.
 // Zellij starts locked so terminal applications receive normal keybindings.
-// Press Ctrl+g to enter the Zellij command flow, then Ctrl+g/Esc to lock again.
+// Press Ctrl+a for the tmux-like command prefix. Ctrl+g remains as the
+// compatibility entry point for the classic Zellij command flow.
 
 keybinds clear-defaults=true {
     locked {
+        bind "Ctrl a" { SwitchToMode "tmux"; }
         bind "Ctrl g" { SwitchToMode "normal"; }
     }
 
     normal {
+        bind "Ctrl a" { SwitchToMode "tmux"; }
         bind "Ctrl g" { SwitchToMode "locked"; }
+    }
+
+    // Tmux-like prefix table. This intentionally mirrors the portable tmux
+    // workflow from configs/tmux/tmux.conf where Zellij has matching actions.
+    tmux {
+        bind "Ctrl a" { Write 1; SwitchToMode "locked"; }
+        bind "Ctrl g" { SwitchToMode "locked"; }
+        bind "esc" { SwitchToMode "locked"; }
+        bind "v" "%" { NewPane "right"; SwitchToMode "locked"; }
+        bind "d" "\"" { NewPane "down"; SwitchToMode "locked"; }
+        bind "D" { Detach; }
+        bind "c" { NewTab; SwitchToMode "locked"; }
+        bind "," { SwitchToMode "renametab"; }
+        bind "n" { GoToNextTab; SwitchToMode "locked"; }
+        bind "p" { GoToPreviousTab; SwitchToMode "locked"; }
+        bind "h" "left" { MoveFocus "left"; SwitchToMode "locked"; }
+        bind "j" "down" { MoveFocus "down"; SwitchToMode "locked"; }
+        bind "k" "up" { MoveFocus "up"; SwitchToMode "locked"; }
+        bind "l" "right" { MoveFocus "right"; SwitchToMode "locked"; }
+        bind "H" { Resize "Decrease left"; SwitchToMode "locked"; }
+        bind "J" { Resize "Increase down"; SwitchToMode "locked"; }
+        bind "K" { Resize "Increase up"; SwitchToMode "locked"; }
+        bind "L" { Resize "Increase right"; SwitchToMode "locked"; }
+        bind "z" { ToggleFocusFullscreen; SwitchToMode "locked"; }
+        bind "x" { CloseFocus; SwitchToMode "locked"; }
+        bind "[" { SwitchToMode "scroll"; }
+        bind "1" { GoToTab 1; SwitchToMode "locked"; }
+        bind "2" { GoToTab 2; SwitchToMode "locked"; }
+        bind "3" { GoToTab 3; SwitchToMode "locked"; }
+        bind "4" { GoToTab 4; SwitchToMode "locked"; }
+        bind "5" { GoToTab 5; SwitchToMode "locked"; }
+        bind "6" { GoToTab 6; SwitchToMode "locked"; }
+        bind "7" { GoToTab 7; SwitchToMode "locked"; }
+        bind "8" { GoToTab 8; SwitchToMode "locked"; }
+        bind "9" { GoToTab 9; SwitchToMode "locked"; }
     }
 
     pane {
@@ -181,6 +219,7 @@ keybinds clear-defaults=true {
     }
 
     shared_except "locked" "renametab" "renamepane" {
+        bind "Ctrl a" { SwitchToMode "tmux"; }
         bind "Ctrl g" { SwitchToMode "locked"; }
         bind "Ctrl q" { Quit; }
     }

--- a/configs/zellij/layouts/default.kdl
+++ b/configs/zellij/layouts/default.kdl
@@ -1,15 +1,15 @@
 layout {
     default_tab_template {
-        children
         pane size=1 borderless=true {
-            // Personal portable status bar preference. The zjstatus plugin
-            // binary is a manual per-machine prerequisite and is not vendored
-            // by this repository.
+            // Tmux-like Catppuccin status bar. The zjstatus plugin binary is a
+            // manual per-machine prerequisite and is not vendored by this
+            // repository. Keeping the status pane before `children` places it
+            // at the top, matching configs/tmux/tmux.conf.
             plugin location="file:~/.config/zellij/plugins/zjstatus.wasm" {
-                format_left  "{mode} #[fg=#89B4FA,bold]{session}"
+                format_left   "{mode} #[fg=#89B4FA,bold]{session}"
                 format_center "{tabs}"
-                format_right "{command_git_branch} {datetime}"
-                format_space ""
+                format_right  "{command_git_branch} {datetime}"
+                format_space  ""
 
                 border_enabled "false"
                 hide_frame_for_single_pane "true"
@@ -17,10 +17,14 @@ layout {
                 mode_normal "#[bg=#89B4FA,fg=#181825,bold] NORMAL "
                 mode_tmux   "#[bg=#FAB387,fg=#181825,bold] TMUX "
                 mode_locked "#[bg=#F38BA8,fg=#181825,bold] LOCKED "
+                mode_resize "#[bg=#F9E2AF,fg=#181825,bold] RESIZE "
+                mode_tab    "#[bg=#A6E3A1,fg=#181825,bold] TAB "
+                mode_scroll "#[bg=#CBA6F7,fg=#181825,bold] SCROLL "
 
                 tab_normal            "#[fg=#6C7086] {name} "
                 tab_active            "#[fg=#A6E3A1,bold,italic] {name} "
                 tab_active_fullscreen "#[fg=#A6E3A1,bold,italic] {name} [F]"
+                tab_separator         ""
 
                 datetime          "#[fg=#9399B2] {format} "
                 datetime_format   "%H:%M"
@@ -31,5 +35,6 @@ layout {
                 command_git_branch_interval "10"
             }
         }
+        children
     }
 }


### PR DESCRIPTION
Closes #261

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Makes `C-a` the primary tmux-like prefix path for Zellij while preserving `Ctrl+g` for the classic Zellij command flow.
- Adds a tmux-like Zellij key table for common split, detach, tab, focus, resize, zoom, close, scroll, and tab-selection actions.
- Keeps `zjstatus` as the long-term tmux-like visual path without vendoring or provisioning the plugin binary.

## Changes

| File | Change |
|------|--------|
| `configs/zellij/config.kdl` | Adds a `tmux` mode key table and binds `C-a` to it from locked/normal command contexts. |
| `configs/zellij/layouts/default.kdl` | Moves the `zjstatus` pane above `children` for a top status bar and expands mode/tab styling. |
| `configs/zellij/README.md` | Documents the tmux parity intent, keybinding map, compatibility path, status-bar decision, and unavoidable Zellij differences. |

## Test Plan

- [x] `zellij --version`
- [x] `HOME=<tmp>/home ZELLIJ_CONFIG_DIR=<tmp>/zellij zellij setup --check`
- [x] Sandboxed install/status with explicit `--home <tmp>/home`, `--source-root "$PWD"`, and `--state-root <tmp>/state`
- [x] `git diff --check`
- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [ ] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp>`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
