### PR TITLE
fix(tmux): reset stale Catppuccin palette

### DIFF
--- a/configs/tmux/README.md
+++ b/configs/tmux/README.md
@@ -32,7 +32,9 @@ selection is opt-in: install or update with `--tag adaptive-theme`, which places
 when macOS light appearance is proven with `defaults read -g AppleInterfaceStyle`;
 macOS dark mode, non-macOS hosts, a missing `defaults` command, or unknown values
 fall back to Mocha. Re-source `~/.tmux.conf` or restart Tmux after changing the
-system appearance or opt-in marker.
+system appearance or opt-in marker. During re-source, the config resets
+Catppuccin/tmux's generated palette and status-module defaults before rebuilding
+the status line, so stale Latte colors cannot survive a switch back to Mocha.
 
 Custom window-status formats use Catppuccin theme variables instead of fixed
 Mocha hex values so the same status bar adapts to Latte or Mocha. The right-side

--- a/configs/tmux/tmux.conf
+++ b/configs/tmux/tmux.conf
@@ -41,20 +41,6 @@ set -g @plugin 'catppuccin/tmux#v2.3.0'
 # marker is absent, or when the appearance cannot be proven to be macOS light,
 # keep the portable Mocha fallback.
 if-shell '[ -r "$HOME/.config/dots/theme.sh" ] && . "$HOME/.config/dots/theme.sh" && [ "$(dots_catppuccin_flavor)" = "latte" ]' 'set -g @catppuccin_flavor "latte"' 'set -g @catppuccin_flavor "mocha"'
-set -g @catppuccin_window_status_style "rounded"
-set -g @catppuccin_status_background "default"
-set -g @catppuccin_status_connect_separator "yes"
-set -g @catppuccin_status_fill "icon"
-# Catppuccin/tmux defaults status module icon foregrounds to @thm_crust.
-# That works in Mocha, where crust is dark, but Latte crust is a pale color and
-# makes the right-side glyphs hard to read on accent backgrounds. Keep Mocha's
-# default and switch Latte status icons to the darker foreground color.
-set -g @dots_catppuccin_status_icon_fg "#{?#{==:#{@catppuccin_flavor},latte},#{@thm_fg},#{@thm_crust}}"
-set -g @catppuccin_status_directory_icon_fg "#{E:@dots_catppuccin_status_icon_fg}"
-set -g @catppuccin_status_cpu_icon_fg "#{E:@dots_catppuccin_status_icon_fg}"
-set -g @catppuccin_status_ram_icon_fg "#{E:@dots_catppuccin_status_icon_fg}"
-set -g @catppuccin_status_session_icon_fg "#{E:@dots_catppuccin_status_icon_fg}"
-set -g @catppuccin_status_uptime_icon_fg "#{E:@dots_catppuccin_status_icon_fg}"
 
 # Floating window
 bind-key -n M-g if-shell -F '#{==:#{session_name},scratch}' {
@@ -111,7 +97,63 @@ set -g status-right-length 100
 set -g status-left-length 100
 
 # Catppuccin status line
-# The theme must be loaded before expanding its status modules.
+# Catppuccin/tmux uses set -o for palette and module defaults. Prime the plugin
+# with its documented reset flag before applying dots' custom options so
+# re-sourcing after a light/dark appearance change cannot keep stale Latte
+# colors when @catppuccin_flavor has switched back to mocha. The second load
+# below regenerates the status modules with the reset palette plus dots options.
+set -g @catppuccin_reset "true"
+if-shell '[ -f "$HOME/.tmux/plugins/tmux/catppuccin.tmux" ]' 'run "$HOME/.tmux/plugins/tmux/catppuccin.tmux"'
+
+# Catppuccin/tmux also keeps module defaults with set -o. Clear the generated
+# defaults for the modules dots renders so their icon/text colors are rebuilt
+# from the freshly reset palette below.
+set -gu @catppuccin_directory_color
+set -gu @catppuccin_cpu_color
+set -gu @catppuccin_ram_color
+set -gu @catppuccin_session_color
+set -gu @catppuccin_uptime_color
+set -gu @catppuccin_status_directory_icon_bg
+set -gu @catppuccin_status_cpu_icon_bg
+set -gu @catppuccin_status_ram_icon_bg
+set -gu @catppuccin_status_session_icon_bg
+set -gu @catppuccin_status_uptime_icon_bg
+set -gu @catppuccin_status_directory_icon_fg
+set -gu @catppuccin_status_cpu_icon_fg
+set -gu @catppuccin_status_ram_icon_fg
+set -gu @catppuccin_status_session_icon_fg
+set -gu @catppuccin_status_uptime_icon_fg
+set -gu @catppuccin_status_directory_text_fg
+set -gu @catppuccin_status_cpu_text_fg
+set -gu @catppuccin_status_ram_text_fg
+set -gu @catppuccin_status_session_text_fg
+set -gu @catppuccin_status_uptime_text_fg
+set -gu @catppuccin_status_directory_text_bg
+set -gu @catppuccin_status_cpu_text_bg
+set -gu @catppuccin_status_ram_text_bg
+set -gu @catppuccin_status_session_text_bg
+set -gu @catppuccin_status_uptime_text_bg
+set -gu @cpu_low_bg_color
+set -gu @cpu_medium_bg_color
+set -gu @ram_low_bg_color
+set -gu @ram_medium_bg_color
+
+set -g @catppuccin_window_status_style "rounded"
+set -g @catppuccin_status_background "default"
+set -g @catppuccin_status_connect_separator "yes"
+set -g @catppuccin_status_fill "icon"
+# Catppuccin/tmux defaults status module icon foregrounds to @thm_crust.
+# That works in Mocha, where crust is dark, but Latte crust is a pale color and
+# makes the right-side glyphs hard to read on accent backgrounds. Keep Mocha's
+# default and switch Latte status icons to the darker foreground color.
+set -g @dots_catppuccin_status_icon_fg "#{?#{==:#{@catppuccin_flavor},latte},#{@thm_fg},#{@thm_crust}}"
+set -g @catppuccin_status_directory_icon_fg "#{E:@dots_catppuccin_status_icon_fg}"
+set -g @catppuccin_status_cpu_icon_fg "#{E:@dots_catppuccin_status_icon_fg}"
+set -g @catppuccin_status_ram_icon_fg "#{E:@dots_catppuccin_status_icon_fg}"
+set -g @catppuccin_status_session_icon_fg "#{E:@dots_catppuccin_status_icon_fg}"
+set -g @catppuccin_status_uptime_icon_fg "#{E:@dots_catppuccin_status_icon_fg}"
+
+# The theme must be loaded after custom options before expanding its status modules.
 if-shell '[ -f "$HOME/.tmux/plugins/tmux/catppuccin.tmux" ]' 'run "$HOME/.tmux/plugins/tmux/catppuccin.tmux"'
 set -g status-left ""
 # Show the active pane directory on the right instead of repeating the current

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -2726,6 +2726,7 @@ func TestRepositoryTmuxConfigClassifiesPortableConfigSafely(t *testing.T) {
 		`@dots_catppuccin_status_icon_fg`,
 		`@catppuccin_status_directory_icon_fg`,
 		`#{E:@dots_catppuccin_status_icon_fg}`,
+		`set -g @catppuccin_reset "true"`,
 		`#{@thm_text}`,
 		"set -g prefix C-a",
 		"set -g mode-keys vi",
@@ -3001,6 +3002,75 @@ func TestRepositoryZellijConfigClassifiesPortableConfigSafely(t *testing.T) {
 	} {
 		if !strings.Contains(doc, want) {
 			t.Fatalf("Zellij config documentation missing %q:\n%s", want, doc)
+		}
+	}
+}
+
+func TestRepositoryTmuxConfigResetsGeneratedCatppuccinStateBeforeReload(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", ".."))
+	managedPath := filepath.Join(root, "configs/tmux/tmux.conf")
+	managedBytes, err := os.ReadFile(managedPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", managedPath, err)
+	}
+	managed := string(managedBytes)
+
+	resetLine := `set -g @catppuccin_reset "true"`
+	resetIndex := strings.Index(managed, resetLine)
+	if resetIndex == -1 {
+		t.Fatalf("managed tmux config missing Catppuccin reset line %q:\n%s", resetLine, managed)
+	}
+
+	firstLoadLine := `run "$HOME/.tmux/plugins/tmux/catppuccin.tmux"`
+	firstLoadIndex := strings.Index(managed[resetIndex:], firstLoadLine)
+	if firstLoadIndex == -1 {
+		t.Fatalf("managed tmux config does not load Catppuccin after reset:\n%s", managed)
+	}
+	firstLoadIndex += resetIndex
+
+	for _, generated := range []string{
+		`set -gu @catppuccin_directory_color`,
+		`set -gu @catppuccin_status_directory_icon_bg`,
+		`set -gu @catppuccin_status_directory_text_fg`,
+		`set -gu @catppuccin_status_uptime_text_bg`,
+		`set -gu @cpu_low_bg_color`,
+		`set -gu @ram_medium_bg_color`,
+	} {
+		generatedIndex := strings.Index(managed, generated)
+		if generatedIndex == -1 {
+			t.Fatalf("managed tmux config missing generated module reset %q", generated)
+		}
+		if generatedIndex < firstLoadIndex {
+			t.Fatalf("generated module reset %q occurs before Catppuccin reset load", generated)
+		}
+	}
+
+	customLine := `set -g @catppuccin_status_directory_icon_fg`
+	customIndex := strings.Index(managed, customLine)
+	if customIndex == -1 {
+		t.Fatalf("managed tmux config missing custom Catppuccin option %q", customLine)
+	}
+	if customIndex < firstLoadIndex {
+		t.Fatalf("custom Catppuccin options are set before reset load; reset would discard them")
+	}
+
+	secondLoadIndex := strings.Index(managed[firstLoadIndex+len(firstLoadLine):], firstLoadLine)
+	if secondLoadIndex == -1 {
+		t.Fatalf("managed tmux config does not reload Catppuccin after custom options:\n%s", managed)
+	}
+	secondLoadIndex += firstLoadIndex + len(firstLoadLine)
+	if secondLoadIndex < customIndex {
+		t.Fatalf("Catppuccin reload occurs before custom options; generated modules may ignore dots options")
+	}
+
+	for _, preserved := range []string{
+		`set -g @catppuccin_window_status_style "rounded"`,
+		`set -g @catppuccin_status_background "default"`,
+		`set -g @catppuccin_status_directory_icon_fg`,
+		`set -g @catppuccin_status_uptime_icon_fg`,
+	} {
+		if !strings.Contains(managed, preserved) {
+			t.Fatalf("managed tmux config missing custom Catppuccin option %q", preserved)
 		}
 	}
 }


### PR DESCRIPTION
Closes #281

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Resets Catppuccin/tmux generated state when the managed tmux config is re-sourced after an adaptive light/dark switch.
- Clears generated defaults for the dots-rendered status modules before rebuilding them with the current palette.
- Documents the stale-palette behavior and adds regression coverage for reset/reload ordering.

## Changes

| File | Change |
|------|--------|
| `configs/tmux/tmux.conf` | Primes Catppuccin/tmux with `@catppuccin_reset`, clears generated module defaults for directory/CPU/RAM/session/uptime, reapplies dots options, and reloads the plugin. |
| `configs/tmux/README.md` | Documents that re-source rebuilds Catppuccin generated state so stale Latte colors do not survive Mocha switches. |
| `internal/manifest/manifest_test.go` | Adds regression coverage for the Catppuccin reset/reload ordering and generated module default cleanup. |

## Test Plan

- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile default --source-root "$PWD" --home <tmp>`
- [x] Sandboxed tmux light→dark re-source: verified `@catppuccin_flavor=mocha`, `@thm_crust=#11111b`, `@thm_rosewater=#f5e0dc`, and directory status module expands with Mocha colors.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #281`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
