### PR TITLE
feat(config): support Herdr adaptive theme

### DIFF
--- a/configs/herdr/config-adaptive.toml
+++ b/configs/herdr/config-adaptive.toml
@@ -1,0 +1,79 @@
+# dots-managed Herdr config.
+# Adaptive variant selected only by dots' adaptive-theme tag.
+# Herdr switches its own UI between Catppuccin Latte and Mocha using its
+# native host-terminal light/dark appearance detection. Herdr does not expose a
+# dots-owned include seam, so keep non-theme sections synchronized with
+# configs/herdr/config.toml; the manifest test guards that invariant.
+onboarding = false
+
+[update]
+channel = "stable"
+version_check = true
+manifest_check = true
+
+[terminal]
+shell_mode = "auto"
+new_cwd = "follow"
+
+[theme]
+name = "catppuccin"
+auto_switch = true
+dark_name = "catppuccin"
+light_name = "catppuccin-latte"
+
+[ui]
+confirm_close = true
+prompt_new_tab_name = true
+pane_borders = true
+pane_gaps = true
+
+[ui.toast]
+delivery = "system"
+delay_seconds = 1
+
+[ui.toast.herdr]
+position = "bottom-right"
+
+[ui.toast.clipboard]
+enabled = true
+position = "bottom-center"
+
+[ui.sound]
+enabled = true
+
+[keys]
+prefix = "ctrl+a"
+
+# Session/workspace
+# Keep Herdr's default detach plus dots' tmux/Zellij capital-D muscle memory.
+detach = ["prefix+q", "prefix+shift+d"]
+workspace_picker = "prefix+w"
+goto = "prefix+g"
+new_workspace = "prefix+shift+n"
+rename_workspace = "prefix+shift+w"
+close_workspace = "prefix+alt+d"
+toggle_sidebar = "prefix+b"
+
+# Tabs: prefix-first tmux-like core plus explicit direct tab navigation.
+new_tab = "prefix+c"
+rename_tab = ["prefix+shift+t", "prefix+comma"]
+previous_tab = ["prefix+p", "ctrl+alt+["]
+next_tab = ["prefix+n", "ctrl+alt+]"]
+switch_tab = "prefix+1..9"
+close_tab = "prefix+shift+x"
+
+# Panes: mirror dots tmux/Zellij intent and add direct pane focus chords.
+focus_pane_left = ["prefix+h", "ctrl+alt+h"]
+focus_pane_down = ["prefix+j", "ctrl+alt+j"]
+focus_pane_up = ["prefix+k", "ctrl+alt+k"]
+focus_pane_right = ["prefix+l", "ctrl+alt+l"]
+swap_pane_left = "prefix+shift+h"
+swap_pane_down = "prefix+shift+j"
+swap_pane_up = "prefix+shift+k"
+swap_pane_right = "prefix+shift+l"
+split_vertical = "prefix+v"
+split_horizontal = ["prefix+minus", "prefix+d"]
+close_pane = "prefix+x"
+zoom = "prefix+z"
+resize_mode = "prefix+r"
+copy_mode = "prefix+["

--- a/docs/adaptive-theme-audit.md
+++ b/docs/adaptive-theme-audit.md
@@ -20,6 +20,12 @@ slice.
 - **Neovim**: `lua/plugins/colorscheme.lua` selects `catppuccin-latte` only when
   the marker exists and macOS light appearance is proven; otherwise it uses
   `catppuccin-mocha`.
+- **Herdr**: default `configs/herdr/config.toml` keeps Herdr on dark
+  `catppuccin`. On macOS, the `adaptive-theme` tag selects
+  `configs/herdr/config-adaptive.toml` for the same target, enabling Herdr's
+  native `theme.auto_switch` with `catppuccin-latte` for light appearance and
+  `catppuccin` for dark appearance. Herdr has no dots-owned include seam, so a
+  manifest test keeps non-theme sections synchronized between both Herdr files.
 - **Claude/Copilot statuslines**: copied statusline scripts source the helper
   and switch only their ANSI palettes. Claude's app-level `theme` is `auto` so
   Claude can use its own light/dark support without dots rewriting the copied

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -135,6 +135,7 @@ Current Managed Entries:
 | `configs/dots/adaptive-theme` | `~/.config/dots/adaptive-theme` | `symlink` | `adaptive-theme` | `darwin`, `linux` | None |
 | `configs/starship/starship.toml` | `~/.config/starship.toml` | `symlink` | `core` | `darwin`, `linux` | `starship` |
 | `configs/tmux/tmux.conf` | `~/.tmux.conf` | `symlink` | `core` | `darwin`, `linux` | `tmux` |
+| `configs/herdr/config.toml` (`adaptive-theme` override: `configs/herdr/config-adaptive.toml`) | `~/.config/herdr/config.toml` | `symlink` | `core` | `darwin` | `herdr` |
 | `configs/zellij/config.kdl` (`adaptive-theme` override: `configs/zellij/config-adaptive.kdl`) | `~/.config/zellij/config.kdl` | `symlink` | `core` | `darwin`, `linux` | `zellij` |
 | `configs/zellij/layouts/default.kdl` | `~/.config/zellij/layouts/default.kdl` | `symlink` | `core` | `darwin`, `linux` | `zellij` |
 | `configs/ghostty/config.ghostty` | `~/.config/ghostty/config.ghostty` | `symlink` | `desktop` | `darwin`, `linux` | `ghostty` |

--- a/dots.yaml
+++ b/dots.yaml
@@ -259,6 +259,8 @@ entries:
         dnf: tmux
         pacman: tmux
   - source: configs/herdr/config.toml
+    source_overrides:
+      adaptive-theme: configs/herdr/config-adaptive.toml
     target: ~/.config/herdr/config.toml
     strategy: symlink
     tags:

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -3505,6 +3505,84 @@ func TestDotsThemeHelperAdaptiveMatrix(t *testing.T) {
 	}
 }
 
+func TestRepositoryHerdrConfigSupportsAdaptiveThemeOverride(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", ".."))
+	manifestPath := filepath.Join(root, "dots.yaml")
+
+	got, err := manifest.LoadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("LoadFile(%q) error = %v", manifestPath, err)
+	}
+
+	var herdrEntry *manifest.Entry
+	for i := range got.Entries {
+		if got.Entries[i].Target == "~/.config/herdr/config.toml" {
+			herdrEntry = &got.Entries[i]
+			break
+		}
+	}
+	if herdrEntry == nil {
+		t.Fatalf("manifest missing Herdr managed entry")
+	}
+	if got := herdrEntry.SourceOverrides["adaptive-theme"]; got != "configs/herdr/config-adaptive.toml" {
+		t.Fatalf("Herdr adaptive source override = %q, want configs/herdr/config-adaptive.toml", got)
+	}
+
+	defaultConfig, err := os.ReadFile(filepath.Join(root, "configs/herdr/config.toml"))
+	if err != nil {
+		t.Fatalf("read default Herdr config: %v", err)
+	}
+	for _, notWant := range []string{
+		`auto_switch = true`,
+		`light_name = "catppuccin-latte"`,
+	} {
+		if strings.Contains(string(defaultConfig), notWant) {
+			t.Fatalf("default Herdr config contains opt-in-only setting %q:\n%s", notWant, defaultConfig)
+		}
+	}
+
+	adaptiveConfig, err := os.ReadFile(filepath.Join(root, "configs/herdr/config-adaptive.toml"))
+	if err != nil {
+		t.Fatalf("read adaptive Herdr config: %v", err)
+	}
+	for _, want := range []string{
+		`name = "catppuccin"`,
+		`auto_switch = true`,
+		`dark_name = "catppuccin"`,
+		`light_name = "catppuccin-latte"`,
+	} {
+		if !strings.Contains(string(adaptiveConfig), want) {
+			t.Fatalf("adaptive Herdr config missing %q:\n%s", want, adaptiveConfig)
+		}
+	}
+
+	defaultText := string(defaultConfig)
+	adaptiveText := string(adaptiveConfig)
+	if got, want := herdrConfigWithoutTheme(t, adaptiveText), herdrConfigWithoutTheme(t, defaultText); got != want {
+		t.Fatalf("adaptive Herdr config non-theme sections drifted from default; got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func herdrConfigWithoutTheme(t *testing.T, config string) string {
+	t.Helper()
+	start := strings.Index(config, "onboarding =")
+	if start == -1 {
+		t.Fatalf("Herdr config missing onboarding setting:\n%s", config)
+	}
+	body := config[start:]
+	themeStart := strings.Index(body, "[theme]")
+	if themeStart == -1 {
+		t.Fatalf("Herdr config missing [theme] section:\n%s", config)
+	}
+	afterThemeHeader := body[themeStart+len("[theme]"):]
+	nextSection := strings.Index(afterThemeHeader, "\n[")
+	if nextSection == -1 {
+		t.Fatalf("Herdr config missing non-theme section after [theme]:\n%s", config)
+	}
+	themeEnd := themeStart + len("[theme]") + nextSection + 1
+	return body[:themeStart] + body[themeEnd:]
+}
+
 func TestAgentStatuslinePalettesUseAdaptiveHelper(t *testing.T) {
 	root := filepath.Clean(filepath.Join("..", ".."))
 	for _, script := range []string{


### PR DESCRIPTION
Closes #301

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)
- [x] Configuration change (`type:config`)

## Summary

- Adds a Herdr adaptive-theme source override for `~/.config/herdr/config.toml`.
- Keeps the default Herdr config on dark `catppuccin` unless `--tag adaptive-theme` is selected.
- Documents Herdr's separate config behavior and tests that non-theme sections stay synchronized across the duplicated whole-target config.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Adds `source_overrides.adaptive-theme` for the Herdr Managed Entry. |
| `configs/herdr/config-adaptive.toml` | Adds the adaptive Herdr config with native `theme.auto_switch` and Latte/Mocha names. |
| `internal/manifest/manifest_test.go` | Adds a repository regression test for the override, opt-in-only settings, adaptive theme settings, and non-theme sync invariant. |
| `docs/adaptive-theme-audit.md` | Documents Herdr's adaptive-theme behavior and no-include-seam rationale. |
| `docs/manifest.md` | Lists the Herdr adaptive-theme source override. |

## Test Plan

- [x] `gofmt -l .` — passed, no output.
- [x] `go vet ./...` — passed.
- [x] `go build ./...` — passed.
- [x] `go test ./...` — passed.
- [x] `go run ./cmd/dots manifest validate --file dots.yaml` — passed (`manifest is valid`).
- [ ] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile core --source-root "$PWD" --home <tmp>` — not run; this change is covered by manifest/test validation and no install/smoke test was needed.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported. No home-targeting CLI smoke test was run.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #301`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
