### PR TITLE
fix(deps): warn on tmux redraw regression

### DIFF
--- a/internal/cli/deps.go
+++ b/internal/cli/deps.go
@@ -54,11 +54,11 @@ func newDepsCheckCommand(profiles *[]string, extraTags *[]string) *cobra.Command
 				return err
 			}
 
-			report, err := deps.Check(*m, deps.Options{
+			report, err := deps.CheckWithToolProbes(*m, deps.Options{
 				Profiles:  *profiles,
 				ExtraTags: *extraTags,
 				OS:        runtime.GOOS,
-			}, lookupCommand, fontInstalled(runtime.GOOS, resolvedHome))
+			}, lookupCommand, fontInstalled(runtime.GOOS, resolvedHome), commandOutput)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/render_deps.go
+++ b/internal/cli/render_deps.go
@@ -28,6 +28,15 @@ func renderDepsCheck(w io.Writer, report deps.CheckReport) {
 			missing++
 		}
 		fmt.Fprintf(w, "  %-8s %s (%s)\n", state, r.Name, dependencyRequirementLabel(r.Requirement))
+		if r.Warning != "" {
+			fmt.Fprintf(w, "    warning: %s\n", r.Warning)
+			if r.ProbeDetail != "" {
+				fmt.Fprintf(w, "    detail: %s\n", r.ProbeDetail)
+			}
+			if r.Hint != "" {
+				fmt.Fprintf(w, "    hint: %s\n", r.Hint)
+			}
+		}
 	}
 
 	fmt.Fprintf(w, "\nSummary: %d present, %d missing\n", present, missing)

--- a/internal/cli/render_deps_golden_test.go
+++ b/internal/cli/render_deps_golden_test.go
@@ -20,7 +20,7 @@ func TestRenderDepsCheckGolden(t *testing.T) {
 			report: deps.CheckReport{
 				Profile: "default",
 				Results: []deps.Result{
-					{Name: "tmux", Command: "tmux", Present: true},
+					{Name: "tmux", Command: "tmux", Present: true, Warning: "tmux 3.7a has a known synchronized-update redraw regression", ProbeDetail: "tmux 3.7a", Hint: "Upgrade tmux to 3.7b or newer, then stop old servers with `tmux kill-server` so new sessions use the fixed binary."},
 					{Name: "ripgrep", Command: "rg", Present: false},
 					{Name: "starship", Command: "starship", Present: false},
 				},

--- a/internal/cli/testdata/deps_check_mixed.golden
+++ b/internal/cli/testdata/deps_check_mixed.golden
@@ -1,6 +1,9 @@
 Dependencies for profile "default"
 
   present  tmux (required)
+    warning: tmux 3.7a has a known synchronized-update redraw regression
+    detail: tmux 3.7a
+    hint: Upgrade tmux to 3.7b or newer, then stop old servers with `tmux kill-server` so new sessions use the fixed binary.
   missing  ripgrep (required)
   missing  starship (required)
 

--- a/internal/deps/deps.go
+++ b/internal/deps/deps.go
@@ -125,6 +125,8 @@ func probeToolchain(result *Result, opts Options, run CommandRunner) {
 		probeGitToolchain(result, opts, run)
 	case "claude":
 		probeClaudeCode(result, run)
+	case "tmux":
+		probeTmuxToolchain(result, run)
 	}
 }
 
@@ -150,6 +152,28 @@ func probeClaudeCode(result *Result, run CommandRunner) {
 	result.Warning = "claude resolved on PATH but `claude --version` failed"
 	result.ProbeDetail = probeDetail(output, err)
 	result.Hint = "Repair Claude Code's native binary install from its package directory with `node install.cjs`, then verify with `claude --version` and rerun `dots doctor`."
+}
+
+func probeTmuxToolchain(result *Result, run CommandRunner) {
+	output, err := run("tmux", "-V")
+	if err != nil {
+		return
+	}
+
+	version := tmuxVersion(output)
+	if version == "3.7" || version == "3.7a" {
+		result.Warning = "tmux " + version + " has a known synchronized-update redraw regression"
+		result.ProbeDetail = probeDetail(output, nil)
+		result.Hint = "Upgrade tmux to 3.7b or newer, then stop old servers with `tmux kill-server` so new sessions use the fixed binary."
+	}
+}
+
+func tmuxVersion(output string) string {
+	fields := strings.Fields(output)
+	if len(fields) < 2 || fields[0] != "tmux" {
+		return ""
+	}
+	return fields[1]
 }
 
 func probeDetail(output string, err error) string {

--- a/internal/deps/deps_test.go
+++ b/internal/deps/deps_test.go
@@ -372,6 +372,85 @@ func TestCheckWithToolProbesDetectsBrokenClaudeCodeBinary(t *testing.T) {
 	}
 }
 
+func TestCheckWithToolProbesWarnsAboutTmux37RedrawRegression(t *testing.T) {
+	tests := []struct {
+		name        string
+		output      string
+		runErr      error
+		wantWarning string
+		wantHint    string
+	}{
+		{
+			name:        "tmux 3.7a warns",
+			output:      "tmux 3.7a",
+			wantWarning: "tmux 3.7a has a known synchronized-update redraw regression",
+			wantHint:    "tmux kill-server",
+		},
+		{
+			name:        "tmux 3.7 warns",
+			output:      "tmux 3.7",
+			wantWarning: "tmux 3.7 has a known synchronized-update redraw regression",
+			wantHint:    "3.7b or newer",
+		},
+		{
+			name:   "tmux 3.7b is clean",
+			output: "tmux 3.7b",
+		},
+		{
+			name:   "older tmux is not this regression",
+			output: "tmux 3.6b",
+		},
+		{
+			name:   "version probe failure is ignored",
+			runErr: errors.New("exit status 1"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := manifest.Manifest{
+				Version:  1,
+				Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}},
+				Entries: []manifest.Entry{{
+					Source: "configs/tmux/tmux.conf", Target: "~/.tmux.conf", Strategy: "symlink", Tags: []string{"core"},
+					Dependencies: []manifest.Dependency{{Name: "tmux"}},
+				}},
+			}
+
+			report, err := deps.CheckWithToolProbes(m, deps.Options{Profile: "default", OS: "darwin"}, lookupSet("tmux"), fontLookupSet(),
+				func(command string, args ...string) (string, error) {
+					if command != "tmux" {
+						t.Fatalf("probe command = %q, want tmux", command)
+					}
+					if len(args) != 1 || args[0] != "-V" {
+						t.Fatalf("probe args = %#v, want [-V]", args)
+					}
+					return tt.output, tt.runErr
+				})
+			if err != nil {
+				t.Fatalf("CheckWithToolProbes() error = %v", err)
+			}
+
+			result := report.Results[0]
+			if tt.wantWarning == "" {
+				if result.Warning != "" {
+					t.Fatalf("Warning = %q, want none", result.Warning)
+				}
+				if result.Hint != "" {
+					t.Fatalf("Hint = %q, want none", result.Hint)
+				}
+				return
+			}
+			if result.Warning != tt.wantWarning {
+				t.Fatalf("Warning = %q, want %q", result.Warning, tt.wantWarning)
+			}
+			if tt.wantHint != "" && !strings.Contains(result.Hint, tt.wantHint) {
+				t.Fatalf("Hint = %q, want to contain %q", result.Hint, tt.wantHint)
+			}
+		})
+	}
+}
+
 func TestCheckDedupesAndSkipsEntriesFilteredOutByOS(t *testing.T) {
 	m := manifest.Manifest{
 		Version:  1,

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -2732,6 +2732,7 @@ func TestRepositoryTmuxConfigClassifiesPortableConfigSafely(t *testing.T) {
 		"set -g prefix C-a",
 		"set -g mode-keys vi",
 		"set -g status-position top",
+		`set -as terminal-features ",*:RGB"`,
 		`set-environment -g COLORTERM "truecolor"`,
 		"display-popup",
 		"source-file ~/.tmux.conf.local",


### PR DESCRIPTION
Closes #295

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Warn when selected dependencies resolve to known-bad `tmux 3.7` or `tmux 3.7a`.
- Surface remediation in `dots deps check`: upgrade to `tmux 3.7b+` and restart old servers with `tmux kill-server`.
- Keep tmux truecolor propagation hardened for panes whose terminfo lacks RGB/Tc hints.

## Changes

| File | Change |
|------|--------|
| `internal/deps/deps.go` | Adds a read-only `tmux -V` probe and warning for the 3.7 synchronized-update redraw regression. |
| `internal/deps/deps_test.go` | Covers `tmux 3.7`, `3.7a`, clean `3.7b`, older tmux, and probe failure behavior. |
| `internal/cli/deps.go` | Makes `deps check` run tool probes, matching `doctor` diagnostics. |
| `internal/cli/render_deps.go` | Renders dependency warnings, probe details, and hints in human output. |
| `internal/cli/*deps_check*` | Updates golden coverage for warning rendering. |
| `configs/tmux/tmux.conf` | Keeps portable truecolor hardening with `*:Tc` and refreshed `COLORTERM`. |
| `internal/manifest/manifest_test.go` | Locks the added tmux config lines as portable managed config. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile core --source-root "$PWD" --home <tmp>`

Additional validation:

- [x] `go build ./...`
- [x] Fake `tmux 3.7a` on sandbox `PATH` makes `dots deps check --profile core` report the warning and hint.
- [x] Real `tmux 3.7b` reports no warning.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #295`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
