### PR TITLE
fix(agents): sync Engram protocol into Copilot CLI

### DIFF
--- a/configs/copilot/README.md
+++ b/configs/copilot/README.md
@@ -3,7 +3,9 @@
 Copilot CLI reads global custom instructions from
 `~/.copilot/copilot-instructions.md`. `gentle-ai` currently supports
 `vscode-copilot`, not Copilot CLI, so dots converges that file after the
-`vscode-copilot` provisioner runs and injects the shared dots agent rules there.
+`vscode-copilot` provisioner runs, injects the shared dots agent rules there,
+and syncs the `gentle-ai:engram-protocol` block from the VS Code Copilot prompt
+instructions so Engram behavior works in Copilot CLI too.
 
 `statusline-command.sh` uses Catppuccin Mocha by default and switches its ANSI
 palette to Catppuccin Latte only when the shared dots `adaptive-theme` marker is

--- a/internal/agentinstructions/trigger_rules.go
+++ b/internal/agentinstructions/trigger_rules.go
@@ -15,6 +15,8 @@ const (
 	gentleAITriggerRulesEnd    = "<!-- /gentle-ai:trigger-rules -->"
 	gentleAIPersonaStart       = "<!-- gentle-ai:persona -->"
 	gentleAIPersonaEnd         = "<!-- /gentle-ai:persona -->"
+	gentleAIEngramStart        = "<!-- gentle-ai:engram-protocol -->"
+	gentleAIEngramEnd          = "<!-- /gentle-ai:engram-protocol -->"
 	dotsRulesStart             = "<!-- dots:rules -->"
 	dotsRulesEnd               = "<!-- /dots:rules -->"
 	codexDelegationStart       = "<!-- dots:codex-spark-delegation -->"
@@ -84,6 +86,40 @@ func ConvergeDotsAgentRules(home string, agents ...string) error {
 		if err := convergeDotsRules(target.path); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// SyncCopilotCLIEngramProtocol copies the gentle-ai generated Engram protocol
+// for vscode-copilot into Copilot CLI's global instruction file. gentle-ai does
+// not write Copilot CLI instructions directly, but the protocol is portable
+// Markdown and required for the same Engram behavior in Copilot CLI.
+func SyncCopilotCLIEngramProtocol(home string) error {
+	sourceBlock, ok, err := firstMarkedBlock(
+		textblock.Markers{Start: gentleAIEngramStart, End: gentleAIEngramEnd},
+		filepath.Join(home, "Library", "Application Support", "Code", "User", "prompts", "gentle-ai.instructions.md"),
+		filepath.Join(home, ".config", "Code", "User", "prompts", "gentle-ai.instructions.md"),
+	)
+	if err != nil || !ok {
+		return err
+	}
+	target := filepath.Join(home, ".copilot", "copilot-instructions.md")
+	content, mode, err := readInstructionFile(target)
+	if err != nil {
+		return err
+	}
+	updated, err := textblock.Upsert(content, textblock.Markers{Start: gentleAIEngramStart, End: gentleAIEngramEnd}, sourceBlock)
+	if err != nil {
+		return fmt.Errorf("upsert gentle-ai Engram protocol in %s: %w", target, err)
+	}
+	if updated == content {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return fmt.Errorf("mkdir Copilot CLI instructions %s: %w", filepath.Dir(target), err)
+	}
+	if err := os.WriteFile(target, []byte(updated), mode); err != nil {
+		return fmt.Errorf("write Copilot CLI instructions %s: %w", target, err)
 	}
 	return nil
 }
@@ -269,6 +305,39 @@ func readInstructionFile(path string) (string, os.FileMode, error) {
 		return "", 0, fmt.Errorf("stat agent instructions %s: %w", path, err)
 	}
 	return string(content), info.Mode().Perm(), nil
+}
+
+func firstMarkedBlock(markers textblock.Markers, paths ...string) (string, bool, error) {
+	for _, path := range paths {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return "", false, fmt.Errorf("read agent instructions %s: %w", path, err)
+		}
+		block, ok, err := markedBlockBody(string(content), markers)
+		if err != nil {
+			return "", false, fmt.Errorf("read marked block from %s: %w", path, err)
+		}
+		if ok {
+			return block, true, nil
+		}
+	}
+	return "", false, nil
+}
+
+func markedBlockBody(content string, markers textblock.Markers) (string, bool, error) {
+	start := strings.Index(content, markers.Start)
+	if start < 0 {
+		return "", false, nil
+	}
+	bodyStart := start + len(markers.Start)
+	end := strings.Index(content[bodyStart:], markers.End)
+	if end < 0 {
+		return "", false, fmt.Errorf("marker %q is missing closing marker %q", markers.Start, markers.End)
+	}
+	return strings.TrimSpace(content[bodyStart : bodyStart+end]), true, nil
 }
 
 func removeLegacyMarkerlessPersona(content string) string {

--- a/internal/agentinstructions/trigger_rules.go
+++ b/internal/agentinstructions/trigger_rules.go
@@ -316,7 +316,7 @@ func firstMarkedBlock(markers textblock.Markers, paths ...string) (string, bool,
 			}
 			return "", false, fmt.Errorf("read agent instructions %s: %w", path, err)
 		}
-		block, ok, err := markedBlockBody(string(content), markers)
+		block, ok, err := textblock.ExtractBody(string(content), markers)
 		if err != nil {
 			return "", false, fmt.Errorf("read marked block from %s: %w", path, err)
 		}
@@ -325,19 +325,6 @@ func firstMarkedBlock(markers textblock.Markers, paths ...string) (string, bool,
 		}
 	}
 	return "", false, nil
-}
-
-func markedBlockBody(content string, markers textblock.Markers) (string, bool, error) {
-	start := strings.Index(content, markers.Start)
-	if start < 0 {
-		return "", false, nil
-	}
-	bodyStart := start + len(markers.Start)
-	end := strings.Index(content[bodyStart:], markers.End)
-	if end < 0 {
-		return "", false, fmt.Errorf("marker %q is missing closing marker %q", markers.Start, markers.End)
-	}
-	return strings.TrimSpace(content[bodyStart : bodyStart+end]), true, nil
 }
 
 func removeLegacyMarkerlessPersona(content string) string {

--- a/internal/agentinstructions/trigger_rules_test.go
+++ b/internal/agentinstructions/trigger_rules_test.go
@@ -132,6 +132,51 @@ func TestConvergeDotsAgentRulesPreservesCustomPersonalitySection(t *testing.T) {
 	}
 }
 
+func TestSyncCopilotCLIEngramProtocolCopiesVSCodePromptBlock(t *testing.T) {
+	home := t.TempDir()
+	source := filepath.Join(home, "Library", "Application Support", "Code", "User", "prompts", "gentle-ai.instructions.md")
+	target := filepath.Join(home, ".copilot", "copilot-instructions.md")
+	if err := os.MkdirAll(filepath.Dir(source), 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	sourceContent := "prefix\n\n" +
+		gentleAIEngramStart + "\n## Engram Persistent Memory — Protocol\n\nUse Engram proactively.\n" + gentleAIEngramEnd +
+		"\n\nsuffix\n"
+	if err := os.WriteFile(source, []byte(sourceContent), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("existing\n\n"+dotsRulesStart+"\n"+dotsRulesBlock+"\n"+dotsRulesEnd+"\n"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	if err := SyncCopilotCLIEngramProtocol(home); err != nil {
+		t.Fatalf("SyncCopilotCLIEngramProtocol() error = %v", err)
+	}
+	if err := SyncCopilotCLIEngramProtocol(home); err != nil {
+		t.Fatalf("SyncCopilotCLIEngramProtocol() second run error = %v", err)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	out := string(got)
+	for _, want := range []string{"existing", dotsRulesStart, "Keep diffs surgical", gentleAIEngramStart, "## Engram Persistent Memory — Protocol", "Use Engram proactively.", gentleAIEngramEnd} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("Copilot CLI instructions missing %q\n%s", want, out)
+		}
+	}
+	if strings.Count(out, gentleAIEngramStart) != 1 || strings.Count(out, gentleAIEngramEnd) != 1 {
+		t.Fatalf("Engram block should be present once\n%s", out)
+	}
+	if strings.Contains(out, "prefix") || strings.Contains(out, "suffix") {
+		t.Fatalf("sync should copy only the marked Engram block body\n%s", out)
+	}
+}
+
 func TestConvergeCodexSparkDelegationIsOptInCodexOnly(t *testing.T) {
 	home := t.TempDir()
 

--- a/internal/cli/claude_config_test.go
+++ b/internal/cli/claude_config_test.go
@@ -49,13 +49,20 @@ stale review-readability rule
 
 after
 '
+engram='
+<!-- gentle-ai:engram-protocol -->
+## Engram Persistent Memory — Protocol
+
+Use Engram proactively in Copilot CLI too.
+<!-- /gentle-ai:engram-protocol -->
+'
 mkdir -p "$HOME/.codex" "$HOME/.claude" "$HOME/.config/opencode" "$HOME/.gemini" "$HOME/Library/Application Support/Code/User/prompts" "$HOME/.config/Code/User/prompts"
 printf '%s' "$block" > "$HOME/.codex/AGENTS.md"
 printf '%s' "$block" > "$HOME/.claude/CLAUDE.md"
 printf '%s' "$block" > "$HOME/.config/opencode/AGENTS.md"
 printf '%s' "$block" > "$HOME/.gemini/GEMINI.md"
-printf '%s' "$block" > "$HOME/Library/Application Support/Code/User/prompts/gentle-ai.instructions.md"
-printf '%s' "$block" > "$HOME/.config/Code/User/prompts/gentle-ai.instructions.md"
+printf '%s%s' "$block" "$engram" > "$HOME/Library/Application Support/Code/User/prompts/gentle-ai.instructions.md"
+printf '%s%s' "$block" "$engram" > "$HOME/.config/Code/User/prompts/gentle-ai.instructions.md"
 `)
 	writeExecStub(t, filepath.Join(stubDir, "engram"), "#!/bin/sh\nexit 0\n")
 	writeExecStub(t, filepath.Join(stubDir, "codegraph"), "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$HOME/codegraph-args\"\n")
@@ -274,6 +281,15 @@ printf '%s' "$block" > "$HOME/.config/Code/User/prompts/gentle-ai.instructions.m
 			if !strings.Contains(string(got), want) {
 				t.Fatalf("agent instructions %s missing dots rules content %q\ncontent:\n%s", path, want, got)
 			}
+		}
+	}
+	copilotInstructions, err := os.ReadFile(filepath.Join(home, ".copilot", "copilot-instructions.md"))
+	if err != nil {
+		t.Fatalf("read Copilot CLI instructions: %v", err)
+	}
+	for _, want := range []string{"<!-- gentle-ai:engram-protocol -->", "## Engram Persistent Memory", "Use Engram proactively in Copilot CLI too.", "<!-- /gentle-ai:engram-protocol -->"} {
+		if !strings.Contains(string(copilotInstructions), want) {
+			t.Fatalf("Copilot CLI instructions missing synced gentle-ai Engram protocol %q\ncontent:\n%s", want, copilotInstructions)
 		}
 	}
 	// And it must never have escaped into the inherited real HOME.

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -457,6 +457,11 @@ func runProvisioners(cmd *cobra.Command, m manifest.Manifest, profiles []string,
 			if cleanupErr := agentinstructions.ConvergeDotsAgentRules(home, agents...); cleanupErr != nil {
 				return report, errors.Join(err, cleanupErr)
 			}
+			if includesString(agents, "vscode-copilot") {
+				if syncErr := agentinstructions.SyncCopilotCLIEngramProtocol(home); syncErr != nil {
+					return report, errors.Join(err, syncErr)
+				}
+			}
 		}
 	}
 	selectedTags := report.Tags
@@ -512,6 +517,15 @@ func selectedGentleAIAgents(selected []manifest.Provisioner) []string {
 		}
 	}
 	return agents
+}
+
+func includesString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func selectedCodeGraphAgents(selected []manifest.Provisioner) []string {

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -457,7 +457,7 @@ func runProvisioners(cmd *cobra.Command, m manifest.Manifest, profiles []string,
 			if cleanupErr := agentinstructions.ConvergeDotsAgentRules(home, agents...); cleanupErr != nil {
 				return report, errors.Join(err, cleanupErr)
 			}
-			if includesString(agents, "vscode-copilot") {
+			if containsString(agents, "vscode-copilot") {
 				if syncErr := agentinstructions.SyncCopilotCLIEngramProtocol(home); syncErr != nil {
 					return report, errors.Join(err, syncErr)
 				}
@@ -465,11 +465,11 @@ func runProvisioners(cmd *cobra.Command, m manifest.Manifest, profiles []string,
 		}
 	}
 	selectedTags := report.Tags
-	if hasTag(selectedTags, "without-codex-spark-delegation") {
+	if containsString(selectedTags, "without-codex-spark-delegation") {
 		if cleanupErr := agentinstructions.RemoveCodexSparkDelegation(home); cleanupErr != nil {
 			return report, errors.Join(err, cleanupErr)
 		}
-	} else if hasTag(selectedTags, "codex-spark-delegation") {
+	} else if containsString(selectedTags, "codex-spark-delegation") {
 		if cleanupErr := agentinstructions.ConvergeCodexSparkDelegation(home); cleanupErr != nil {
 			return report, errors.Join(err, cleanupErr)
 		}
@@ -483,9 +483,9 @@ func runProvisioners(cmd *cobra.Command, m manifest.Manifest, profiles []string,
 	return report, nil
 }
 
-func hasTag(tags []string, want string) bool {
-	for _, tag := range tags {
-		if tag == want {
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
 			return true
 		}
 	}
@@ -517,15 +517,6 @@ func selectedGentleAIAgents(selected []manifest.Provisioner) []string {
 		}
 	}
 	return agents
-}
-
-func includesString(values []string, want string) bool {
-	for _, value := range values {
-		if value == want {
-			return true
-		}
-	}
-	return false
 }
 
 func selectedCodeGraphAgents(selected []manifest.Provisioner) []string {

--- a/internal/textblock/textblock.go
+++ b/internal/textblock/textblock.go
@@ -49,6 +49,23 @@ func Upsert(content string, primary Markers, block string, legacy ...Markers) (s
 	return b.String(), nil
 }
 
+// ExtractBody returns the trimmed body of the first marker-delimited block.
+func ExtractBody(content string, markers Markers) (string, bool, error) {
+	if markers.Start == "" || markers.End == "" {
+		return "", false, fmt.Errorf("markers are required")
+	}
+	start := strings.Index(content, markers.Start)
+	if start < 0 {
+		return "", false, nil
+	}
+	bodyStart := start + len(markers.Start)
+	end := strings.Index(content[bodyStart:], markers.End)
+	if end < 0 {
+		return "", false, fmt.Errorf("marker %q is missing closing marker %q", markers.Start, markers.End)
+	}
+	return strings.TrimSpace(content[bodyStart : bodyStart+end]), true, nil
+}
+
 // Remove deletes every marker-delimited block matching the provided markers.
 func Remove(content string, markers ...Markers) (string, error) {
 	if len(markers) == 0 {

--- a/internal/textblock/textblock_test.go
+++ b/internal/textblock/textblock_test.go
@@ -56,3 +56,28 @@ func TestUpsertInsertsUpdatesAndMigratesBlocks(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractBodyReturnsTrimmedMarkedBlock(t *testing.T) {
+	markers := Markers{Start: "<!-- dots:block -->", End: "<!-- /dots:block -->"}
+	content := "prefix\n" + markers.Start + "\n\nbody\n\n" + markers.End + "\nsuffix\n"
+
+	got, ok, err := ExtractBody(content, markers)
+	if err != nil {
+		t.Fatalf("ExtractBody() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("ExtractBody() ok = false, want true")
+	}
+	if got != "body" {
+		t.Fatalf("ExtractBody() = %q, want %q", got, "body")
+	}
+}
+
+func TestExtractBodyReportsMissingClosingMarker(t *testing.T) {
+	markers := Markers{Start: "<!-- dots:block -->", End: "<!-- /dots:block -->"}
+
+	_, _, err := ExtractBody(markers.Start+"\nbody\n", markers)
+	if err == nil {
+		t.Fatal("ExtractBody() error = nil, want missing closing marker error")
+	}
+}


### PR DESCRIPTION
Closes #287

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Syncs the gentle-ai generated Engram protocol into Copilot CLI instructions after the `vscode-copilot` provisioner runs.
- Preserves the existing dots-managed rules block in `~/.copilot/copilot-instructions.md`.
- Covers the sync with unit and sandboxed install tests.

## Changes

| File | Change |
|------|--------|
| `internal/agentinstructions/trigger_rules.go` | Adds Engram protocol extraction from VS Code Copilot prompt files and upsert into Copilot CLI instructions. |
| `internal/cli/install.go` | Runs the Copilot CLI Engram sync after selected gentle-ai `vscode-copilot` provisioners complete. |
| `internal/agentinstructions/trigger_rules_test.go` | Verifies idempotent sync of only the marked Engram protocol block. |
| `internal/cli/claude_config_test.go` | Extends sandboxed agents-profile install coverage for Copilot CLI Engram instructions. |
| `configs/copilot/README.md` | Documents the Copilot CLI Engram sync behavior. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile core --source-root "$PWD" --home <tmp>`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #287`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
