### PR TITLE
fix(bootstrap): sync installed repository release ref

### DIFF
--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -12,9 +12,10 @@ import (
 const DefaultRepositoryURL = "https://github.com/yersonargotev/dots.git"
 
 type Options struct {
-	SourceRoot    string
-	RepositoryURL string
-	RepositoryRef string
+	SourceRoot     string
+	RepositoryURL  string
+	RepositoryRef  string
+	UpdateExisting bool
 }
 
 type Result struct {
@@ -32,6 +33,11 @@ func Ensure(opts Options) (Result, error) {
 
 	result := Result{SourceRoot: opts.SourceRoot}
 	if validSourceRoot(opts.SourceRoot) {
+		if opts.UpdateExisting {
+			if err := ensureRepositoryRef(opts); err != nil {
+				return Result{}, err
+			}
+		}
 		return result, nil
 	}
 
@@ -62,6 +68,107 @@ func Ensure(opts Options) (Result, error) {
 	}
 	result.Cloned = true
 	return result, nil
+}
+
+func ensureRepositoryRef(opts Options) error {
+	ref := strings.TrimSpace(opts.RepositoryRef)
+	if ref == "" {
+		return nil
+	}
+	matches, err := repositoryRefMatches(opts.SourceRoot, ref, fmt.Sprintf("cannot update it to %s", ref))
+	if err != nil {
+		return err
+	}
+	if matches {
+		return nil
+	}
+	if dirty, err := repositoryDirty(opts.SourceRoot); err != nil {
+		return err
+	} else if dirty {
+		return fmt.Errorf("Installed Repository at %s has local changes; refusing to update to %s. Commit/stash them, move it aside, or pass --source-root", opts.SourceRoot, ref)
+	}
+	if err := fetchRepositoryRef(opts.SourceRoot, ref); err != nil {
+		return err
+	}
+	if err := checkoutFetchHead(opts.SourceRoot, ref); err != nil {
+		return err
+	}
+	if !validSourceRoot(opts.SourceRoot) {
+		return errors.New("updated Source of Truth does not contain a valid dots.yaml at repository root")
+	}
+	return nil
+}
+
+// RequireCurrentRef verifies a valid Installed Repository already matches the
+// requested release ref without mutating it. It lets dry-run commands fail before
+// reading a stale manifest while preserving dry-run's no-write contract.
+func RequireCurrentRef(opts Options) error {
+	ref := strings.TrimSpace(opts.RepositoryRef)
+	if ref == "" || !validSourceRoot(opts.SourceRoot) {
+		return nil
+	}
+	matches, err := repositoryRefMatches(opts.SourceRoot, ref, fmt.Sprintf("cannot verify it is at %s", ref))
+	if err != nil {
+		return err
+	}
+	if !matches {
+		return fmt.Errorf("Installed Repository at %s is not at %s; rerun without --dry-run to update it, or pass --source-root", opts.SourceRoot, ref)
+	}
+	return nil
+}
+
+func repositoryRefMatches(sourceRoot, ref, missingGitReason string) (bool, error) {
+	if _, err := os.Stat(filepath.Join(sourceRoot, ".git")); err != nil {
+		if os.IsNotExist(err) {
+			return false, fmt.Errorf("Installed Repository at %s is not a git checkout; %s. Move it aside or pass --source-root", sourceRoot, missingGitReason)
+		}
+		return false, fmt.Errorf("inspect Installed Repository git metadata: %w", err)
+	}
+	return repositoryAtRef(sourceRoot, ref)
+}
+
+func repositoryAtRef(sourceRoot, ref string) (bool, error) {
+	head, err := gitOutput(sourceRoot, "rev-parse", "--verify", "HEAD")
+	if err != nil {
+		return false, fmt.Errorf("inspect Installed Repository HEAD: %w", err)
+	}
+	target, err := gitOutput(sourceRoot, "rev-parse", "--verify", ref+"^{commit}")
+	if err != nil {
+		return false, nil
+	}
+	return strings.TrimSpace(head) == strings.TrimSpace(target), nil
+}
+
+func repositoryDirty(sourceRoot string) (bool, error) {
+	status, err := gitOutput(sourceRoot, "status", "--porcelain")
+	if err != nil {
+		return false, fmt.Errorf("inspect Installed Repository status: %w", err)
+	}
+	return strings.TrimSpace(status) != "", nil
+}
+
+func fetchRepositoryRef(sourceRoot, ref string) error {
+	if _, err := gitOutput(sourceRoot, "fetch", "--depth", "1", "origin", ref); err != nil {
+		return fmt.Errorf("update Installed Repository to %s: %w", ref, err)
+	}
+	return nil
+}
+
+func checkoutFetchHead(sourceRoot, ref string) error {
+	if _, err := gitOutput(sourceRoot, "checkout", "--detach", "FETCH_HEAD"); err != nil {
+		return fmt.Errorf("checkout Installed Repository ref %s: %w", ref, err)
+	}
+	return nil
+}
+
+func gitOutput(sourceRoot string, args ...string) (string, error) {
+	cmd := exec.Command("git", append([]string{"-C", sourceRoot}, args...)...)
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("git %s failed: %w\n%s", strings.Join(args, " "), err, strings.TrimSpace(string(output)))
+	}
+	return string(output), nil
 }
 
 func validSourceRoot(dir string) bool {

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -94,7 +94,7 @@ func ensureRepositoryRef(opts Options) error {
 		return err
 	}
 	if !validSourceRoot(opts.SourceRoot) {
-		return errors.New("updated Source of Truth does not contain a valid dots.yaml at repository root")
+		return errors.New("updated Installed Repository does not contain a valid dots.yaml at repository root")
 	}
 	return nil
 }

--- a/internal/bootstrap/bootstrap_cli_test.go
+++ b/internal/bootstrap/bootstrap_cli_test.go
@@ -3,9 +3,11 @@ package bootstrap_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/yersonargotev/dots/internal/bootstrap"
+	"github.com/yersonargotev/dots/internal/testrepo"
 )
 
 func TestEnsureClonesMissingInstalledRepository(t *testing.T) {
@@ -52,4 +54,102 @@ func TestEnsureRejectsNonEmptyInvalidInstalledRepository(t *testing.T) {
 	if err == nil {
 		t.Fatal("Ensure() should reject a non-empty invalid Installed Repository")
 	}
+}
+
+func TestEnsureUpdatesExistingInstalledRepositoryToPinnedRef(t *testing.T) {
+	sourceRepo, sourceRoot := seedStaleBootstrapInstalledRepository(t)
+
+	_, err := bootstrap.Ensure(bootstrap.Options{
+		SourceRoot:     sourceRoot,
+		RepositoryURL:  sourceRepo,
+		RepositoryRef:  "v0.99.1",
+		UpdateExisting: true,
+	})
+	if err != nil {
+		t.Fatalf("Ensure() update error = %v", err)
+	}
+	manifest, err := os.ReadFile(filepath.Join(sourceRoot, "dots.yaml"))
+	if err != nil {
+		t.Fatalf("read updated manifest: %v", err)
+	}
+	if !strings.Contains(string(manifest), "configs/herdr/config.toml") {
+		t.Fatalf("updated manifest should come from v0.99.1, got:\n%s", manifest)
+	}
+	if err := bootstrap.RequireCurrentRef(bootstrap.Options{SourceRoot: sourceRoot, RepositoryRef: "v0.99.1"}); err != nil {
+		t.Fatalf("updated Installed Repository should satisfy dry-run ref verification: %v", err)
+	}
+}
+
+func TestEnsureRefusesToUpdateDirtyInstalledRepository(t *testing.T) {
+	sourceRepo, sourceRoot := seedStaleBootstrapInstalledRepository(t)
+	writeFile(t, filepath.Join(sourceRoot, "local.txt"), "local change\n", 0o600)
+
+	_, err := bootstrap.Ensure(bootstrap.Options{
+		SourceRoot:     sourceRoot,
+		RepositoryURL:  sourceRepo,
+		RepositoryRef:  "v0.99.1",
+		UpdateExisting: true,
+	})
+	if err == nil {
+		t.Fatal("Ensure() should refuse to update a dirty Installed Repository")
+	}
+	if !strings.Contains(err.Error(), "has local changes") {
+		t.Fatalf("dirty update error should be actionable, got: %v", err)
+	}
+}
+
+func TestEnsureLeavesExistingInstalledRepositoryUnlessUpdateRequested(t *testing.T) {
+	sourceRepo, sourceRoot := seedStaleBootstrapInstalledRepository(t)
+
+	if _, err := bootstrap.Ensure(bootstrap.Options{
+		SourceRoot:    sourceRoot,
+		RepositoryURL: sourceRepo,
+		RepositoryRef: "v0.99.1",
+	}); err != nil {
+		t.Fatalf("Ensure() without update request error = %v", err)
+	}
+	manifest, err := os.ReadFile(filepath.Join(sourceRoot, "dots.yaml"))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	if strings.Contains(string(manifest), "configs/herdr/config.toml") {
+		t.Fatalf("Ensure() without UpdateExisting should not update an existing source root, got:\n%s", manifest)
+	}
+}
+
+func TestRequireCurrentRefRejectsStaleInstalledRepositoryWithoutUpdating(t *testing.T) {
+	_, sourceRoot := seedStaleBootstrapInstalledRepository(t)
+
+	err := bootstrap.RequireCurrentRef(bootstrap.Options{SourceRoot: sourceRoot, RepositoryRef: "v0.99.1"})
+	if err == nil {
+		t.Fatal("RequireCurrentRef() should reject a stale Installed Repository")
+	}
+	if !strings.Contains(err.Error(), "not at v0.99.1") {
+		t.Fatalf("stale ref error should explain remediation, got: %v", err)
+	}
+	manifest, err := os.ReadFile(filepath.Join(sourceRoot, "dots.yaml"))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	if strings.Contains(string(manifest), "configs/herdr/config.toml") {
+		t.Fatalf("RequireCurrentRef() must not update the source root, got:\n%s", manifest)
+	}
+}
+
+func seedStaleBootstrapInstalledRepository(t *testing.T) (string, string) {
+	t.Helper()
+	sourceRepo := newBootstrapSourceRepo(t)
+	if err := testrepo.TagWithHerdrManifest(sourceRepo, "v0.99.1"); err != nil {
+		t.Fatalf("tag Source of Truth with Herdr manifest: %v", err)
+	}
+
+	sourceRoot := filepath.Join(t.TempDir(), ".local", "share", "dots")
+	if _, err := bootstrap.Ensure(bootstrap.Options{
+		SourceRoot:    sourceRoot,
+		RepositoryURL: sourceRepo,
+		RepositoryRef: "v0.99.0",
+	}); err != nil {
+		t.Fatalf("seed old Installed Repository: %v", err)
+	}
+	return sourceRepo, sourceRoot
 }

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -8,7 +8,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/yersonargotev/dots/internal/bootstrap"
 	"github.com/yersonargotev/dots/internal/cli"
+	"github.com/yersonargotev/dots/internal/testrepo"
+	"github.com/yersonargotev/dots/internal/version"
 )
 
 func TestInitCommandClonesInstalledRepository(t *testing.T) {
@@ -104,5 +107,42 @@ func writeCLISourceFile(t *testing.T, path, content string) {
 	}
 	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestInstallDryRunRejectsStaleDefaultInstalledRepository(t *testing.T) {
+	sourceRepo := newCLISourceRepo(t)
+	if err := testrepo.TagWithHerdrManifest(sourceRepo, "v0.99.1"); err != nil {
+		t.Fatalf("tag Source of Truth with Herdr manifest: %v", err)
+	}
+
+	home := t.TempDir()
+	sourceRoot := filepath.Join(home, ".local", "share", "dots")
+	if _, err := bootstrap.Ensure(bootstrap.Options{
+		SourceRoot:    sourceRoot,
+		RepositoryURL: sourceRepo,
+		RepositoryRef: "v0.99.0",
+	}); err != nil {
+		t.Fatalf("seed stale Installed Repository: %v", err)
+	}
+
+	oldVersion := version.Value
+	version.Value = "v0.99.1"
+	defer func() { version.Value = oldVersion }()
+
+	var out, errOut bytes.Buffer
+	code := cli.Run([]string{"install", "--dry-run", "--profile", "default", "--home", home}, &out, &errOut)
+	if code != 1 {
+		t.Fatalf("install --dry-run with stale source exit code = %d, want 1\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "not at v0.99.1") {
+		t.Fatalf("dry-run stale source error should explain release mismatch, got:\n%s", errOut.String())
+	}
+	manifest, err := os.ReadFile(filepath.Join(sourceRoot, "dots.yaml"))
+	if err != nil {
+		t.Fatalf("read stale manifest: %v", err)
+	}
+	if strings.Contains(string(manifest), "configs/herdr/config.toml") {
+		t.Fatalf("dry-run must not update the Installed Repository, got:\n%s", manifest)
 	}
 }

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -65,11 +65,17 @@ func newInstallCommand() *cobra.Command {
 				return fmt.Errorf("--backup-and-replace requires --yes for non-interactive conflict replacement")
 			}
 
-			if !dryRun && !cmd.Flags().Changed("file") && !cmd.Flags().Changed("source-root") {
-				if _, err := bootstrap.Ensure(bootstrap.Options{
-					SourceRoot:    paths.SourceRoot,
-					RepositoryRef: defaultInitRepositoryRef("", version.Value),
-				}); err != nil {
+			if !cmd.Flags().Changed("file") && !cmd.Flags().Changed("source-root") {
+				bootstrapOpts := bootstrap.Options{
+					SourceRoot:     paths.SourceRoot,
+					RepositoryRef:  defaultInitRepositoryRef("", version.Value),
+					UpdateExisting: !dryRun,
+				}
+				if dryRun {
+					if err := bootstrap.RequireCurrentRef(bootstrapOpts); err != nil {
+						return err
+					}
+				} else if _, err := bootstrap.Ensure(bootstrapOpts); err != nil {
 					return err
 				}
 			}

--- a/internal/testrepo/herdr.go
+++ b/internal/testrepo/herdr.go
@@ -1,0 +1,61 @@
+package testrepo
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+const herdrManifest = `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/herdr/config.toml
+    target: ~/.config/herdr/config.toml
+    strategy: symlink
+    tags: [core]
+`
+
+// TagWithHerdrManifest adds a Herdr-managed entry to a test Source of Truth and
+// tags the resulting commit. The repository must already be initialized and
+// configured for commits.
+func TagWithHerdrManifest(repo, tag string) error {
+	if err := writeFile(filepath.Join(repo, "dots.yaml"), herdrManifest); err != nil {
+		return err
+	}
+	if err := writeFile(filepath.Join(repo, "configs", "herdr", "config.toml"), "[keys]\nprefix = \"ctrl+a\"\n"); err != nil {
+		return err
+	}
+	for _, args := range [][]string{
+		{"add", "."},
+		{"commit", "-m", "add herdr"},
+		{"tag", tag},
+	} {
+		if err := git(repo, args...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeFile(path, content string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(content), 0o600)
+}
+
+func git(repo string, args ...string) error {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repo
+	cmd.Env = append(os.Environ(),
+		"GIT_CONFIG_GLOBAL="+os.DevNull,
+		"GIT_CONFIG_NOSYSTEM=1",
+	)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git %v failed: %w\n%s", args, err, output)
+	}
+	return nil
+}


### PR DESCRIPTION
Closes #299

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Sync an existing default Installed Repository to the release binary's pinned tag before non-dry-run installs load the manifest.
- Make dry-run installs fail before reading a stale default Installed Repository, without mutating the source root.
- Keep `dots init` behavior scoped to initialization and avoid changing its JSON output contract.

## Changes

| File | Change |
|------|--------|
| `internal/bootstrap/bootstrap.go` | Adds opt-in existing-repo update and read-only release-ref verification. |
| `internal/bootstrap/bootstrap_cli_test.go` | Adds regression coverage for stale repo update, dirty repo refusal, no-update default behavior, and dry-run ref verification. |
| `internal/cli/install.go` | Uses update mode for real installs and read-only verification for dry-runs before manifest load. |
| `internal/cli/init_test.go` | Covers `install --dry-run` rejecting a stale default Installed Repository without updating it. |

## Test Plan

- [x] `go test ./internal/bootstrap ./internal/cli -count=1`
- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [ ] Sandboxed plan only when dotfiles behavior changes: not run; this fix is bootstrap Source of Truth synchronization and regression coverage uses temporary repositories/homes.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #299`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed. Not needed; behavior is covered by tests and existing init/install semantics.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
