### PR TITLE
feat(zellij): add direct tmux navigation

### DIFF
--- a/configs/zellij/README.md
+++ b/configs/zellij/README.md
@@ -41,8 +41,9 @@ The live `~/.config/zellij` directory was classified before adoption:
 
 ## Behavior carried by the portable config
 
-- Zellij starts in `default_mode "locked"` so Neovim/LazyVim receives normal
-  bindings without terminal multiplexer interference.
+- Zellij starts in `default_mode "locked"` so most terminal applications receive
+  normal bindings. The deliberate exception is direct tmux-style navigation:
+  `Ctrl+h/j/k/l` moves between Zellij panes without a prefix.
 - `C-a` is the primary tmux-like multiplexer prefix. From locked or normal mode
   it enters Zellij's `tmux` mode for one command, then most commands return to
   locked mode.
@@ -73,7 +74,9 @@ exact emulation.
 | New tab/window | `C-a c` | `NewTab` | Zellij tabs are the closest equivalent to tmux windows. |
 | Rename tab/window | `C-a ,` | rename tab | Mirrors tmux rename-window habit. |
 | Previous/next tab | `C-a p` / `C-a n` | previous/next tab | Zellij tab navigation equivalent. |
+| Direct previous/next tab | `Cmd+h` / `Cmd+l` when forwarded as `Super+h` / `Super+l` | previous/next tab | Mirrors the maintainer's direct tmux window navigation habit. Some terminals or macOS defaults may reserve Cmd keys before Zellij sees them. |
 | Focus pane | `C-a h/j/k/l` | move focus | Zellij pane focus equivalent. |
+| Direct focus pane | `Ctrl+h/j/k/l` | move focus | No-prefix navigation equivalent to the tmux/vim-tmux-navigator habit. |
 | Resize pane | `C-a H/J/K/L` | resize focused pane | Zellij resize actions use directional growth/shrink semantics. |
 | Fullscreen/zoom | `C-a z` | toggle fullscreen | Closest equivalent to tmux zoom. |
 | Close focused pane | `C-a x` | close focus | Zellij close equivalent. |

--- a/configs/zellij/config.kdl
+++ b/configs/zellij/config.kdl
@@ -183,6 +183,19 @@ keybinds clear-defaults=true {
         }
     }
 
+    // Direct tmux-style navigation shortcuts stay available in locked mode for
+    // no-prefix pane/tab movement. Cmd on supported terminals is delivered to
+    // Zellij as Super; terminals that cannot forward Cmd can keep using the
+    // existing Alt and C-a bindings below.
+    shared_among "normal" "locked" {
+        bind "Super h" { GoToPreviousTab; }
+        bind "Super l" { GoToNextTab; }
+        bind "Ctrl h" { MoveFocus "left"; }
+        bind "Ctrl j" { MoveFocus "down"; }
+        bind "Ctrl k" { MoveFocus "up"; }
+        bind "Ctrl l" { MoveFocus "right"; }
+    }
+
     // Shared Alt bindings stay available in locked mode because they do not
     // collide with normal Vim/LazyVim bindings.
     shared_among "normal" "locked" {


### PR DESCRIPTION
Closes #269

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds direct no-prefix Zellij pane navigation for `Ctrl+h/j/k/l`.
- Adds direct tab navigation for Cmd-style `h/l` when the terminal forwards Cmd as Zellij `Super`.
- Documents the new direct navigation map and terminal/macOS forwarding caveat.

## Changes

| File | Change |
|------|--------|
| `configs/zellij/config.kdl` | Added direct tmux-style `Super+h/l` tab navigation and `Ctrl+h/j/k/l` pane focus bindings in locked/normal modes. |
| `configs/zellij/README.md` | Documented the no-prefix navigation behavior and Cmd/Super compatibility caveat. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed Zellij config validation: `ZELLIJ_CONFIG_DIR=<tmp> zellij setup --check`
- [x] Sandboxed install/status validation with temporary `--home`, `--source-root`, and `--state-root`: `go run ./cmd/dots install --yes --output json`; `go run ./cmd/dots status --output json`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #269`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
