### PR TITLE
feat(config): add adaptive theme opt-in

### DIFF
--- a/configs/claude/README.md
+++ b/configs/claude/README.md
@@ -1,10 +1,11 @@
 # Claude Code configuration
 
-`settings.json` keeps Claude's built-in theme at `dark-ansi` so default installs
-preserve the current dark CLI behavior. `statusline-command.sh` uses Catppuccin
-Mocha by default and switches its ANSI palette to Catppuccin Latte only when the
-shared dots `adaptive-theme` marker is installed and macOS light appearance is
-proven by `~/.config/dots/theme.sh`.
+`settings.json` keeps Claude's app-level theme at `auto` so Claude can follow
+its own light/dark appearance support while dots keeps owning only the JSON
+subset. `statusline-command.sh` uses Catppuccin Mocha by default and switches
+its ANSI palette to Catppuccin Latte only when the shared dots `adaptive-theme`
+marker is installed and macOS light appearance is proven by
+`~/.config/dots/theme.sh`.
 
 The script is copied into `~/.claude/statusline-command.sh` and must remain
 executable. Validate it with a sandboxed `HOME`; never run install/status checks

--- a/configs/claude/README.md
+++ b/configs/claude/README.md
@@ -1,0 +1,11 @@
+# Claude Code configuration
+
+`settings.json` keeps Claude's built-in theme at `dark-ansi` so default installs
+preserve the current dark CLI behavior. `statusline-command.sh` uses Catppuccin
+Mocha by default and switches its ANSI palette to Catppuccin Latte only when the
+shared dots `adaptive-theme` marker is installed and macOS light appearance is
+proven by `~/.config/dots/theme.sh`.
+
+The script is copied into `~/.claude/statusline-command.sh` and must remain
+executable. Validate it with a sandboxed `HOME`; never run install/status checks
+against the operator's real Claude config.

--- a/configs/claude/settings.json
+++ b/configs/claude/settings.json
@@ -20,5 +20,5 @@
     "command": "bash ~/.claude/statusline-command.sh",
     "type": "command"
   },
-  "theme": "dark-ansi"
+  "theme": "auto"
 }

--- a/configs/claude/statusline-command.sh
+++ b/configs/claude/statusline-command.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Claude Code statusLine — plain text + Catppuccin Mocha palette
+# Claude Code statusLine — plain text + Catppuccin adaptive palette
 
 input=$(cat)
 
@@ -13,16 +13,23 @@ seven_d_resets=$(echo "$input" | jq -r '.rate_limits.seven_day.resets_at // empt
 vim_mode=$(echo "$input" | jq -r '.vim.mode // ""')
 perm_mode=$(echo "$input" | jq -r '.permission_mode // .permissionMode // ""')
 
-# Catppuccin Mocha palette
-blue='\033[38;2;137;180;250m'
-mauve='\033[38;2;203;166;247m'
-green='\033[38;2;166;227;161m'
-yellow='\033[38;2;249;226;175m'
-subtext='\033[38;2;166;173;200m'
-overlay='\033[38;2;108;112;134m'
-red='\033[38;2;243;139;168m'
-pink='\033[38;2;245;194;231m'
-reset='\033[0m'
+# Catppuccin palette. Latte is used only when the adaptive-theme marker is
+# installed and macOS reports light appearance; otherwise Mocha is the fallback.
+if [ -r "$HOME/.config/dots/theme.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOME/.config/dots/theme.sh"
+  dots_apply_catppuccin_ansi_palette
+else
+  blue='\033[38;2;137;180;250m'
+  mauve='\033[38;2;203;166;247m'
+  green='\033[38;2;166;227;161m'
+  yellow='\033[38;2;249;226;175m'
+  subtext='\033[38;2;166;173;200m'
+  overlay='\033[38;2;108;112;134m'
+  red='\033[38;2;243;139;168m'
+  pink='\033[38;2;245;194;231m'
+  reset='\033[0m'
+fi
 
 sep="${overlay} | ${reset}"
 

--- a/configs/copilot/README.md
+++ b/configs/copilot/README.md
@@ -1,0 +1,9 @@
+# GitHub Copilot CLI configuration
+
+`statusline-command.sh` uses Catppuccin Mocha by default and switches its ANSI
+palette to Catppuccin Latte only when the shared dots `adaptive-theme` marker is
+installed and macOS light appearance is proven by `~/.config/dots/theme.sh`.
+
+The script is copied into `~/.copilot/statusline-command.sh` and must remain
+executable. Validate it with a sandboxed `HOME`; never run install/status checks
+against the operator's real Copilot config.

--- a/configs/copilot/statusline-command.sh
+++ b/configs/copilot/statusline-command.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# GitHub Copilot CLI statusLine — plain text + Catppuccin Mocha palette
+# GitHub Copilot CLI statusLine — plain text + Catppuccin adaptive palette
 
 input=$(cat)
 
@@ -17,16 +17,23 @@ agent=$(field '.agent.name // .agent // .customAgent.name')
 yolo=$(field '.yolo // .allowAllTools // .permissions.allowAll')
 sandbox=$(field '.sandbox.enabled // .sandbox')
 
-# Catppuccin Mocha palette
-blue='\033[38;2;137;180;250m'
-mauve='\033[38;2;203;166;247m'
-green='\033[38;2;166;227;161m'
-yellow='\033[38;2;249;226;175m'
-subtext='\033[38;2;166;173;200m'
-overlay='\033[38;2;108;112;134m'
-red='\033[38;2;243;139;168m'
-pink='\033[38;2;245;194;231m'
-reset='\033[0m'
+# Catppuccin palette. Latte is used only when the adaptive-theme marker is
+# installed and macOS reports light appearance; otherwise Mocha is the fallback.
+if [ -r "$HOME/.config/dots/theme.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOME/.config/dots/theme.sh"
+  dots_apply_catppuccin_ansi_palette
+else
+  blue='\033[38;2;137;180;250m'
+  mauve='\033[38;2;203;166;247m'
+  green='\033[38;2;166;227;161m'
+  yellow='\033[38;2;249;226;175m'
+  subtext='\033[38;2;166;173;200m'
+  overlay='\033[38;2;108;112;134m'
+  red='\033[38;2;243;139;168m'
+  pink='\033[38;2;245;194;231m'
+  reset='\033[0m'
+fi
 sep="${overlay} | ${reset}"
 printed=0
 

--- a/configs/dots/README.md
+++ b/configs/dots/README.md
@@ -1,0 +1,14 @@
+# dots runtime configuration
+
+`configs/dots/theme.sh` is installed for every `core` profile as
+`~/.config/dots/theme.sh`. Shell-readable managed configs source it to answer one
+question: should this session use Catppuccin Latte or Mocha?
+
+`configs/dots/adaptive-theme` is installed only when the user explicitly selects
+`--tag adaptive-theme`. The helper returns `latte` only when that marker exists
+and macOS light appearance is proven through `defaults read -g AppleInterfaceStyle`.
+Every other case — tag absent, macOS dark mode, Linux/non-macOS, missing
+`defaults`, or unknown output — returns `mocha`.
+
+This marker avoids duplicate managed targets in the Install Plan while giving
+symlinked configs and copied statusline scripts a shared opt-in seam.

--- a/configs/dots/adaptive-theme
+++ b/configs/dots/adaptive-theme
@@ -1,0 +1,1 @@
+adaptive-theme

--- a/configs/dots/theme.sh
+++ b/configs/dots/theme.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env sh
+# Shared dots adaptive-theme detection and Catppuccin palette helpers for
+# shell-readable managed config. Opt-in is selected by installing
+# ~/.config/dots/adaptive-theme through the manifest tag of the same name.
+# Mocha/dark remains the safe fallback.
+
+dots_adaptive_theme_marker=${DOTS_ADAPTIVE_THEME_MARKER:-"$HOME/.config/dots/adaptive-theme"}
+
+dots_adaptive_theme_enabled() {
+  [ -f "$dots_adaptive_theme_marker" ]
+}
+
+dots_macos_light_appearance() {
+  [ "$(uname -s 2>/dev/null)" = "Darwin" ] || return 1
+  command -v defaults >/dev/null 2>&1 || return 1
+  case "$(defaults read -g AppleInterfaceStyle 2>/dev/null)" in
+    "") return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+dots_catppuccin_flavor() {
+  if dots_adaptive_theme_enabled && dots_macos_light_appearance; then
+    printf '%s\n' latte
+  else
+    printf '%s\n' mocha
+  fi
+}
+
+dots_catppuccin_ansi_palette() {
+  case "${1:-$(dots_catppuccin_flavor)}" in
+    latte)
+      cat <<'PALETTE'
+blue='\033[38;2;30;102;245m'
+mauve='\033[38;2;136;57;239m'
+green='\033[38;2;64;160;43m'
+yellow='\033[38;2;223;142;29m'
+subtext='\033[38;2;92;95;119m'
+overlay='\033[38;2;156;160;176m'
+red='\033[38;2;210;15;57m'
+pink='\033[38;2;234;118;203m'
+PALETTE
+      ;;
+    *)
+      cat <<'PALETTE'
+blue='\033[38;2;137;180;250m'
+mauve='\033[38;2;203;166;247m'
+green='\033[38;2;166;227;161m'
+yellow='\033[38;2;249;226;175m'
+subtext='\033[38;2;166;173;200m'
+overlay='\033[38;2;108;112;134m'
+red='\033[38;2;243;139;168m'
+pink='\033[38;2;245;194;231m'
+PALETTE
+      ;;
+  esac
+}
+
+dots_apply_catppuccin_ansi_palette() {
+  eval "$(dots_catppuccin_ansi_palette "$@")"
+  reset='\033[0m'
+}

--- a/configs/ghostty/README.md
+++ b/configs/ghostty/README.md
@@ -29,10 +29,22 @@ The live `~/.config/ghostty/config` file was classified before adoption:
 
 | Category | Examples | Repository decision |
 | --- | --- | --- |
-| **Portable** | font family, font size, Catppuccin Mocha palette, foreground/background/cursor/selection colors, split divider color, intentional keybindings for terminal workflow and Zellij/tmux forwarding | Managed in `configs/ghostty/config.ghostty`. |
+| **Portable** | font family, font size, Catppuccin Mocha fallback theme, optional `adaptive-theme` native light/dark include, intentional keybindings for terminal workflow and Zellij/tmux forwarding | Managed in `configs/ghostty/config.ghostty`. |
 | **Machine-specific** | window dimensions, opacity/blur, window padding ergonomics, explicit shell/command paths, initial working directories, OS integrations, display/GPU/host-dependent behavior | Excluded from the shared file; document deliberate host-specific exceptions in `configs/ghostty/config.local.ghostty.example`. |
 | **Generated** | logs, caches, sessions, backups, temporary files, generated state, local shaders | Never committed. |
 | **Private** | secrets, authenticated state, private paths, hostnames, machine IDs | Excluded. |
+
+
+## Adaptive theme opt-in
+
+Fresh installs keep the Mocha theme from `config.ghostty`. When the user selects
+`--tag adaptive-theme`, dots also installs
+`~/.config/ghostty/adaptive-theme.ghostty`, and the shared config includes it with
+`config-file = ?adaptive-theme.ghostty`. That fragment uses Ghostty's native
+`theme = light:catppuccin-latte,dark:catppuccin-mocha` syntax, so Ghostty follows
+the desktop appearance while keeping Mocha as the dark fallback. The optional
+include is absent unless the tag is selected, so default desktop installs do not
+change theme behavior.
 
 ## Legacy config migration
 
@@ -43,7 +55,7 @@ legacy file can override the repository-managed Source of Truth after install.
 Before switching a real workstation to this slice, classify the legacy file, move
 portable settings into `configs/ghostty/config.ghostty`, move machine-specific
 settings into `~/.config/ghostty/config.local.ghostty`, then archive or remove
-the legacy `~/.config/ghostty/config` file. Do not leave duplicated font, color,
+the legacy `~/.config/ghostty/config` file. Do not leave duplicated font, theme/color,
 or keybinding settings in the legacy file because they can override the managed
 Source of Truth. Do the same review for macOS
 Application Support Ghostty config files if they exist.
@@ -98,6 +110,7 @@ GOMODCACHE="$sandbox_modcache" \
 XDG_CACHE_HOME="$sandbox_cache" \
 go run ./cmd/dots install \
   --profile desktop \
+  --tag adaptive-theme \
   --yes \
   --home "$sandbox_home" \
   --source-root "$PWD" \
@@ -115,6 +128,5 @@ go run ./cmd/dots status \
   --state-root "$sandbox_state"
 ```
 
-The expected result is that `~/.config/ghostty/config.ghostty` is
-installed/aligned inside `$sandbox_home` as a symlink to the repository source.
+The expected result is that `~/.config/ghostty/config.ghostty` is installed/aligned inside `$sandbox_home` as a symlink to the repository source; add `--tag adaptive-theme` on macOS to also install `~/.config/ghostty/adaptive-theme.ghostty`. Linux keeps the Mocha fallback because the adaptive fragment is Darwin-only.
 The maintainer's real home directory must not be touched.

--- a/configs/ghostty/adaptive/adaptive-theme.ghostty
+++ b/configs/ghostty/adaptive/adaptive-theme.ghostty
@@ -1,0 +1,3 @@
+# Installed only by the adaptive-theme tag. Ghostty uses the desktop appearance
+# to choose Catppuccin Latte in light mode and Mocha in dark mode.
+theme = light:catppuccin-latte,dark:catppuccin-mocha

--- a/configs/ghostty/config.ghostty
+++ b/configs/ghostty/config.ghostty
@@ -2,39 +2,24 @@
 #
 # Machine-specific settings such as window dimensions, opacity/blur, shell paths,
 # working directories, and platform integrations live in the optional local file
-# below. Ghostty resolves this relative to this file and ignores it when it does
-# not exist.
-config-file = ?config.local.ghostty
+# included after the shared defaults below. Ghostty resolves optional includes
+# relative to this file and ignores them when they do not exist.
 
 # Shared font baseline. The Desktop Nerd Font dependency keeps this portable
 # across supported desktop hosts.
 font-family = "Cascadia Code NF"
 font-size = 20
 
-# Catppuccin Mocha palette and terminal colors.
-palette = 0=#45475a
-palette = 1=#f38ba8
-palette = 2=#a6e3a1
-palette = 3=#f9e2af
-palette = 4=#89b4fa
-palette = 5=#f5c2e7
-palette = 6=#94e2d5
-palette = 7=#a6adc8
-palette = 8=#585b70
-palette = 9=#f38ba8
-palette = 10=#a6e3a1
-palette = 11=#f9e2af
-palette = 12=#89b4fa
-palette = 13=#f5c2e7
-palette = 14=#94e2d5
-palette = 15=#bac2de
-background = 1e1e2e
-foreground = cdd6f4
-cursor-color = f5e0dc
-cursor-text = 11111b
-selection-background = 353749
-selection-foreground = cdd6f4
-split-divider-color = 313244
+# Catppuccin Mocha is the default. The optional adaptive-theme include below
+# overrides this with Ghostty's native light/dark theme syntax.
+theme = catppuccin-mocha
+
+# Installed only by `dots install --tag adaptive-theme`; absent by default so
+# Mocha/dark remains the fallback for fresh installs. Loaded after the fallback
+# theme so the opt-in fragment can override it.
+config-file = ?adaptive-theme.ghostty
+# Local overrides are loaded last so explicit machine preferences win.
+config-file = ?config.local.ghostty
 
 # Portable keyboard behavior for the terminal workflow.
 keybind = alt+left=unbind

--- a/configs/nvim/README.md
+++ b/configs/nvim/README.md
@@ -1,0 +1,11 @@
+# Neovim configuration
+
+The managed LazyVim/Catppuccin setup defaults to `catppuccin-mocha`. When the
+`adaptive-theme` tag has installed `~/.config/dots/adaptive-theme`, Neovim checks
+macOS appearance at startup and selects `catppuccin-latte` only when light mode is
+proven. macOS dark mode, Linux/non-macOS, missing `defaults`, unknown values, and
+tag absence keep Mocha.
+
+The check happens inside `lua/plugins/colorscheme.lua`; no real `$HOME` files are
+needed to validate it beyond a temporary marker path such as
+`DOTS_ADAPTIVE_THEME_MARKER=/tmp/.../adaptive-theme`.

--- a/configs/nvim/lua/plugins/colorscheme.lua
+++ b/configs/nvim/lua/plugins/colorscheme.lua
@@ -1,3 +1,20 @@
+local function dots_catppuccin_flavour()
+  local marker = os.getenv("DOTS_ADAPTIVE_THEME_MARKER") or ((os.getenv("HOME") or "") .. "/.config/dots/adaptive-theme")
+  if vim.fn.filereadable(marker) ~= 1 then
+    return "mocha"
+  end
+  if vim.loop.os_uname().sysname ~= "Darwin" or vim.fn.executable("defaults") ~= 1 then
+    return "mocha"
+  end
+  local out = vim.fn.system({ "defaults", "read", "-g", "AppleInterfaceStyle" })
+  if vim.trim(out) == "" then
+    return "latte"
+  end
+  return "mocha"
+end
+
+local flavour = dots_catppuccin_flavour()
+
 return {
   {
     {
@@ -5,7 +22,7 @@ return {
       name = "catppuccin",
       priority = 1000,
       opts = {
-        flavour = "mocha", -- latte, frappe, macchiato, mocha
+        flavour = flavour, -- latte only when adaptive-theme + macOS light; mocha fallback
         transparent_background = true, -- disables setting the background color.
         term_colors = true, -- sets terminal colors (e.g. `g:terminal_color_0`)
       },
@@ -13,7 +30,7 @@ return {
     {
       "LazyVim/LazyVim",
       opts = {
-        colorscheme = "catppuccin-mocha",
+        colorscheme = "catppuccin-" .. flavour,
       },
     },
   },

--- a/configs/nvim/lua/plugins/colorscheme.lua
+++ b/configs/nvim/lua/plugins/colorscheme.lua
@@ -1,18 +1,14 @@
 local function dots_catppuccin_flavour()
-  local marker = os.getenv("DOTS_ADAPTIVE_THEME_MARKER") or ((os.getenv("HOME") or "") .. "/.config/dots/adaptive-theme")
-  if vim.fn.filereadable(marker) ~= 1 then
+  local helper = (os.getenv("HOME") or "") .. "/.config/dots/theme.sh"
+  if vim.fn.filereadable(helper) ~= 1 or vim.fn.executable("sh") ~= 1 then
     return "mocha"
   end
-  if vim.loop.os_uname().sysname ~= "Darwin" or vim.fn.executable("defaults") ~= 1 then
-    return "mocha"
-  end
-  local out = vim.fn.system({ "defaults", "read", "-g", "AppleInterfaceStyle" })
-  if vim.trim(out) == "" then
+  local out = vim.fn.system({ "sh", "-c", '. "$1" && dots_catppuccin_flavor', "sh", helper })
+  if vim.v.shell_error == 0 and vim.trim(out) == "latte" then
     return "latte"
   end
   return "mocha"
 end
-
 local flavour = dots_catppuccin_flavour()
 
 return {

--- a/configs/tmux/README.md
+++ b/configs/tmux/README.md
@@ -25,13 +25,14 @@ maintainer's machine state.
 
 ## Catppuccin light/dark behavior
 
-The managed config uses Catppuccin Latte when macOS is in light appearance and
-Catppuccin Mocha when macOS is in dark appearance. The selection is made when
-Tmux sources this config with `defaults read -g AppleInterfaceStyle`: macOS
-reports `Dark` only for dark mode and leaves `AppleInterfaceStyle` unset in
-light mode. Only that expected empty value selects Latte. Non-macOS hosts, a
-missing `defaults` command, or unknown appearance values fall back to Mocha.
-Re-source `~/.tmux.conf` or restart Tmux after changing the system appearance.
+The managed config keeps Catppuccin Mocha by default. Adaptive Latte/Mocha
+selection is opt-in: install or update with `--tag adaptive-theme`, which places
+`~/.config/dots/adaptive-theme` and the shared helper at
+`~/.config/dots/theme.sh`. When that marker is present, Tmux selects Latte only
+when macOS light appearance is proven with `defaults read -g AppleInterfaceStyle`;
+macOS dark mode, non-macOS hosts, a missing `defaults` command, or unknown values
+fall back to Mocha. Re-source `~/.tmux.conf` or restart Tmux after changing the
+system appearance or opt-in marker.
 
 Custom window-status formats use Catppuccin theme variables instead of fixed
 Mocha hex values so the same status bar adapts to Latte or Mocha.
@@ -43,7 +44,7 @@ before adoption and bucketed into four categories:
 
 | Category | Examples | Repository decision |
 | --- | --- | --- |
-| **Portable** | prefix remap `C-a`, vi copy-mode + clipboard binding, split/pane keymaps (`v`/`d`/`D`), window nav (`M-h`/`M-l`), pane resize (`M-H/J/K/L`), `mouse`, status position/lengths, base/pane index, terminal/key options (`default-terminal`, `terminal-features`, `extended-keys`, `escape-time`), the floating `scratch` popup, kill-other-sessions confirm, window-status formatting, the TPM `@plugin` declarations, the Catppuccin Latte/Mocha theme selection + status modules, and guarded `run` lines that load TPM/Catppuccin when their runtime files exist | Managed in `configs/tmux/tmux.conf`. |
+| **Portable** | prefix remap `C-a`, vi copy-mode + clipboard binding, split/pane keymaps (`v`/`d`/`D`), window nav (`M-h`/`M-l`), pane resize (`M-H/J/K/L`), `mouse`, status position/lengths, base/pane index, terminal/key options (`default-terminal`, `terminal-features`, `extended-keys`, `escape-time`), the floating `scratch` popup, kill-other-sessions confirm, window-status formatting, the TPM `@plugin` declarations, the opt-in Catppuccin Latte/Mocha theme selection + status modules, and guarded `run` lines that load TPM/Catppuccin when their runtime files exist | Managed in `configs/tmux/tmux.conf`. |
 | **Machine-specific** | `default-command`/`default-shell` hardcoding an absolute shell path (`/bin/zsh`); a status comment leaking `user@host` | **Excluded.** tmux inherits the login shell on its own; an absolute shell path is an installer concern. Put it in `~/.tmux.conf.local` if a host needs it. |
 | **Generated** | everything under `~/.tmux/plugins/...` (downloaded plugin contents, TPM bootstrap output) | **Never committed.** Plugin *declarations* are versioned; downloaded *contents* are runtime state. The `run` lines that load them are config and stay. |
 | **Private** | secrets, machine IDs, per-host overrides | **Excluded.** They live in the untracked `~/.tmux.conf.local`. |

--- a/configs/tmux/tmux.conf
+++ b/configs/tmux/tmux.conf
@@ -37,11 +37,10 @@ set -g @plugin 'tmux-plugins/tmux-cpu'
 
 # Catppuccin theme
 set -g @plugin 'catppuccin/tmux#v2.3.0'
-# Follow macOS appearance: Latte in light mode, Mocha in dark mode.
-# Non-macOS hosts, missing defaults(1), or unknown values keep Mocha as the
-# portable fallback. macOS light mode is represented by a missing
-# AppleInterfaceStyle value from defaults(1).
-if-shell '[ "$(uname -s)" = "Darwin" ] && command -v defaults >/dev/null 2>&1 && case "$(defaults read -g AppleInterfaceStyle 2>/dev/null)" in "") exit 0 ;; *) exit 1 ;; esac' 'set -g @catppuccin_flavor "latte"' 'set -g @catppuccin_flavor "mocha"'
+# Adaptive theming is opt-in via ~/.config/dots/adaptive-theme. When the
+# marker is absent, or when the appearance cannot be proven to be macOS light,
+# keep the portable Mocha fallback.
+if-shell '[ -r "$HOME/.config/dots/theme.sh" ] && . "$HOME/.config/dots/theme.sh" && [ "$(dots_catppuccin_flavor)" = "latte" ]' 'set -g @catppuccin_flavor "latte"' 'set -g @catppuccin_flavor "mocha"'
 set -g @catppuccin_window_status_style "rounded"
 set -g @catppuccin_status_background "default"
 set -g @catppuccin_status_connect_separator "yes"

--- a/configs/zellij/README.md
+++ b/configs/zellij/README.md
@@ -1,8 +1,11 @@
 # Zellij configuration
 
-`configs/zellij/config.kdl` is the repository-managed Zellij configuration
+`configs/zellij/config.kdl` is the default repository-managed Zellij configuration
 installed as `~/.config/zellij/config.kdl` (symlink strategy, `core` tag,
-`darwin`+`linux`). `configs/zellij/layouts/default.kdl` is installed as
+`darwin`+`linux`). When the manifest selection includes `--tag adaptive-theme`,
+that same Managed Entry uses the `configs/zellij/config-adaptive.kdl` source
+override for the same target instead of adding a duplicate Install Plan action.
+`configs/zellij/layouts/default.kdl` is installed as
 `~/.config/zellij/layouts/default.kdl` and selected by `default_layout "default"`.
 
 The Zellij UX intentionally follows the repository-managed tmux configuration
@@ -34,7 +37,7 @@ The live `~/.config/zellij` directory was classified before adoption:
 
 | Category | Examples | Repository decision |
 | --- | --- | --- |
-| **Portable** | locked-by-default mode, tmux-like `C-a` prefix, `Ctrl+g` compatibility command flow, pane/tab/resize/move/scroll keybindings, Alt navigation shortcuts, Catppuccin Mocha fallback theme, rounded pane frames, mouse mode, scroll buffer size, Neovim scrollback editor, built-in plugin aliases, default layout selection, and the tmux-like personal `zjstatus` status bar layout | Managed in `configs/zellij/config.kdl` and `configs/zellij/layouts/default.kdl`. |
+| **Portable** | locked-by-default mode, tmux-like `C-a` prefix, `Ctrl+g` compatibility command flow, pane/tab/resize/move/scroll keybindings, Alt navigation shortcuts, Catppuccin Mocha fallback theme plus an opt-in adaptive source override, rounded pane frames, mouse mode, scroll buffer size, Neovim scrollback editor, built-in plugin aliases, default layout selection, and the tmux-like personal `zjstatus` status bar layout | Managed in `configs/zellij/config.kdl` and `configs/zellij/layouts/default.kdl`. |
 | **Machine-specific** | absolute user paths, hostnames, machine IDs, per-host overrides | **Excluded.** Use a separate config file or config directory through real Zellij mechanisms when a host needs divergence. |
 | **Generated** | downloaded `.wasm` plugin binaries, `plugexit`, plugin-manager output, caches, logs, sessions, serialized runtime state, backup files such as `config.kdl.bak-*` | **Never committed.** Runtime files live under the user's Zellij data/config locations. |
 | **Private** | secrets, tokens, local-only paths, private command wiring | **Excluded.** Keep them outside the managed files. |
@@ -50,13 +53,14 @@ The live `~/.config/zellij` directory was classified before adoption:
 - `Ctrl+g` remains as the compatibility entry point for the classic Zellij
   command flow: from locked mode it enters normal mode, and from active command
   modes it returns to locked mode.
-- The UI uses built-in `theme "catppuccin-mocha"` as the safe default. Zellij
-  does not have a dots-owned optional include seam in this symlinked config, so
-  the previous untagged `theme_light`/`theme_dark` switching is intentionally not
-  enabled by default. A future slice can add a generated or app-native seam if
-  it can be kept behind the `adaptive-theme` opt-in without duplicate Install
-  Plan targets. Rounded pane frames, `mouse_mode true`, and
-  `scroll_buffer_size 10000` stay managed here.
+- The default UI uses built-in `theme "catppuccin-mocha"` as the safe default.
+  The `adaptive-theme` tag switches this target's source to
+  `configs/zellij/config-adaptive.kdl`, which adds Zellij's native
+  `theme_light "catppuccin-latte"` and `theme_dark "catppuccin-mocha"` settings
+  behind the same opt-in without duplicate Install Plan targets. Zellij follows
+  terminal-reported light/dark appearance when available; otherwise Mocha remains
+  the fallback. Rounded pane frames, `mouse_mode true`, and
+  `scroll_buffer_size 10000` stay managed in both sources.
 - Scrollback opens in Neovim via `scrollback_editor "nvim"`.
 - The default layout includes a top `zjstatus` status bar with an intentional
   tmux-like left/center/right shape: mode and session on the left, tabs in the
@@ -148,7 +152,8 @@ go run ./cmd/dots status \
   --state-root "$sandbox_state"
 ```
 
-The expected result is that both `~/.config/zellij/config.kdl` and
-`~/.config/zellij/layouts/default.kdl` are installed/aligned inside
-`$sandbox_home` as symlinks to repository sources. The maintainer's real home
-directory must not be touched.
+The expected default result is that `~/.config/zellij/config.kdl` points at
+`configs/zellij/config.kdl` and `~/.config/zellij/layouts/default.kdl` points at
+`configs/zellij/layouts/default.kdl`. With `--tag adaptive-theme`, the config
+symlink points at `configs/zellij/config-adaptive.kdl` instead. The maintainer's
+real home directory must not be touched.

--- a/configs/zellij/README.md
+++ b/configs/zellij/README.md
@@ -34,7 +34,7 @@ The live `~/.config/zellij` directory was classified before adoption:
 
 | Category | Examples | Repository decision |
 | --- | --- | --- |
-| **Portable** | locked-by-default mode, tmux-like `C-a` prefix, `Ctrl+g` compatibility command flow, pane/tab/resize/move/scroll keybindings, Alt navigation shortcuts, Catppuccin Latte/Mocha light-dark theme selection, rounded pane frames, mouse mode, scroll buffer size, Neovim scrollback editor, built-in plugin aliases, default layout selection, and the tmux-like personal `zjstatus` status bar layout | Managed in `configs/zellij/config.kdl` and `configs/zellij/layouts/default.kdl`. |
+| **Portable** | locked-by-default mode, tmux-like `C-a` prefix, `Ctrl+g` compatibility command flow, pane/tab/resize/move/scroll keybindings, Alt navigation shortcuts, Catppuccin Mocha fallback theme, rounded pane frames, mouse mode, scroll buffer size, Neovim scrollback editor, built-in plugin aliases, default layout selection, and the tmux-like personal `zjstatus` status bar layout | Managed in `configs/zellij/config.kdl` and `configs/zellij/layouts/default.kdl`. |
 | **Machine-specific** | absolute user paths, hostnames, machine IDs, per-host overrides | **Excluded.** Use a separate config file or config directory through real Zellij mechanisms when a host needs divergence. |
 | **Generated** | downloaded `.wasm` plugin binaries, `plugexit`, plugin-manager output, caches, logs, sessions, serialized runtime state, backup files such as `config.kdl.bak-*` | **Never committed.** Runtime files live under the user's Zellij data/config locations. |
 | **Private** | secrets, tokens, local-only paths, private command wiring | **Excluded.** Keep them outside the managed files. |
@@ -50,12 +50,13 @@ The live `~/.config/zellij` directory was classified before adoption:
 - `Ctrl+g` remains as the compatibility entry point for the classic Zellij
   command flow: from locked mode it enters normal mode, and from active command
   modes it returns to locked mode.
-- The UI uses built-in Catppuccin themes: `theme_light "catppuccin-latte"`,
-  `theme_dark "catppuccin-mocha"`, and `theme "catppuccin-mocha"` as the
-  fallback when the terminal does not report light/dark appearance. On macOS,
-  this follows the system setting when the terminal forwards appearance changes
-  to Zellij; otherwise Mocha remains the safe default. Rounded pane frames,
-  `mouse_mode true`, and `scroll_buffer_size 10000` stay managed here.
+- The UI uses built-in `theme "catppuccin-mocha"` as the safe default. Zellij
+  does not have a dots-owned optional include seam in this symlinked config, so
+  the previous untagged `theme_light`/`theme_dark` switching is intentionally not
+  enabled by default. A future slice can add a generated or app-native seam if
+  it can be kept behind the `adaptive-theme` opt-in without duplicate Install
+  Plan targets. Rounded pane frames, `mouse_mode true`, and
+  `scroll_buffer_size 10000` stay managed here.
 - Scrollback opens in Neovim via `scrollback_editor "nvim"`.
 - The default layout includes a top `zjstatus` status bar with an intentional
   tmux-like left/center/right shape: mode and session on the left, tabs in the

--- a/configs/zellij/config-adaptive.kdl
+++ b/configs/zellij/config-adaptive.kdl
@@ -1,0 +1,347 @@
+// Zellij configuration - portable defaults for Neovim/LazyVim workflows.
+// Zellij starts locked so terminal applications receive normal keybindings.
+// Press Ctrl+a for the tmux-like command prefix. Ctrl+g remains as the
+// compatibility entry point for the classic Zellij command flow.
+
+keybinds clear-defaults=true {
+    locked {
+        bind "Ctrl a" { SwitchToMode "tmux"; }
+        bind "Ctrl g" { SwitchToMode "normal"; }
+    }
+
+    normal {
+        bind "Ctrl a" { SwitchToMode "tmux"; }
+        bind "Ctrl g" { SwitchToMode "locked"; }
+    }
+
+    // Tmux-like prefix table. This intentionally mirrors the portable tmux
+    // workflow from configs/tmux/tmux.conf where Zellij has matching actions.
+    tmux {
+        bind "Ctrl a" { Write 1; SwitchToMode "locked"; }
+        bind "Ctrl g" { SwitchToMode "locked"; }
+        bind "esc" { SwitchToMode "locked"; }
+        bind "v" "%" { NewPane "right"; SwitchToMode "locked"; }
+        bind "d" "\"" { NewPane "down"; SwitchToMode "locked"; }
+        bind "D" { Detach; }
+        bind "c" { NewTab; SwitchToMode "locked"; }
+        bind "," { SwitchToMode "renametab"; }
+        bind "n" { GoToNextTab; SwitchToMode "locked"; }
+        bind "p" { GoToPreviousTab; SwitchToMode "locked"; }
+        bind "h" "left" { MoveFocus "left"; SwitchToMode "locked"; }
+        bind "j" "down" { MoveFocus "down"; SwitchToMode "locked"; }
+        bind "k" "up" { MoveFocus "up"; SwitchToMode "locked"; }
+        bind "l" "right" { MoveFocus "right"; SwitchToMode "locked"; }
+        bind "H" { Resize "Decrease left"; SwitchToMode "locked"; }
+        bind "J" { Resize "Increase down"; SwitchToMode "locked"; }
+        bind "K" { Resize "Increase up"; SwitchToMode "locked"; }
+        bind "L" { Resize "Increase right"; SwitchToMode "locked"; }
+        bind "z" { ToggleFocusFullscreen; SwitchToMode "locked"; }
+        bind "x" { CloseFocus; SwitchToMode "locked"; }
+        bind "[" { SwitchToMode "scroll"; }
+        bind "1" { GoToTab 1; SwitchToMode "locked"; }
+        bind "2" { GoToTab 2; SwitchToMode "locked"; }
+        bind "3" { GoToTab 3; SwitchToMode "locked"; }
+        bind "4" { GoToTab 4; SwitchToMode "locked"; }
+        bind "5" { GoToTab 5; SwitchToMode "locked"; }
+        bind "6" { GoToTab 6; SwitchToMode "locked"; }
+        bind "7" { GoToTab 7; SwitchToMode "locked"; }
+        bind "8" { GoToTab 8; SwitchToMode "locked"; }
+        bind "9" { GoToTab 9; SwitchToMode "locked"; }
+    }
+
+    pane {
+        bind "left" { MoveFocus "left"; }
+        bind "down" { MoveFocus "down"; }
+        bind "up" { MoveFocus "up"; }
+        bind "right" { MoveFocus "right"; }
+        bind "c" { SwitchToMode "renamepane"; PaneNameInput 0; }
+        bind "d" { NewPane "down"; SwitchToMode "locked"; }
+        bind "e" { TogglePaneEmbedOrFloating; SwitchToMode "locked"; }
+        bind "f" { ToggleFocusFullscreen; SwitchToMode "locked"; }
+        bind "h" { MoveFocus "left"; }
+        bind "j" { MoveFocus "down"; }
+        bind "k" { MoveFocus "up"; }
+        bind "l" { MoveFocus "right"; }
+        bind "n" { NewPane; SwitchToMode "locked"; }
+        bind "p" { SwitchToMode "normal"; }
+        bind "r" { NewPane "right"; SwitchToMode "locked"; }
+        bind "s" { NewPane "stacked"; SwitchToMode "locked"; }
+        bind "w" { ToggleFloatingPanes; SwitchToMode "locked"; }
+        bind "x" { CloseFocus; SwitchToMode "locked"; }
+        bind "z" { TogglePaneFrames; SwitchToMode "locked"; }
+        bind "i" { TogglePanePinned; SwitchToMode "locked"; }
+        bind "tab" { SwitchFocus; }
+    }
+
+    tab {
+        bind "left" { GoToPreviousTab; }
+        bind "down" { GoToNextTab; }
+        bind "up" { GoToPreviousTab; }
+        bind "right" { GoToNextTab; }
+        bind "1" { GoToTab 1; SwitchToMode "locked"; }
+        bind "2" { GoToTab 2; SwitchToMode "locked"; }
+        bind "3" { GoToTab 3; SwitchToMode "locked"; }
+        bind "4" { GoToTab 4; SwitchToMode "locked"; }
+        bind "5" { GoToTab 5; SwitchToMode "locked"; }
+        bind "6" { GoToTab 6; SwitchToMode "locked"; }
+        bind "7" { GoToTab 7; SwitchToMode "locked"; }
+        bind "8" { GoToTab 8; SwitchToMode "locked"; }
+        bind "9" { GoToTab 9; SwitchToMode "locked"; }
+        bind "[" { BreakPaneLeft; SwitchToMode "locked"; }
+        bind "]" { BreakPaneRight; SwitchToMode "locked"; }
+        bind "b" { BreakPane; SwitchToMode "locked"; }
+        bind "h" { GoToPreviousTab; }
+        bind "j" { GoToNextTab; }
+        bind "k" { GoToPreviousTab; }
+        bind "l" { GoToNextTab; }
+        bind "n" { NewTab; SwitchToMode "locked"; }
+        bind "r" { SwitchToMode "renametab"; TabNameInput 0; }
+        bind "s" { ToggleActiveSyncTab; SwitchToMode "locked"; }
+        bind "t" { SwitchToMode "normal"; }
+        bind "x" { CloseTab; SwitchToMode "locked"; }
+        bind "tab" { ToggleTab; }
+    }
+
+    resize {
+        bind "left" { Resize "Increase left"; }
+        bind "down" { Resize "Increase down"; }
+        bind "up" { Resize "Increase up"; }
+        bind "right" { Resize "Increase right"; }
+        bind "+" { Resize "Increase"; }
+        bind "-" { Resize "Decrease"; }
+        bind "=" { Resize "Increase"; }
+        bind "H" { Resize "Decrease left"; }
+        bind "J" { Resize "Decrease down"; }
+        bind "K" { Resize "Decrease up"; }
+        bind "L" { Resize "Decrease right"; }
+        bind "h" { Resize "Increase left"; }
+        bind "j" { Resize "Increase down"; }
+        bind "k" { Resize "Increase up"; }
+        bind "l" { Resize "Increase right"; }
+        bind "r" { SwitchToMode "normal"; }
+    }
+
+    move {
+        bind "left" { MovePane "left"; }
+        bind "down" { MovePane "down"; }
+        bind "up" { MovePane "up"; }
+        bind "right" { MovePane "right"; }
+        bind "h" { MovePane "left"; }
+        bind "j" { MovePane "down"; }
+        bind "k" { MovePane "up"; }
+        bind "l" { MovePane "right"; }
+        bind "m" { SwitchToMode "normal"; }
+        bind "n" { MovePane; }
+        bind "p" { MovePaneBackwards; }
+        bind "tab" { MovePane; }
+    }
+
+    scroll {
+        bind "e" { EditScrollback; SwitchToMode "locked"; }
+        bind "f" { SwitchToMode "entersearch"; SearchInput 0; }
+        bind "s" { SwitchToMode "normal"; }
+    }
+
+    search {
+        bind "c" { SearchToggleOption "CaseSensitivity"; }
+        bind "n" { Search "down"; }
+        bind "o" { SearchToggleOption "WholeWord"; }
+        bind "p" { Search "up"; }
+        bind "w" { SearchToggleOption "Wrap"; }
+    }
+
+    session {
+        bind "c" {
+            LaunchOrFocusPlugin "configuration" {
+                floating true
+                move_to_focused_tab true
+            }
+            SwitchToMode "locked"
+        }
+        bind "d" { Detach; }
+        bind "o" { SwitchToMode "normal"; }
+        bind "p" {
+            LaunchOrFocusPlugin "plugin-manager" {
+                floating true
+                move_to_focused_tab true
+            }
+            SwitchToMode "locked"
+        }
+        bind "w" {
+            LaunchOrFocusPlugin "session-manager" {
+                floating true
+                move_to_focused_tab true
+            }
+            SwitchToMode "locked"
+        }
+        bind "a" {
+            LaunchOrFocusPlugin "about" {
+                floating true
+                move_to_focused_tab true
+            }
+            SwitchToMode "locked"
+        }
+    }
+
+    // Direct tmux-style navigation shortcuts stay available in locked mode for
+    // no-prefix pane/tab movement. Cmd on supported terminals is delivered to
+    // Zellij as Super; terminals that cannot forward Cmd can keep using the
+    // existing Alt and C-a bindings below.
+    shared_among "normal" "locked" {
+        bind "Super h" { GoToPreviousTab; }
+        bind "Super l" { GoToNextTab; }
+        bind "Ctrl h" { MoveFocus "left"; }
+        bind "Ctrl j" { MoveFocus "down"; }
+        bind "Ctrl k" { MoveFocus "up"; }
+        bind "Ctrl l" { MoveFocus "right"; }
+    }
+
+    // Shared Alt bindings stay available in locked mode because they do not
+    // collide with normal Vim/LazyVim bindings.
+    shared_among "normal" "locked" {
+        bind "Alt left" { MoveFocusOrTab "left"; }
+        bind "Alt down" { MoveFocus "down"; }
+        bind "Alt up" { MoveFocus "up"; }
+        bind "Alt right" { MoveFocusOrTab "right"; }
+        bind "Alt +" { Resize "Increase"; }
+        bind "Alt -" { Resize "Decrease"; }
+        bind "Alt =" { Resize "Increase"; }
+        bind "Alt [" { PreviousSwapLayout; }
+        bind "Alt ]" { NextSwapLayout; }
+        bind "Alt f" { ToggleFloatingPanes; }
+        bind "Alt h" { MoveFocusOrTab "left"; }
+        bind "Alt i" { MoveTab "Left"; }
+        bind "Alt j" { MoveFocus "down"; }
+        bind "Alt k" { MoveFocus "up"; }
+        bind "Alt l" { MoveFocusOrTab "right"; }
+        bind "Alt n" { NewPane; }
+        bind "Alt o" { MoveTab "Right"; }
+        bind "Alt p" { TogglePaneInGroup; }
+        bind "Alt Shift p" { ToggleGroupMarking; }
+        bind "Alt t" { NewTab; }
+        bind "Alt w" { CloseTab; }
+        bind "Alt 1" { GoToTab 1; }
+        bind "Alt 2" { GoToTab 2; }
+        bind "Alt 3" { GoToTab 3; }
+        bind "Alt 4" { GoToTab 4; }
+        bind "Alt 5" { GoToTab 5; }
+        bind "Alt 6" { GoToTab 6; }
+        bind "Alt 7" { GoToTab 7; }
+        bind "Alt 8" { GoToTab 8; }
+        bind "Alt 9" { GoToTab 9; }
+    }
+
+    shared_except "locked" "renametab" "renamepane" {
+        bind "Ctrl a" { SwitchToMode "tmux"; }
+        bind "Ctrl g" { SwitchToMode "locked"; }
+        bind "Ctrl q" { Quit; }
+    }
+
+    shared_except "locked" "entersearch" {
+        bind "enter" { SwitchToMode "locked"; }
+    }
+
+    shared_except "locked" "entersearch" "renametab" "renamepane" {
+        bind "esc" { SwitchToMode "locked"; }
+    }
+
+    shared_except "locked" "entersearch" "renametab" "renamepane" "move" {
+        bind "m" { SwitchToMode "move"; }
+    }
+
+    shared_except "locked" "entersearch" "search" "renametab" "renamepane" "session" {
+        bind "o" { SwitchToMode "session"; }
+    }
+
+    shared_except "locked" "tab" "entersearch" "renametab" "renamepane" {
+        bind "t" { SwitchToMode "tab"; }
+    }
+
+    shared_except "locked" "tab" "scroll" "entersearch" "renametab" "renamepane" {
+        bind "s" { SwitchToMode "scroll"; }
+    }
+
+    shared_among "normal" "resize" "tab" "scroll" "prompt" "tmux" {
+        bind "p" { SwitchToMode "pane"; }
+    }
+
+    shared_except "locked" "resize" "pane" "tab" "entersearch" "renametab" "renamepane" {
+        bind "r" { SwitchToMode "resize"; }
+    }
+
+    shared_among "scroll" "search" {
+        bind "PageDown" { PageScrollDown; }
+        bind "PageUp" { PageScrollUp; }
+        bind "left" { PageScrollUp; }
+        bind "down" { ScrollDown; }
+        bind "up" { ScrollUp; }
+        bind "right" { PageScrollDown; }
+        bind "Ctrl b" { PageScrollUp; }
+        bind "Ctrl c" { ScrollToBottom; SwitchToMode "locked"; }
+        bind "d" { HalfPageScrollDown; }
+        bind "Ctrl f" { PageScrollDown; }
+        bind "h" { PageScrollUp; }
+        bind "j" { ScrollDown; }
+        bind "k" { ScrollUp; }
+        bind "l" { PageScrollDown; }
+        bind "u" { HalfPageScrollUp; }
+    }
+
+    entersearch {
+        bind "Ctrl c" { SwitchToMode "scroll"; }
+        bind "esc" { SwitchToMode "scroll"; }
+        bind "enter" { SwitchToMode "search"; }
+    }
+
+    renametab {
+        bind "esc" { UndoRenameTab; SwitchToMode "tab"; }
+    }
+
+    shared_among "renametab" "renamepane" {
+        bind "Ctrl c" { SwitchToMode "locked"; }
+    }
+
+    renamepane {
+        bind "esc" { UndoRenamePane; SwitchToMode "pane"; }
+    }
+}
+
+// Built-in plugin aliases. Third-party plugins are intentionally not vendored
+// here; optional plugin binaries remain manual per-machine prerequisites.
+plugins {
+    tab-bar location="zellij:tab-bar"
+    status-bar location="zellij:status-bar"
+    strider location="zellij:strider"
+    compact-bar location="zellij:compact-bar"
+    session-manager location="zellij:session-manager"
+    welcome-screen location="zellij:session-manager" {
+        welcome_screen true
+    }
+    filepicker location="zellij:strider" {
+        cwd "/"
+    }
+    configuration location="zellij:configuration"
+    plugin-manager location="zellij:plugin-manager"
+    about location="zellij:about"
+}
+
+load_plugins {
+}
+
+// Follow terminal-reported light/dark appearance only when the manifest
+// adaptive-theme tag selects this source override. Mocha remains the fallback
+// when no appearance is reported.
+theme "catppuccin-mocha"
+theme_light "catppuccin-latte"
+theme_dark "catppuccin-mocha"
+default_mode "locked"
+mouse_mode true
+scroll_buffer_size 10000
+default_layout "default"
+scrollback_editor "nvim"
+
+ui {
+    pane_frames {
+        rounded_corners true
+    }
+}

--- a/configs/zellij/config.kdl
+++ b/configs/zellij/config.kdl
@@ -328,12 +328,10 @@ plugins {
 load_plugins {
 }
 
-// Follow terminal-reported light/dark appearance (macOS-aware terminals
-// usually mirror the system setting). Mocha remains the fallback when no
-// appearance is reported.
+// Mocha is the safe default. Zellij has no native include mechanism in this
+// managed config, so automatic Latte switching is not enabled unless a future
+// dots-owned generation seam can put it behind the adaptive-theme opt-in.
 theme "catppuccin-mocha"
-theme_light "catppuccin-latte"
-theme_dark "catppuccin-mocha"
 default_mode "locked"
 mouse_mode true
 scroll_buffer_size 10000

--- a/docs/adaptive-theme-audit.md
+++ b/docs/adaptive-theme-audit.md
@@ -1,0 +1,48 @@
+# Adaptive theme audit
+
+Issue #275 introduces an explicit `adaptive-theme` tag. The default profile/tag
+sets continue to prefer Catppuccin Mocha or app dark defaults. Adaptive behavior
+must either be behind the tag or intentionally documented as out of scope for the
+slice.
+
+## Implemented behind `adaptive-theme`
+
+- **Shared marker/helper**: `configs/dots/theme.sh` is installed by `core` and
+  reads `~/.config/dots/adaptive-theme`, which is installed only by the
+  `adaptive-theme` tag. The helper returns Latte only for opt-in macOS light
+  appearance; everything else returns Mocha.
+- **tmux**: `configs/tmux/tmux.conf` sources the helper before setting
+  `@catppuccin_flavor`. Missing helper/marker, macOS dark, Linux, unknown values,
+  or missing `defaults` fall back to Mocha.
+- **Ghostty**: default `configs/ghostty/config.ghostty` uses `theme =
+  catppuccin-mocha`. On macOS, the tag installs `adaptive-theme.ghostty`, which uses
+  Ghostty's native `theme = light:catppuccin-latte,dark:catppuccin-mocha` form.
+- **Neovim**: `lua/plugins/colorscheme.lua` selects `catppuccin-latte` only when
+  the marker exists and macOS light appearance is proven; otherwise it uses
+  `catppuccin-mocha`.
+- **Claude/Copilot statuslines**: copied statusline scripts source the helper
+  and switch only their ANSI palettes. Claude's app-level `theme` remains
+  `dark-ansi` because changing that setting dynamically would require rewriting
+  the copied JSON settings file.
+
+## Audited and left unchanged
+
+- **Zellij**: default `configs/zellij/config.kdl` stays Mocha-only. Zellij has
+  no safe dots-owned optional include seam in this symlinked config, and adding
+  a second whole config would duplicate the Install Plan target surface, so the
+  previous untagged light/dark switching was removed rather than moved.
+- **Codex**: dots owns a TOML subset for status-line fields, not an app theme
+  with a light/dark seam. No adaptive change was made.
+- **OpenCode**: dots owns only the MCP overlay from ADR 0005. There is no
+  dots-owned theme/status fragment to change without touching gentle-ai-owned
+  global config, so it remains unchanged.
+- **bat**: bat supports native `auto:system` and `--theme-light/--theme-dark`,
+  but the managed config has no include seam. Enabling it in the default config
+  would make adaptive behavior untagged, so bat remains Mocha for this slice.
+- **Starship**: no native include mechanism; the managed config remains Mocha.
+- **Atuin**: no native include mechanism for the managed config; the managed
+  config remains Mocha.
+- **Warp**: managed settings remain `theme = "dark"`; no safe optional include
+  seam was introduced.
+- **Zed**: already uses `"mode": "system"` with Catppuccin Mocha for dark and
+  One Light for light. That existing app-native behavior is unchanged.

--- a/docs/adaptive-theme-audit.md
+++ b/docs/adaptive-theme-audit.md
@@ -21,16 +21,17 @@ slice.
   the marker exists and macOS light appearance is proven; otherwise it uses
   `catppuccin-mocha`.
 - **Claude/Copilot statuslines**: copied statusline scripts source the helper
-  and switch only their ANSI palettes. Claude's app-level `theme` remains
-  `dark-ansi` because changing that setting dynamically would require rewriting
-  the copied JSON settings file.
+  and switch only their ANSI palettes. Claude's app-level `theme` is `auto` so
+  Claude can use its own light/dark support without dots rewriting the copied
+  JSON settings file.
 
 ## Audited and left unchanged
 
-- **Zellij**: default `configs/zellij/config.kdl` stays Mocha-only. Zellij has
-  no safe dots-owned optional include seam in this symlinked config, and adding
-  a second whole config would duplicate the Install Plan target surface, so the
-  previous untagged light/dark switching was removed rather than moved.
+- **Zellij**: default `configs/zellij/config.kdl` stays Mocha-only. The same
+  Managed Entry uses `source_overrides.adaptive-theme` to select
+  `configs/zellij/config-adaptive.kdl`, restoring Zellij's native
+  `theme_light`/`theme_dark` behavior only when the opt-in tag is selected and
+  without adding a duplicate Install Plan target.
 - **Codex**: dots owns a TOML subset for status-line fields, not an app theme
   with a light/dark seam. No adaptive change was made.
 - **OpenCode**: dots owns only the MCP overlay from ADR 0005. There is no

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -99,9 +99,12 @@ Ghostty's optional `adaptive-theme.ghostty`. Shell-readable configs source
 exists and macOS light appearance is proven. Missing marker, macOS dark mode,
 Linux, missing appearance APIs, and unknown values keep Mocha/dark fallbacks.
 
-Static apps without a safe optional include/generation seam are documented in
-[`docs/adaptive-theme-audit.md`](adaptive-theme-audit.md) and left on Mocha rather
-than adding duplicate Install Plan targets or clobbering co-owned files.
+Static apps without a safe optional include seam can use a `source_overrides`
+entry when a whole target must switch sources behind the opt-in. The override
+keeps one Managed Entry/target in the Install Plan while selecting the tagged
+source, so `--tag adaptive-theme` does not create duplicate target actions.
+Co-owned files are still documented in [`docs/adaptive-theme-audit.md`](adaptive-theme-audit.md)
+when no safe dots-owned source can be selected.
 
 
 A Managed Entry declares one repository source and one target under `$HOME`.
@@ -111,6 +114,7 @@ home directory.
 | Field | Required | Supported values |
 |-------|----------|------------------|
 | `source` | Yes | Repository-relative path to Managed Configuration. |
+| `source_overrides` | No | Map of selected tag to alternate repository-relative source for the same target. Used for opt-in variants without duplicate Install Plan targets. |
 | `target` | Yes | Home-relative target: `~` or `~/...`. |
 | `strategy` | Yes | `symlink`, `copy`, or `template` in the manifest schema. Current install execution supports `symlink` and `copy`. |
 | `ownership` | No | Empty, `json-subset`, or `toml-subset`. Subset ownership requires `strategy: copy`. |
@@ -130,7 +134,7 @@ Current Managed Entries:
 | `configs/dots/adaptive-theme` | `~/.config/dots/adaptive-theme` | `symlink` | `adaptive-theme` | `darwin`, `linux` | None |
 | `configs/starship/starship.toml` | `~/.config/starship.toml` | `symlink` | `core` | `darwin`, `linux` | `starship` |
 | `configs/tmux/tmux.conf` | `~/.tmux.conf` | `symlink` | `core` | `darwin`, `linux` | `tmux` |
-| `configs/zellij/config.kdl` | `~/.config/zellij/config.kdl` | `symlink` | `core` | `darwin`, `linux` | `zellij` |
+| `configs/zellij/config.kdl` (`adaptive-theme` override: `configs/zellij/config-adaptive.kdl`) | `~/.config/zellij/config.kdl` | `symlink` | `core` | `darwin`, `linux` | `zellij` |
 | `configs/zellij/layouts/default.kdl` | `~/.config/zellij/layouts/default.kdl` | `symlink` | `core` | `darwin`, `linux` | `zellij` |
 | `configs/ghostty/config.ghostty` | `~/.config/ghostty/config.ghostty` | `symlink` | `desktop` | `darwin`, `linux` | `ghostty` |
 | `configs/ghostty/adaptive/adaptive-theme.ghostty` | `~/.config/ghostty/adaptive-theme.ghostty` | `symlink` | `adaptive-theme` | `darwin` | None |

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -32,7 +32,9 @@ Unknown YAML fields are rejected during manifest loading.
 A Profile is selected by commands such as `dots plan`, `dots install`,
 `dots status`, and `dots deps check`. Commands that expose `--tag` can add
 optional capability tags on top of the selected Profile without creating another
-Profile.
+Profile. For example, `--tag adaptive-theme` installs the opt-in marker and
+app-specific fragments used by managed configs to follow macOS light appearance
+where the app has a safe seam.
 
 | Field | Required | Supported values |
 |-------|----------|------------------|
@@ -88,6 +90,20 @@ unresolved Dependency.
 
 ## Managed Entries
 
+### Adaptive theme tag
+
+`adaptive-theme` is an explicit opt-in tag, not part of any default Profile. It
+installs `~/.config/dots/adaptive-theme` plus app-specific fragments such as
+Ghostty's optional `adaptive-theme.ghostty`. Shell-readable configs source
+`~/.config/dots/theme.sh` and select Catppuccin Latte only when both the marker
+exists and macOS light appearance is proven. Missing marker, macOS dark mode,
+Linux, missing appearance APIs, and unknown values keep Mocha/dark fallbacks.
+
+Static apps without a safe optional include/generation seam are documented in
+[`docs/adaptive-theme-audit.md`](adaptive-theme-audit.md) and left on Mocha rather
+than adding duplicate Install Plan targets or clobbering co-owned files.
+
+
 A Managed Entry declares one repository source and one target under `$HOME`.
 Targets must be `~` or `~/...`; `dots` rejects targets that escape the selected
 home directory.
@@ -110,11 +126,14 @@ Current Managed Entries:
 | `configs/zsh/zimrc` | `~/.zimrc` | `symlink` | `core` | `darwin`, `linux` | `zsh` |
 | `configs/zsh/zshenv` | `~/.zshenv` | `symlink` | `core` | `darwin`, `linux` | `zsh` |
 | `configs/git/gitconfig` | `~/.gitconfig` | `symlink` | `core` | `darwin`, `linux` | `git` |
+| `configs/dots/theme.sh` | `~/.config/dots/theme.sh` | `symlink` | `core` | `darwin`, `linux` | None |
+| `configs/dots/adaptive-theme` | `~/.config/dots/adaptive-theme` | `symlink` | `adaptive-theme` | `darwin`, `linux` | None |
 | `configs/starship/starship.toml` | `~/.config/starship.toml` | `symlink` | `core` | `darwin`, `linux` | `starship` |
 | `configs/tmux/tmux.conf` | `~/.tmux.conf` | `symlink` | `core` | `darwin`, `linux` | `tmux` |
 | `configs/zellij/config.kdl` | `~/.config/zellij/config.kdl` | `symlink` | `core` | `darwin`, `linux` | `zellij` |
 | `configs/zellij/layouts/default.kdl` | `~/.config/zellij/layouts/default.kdl` | `symlink` | `core` | `darwin`, `linux` | `zellij` |
 | `configs/ghostty/config.ghostty` | `~/.config/ghostty/config.ghostty` | `symlink` | `desktop` | `darwin`, `linux` | `ghostty` |
+| `configs/ghostty/adaptive/adaptive-theme.ghostty` | `~/.config/ghostty/adaptive-theme.ghostty` | `symlink` | `adaptive-theme` | `darwin` | None |
 | `configs/warp/settings.toml` | `~/.warp/settings.toml` | `copy` | `desktop` | `darwin` | None |
 | `configs/warp/keybindings.yaml` | `~/.warp/keybindings.yaml` | `copy` | `desktop` | `darwin` | None |
 | `configs/warp/settings.toml` | `~/.config/warp-terminal/settings.toml` | `copy` | `desktop` | `linux` | `Warp` |

--- a/dots.yaml
+++ b/dots.yaml
@@ -212,6 +212,22 @@ entries:
         apt: git
         dnf: git
         pacman: git
+  - source: configs/dots/theme.sh
+    target: ~/.config/dots/theme.sh
+    strategy: symlink
+    tags:
+      - core
+    os:
+      - darwin
+      - linux
+  - source: configs/dots/adaptive-theme
+    target: ~/.config/dots/adaptive-theme
+    strategy: symlink
+    tags:
+      - adaptive-theme
+    os:
+      - darwin
+      - linux
   - source: configs/starship/starship.toml
     target: ~/.config/starship.toml
     strategy: symlink
@@ -305,6 +321,13 @@ entries:
           interactivity. After installation, verify ghostty --version and rerun
           dots deps check.
         brew: ghostty
+  - source: configs/ghostty/adaptive/adaptive-theme.ghostty
+    target: ~/.config/ghostty/adaptive-theme.ghostty
+    strategy: symlink
+    tags:
+      - adaptive-theme
+    os:
+      - darwin
   - source: configs/warp/settings.toml
     target: ~/.warp/settings.toml
     strategy: copy

--- a/dots.yaml
+++ b/dots.yaml
@@ -263,6 +263,8 @@ entries:
         dnf: tmux
         pacman: tmux
   - source: configs/zellij/config.kdl
+    source_overrides:
+      adaptive-theme: configs/zellij/config-adaptive.kdl
     target: ~/.config/zellij/config.kdl
     strategy: symlink
     tags:

--- a/internal/cli/claude_config_test.go
+++ b/internal/cli/claude_config_test.go
@@ -398,7 +398,7 @@ cat > "$HOME/.claude/settings.json" <<'JSON'
     "command": "bash ~/.claude/statusline-command.sh",
     "type": "command"
   },
-  "theme": "dark-ansi",
+  "theme": "auto",
   "enabledPlugins": {
     "chrome-devtools-mcp": true
   }

--- a/internal/cli/ghostty_config_test.go
+++ b/internal/cli/ghostty_config_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -65,6 +66,7 @@ func TestGhosttyDesktopProfileInstallsAndReportsAlignedInSandbox(t *testing.T) {
 	for _, want := range []string{
 		`font-family = "Cascadia Code NF"`,
 		"font-size = 20",
+		"config-file = ?adaptive-theme.ghostty",
 	} {
 		if !strings.Contains(string(managedConfig), want) {
 			t.Fatalf("managed ghostty config missing %q", want)
@@ -141,5 +143,70 @@ func TestGhosttyDesktopProfileInstallsAndReportsAlignedInSandbox(t *testing.T) {
 
 	if !strings.Contains(installOut.String(), "configs/ghostty/config.ghostty") {
 		t.Fatalf("install plan did not include the Ghostty managed entry\noutput:\n%s", installOut.String())
+	}
+	if strings.Contains(installOut.String(), "adaptive-theme.ghostty") {
+		t.Fatalf("install without adaptive-theme tag included adaptive Ghostty fragment\noutput:\n%s", installOut.String())
+	}
+}
+
+func TestAdaptiveThemeTagInstallsMarkerAndGhosttyFragmentInSandbox(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	stubGentleAIProvisionerTools(t)
+	seedDesktopNerdFont(t, home)
+
+	install := cli.NewRootCommand()
+	var installOut bytes.Buffer
+	install.SetOut(&installOut)
+	install.SetErr(&installOut)
+	install.SetArgs([]string{
+		"install",
+		"--file", filepath.Join(repoRoot, "dots.yaml"),
+		"--profile", "desktop",
+		"--tag", "adaptive-theme",
+		"--source-root", repoRoot,
+		"--home", home,
+		"--state-root", stateRoot,
+		"--yes",
+	})
+
+	if err := install.Execute(); err != nil {
+		t.Fatalf("dots install with adaptive-theme failed in sandbox: %v\noutput:\n%s", err, installOut.String())
+	}
+
+	targets := map[string]string{
+		filepath.Join(home, ".config", "dots", "theme.sh"):       filepath.Join(repoRoot, "configs", "dots", "theme.sh"),
+		filepath.Join(home, ".config", "dots", "adaptive-theme"): filepath.Join(repoRoot, "configs", "dots", "adaptive-theme"),
+	}
+	ghosttyAdaptiveTarget := filepath.Join(home, ".config", "ghostty", "adaptive-theme.ghostty")
+	if runtime.GOOS == "darwin" {
+		targets[ghosttyAdaptiveTarget] = filepath.Join(repoRoot, "configs", "ghostty", "adaptive", "adaptive-theme.ghostty")
+	}
+	for target, wantSource := range targets {
+		gotSource, err := os.Readlink(target)
+		if err != nil {
+			t.Fatalf("adaptive-theme target %s is not a symlink: %v\noutput:\n%s", target, err, installOut.String())
+		}
+		if gotSource != wantSource {
+			t.Fatalf("adaptive-theme symlink %s = %q, want %q", target, gotSource, wantSource)
+		}
+	}
+
+	fragment, err := os.ReadFile(filepath.Join(repoRoot, "configs", "ghostty", "adaptive", "adaptive-theme.ghostty"))
+	if err != nil {
+		t.Fatalf("read Ghostty adaptive fragment: %v", err)
+	}
+	if !strings.Contains(string(fragment), "theme = light:catppuccin-latte,dark:catppuccin-mocha") {
+		t.Fatalf("Ghostty adaptive fragment does not use native light/dark theme syntax\ncontent:\n%s", fragment)
+	}
+	if runtime.GOOS != "darwin" {
+		if _, err := os.Lstat(ghosttyAdaptiveTarget); !os.IsNotExist(err) {
+			t.Fatalf("non-Darwin adaptive-theme install created Ghostty adaptive fragment; err=%v output:\n%s", err, installOut.String())
+		}
 	}
 }

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -136,12 +136,16 @@ func ScanSecrets(m manifest.Manifest, opts Options) (SecretReport, error) {
 	var report SecretReport
 	seen := map[string]bool{}
 	for _, entry := range m.Entries {
-		if !manifest.SharesTag(entry.Tags, tags) || !manifest.MatchesOS(entry.OS, opts.OS) || seen[entry.Source] {
+		if !manifest.SharesTag(entry.Tags, tags) || !manifest.MatchesOS(entry.OS, opts.OS) {
 			continue
 		}
-		seen[entry.Source] = true
+		source := manifest.EntrySource(entry, tags)
+		if seen[source] {
+			continue
+		}
+		seen[source] = true
 
-		sourceAbs, err := plan.ResolveSource(entry.Source, opts.SourceRoot)
+		sourceAbs, err := plan.ResolveSource(source, opts.SourceRoot)
 		if err != nil {
 			return SecretReport{}, err
 		}
@@ -152,7 +156,7 @@ func ScanSecrets(m manifest.Manifest, opts Options) (SecretReport, error) {
 			return SecretReport{}, err
 		}
 
-		findings, err := scanSource(entry.Source, sourceAbs)
+		findings, err := scanSource(source, sourceAbs)
 		if err != nil {
 			return SecretReport{}, err
 		}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -31,13 +31,14 @@ type Profile struct {
 }
 
 type Entry struct {
-	Source       string       `yaml:"source"`
-	Target       string       `yaml:"target"`
-	Strategy     string       `yaml:"strategy"`
-	Ownership    string       `yaml:"ownership,omitempty"`
-	Tags         []string     `yaml:"tags"`
-	OS           []string     `yaml:"os,omitempty"`
-	Dependencies []Dependency `yaml:"dependencies,omitempty"`
+	Source          string            `yaml:"source"`
+	SourceOverrides map[string]string `yaml:"source_overrides,omitempty"`
+	Target          string            `yaml:"target"`
+	Strategy        string            `yaml:"strategy"`
+	Ownership       string            `yaml:"ownership,omitempty"`
+	Tags            []string          `yaml:"tags"`
+	OS              []string          `yaml:"os,omitempty"`
+	Dependencies    []Dependency      `yaml:"dependencies,omitempty"`
 }
 
 // DependencySet declares Dependencies selected directly by tags rather than by
@@ -332,6 +333,19 @@ func (m Manifest) Validate() error {
 		}
 		if entry.Target == "" {
 			return fmt.Errorf("entries[%d].target is required", i)
+		}
+		overrideTags := make([]string, 0, len(entry.SourceOverrides))
+		for tag := range entry.SourceOverrides {
+			overrideTags = append(overrideTags, tag)
+		}
+		sort.Strings(overrideTags)
+		for _, tag := range overrideTags {
+			if strings.TrimSpace(tag) == "" {
+				return fmt.Errorf("entries[%d].source_overrides contains an empty tag", i)
+			}
+			if strings.TrimSpace(entry.SourceOverrides[tag]) == "" {
+				return fmt.Errorf("entries[%d].source_overrides[%q] must not be empty", i, tag)
+			}
 		}
 		if !allowedStrategy(entry.Strategy) {
 			return fmt.Errorf("entries[%d].strategy must be one of copy, symlink, template", i)
@@ -807,6 +821,15 @@ func SelectionTags(profile Profile, extraTags []string) []string {
 		tags = append(tags, tag)
 	}
 	return tags
+}
+
+func EntrySource(entry Entry, selectionTags []string) string {
+	for i := len(selectionTags) - 1; i >= 0; i-- {
+		if source, ok := entry.SourceOverrides[selectionTags[i]]; ok {
+			return source
+		}
+	}
+	return entry.Source
 }
 
 func SharesTag(itemTags, profileTags []string) bool {

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -2993,6 +2993,8 @@ func TestRepositoryZellijConfigClassifiesPortableConfigSafely(t *testing.T) {
 		"manual prerequisite",
 		"America/Bogota",
 		"Sandbox validation",
+		"adaptive-theme",
+		"config-adaptive.kdl",
 	} {
 		if !strings.Contains(doc, want) {
 			t.Fatalf("Zellij config documentation missing %q:\n%s", want, doc)
@@ -3181,17 +3183,23 @@ func TestRepositoryManifestSourcesExist(t *testing.T) {
 	}
 
 	for i, entry := range got.Entries {
-		sourcePath := filepath.Join(root, entry.Source)
-		info, err := os.Stat(sourcePath)
-		if err != nil {
-			t.Fatalf("entries[%d].source %q does not exist at %s: %v", i, entry.Source, sourcePath, err)
+		sources := []string{entry.Source}
+		for _, override := range entry.SourceOverrides {
+			sources = append(sources, override)
 		}
-		// For symlink strategy a directory source is valid: dots creates a directory
-		// symlink at the target pointing at the source directory. For copy and
-		// template strategies the source must be a regular file because those
-		// strategies operate on file content.
-		if info.IsDir() && entry.Strategy != "symlink" {
-			t.Fatalf("entries[%d].source %q points to a directory, want a file for strategy %q", i, entry.Source, entry.Strategy)
+		for _, source := range sources {
+			sourcePath := filepath.Join(root, source)
+			info, err := os.Stat(sourcePath)
+			if err != nil {
+				t.Fatalf("entries[%d].source %q does not exist at %s: %v", i, source, sourcePath, err)
+			}
+			// For symlink strategy a directory source is valid: dots creates a directory
+			// symlink at the target pointing at the source directory. For copy and
+			// template strategies the source must be a regular file because those
+			// strategies operate on file content.
+			if info.IsDir() && entry.Strategy != "symlink" {
+				t.Fatalf("entries[%d].source %q points to a directory, want a file for strategy %q", i, source, entry.Strategy)
+			}
 		}
 	}
 }
@@ -3359,6 +3367,28 @@ func TestRepositoryManifestIncludesCoreDevelopmentBaselineDependencies(t *testin
 		if dep.Command != wantDep.command || dep.Brew != wantDep.brew || dep.Apt != wantDep.apt || dep.Dnf != wantDep.dnf || dep.Pacman != wantDep.pacman || dep.Toolchain != wantDep.toolchain || dep.LinuxHomebrew != wantDep.linuxBrew || !sameStrings(dep.Commands, wantDep.commands) {
 			t.Fatalf("%s dependency = %#v, want command %q, commands %#v, brew %q, apt %q, dnf %q, pacman %q, toolchain %q, linux_homebrew %v", name, *dep, wantDep.command, wantDep.commands, wantDep.brew, wantDep.apt, wantDep.dnf, wantDep.pacman, wantDep.toolchain, wantDep.linuxBrew)
 		}
+	}
+}
+
+func TestRepositoryNeovimColorschemeUsesSharedAdaptiveHelper(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", ".."))
+	path := filepath.Join(root, "configs/nvim/lua/plugins/colorscheme.lua")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+	config := string(data)
+	for _, want := range []string{
+		`/.config/dots/theme.sh`,
+		`dots_catppuccin_flavor`,
+		`catppuccin-" .. flavour`,
+	} {
+		if !strings.Contains(config, want) {
+			t.Fatalf("Neovim colorscheme config missing %q:\n%s", want, config)
+		}
+	}
+	if strings.Contains(config, `defaults read -g AppleInterfaceStyle`) {
+		t.Fatalf("Neovim colorscheme duplicates macOS defaults probing instead of using shared helper:\n%s", config)
 	}
 }
 

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -2719,7 +2719,8 @@ func TestRepositoryTmuxConfigClassifiesPortableConfigSafely(t *testing.T) {
 	for _, want := range []string{
 		"set -g @plugin 'tmux-plugins/tpm'",
 		"set -g @plugin 'catppuccin/tmux#v2.3.0'",
-		`defaults read -g AppleInterfaceStyle`,
+		`.config/dots/theme.sh`,
+		`dots_catppuccin_flavor`,
 		`set -g @catppuccin_flavor "latte"`,
 		`set -g @catppuccin_flavor "mocha"`,
 		`#{@thm_text}`,
@@ -2884,8 +2885,6 @@ func TestRepositoryZellijConfigClassifiesPortableConfigSafely(t *testing.T) {
 		`bind "Ctrl g" { SwitchToMode "normal"; }`,
 		`bind "Ctrl g" { SwitchToMode "locked"; }`,
 		`theme "catppuccin-mocha"`,
-		`theme_light "catppuccin-latte"`,
-		`theme_dark "catppuccin-mocha"`,
 		`default_mode "locked"`,
 		`mouse_mode true`,
 		`scroll_buffer_size 10000`,
@@ -2899,6 +2898,12 @@ func TestRepositoryZellijConfigClassifiesPortableConfigSafely(t *testing.T) {
 	} {
 		if !strings.Contains(config, want) {
 			t.Fatalf("managed Zellij config missing portable segment %q:\n%s", want, config)
+		}
+	}
+
+	for _, notWant := range []string{`theme_light "catppuccin-latte"`, `theme_dark "catppuccin-mocha"`} {
+		if strings.Contains(config, notWant) {
+			t.Fatalf("default Zellij config contains untagged adaptive segment %q:\n%s", notWant, config)
 		}
 	}
 
@@ -3013,12 +3018,14 @@ func TestRepositoryTmuxCatppuccinFlavorCondition(t *testing.T) {
 		uname        string
 		defaults     string
 		defaultsExit int
+		marker       bool
 		wantLatte    bool
 	}{
-		{name: "darwin light", uname: "Darwin", defaults: "", defaultsExit: 1, wantLatte: true},
-		{name: "darwin dark", uname: "Darwin", defaults: "Dark", wantLatte: false},
-		{name: "darwin unknown", uname: "Darwin", defaults: "Blue", wantLatte: false},
-		{name: "linux", uname: "Linux", defaults: "", wantLatte: false},
+		{name: "darwin light with opt-in marker", uname: "Darwin", defaults: "", defaultsExit: 1, marker: true, wantLatte: true},
+		{name: "darwin light without marker", uname: "Darwin", defaults: "", defaultsExit: 1, marker: false, wantLatte: false},
+		{name: "darwin dark with marker", uname: "Darwin", defaults: "Dark", marker: true, wantLatte: false},
+		{name: "darwin unknown with marker", uname: "Darwin", defaults: "Blue", marker: true, wantLatte: false},
+		{name: "linux with marker", uname: "Linux", defaults: "", marker: true, wantLatte: false},
 	}
 
 	for _, tt := range tests {
@@ -3027,7 +3034,10 @@ func TestRepositoryTmuxCatppuccinFlavorCondition(t *testing.T) {
 			writeExecutable(t, filepath.Join(bin, "uname"), "#!/bin/sh\nprintf '%s\\n' '"+tt.uname+"'\n")
 			writeDefaultsStub(t, filepath.Join(bin, "defaults"), tt.defaults, tt.defaultsExit)
 
-			gotLatte := shellConditionSucceeds(t, condition, bin)
+			home := t.TempDir()
+			installAdaptiveThemeHelperForCondition(t, root, home, tt.marker)
+
+			gotLatte := shellConditionSucceeds(t, condition, bin, home)
 			if gotLatte != tt.wantLatte {
 				t.Fatalf("condition selected latte = %v, want %v; condition: %s", gotLatte, tt.wantLatte, condition)
 			}
@@ -3038,7 +3048,10 @@ func TestRepositoryTmuxCatppuccinFlavorCondition(t *testing.T) {
 		bin := t.TempDir()
 		writeExecutable(t, filepath.Join(bin, "uname"), "#!/bin/sh\nprintf '%s\\n' 'Darwin'\n")
 
-		gotLatte := shellConditionSucceeds(t, condition, bin)
+		home := t.TempDir()
+		installAdaptiveThemeHelperForCondition(t, root, home, true)
+
+		gotLatte := shellConditionSucceeds(t, condition, bin, home)
 		if gotLatte {
 			t.Fatalf("condition selected latte when defaults(1) was unavailable; condition: %s", condition)
 		}
@@ -3061,12 +3074,32 @@ func tmuxIfShellCondition(config, marker string) (string, bool) {
 	return "", false
 }
 
-func shellConditionSucceeds(t *testing.T, condition, path string) bool {
+func shellConditionSucceeds(t *testing.T, condition, path, home string) bool {
 	t.Helper()
 	cmd := exec.Command("sh", "-c", condition)
-	cmd.Env = append(os.Environ(), "PATH="+path)
+	cmd.Env = append(os.Environ(), "PATH="+path, "HOME="+home)
 	err := cmd.Run()
 	return err == nil
+}
+
+func installAdaptiveThemeHelperForCondition(t *testing.T, root, home string, marker bool) {
+	t.Helper()
+	dir := filepath.Join(home, ".config", "dots")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", dir, err)
+	}
+	helper, err := os.ReadFile(filepath.Join(root, "configs", "dots", "theme.sh"))
+	if err != nil {
+		t.Fatalf("read theme helper: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "theme.sh"), helper, 0o755); err != nil {
+		t.Fatalf("write theme helper: %v", err)
+	}
+	if marker {
+		if err := os.WriteFile(filepath.Join(dir, "adaptive-theme"), []byte("adaptive-theme\n"), 0o644); err != nil {
+			t.Fatalf("write adaptive marker: %v", err)
+		}
+	}
 }
 
 func writeDefaultsStub(t *testing.T, path, output string, exitCode int) {
@@ -3326,5 +3359,74 @@ func TestRepositoryManifestIncludesCoreDevelopmentBaselineDependencies(t *testin
 		if dep.Command != wantDep.command || dep.Brew != wantDep.brew || dep.Apt != wantDep.apt || dep.Dnf != wantDep.dnf || dep.Pacman != wantDep.pacman || dep.Toolchain != wantDep.toolchain || dep.LinuxHomebrew != wantDep.linuxBrew || !sameStrings(dep.Commands, wantDep.commands) {
 			t.Fatalf("%s dependency = %#v, want command %q, commands %#v, brew %q, apt %q, dnf %q, pacman %q, toolchain %q, linux_homebrew %v", name, *dep, wantDep.command, wantDep.commands, wantDep.brew, wantDep.apt, wantDep.dnf, wantDep.pacman, wantDep.toolchain, wantDep.linuxBrew)
 		}
+	}
+}
+
+func TestDotsThemeHelperAdaptiveMatrix(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", ".."))
+	tests := []struct {
+		name       string
+		uname      string
+		defaults   string
+		exitCode   int
+		marker     bool
+		wantFlavor string
+	}{
+		{name: "tag present macOS light", uname: "Darwin", defaults: "", exitCode: 1, marker: true, wantFlavor: "latte"},
+		{name: "tag absent macOS light", uname: "Darwin", defaults: "", exitCode: 1, marker: false, wantFlavor: "mocha"},
+		{name: "tag present macOS dark", uname: "Darwin", defaults: "Dark", marker: true, wantFlavor: "mocha"},
+		{name: "tag present macOS unknown", uname: "Darwin", defaults: "Blue", marker: true, wantFlavor: "mocha"},
+		{name: "tag present Linux", uname: "Linux", defaults: "", marker: true, wantFlavor: "mocha"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bin := t.TempDir()
+			writeExecutable(t, filepath.Join(bin, "uname"), "#!/bin/sh\nprintf '%s\n' '"+tt.uname+"'\n")
+			writeDefaultsStub(t, filepath.Join(bin, "defaults"), tt.defaults, tt.exitCode)
+			home := t.TempDir()
+			installAdaptiveThemeHelperForCondition(t, root, home, tt.marker)
+
+			cmd := exec.Command("sh", "-c", `. "$HOME/.config/dots/theme.sh" && dots_catppuccin_flavor`)
+			cmd.Env = append(os.Environ(), "PATH="+bin, "HOME="+home)
+			out, err := cmd.Output()
+			if err != nil {
+				t.Fatalf("dots_catppuccin_flavor error = %v", err)
+			}
+			if got := strings.TrimSpace(string(out)); got != tt.wantFlavor {
+				t.Fatalf("flavor = %q, want %q", got, tt.wantFlavor)
+			}
+		})
+	}
+}
+
+func TestAgentStatuslinePalettesUseAdaptiveHelper(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", ".."))
+	for _, script := range []string{
+		"configs/claude/statusline-command.sh",
+		"configs/copilot/statusline-command.sh",
+	} {
+		t.Run(script, func(t *testing.T) {
+			bin := t.TempDir()
+			writeExecutable(t, filepath.Join(bin, "uname"), "#!/bin/sh\nprintf '%s\n' 'Darwin'\n")
+			writeDefaultsStub(t, filepath.Join(bin, "defaults"), "", 1)
+			writeExecutable(t, filepath.Join(bin, "jq"), `#!/bin/sh
+case "$*" in
+  *model*) printf 'opus\n' ;;
+esac
+`)
+			home := t.TempDir()
+			installAdaptiveThemeHelperForCondition(t, root, home, true)
+
+			cmd := exec.Command("bash", filepath.Join(root, script))
+			cmd.Env = append(os.Environ(), "PATH="+bin+string(os.PathListSeparator)+os.Getenv("PATH"), "HOME="+home)
+			cmd.Stdin = strings.NewReader(`{"model":{"display_name":"opus"}}`)
+			out, err := cmd.Output()
+			if err != nil {
+				t.Fatalf("%s error = %v", script, err)
+			}
+			if !strings.Contains(string(out), "\033[38;2;92;95;119m") {
+				t.Fatalf("%s did not use Latte subtext color with adaptive marker; output %q", script, out)
+			}
+		})
 	}
 }

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -86,20 +86,22 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 			continue
 		}
 
+		source := manifest.EntrySource(entry, tags)
 		target, err := ResolveTarget(entry.Target, opts.Home)
 		if err != nil {
 			return Plan{}, err
 		}
-		sourceAbs, err := ResolveSource(entry.Source, opts.SourceRoot)
+		sourceAbs, err := ResolveSource(source, opts.SourceRoot)
 		if err != nil {
 			return Plan{}, err
 		}
+		entry.Source = source
 		actionStatus, err := status(entry, target, sourceAbs, opts.SourceRoot, opts.Metadata)
 		if err != nil {
 			return Plan{}, err
 		}
 		plan.Actions = append(plan.Actions, Action{
-			Source:         entry.Source,
+			Source:         source,
 			ResolvedSource: sourceAbs,
 			Target:         target,
 			Strategy:       entry.Strategy,

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -714,6 +714,46 @@ func TestBuildSelection(t *testing.T) {
 	}
 }
 
+func TestBuildUsesSourceOverrideForSelectedExtraTag(t *testing.T) {
+	sourceRoot := t.TempDir()
+	home := t.TempDir()
+	writeSource(t, sourceRoot, "default.conf", "dark\n")
+	writeSource(t, sourceRoot, "adaptive.conf", "light\n")
+
+	m := manifest.Manifest{
+		Version: 1,
+		Profiles: map[string]manifest.Profile{
+			"default": {Tags: []string{"core"}},
+		},
+		Entries: []manifest.Entry{{
+			Source:          "default.conf",
+			SourceOverrides: map[string]string{"adaptive-theme": "adaptive.conf"},
+			Target:          "~/.config/app/config",
+			Strategy:        "symlink",
+			Tags:            []string{"core"},
+		}},
+	}
+
+	withoutTag, err := plan.Build(m, plan.Options{Profile: "default", OS: "darwin", SourceRoot: sourceRoot, Home: home})
+	if err != nil {
+		t.Fatalf("Build() without tag error = %v", err)
+	}
+	if got := withoutTag.Actions[0].Source; got != "default.conf" {
+		t.Fatalf("source without extra tag = %q, want default.conf", got)
+	}
+
+	withTag, err := plan.Build(m, plan.Options{Profile: "default", ExtraTags: []string{"adaptive-theme"}, OS: "darwin", SourceRoot: sourceRoot, Home: home})
+	if err != nil {
+		t.Fatalf("Build() with tag error = %v", err)
+	}
+	if got := withTag.Actions[0].Source; got != "adaptive.conf" {
+		t.Fatalf("source with adaptive-theme = %q, want adaptive.conf", got)
+	}
+	if len(withTag.Actions) != 1 {
+		t.Fatalf("len(Actions) with source override = %d, want 1", len(withTag.Actions))
+	}
+}
+
 func TestBuildRejectsUnknownProfile(t *testing.T) {
 	m := manifest.Manifest{
 		Version:  1,

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -92,7 +92,8 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options) (Report, erro
 			continue
 		}
 
-		evaluated := Entry{Source: entry.Source, Target: entry.Target, Strategy: entry.Strategy}
+		source := manifest.EntrySource(entry, tags)
+		evaluated := Entry{Source: source, Target: entry.Target, Strategy: entry.Strategy}
 		if !manifest.MatchesOS(entry.OS, opts.OS) {
 			evaluated.State = StateSkipped
 			report.Entries = append(report.Entries, evaluated)
@@ -108,6 +109,7 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options) (Report, erro
 			return Report{}, err
 		}
 
+		entry.Source = source
 		st, err := evaluate(entry, target, meta, opts.SourceRoot)
 		if err != nil {
 			return Report{}, err


### PR DESCRIPTION
Refs #275

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds an explicit `adaptive-theme` manifest tag with a shared dots marker/helper.
- Moves tmux, Neovim, Ghostty macOS, and Claude/Copilot statusline adaptive behavior behind the opt-in while preserving Mocha defaults.
- Documents audited tools and safe fallbacks; leaves Zellij/Claude app theme limitations explicit instead of duplicating/co-owning unsafe config.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Adds `configs/dots/theme.sh`, the `adaptive-theme` marker, and a Darwin-only Ghostty adaptive fragment. |
| `configs/dots/*` | Adds shared adaptive-theme marker and shell helper for macOS light detection plus Catppuccin ANSI palettes. |
| `configs/tmux/tmux.conf` | Uses the helper to select Latte only when opt-in + macOS light are true; otherwise Mocha. |
| `configs/nvim/lua/plugins/colorscheme.lua` | Selects `catppuccin-latte` only for opt-in macOS light, with Mocha fallback. |
| `configs/ghostty/*` | Defaults to Mocha; macOS opt-in fragment uses Ghostty native light/dark theme syntax. |
| `configs/claude/*`, `configs/copilot/*` | Statusline scripts source the shared helper and document fallback behavior. |
| `configs/zellij/*`, `docs/adaptive-theme-audit.md` | Removes untagged light/dark switching and documents the missing safe opt-in seam. |
| `internal/cli/ghostty_config_test.go`, `internal/manifest/manifest_test.go` | Adds regression coverage for tag selection, helper fallback matrix, tmux, statuslines, and docs/manifest invariants. |
| `docs/manifest.md` | Documents the `adaptive-theme` tag and managed entries. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots install --profile workstation --yes --home "$(mktemp -d)" --source-root "$PWD" --state-root "$(mktemp -d)" --dry-run` and default-plan check confirmed no `adaptive-theme` entries without the tag.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Refs #275`. This PR intentionally does not close #275 because Zellij/Claude app-theme seams need an explicit product decision/follow-up.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
