### PR TITLE
fix(ghostty): use valid catppuccin theme names

### DIFF
--- a/configs/ghostty/README.md
+++ b/configs/ghostty/README.md
@@ -41,7 +41,7 @@ Fresh installs keep the Mocha theme from `config.ghostty`. When the user selects
 `--tag adaptive-theme`, dots also installs
 `~/.config/ghostty/adaptive-theme.ghostty`, and the shared config includes it with
 `config-file = ?adaptive-theme.ghostty`. That fragment uses Ghostty's native
-`theme = light:catppuccin-latte,dark:catppuccin-mocha` syntax, so Ghostty follows
+`theme = light:Catppuccin Latte,dark:Catppuccin Mocha` syntax, so Ghostty follows
 the desktop appearance while keeping Mocha as the dark fallback. The optional
 include is absent unless the tag is selected, so default desktop installs do not
 change theme behavior.

--- a/configs/ghostty/adaptive/adaptive-theme.ghostty
+++ b/configs/ghostty/adaptive/adaptive-theme.ghostty
@@ -1,3 +1,3 @@
 # Installed only by the adaptive-theme tag. Ghostty uses the desktop appearance
 # to choose Catppuccin Latte in light mode and Mocha in dark mode.
-theme = light:catppuccin-latte,dark:catppuccin-mocha
+theme = light:Catppuccin Latte,dark:Catppuccin Mocha

--- a/configs/ghostty/config.ghostty
+++ b/configs/ghostty/config.ghostty
@@ -12,7 +12,7 @@ font-size = 20
 
 # Catppuccin Mocha is the default. The optional adaptive-theme include below
 # overrides this with Ghostty's native light/dark theme syntax.
-theme = catppuccin-mocha
+theme = Catppuccin Mocha
 
 # Installed only by `dots install --tag adaptive-theme`; absent by default so
 # Mocha/dark remains the fallback for fresh installs. Loaded after the fallback

--- a/docs/adaptive-theme-audit.md
+++ b/docs/adaptive-theme-audit.md
@@ -15,8 +15,8 @@ slice.
   `@catppuccin_flavor`. Missing helper/marker, macOS dark, Linux, unknown values,
   or missing `defaults` fall back to Mocha.
 - **Ghostty**: default `configs/ghostty/config.ghostty` uses `theme =
-  catppuccin-mocha`. On macOS, the tag installs `adaptive-theme.ghostty`, which uses
-  Ghostty's native `theme = light:catppuccin-latte,dark:catppuccin-mocha` form.
+  Catppuccin Mocha`. On macOS, the tag installs `adaptive-theme.ghostty`, which uses
+  Ghostty's native `theme = light:Catppuccin Latte,dark:Catppuccin Mocha` form.
 - **Neovim**: `lua/plugins/colorscheme.lua` selects `catppuccin-latte` only when
   the marker exists and macOS light appearance is proven; otherwise it uses
   `catppuccin-mocha`.

--- a/internal/cli/ghostty_config_test.go
+++ b/internal/cli/ghostty_config_test.go
@@ -66,6 +66,7 @@ func TestGhosttyDesktopProfileInstallsAndReportsAlignedInSandbox(t *testing.T) {
 	for _, want := range []string{
 		`font-family = "Cascadia Code NF"`,
 		"font-size = 20",
+		"theme = Catppuccin Mocha",
 		"config-file = ?adaptive-theme.ghostty",
 	} {
 		if !strings.Contains(string(managedConfig), want) {
@@ -201,8 +202,13 @@ func TestAdaptiveThemeTagInstallsMarkerAndGhosttyFragmentInSandbox(t *testing.T)
 	if err != nil {
 		t.Fatalf("read Ghostty adaptive fragment: %v", err)
 	}
-	if !strings.Contains(string(fragment), "theme = light:catppuccin-latte,dark:catppuccin-mocha") {
+	if !strings.Contains(string(fragment), "theme = light:Catppuccin Latte,dark:Catppuccin Mocha") {
 		t.Fatalf("Ghostty adaptive fragment does not use native light/dark theme syntax\ncontent:\n%s", fragment)
+	}
+	for _, invalidName := range []string{"catppuccin-latte", "catppuccin-mocha"} {
+		if strings.Contains(string(fragment), invalidName) {
+			t.Fatalf("Ghostty adaptive fragment uses invalid built-in theme name %q\ncontent:\n%s", invalidName, fragment)
+		}
 	}
 	if runtime.GOOS != "darwin" {
 		if _, err := os.Lstat(ghosttyAdaptiveTarget); !os.IsNotExist(err) {


### PR DESCRIPTION
Closes #277

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Fixes Ghostty adaptive theme validation by using Ghostty's exact built-in Catppuccin theme names.
- Keeps the adaptive-theme tag behavior unchanged: Latte in light mode, Mocha in dark mode.
- Adds regression coverage so lowercase hyphenated Ghostty theme names do not return.

## Changes

| File | Change |
|------|--------|
| `configs/ghostty/config.ghostty` | Uses `Catppuccin Mocha`, matching Ghostty's built-in theme name. |
| `configs/ghostty/adaptive/adaptive-theme.ghostty` | Uses `Catppuccin Latte` / `Catppuccin Mocha` in native light/dark syntax. |
| `internal/cli/ghostty_config_test.go` | Asserts valid display names and rejects invalid lowercase hyphenated Ghostty names. |
| `configs/ghostty/README.md` | Documents the corrected Ghostty syntax. |
| `docs/adaptive-theme-audit.md` | Updates the Ghostty audit entry. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile desktop --tag adaptive-theme --source-root "$PWD" --home <tmp> --output json`
- [x] `ghostty +validate-config --config-file="$PWD/configs/ghostty/config.ghostty"`
- [x] `ghostty +validate-config --config-file="$PWD/configs/ghostty/adaptive/adaptive-theme.ghostty"`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #277`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
