### PR TITLE
fix(tmux): preserve truecolor hint for TUI themes

### DIFF
--- a/configs/tmux/tmux.conf
+++ b/configs/tmux/tmux.conf
@@ -53,6 +53,9 @@ bind-key -n M-g if-shell -F '#{==:#{session_name},scratch}' {
 # --- terminal & key handling ---
 set -g default-terminal "tmux-256color"
 set -as terminal-features ",*:RGB"
+# Panes use TERM=tmux-256color, whose system terminfo may not advertise RGB.
+# Export the conventional truecolor hint so TUIs can keep Catppuccin colors.
+set-environment -g COLORTERM "truecolor"
 set -as terminal-features ",*:usstyle"
 set -as terminal-features ",*:hyperlinks"
 

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -2732,6 +2732,7 @@ func TestRepositoryTmuxConfigClassifiesPortableConfigSafely(t *testing.T) {
 		"set -g prefix C-a",
 		"set -g mode-keys vi",
 		"set -g status-position top",
+		`set-environment -g COLORTERM "truecolor"`,
 		"display-popup",
 		"source-file ~/.tmux.conf.local",
 	} {


### PR DESCRIPTION
Closes #291

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Preserve the conventional `COLORTERM=truecolor` hint inside managed tmux panes.
- Keep Neovim, Codex, and other TUIs from degrading theme/color detection when `TERM=tmux-256color` lacks RGB terminfo capabilities.
- Guard the managed tmux setting in the manifest portability test.

## Changes

| File | Change |
|------|--------|
| `configs/tmux/tmux.conf` | Exports `COLORTERM=truecolor` from tmux so panes advertise truecolor support to TUIs. |
| `internal/manifest/manifest_test.go` | Asserts the managed tmux config keeps the truecolor environment hint. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed tmux validation: `tmux -L dots-pr-colorterm -f configs/tmux/tmux.conf new-session ...` produced `TERM=tmux-256color COLORTERM=truecolor` and `tmux show-environment -g COLORTERM` returned `COLORTERM=truecolor`.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #291`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed. Not applicable; no workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
