### PR TITLE
fix(codex): migrate CodeGraph hook config

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ dots uninstall --restore-backups  # also restore each target's pre-install Backu
 | Source of Truth | This repository's tracked dotfiles and manifest are the canonical desired state. |
 | Install Manifest | The manifest that maps repository files to home-directory targets. |
 | Managed Entry | A target file or link managed by `dots`, such as shell, git, terminal, editor, or agent-tool config. |
-| Install Plan | The preview of create, replace, skip, or conflict actions before install applies changes. |
+| Install Plan | The preview of create, update, replace, skip, or conflict actions before install applies changes. |
 | Uninstall Plan | The preview of remove, skip, modified, or not-owned actions before uninstall reverses an install, driven by the Installation Metadata. |
 | Installation Metadata | Local state used to remember what `dots` installed. |
 | Backup Set | A preserved copy of user-owned files before a restore or overwrite path changes them. |

--- a/docs/agents/output-contract.md
+++ b/docs/agents/output-contract.md
@@ -108,6 +108,12 @@ prose the text surface prints:
   `probe_detail`/`hint` (unstable human prose) are excluded. Agents key on the
   portable, structured fields (`source`, `present`, `warning`, and the
   `deps plan` install action).
+- `plan` action `status` values are portable intent, not prose. `create`,
+  `update`, and `unchanged` are non-findings; `conflict` and `missing-source`
+  are findings. `update` means dots has enough Installation Metadata and
+  Entry Ownership proof to safely mutate a previously managed target, creating a
+  Backup Set before writing, while preserving the conservative conflict model
+  for unmanaged or incompatible targets.
 - Dependency provider availability is an internal planning check, not a JSON
   contract field. `deps plan` and dependency install previews expose the stable
   outcome (`status`, selected `provider`, executable action, `manual` guidance)

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -1,6 +1,6 @@
 # `dots backups`
 
-`dots backups` inspects and restores the [Backup Sets](../CONTEXT.md) the Dotfiles CLI records under the state root (default `~/.local/state/dots/backups`). Every time `install` or `update` would overwrite an existing target — a `replace`, or an `adopt` with the symlink strategy — it first copies that target into a timestamped Backup Set and records [Backup Metadata](../CONTEXT.md) describing it. These commands read that history so preserved files can be audited and, in v1.1, returned to disk.
+`dots backups` inspects and restores the [Backup Sets](../CONTEXT.md) the Dotfiles CLI records under the state root (default `~/.local/state/dots/backups`). Every time `install` or `update` would overwrite an existing target — a `replace`, an `update`, or an `adopt` with the symlink strategy — it first copies that target into a timestamped Backup Set and records [Backup Metadata](../CONTEXT.md) describing it. These commands read that history so preserved files can be audited and, in v1.1, returned to disk.
 
 ## `dots backups list`
 

--- a/docs/update.md
+++ b/docs/update.md
@@ -40,6 +40,15 @@ A fast-forward changes the Source of Truth, so targets that were previously alig
 
 Non-interactive runs (`--yes`) default every conflict to `skip`, so an unattended `update` never silently overwrites a workstation file.
 
+Some co-owned copied configuration can be updated without treating the target as
+a Conflict. When Installation Metadata proves dots installed the previous
+Source of Truth and the target still contains that dots-owned subset, the Install
+Plan may report an `update` action. Today this is used for TOML subset-owned
+Codex config migrations such as adding the CodeGraph `SessionStart` hook while
+preserving Codex- or user-owned settings. An `update` creates a Backup Set before
+mutating the target, and it is safe for Confirmed Install mode because unmanaged
+or incompatible targets still remain Conflicts.
+
 ## Flags
 
 `update` accepts the same path, explicit profile composition, and safety flags as `install`:

--- a/internal/cli/install_provision_test.go
+++ b/internal/cli/install_provision_test.go
@@ -756,6 +756,101 @@ mkdir -p .codegraph
 	}
 }
 
+func TestInstallAgentsCodeGraphTagMigratesExistingManagedCodexConfig(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	sandboxHome := t.TempDir()
+	stateRoot := t.TempDir()
+	fakeRealHome := t.TempDir()
+	t.Setenv("HOME", fakeRealHome)
+
+	stubDir := t.TempDir()
+	writeExecStub(t, filepath.Join(stubDir, "gentle-ai"), "#!/bin/sh\nexit 0\n")
+	writeExecStub(t, filepath.Join(stubDir, "engram"), "#!/bin/sh\nexit 0\n")
+	writeExecStub(t, filepath.Join(stubDir, "codegraph"), `#!/bin/sh
+printf '%s\n' "$*" >> "$HOME/codegraph-args"
+mkdir -p "$HOME/.codex" "$HOME/.claude" "$HOME/.gemini" "$HOME/.config/opencode"
+for file in "$HOME/.codex/AGENTS.md" "$HOME/.claude/CLAUDE.md" "$HOME/.gemini/GEMINI.md" "$HOME/.config/opencode/codegraph.md"; do
+  cat > "$file" <<'EOF'
+<!-- CODEGRAPH_START -->
+Treat CodeGraph-returned source as already read.
+<!-- CODEGRAPH_END -->
+EOF
+done
+`)
+	writeExecStub(t, filepath.Join(stubDir, "curl"), "#!/bin/sh\nexit 0\n")
+	writeManifestDependencyStubs(t, stubDir)
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	base := cli.NewRootCommand()
+	var baseOut bytes.Buffer
+	base.SetOut(&baseOut)
+	base.SetErr(&baseOut)
+	base.SetArgs([]string{
+		"install",
+		"--file", filepath.Join(repoRoot, "dots.yaml"),
+		"--profile", "agents",
+		"--source-root", repoRoot,
+		"--home", sandboxHome,
+		"--state-root", stateRoot,
+		"--yes",
+	})
+	if err := base.Execute(); err != nil {
+		t.Fatalf("base dots install failed in sandbox: %v\noutput:\n%s", err, baseOut.String())
+	}
+
+	codexConfigPath := filepath.Join(sandboxHome, ".codex", "config.toml")
+	baseCodexConfig, err := os.ReadFile(codexConfigPath)
+	if err != nil {
+		t.Fatalf("read base Codex config: %v", err)
+	}
+	if strings.Contains(string(baseCodexConfig), "codegraph init") {
+		t.Fatalf("base Codex config unexpectedly contains CodeGraph hook\ncontent:\n%s", baseCodexConfig)
+	}
+	runtimeAugmented := append([]byte("model = \"gpt-5.5\"\n\n"), baseCodexConfig...)
+	runtimeAugmented = append(runtimeAugmented, []byte("\n[mcp_servers.codegraph]\ncommand = \"codegraph\"\nargs = [\"serve\", \"--mcp\"]\n")...)
+	if err := os.WriteFile(codexConfigPath, runtimeAugmented, 0o600); err != nil {
+		t.Fatalf("write runtime-augmented Codex config: %v", err)
+	}
+
+	upgrade := cli.NewRootCommand()
+	var upgradeOut bytes.Buffer
+	upgrade.SetOut(&upgradeOut)
+	upgrade.SetErr(&upgradeOut)
+	upgrade.SetArgs([]string{
+		"install",
+		"--file", filepath.Join(repoRoot, "dots.yaml"),
+		"--profile", "agents",
+		"--tag", "codegraph",
+		"--source-root", repoRoot,
+		"--home", sandboxHome,
+		"--state-root", stateRoot,
+		"--yes",
+	})
+	if err := upgrade.Execute(); err != nil {
+		t.Fatalf("CodeGraph tagged dots install failed in sandbox: %v\noutput:\n%s", err, upgradeOut.String())
+	}
+	if strings.Contains(upgradeOut.String(), "conflict        copy      configs/codex/config-codegraph.toml") {
+		t.Fatalf("CodeGraph tagged install reported Codex config conflict\noutput:\n%s", upgradeOut.String())
+	}
+	got, err := os.ReadFile(codexConfigPath)
+	if err != nil {
+		t.Fatalf("read migrated Codex config: %v", err)
+	}
+	for _, want := range []string{
+		`model = "gpt-5.5"`,
+		`[mcp_servers.codegraph]`,
+		`[[hooks.SessionStart]]`,
+		"codegraph init",
+	} {
+		if !strings.Contains(string(got), want) {
+			t.Fatalf("migrated Codex config missing %q\ncontent:\n%s", want, got)
+		}
+	}
+}
+
 // TestInstallExecutesClaudeProvisionerHomeThreaded proves a claude provisioner
 // renders and runs the exact `claude plugin ...` invocations, in manifest order,
 // under the sandbox HOME and never the inherited one.

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -21,13 +21,15 @@ func renderPlan(w io.Writer, p plan.Plan) {
 	}
 
 	var counts struct {
-		create, conflict, unchanged, missingSource int
+		create, update, conflict, unchanged, missingSource int
 	}
 	for _, a := range p.Actions {
 		fmt.Fprintf(w, "  %-15s %-9s %s -> %s\n", a.Status, a.Strategy, a.Source, a.Target)
 		switch a.Status {
 		case plan.StatusCreate:
 			counts.create++
+		case plan.StatusUpdate:
+			counts.update++
 		case plan.StatusConflict:
 			counts.conflict++
 		case plan.StatusUnchanged:
@@ -41,8 +43,13 @@ func renderPlan(w io.Writer, p plan.Plan) {
 		}
 	}
 
-	fmt.Fprintf(w, "\nSummary: %d create, %d conflict, %d unchanged, %d missing-source\n",
-		counts.create, counts.conflict, counts.unchanged, counts.missingSource)
+	if counts.update > 0 {
+		fmt.Fprintf(w, "\nSummary: %d create, %d update, %d conflict, %d unchanged, %d missing-source\n",
+			counts.create, counts.update, counts.conflict, counts.unchanged, counts.missingSource)
+	} else {
+		fmt.Fprintf(w, "\nSummary: %d create, %d conflict, %d unchanged, %d missing-source\n",
+			counts.create, counts.conflict, counts.unchanged, counts.missingSource)
+	}
 	if counts.conflict > 0 {
 		renderConflictResolutionGuidance(w)
 	}

--- a/internal/configsubset/subset.go
+++ b/internal/configsubset/subset.go
@@ -70,6 +70,62 @@ func TOMLFileContains(target, source string) (bool, error) {
 	return true, nil
 }
 
+// MergeTOMLFile appends missing source-owned array-of-table blocks to target.
+// It is intentionally narrower than a full TOML formatter: dots only needs this
+// for co-owned Codex config hooks, where preserving user/Codex-owned settings is
+// more important than reformatting the whole file. Scalar/table value changes
+// remain conflicts unless a caller adds a dedicated migration.
+func MergeTOMLFile(target, source string) error {
+	contains, err := TOMLFileContains(target, source)
+	if err != nil {
+		return err
+	}
+	if contains {
+		return nil
+	}
+
+	sourceData, err := os.ReadFile(source)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", source, err)
+	}
+	targetData, err := os.ReadFile(target)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", target, err)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", target, err)
+	}
+	blocks, err := missingArrayTableBlocks(targetData, sourceData)
+	if err != nil {
+		return err
+	}
+	if len(blocks) == 0 {
+		return fmt.Errorf("source-owned TOML differences cannot be merged safely")
+	}
+
+	merged := append([]byte(nil), targetData...)
+	if len(merged) > 0 && merged[len(merged)-1] != '\n' {
+		merged = append(merged, '\n')
+	}
+	merged = append(merged, '\n')
+	for _, block := range blocks {
+		merged = append(merged, strings.TrimRight(block, "\n")...)
+		merged = append(merged, '\n', '\n')
+	}
+	if err := os.WriteFile(target, merged, info.Mode().Perm()); err != nil {
+		return fmt.Errorf("write %s: %w", target, err)
+	}
+	contains, err = TOMLFileContains(target, source)
+	if err != nil {
+		return err
+	}
+	if !contains {
+		return fmt.Errorf("merged TOML target still misses source-owned values")
+	}
+	return nil
+}
+
 func jsonContains(target, source any) bool {
 	switch sourceTyped := source.(type) {
 	case map[string]any:
@@ -124,9 +180,6 @@ func parseSimpleTOML(data []byte, wanted map[string]struct{}) (map[string]string
 			continue
 		}
 		if strings.HasPrefix(line, "[[") {
-			if wanted == nil {
-				return nil, fmt.Errorf("line %d: arrays of tables are unsupported", lineNo+1)
-			}
 			if !strings.HasSuffix(line, "]]") {
 				return nil, fmt.Errorf("line %d: malformed array-of-table header", lineNo+1)
 			}
@@ -173,6 +226,67 @@ func parseSimpleTOML(data []byte, wanted map[string]struct{}) (map[string]string
 		values[path] = canonical
 	}
 	return values, nil
+}
+
+func missingArrayTableBlocks(targetData, sourceData []byte) ([]string, error) {
+	sourceValues, err := parseSimpleTOML(sourceData, nil)
+	if err != nil {
+		return nil, err
+	}
+	targetValues, err := parseSimpleTOML(targetData, sourceValuePaths(sourceValues))
+	if err != nil {
+		return nil, err
+	}
+	missing := map[string]struct{}{}
+	for path, sourceValue := range sourceValues {
+		if targetValues[path] != sourceValue {
+			missing[path] = struct{}{}
+		}
+	}
+	if len(missing) == 0 {
+		return nil, nil
+	}
+
+	var blocks []string
+	lines := strings.Split(string(sourceData), "\n")
+	for i := 0; i < len(lines); {
+		line := strings.TrimSpace(stripTOMLComment(lines[i]))
+		if !strings.HasPrefix(line, "[[") || !strings.HasSuffix(line, "]]") {
+			i++
+			continue
+		}
+		start := i
+		section := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "[["), "]]"))
+		i++
+		blockValues := map[string]string{}
+		for i < len(lines) {
+			next := strings.TrimSpace(stripTOMLComment(lines[i]))
+			if strings.HasPrefix(next, "[") && strings.HasSuffix(next, "]") {
+				break
+			}
+			key, value, ok := strings.Cut(next, "=")
+			if ok {
+				path := section + "." + strings.TrimSpace(key)
+				canonical, err := canonicalTOMLValue(strings.TrimSpace(value))
+				if err != nil {
+					return nil, err
+				}
+				blockValues[path] = canonical
+			}
+			i++
+		}
+		appendBlock := false
+		for path := range blockValues {
+			if _, ok := missing[path]; ok {
+				appendBlock = true
+				break
+			}
+		}
+		if appendBlock {
+			blocks = append(blocks, strings.Join(lines[start:i], "\n"))
+		}
+	}
+	return blocks, nil
 }
 
 func stripTOMLComment(line string) string {

--- a/internal/configsubset/subset_test.go
+++ b/internal/configsubset/subset_test.go
@@ -3,6 +3,7 @@ package configsubset
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -76,5 +77,89 @@ status_line = ["model", "git-branch"]
 	}
 	if !got {
 		t.Fatal("TOMLFileContains() = false, want true")
+	}
+}
+
+func TestTOMLFileContainsSupportsSourceArrayOfTables(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source.toml")
+	target := filepath.Join(dir, "target.toml")
+
+	hook := `[[hooks.SessionStart]]
+matcher = "startup|resume"
+
+[[hooks.SessionStart.hooks]]
+type = "command"
+command = "codegraph init"
+timeout = 120
+`
+	if err := os.WriteFile(source, []byte(hook), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("model = \"gpt-5.5\"\n\n"+hook), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	got, err := TOMLFileContains(target, source)
+	if err != nil {
+		t.Fatalf("TOMLFileContains() error = %v", err)
+	}
+	if !got {
+		t.Fatal("TOMLFileContains() = false, want true")
+	}
+}
+
+func TestMergeTOMLFileAppendsMissingArrayTableBlocks(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source.toml")
+	target := filepath.Join(dir, "target.toml")
+
+	if err := os.WriteFile(source, []byte(`sandbox_mode = "danger-full-access"
+approval_policy = "never"
+
+[[hooks.SessionStart]]
+matcher = "startup|resume"
+
+[[hooks.SessionStart.hooks]]
+type = "command"
+command = "codegraph init"
+timeout = 120
+statusMessage = "Initializing CodeGraph index"
+`), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := os.WriteFile(target, []byte(`model = "gpt-5.5"
+sandbox_mode = "danger-full-access"
+approval_policy = "never"
+
+[tui]
+theme = "catppuccin-mocha"
+`), 0o640); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	if err := MergeTOMLFile(target, source); err != nil {
+		t.Fatalf("MergeTOMLFile() error = %v", err)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	for _, want := range []string{
+		`model = "gpt-5.5"`,
+		`[tui]`,
+		`[[hooks.SessionStart]]`,
+		`command = "codegraph init"`,
+	} {
+		if !strings.Contains(string(got), want) {
+			t.Fatalf("merged target missing %q\ncontent:\n%s", want, got)
+		}
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat target: %v", err)
+	}
+	if gotMode := info.Mode().Perm(); gotMode != 0o640 {
+		t.Fatalf("target mode = %v, want 0640", gotMode)
 	}
 }

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/yersonargotev/dots/internal/backups"
+	"github.com/yersonargotev/dots/internal/configsubset"
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/state"
 )
@@ -47,6 +48,10 @@ func Apply(p plan.Plan, opts Options) error {
 			continue
 		case plan.StatusCreate:
 			if err := applyCreate(action, resolvedSources[i]); err != nil {
+				return err
+			}
+		case plan.StatusUpdate:
+			if err := applyUpdate(action, resolvedSources[i], opts); err != nil {
 				return err
 			}
 		case plan.StatusConflict:
@@ -173,6 +178,28 @@ func validatePlan(p plan.Plan, opts Options) ([]string, error) {
 			}
 		case plan.StatusUnchanged:
 			continue
+		case plan.StatusUpdate:
+			if opts.StateRoot == "" {
+				return nil, fmt.Errorf("update for %s requires state root for Backup Set metadata", action.Target)
+			}
+			if action.Strategy != "copy" || action.Ownership != "toml-subset" {
+				return nil, fmt.Errorf("update for %s requires copy strategy with toml-subset ownership", action.Target)
+			}
+			if err := validateBackupStateRoot(opts.StateRoot, home); err != nil {
+				return nil, err
+			}
+			if err := validateTargetParentInsideHome(action.Target, home); err != nil {
+				return nil, err
+			}
+			if err := plan.ValidateFilePathInsideHomeNoSymlinkEscape(action.Target, home, "update target"); err != nil {
+				return nil, err
+			}
+			if err := plan.ValidateBackupableTarget(action.Target); err != nil {
+				return nil, err
+			}
+			if err := validateSource(action.Strategy, source, sourceRoot); err != nil {
+				return nil, err
+			}
 		case plan.StatusConflict:
 			switch conflictDecision(action, opts) {
 			case DecisionSkip:
@@ -241,7 +268,7 @@ func conflictDecision(action plan.Action, opts Options) ConflictDecision {
 }
 
 func recordsMetadata(action plan.Action, decision ConflictDecision) bool {
-	if action.Status == plan.StatusCreate || action.Status == plan.StatusUnchanged {
+	if action.Status == plan.StatusCreate || action.Status == plan.StatusUpdate || action.Status == plan.StatusUnchanged {
 		return true
 	}
 	return action.Status == plan.StatusConflict && (decision == DecisionReplace || decision == DecisionAdopt)
@@ -382,6 +409,19 @@ func applyReplace(action plan.Action, source string, opts Options) error {
 	}
 	if err := applyCreate(action, source); err != nil {
 		return err
+	}
+	return nil
+}
+
+func applyUpdate(action plan.Action, source string, opts Options) error {
+	if err := createBackupSet(opts, action.Target); err != nil {
+		return err
+	}
+	if action.Ownership != "toml-subset" {
+		return fmt.Errorf("update ownership %q is not supported for %s", action.Ownership, action.Target)
+	}
+	if err := configsubset.MergeTOMLFile(action.Target, source); err != nil {
+		return fmt.Errorf("merge TOML update for %s: %w", action.Target, err)
 	}
 	return nil
 }

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -441,6 +441,125 @@ func TestApplyLeavesUnchangedActionUntouched(t *testing.T) {
 	}
 }
 
+func TestApplyStatusUpdateMergesTOMLSubsetAndRecordsMetadata(t *testing.T) {
+	sourceRoot := t.TempDir()
+	home := t.TempDir()
+	stateRoot := filepath.Join(home, ".local", "state", "dots")
+	source := filepath.Join(sourceRoot, "configs", "codex", "config-codegraph.toml")
+	if err := os.MkdirAll(filepath.Dir(source), 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	if err := os.WriteFile(source, []byte(`sandbox_mode = "danger-full-access"
+approval_policy = "never"
+
+[[hooks.SessionStart]]
+matcher = "startup|resume"
+
+[[hooks.SessionStart.hooks]]
+type = "command"
+command = "codegraph init"
+timeout = 120
+`), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	target := filepath.Join(home, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	if err := os.WriteFile(target, []byte(`model = "gpt-5.5"
+sandbox_mode = "danger-full-access"
+approval_policy = "never"
+
+[tui]
+theme = "catppuccin-mocha"
+`), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	p := plan.Plan{Profile: "default", Actions: []plan.Action{{
+		Source:    "configs/codex/config-codegraph.toml",
+		Target:    target,
+		Strategy:  "copy",
+		Status:    plan.StatusUpdate,
+		Ownership: "toml-subset",
+	}}}
+	if err := install.Apply(p, install.Options{SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot}); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	for _, want := range []string{`model = "gpt-5.5"`, `[tui]`, `command = "codegraph init"`} {
+		if !strings.Contains(string(got), want) {
+			t.Fatalf("target missing %q\ncontent:\n%s", want, got)
+		}
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load metadata: %v", err)
+	}
+	rec, ok := meta.FindByTarget(target)
+	if !ok {
+		t.Fatalf("metadata missing target %s", target)
+	}
+	if rec.Source != "configs/codex/config-codegraph.toml" {
+		t.Fatalf("metadata source = %q, want CodeGraph source", rec.Source)
+	}
+	backupMeta, err := backups.Load(backups.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load Backup Metadata: %v", err)
+	}
+	if len(backupMeta.Sets) != 1 {
+		t.Fatalf("backup sets = %d, want 1", len(backupMeta.Sets))
+	}
+}
+
+func TestApplyStatusUpdateRejectsSymlinkTargetBeforeMutation(t *testing.T) {
+	sourceRoot := t.TempDir()
+	home := t.TempDir()
+	stateRoot := filepath.Join(home, ".local", "state", "dots")
+	source := filepath.Join(sourceRoot, "configs", "codex", "config-codegraph.toml")
+	if err := os.MkdirAll(filepath.Dir(source), 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	if err := os.WriteFile(source, []byte(`[[hooks.SessionStart]]
+matcher = "startup|resume"
+`), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	outside := filepath.Join(t.TempDir(), "outside.toml")
+	if err := os.WriteFile(outside, []byte("outside\n"), 0o600); err != nil {
+		t.Fatalf("write outside target: %v", err)
+	}
+	target := filepath.Join(home, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	if err := os.Symlink(outside, target); err != nil {
+		t.Fatalf("symlink target: %v", err)
+	}
+
+	p := plan.Plan{Profile: "default", Actions: []plan.Action{{
+		Source:    "configs/codex/config-codegraph.toml",
+		Target:    target,
+		Strategy:  "copy",
+		Status:    plan.StatusUpdate,
+		Ownership: "toml-subset",
+	}}}
+	if err := install.Apply(p, install.Options{SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot}); err == nil {
+		t.Fatal("Apply() error = nil, want symlink update target rejection")
+	}
+	got, err := os.ReadFile(outside)
+	if err != nil {
+		t.Fatalf("read outside target: %v", err)
+	}
+	if string(got) != "outside\n" {
+		t.Fatalf("outside target changed to %q", got)
+	}
+}
+
 func TestApplyRejectsMissingSourceWithoutMutatingAnyAction(t *testing.T) {
 	sourceRoot := t.TempDir()
 	home := t.TempDir()

--- a/internal/plan/findings_test.go
+++ b/internal/plan/findings_test.go
@@ -9,6 +9,7 @@ func TestPlanHasFindings(t *testing.T) {
 		want   bool
 	}{
 		{"create is not a finding", StatusCreate, false},
+		{"update is not a finding", StatusUpdate, false},
 		{"unchanged is not a finding", StatusUnchanged, false},
 		{"conflict is a finding", StatusConflict, true},
 		{"missing-source is a finding", StatusMissingSource, true},

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -18,6 +18,7 @@ type Status string
 
 const (
 	StatusCreate        Status = "create"
+	StatusUpdate        Status = "update"
 	StatusConflict      Status = "conflict"
 	StatusUnchanged     Status = "unchanged"
 	StatusMissingSource Status = "missing-source"
@@ -34,6 +35,7 @@ type Action struct {
 	Target         string `json:"target"`
 	Strategy       string `json:"strategy"`
 	Status         Status `json:"status"`
+	Ownership      string `json:"-"`
 }
 
 // Plan is the preview of changes the installer would apply for a Profile.
@@ -88,6 +90,7 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 			continue
 		}
 
+		defaultSource := entry.Source
 		source := manifest.EntrySource(entry, tags)
 		target, err := ResolveTarget(entry.Target, opts.Home)
 		if err != nil {
@@ -98,7 +101,7 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 			return Plan{}, err
 		}
 		entry.Source = source
-		actionStatus, err := status(entry, target, sourceAbs, opts.SourceRoot, opts.Metadata)
+		actionStatus, err := status(entry, target, sourceAbs, opts.SourceRoot, opts.Metadata, defaultSource)
 		if err != nil {
 			return Plan{}, err
 		}
@@ -108,6 +111,7 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 			Target:         target,
 			Strategy:       entry.Strategy,
 			Status:         actionStatus,
+			Ownership:      entry.Ownership,
 		})
 	}
 
@@ -280,7 +284,7 @@ func InsideRoot(path, root string) bool {
 	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }
 
-func status(entry manifest.Entry, target, sourceAbs, sourceRoot string, meta state.Metadata) (Status, error) {
+func status(entry manifest.Entry, target, sourceAbs, sourceRoot string, meta state.Metadata, defaultSource string) (Status, error) {
 	// The managed source must exist before any target comparison is
 	// meaningful: a missing source cannot be installed, and a symlink that
 	// still points at a deleted source is broken, not unchanged.
@@ -322,6 +326,9 @@ func status(entry manifest.Entry, target, sourceAbs, sourceRoot string, meta sta
 					return StatusUnchanged, nil
 				}
 			}
+			if entry.Ownership == "toml-subset" && targetContainsCompatibleRecordedSource(entry, target, sourceRoot, meta, defaultSource) {
+				return StatusUpdate, nil
+			}
 			return StatusConflict, nil
 		}
 		return StatusUnchanged, nil
@@ -333,6 +340,34 @@ func status(entry manifest.Entry, target, sourceAbs, sourceRoot string, meta sta
 func metadataMatchesEntry(meta state.Metadata, target, source, strategy string) bool {
 	rec, ok := meta.FindByTarget(target)
 	return ok && rec.Source == source && rec.Strategy == strategy
+}
+
+func targetContainsCompatibleRecordedSource(entry manifest.Entry, target, sourceRoot string, meta state.Metadata, defaultSource string) bool {
+	rec, ok := meta.FindByTarget(target)
+	if !ok || rec.Strategy != entry.Strategy || !compatibleEntrySource(entry, defaultSource, rec.Source) {
+		return false
+	}
+	sourceAbs, err := ResolveSource(rec.Source, sourceRoot)
+	if err != nil {
+		return false
+	}
+	if err := ValidateResolvedSource(sourceAbs, sourceRoot); err != nil {
+		return false
+	}
+	subset, err := subsetContent(entry.Ownership, target, sourceAbs)
+	return err == nil && subset
+}
+
+func compatibleEntrySource(entry manifest.Entry, defaultSource, source string) bool {
+	if source == entry.Source || source == defaultSource {
+		return true
+	}
+	for _, override := range entry.SourceOverrides {
+		if source == override {
+			return true
+		}
+	}
+	return false
 }
 
 func safeSourceExists(sourceAbs, sourceRoot string) (bool, error) {

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -29,7 +29,7 @@ func buildOne(t *testing.T, sourceRoot, home string, e manifest.Entry) plan.Acti
 	return buildOneWithMetadata(t, sourceRoot, home, e, state.Metadata{})
 }
 
-func buildOneWithMetadata(t *testing.T, sourceRoot, home string, e manifest.Entry, meta state.Metadata) plan.Action {
+func buildOneWithMetadata(t *testing.T, sourceRoot, home string, e manifest.Entry, meta state.Metadata, extraTags ...string) plan.Action {
 	t.Helper()
 	m := manifest.Manifest{
 		Version:  1,
@@ -42,6 +42,7 @@ func buildOneWithMetadata(t *testing.T, sourceRoot, home string, e manifest.Entr
 		SourceRoot: sourceRoot,
 		Home:       home,
 		Metadata:   meta,
+		ExtraTags:  extraTags,
 	})
 	if err != nil {
 		t.Fatalf("Build() error = %v", err)
@@ -373,6 +374,53 @@ func TestBuildCopyTOMLSubsetOwnership(t *testing.T) {
 				t.Fatalf("Status = %q, want %q", action.Status, tt.want)
 			}
 		})
+	}
+}
+
+func TestBuildReportsUpdateForTOMLSubsetSourceOverrideFromCompatibleManagedTarget(t *testing.T) {
+	sourceRoot := t.TempDir()
+	home := t.TempDir()
+	writeSource(t, sourceRoot, "configs/codex/config.toml", "sandbox_mode = \"danger-full-access\"\napproval_policy = \"never\"\n")
+	writeSource(t, sourceRoot, "configs/codex/config-codegraph.toml", `sandbox_mode = "danger-full-access"
+approval_policy = "never"
+
+[[hooks.SessionStart]]
+matcher = "startup|resume"
+
+[[hooks.SessionStart.hooks]]
+type = "command"
+command = "codegraph init"
+timeout = 120
+`)
+	target := filepath.Join(home, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("model = \"gpt-5.5\"\nsandbox_mode = \"danger-full-access\"\napproval_policy = \"never\"\n"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	action := buildOneWithMetadata(t, sourceRoot, home, manifest.Entry{
+		Source: "configs/codex/config.toml",
+		SourceOverrides: map[string]string{
+			"codegraph": "configs/codex/config-codegraph.toml",
+		},
+		Target:    "~/.codex/config.toml",
+		Strategy:  "copy",
+		Ownership: "toml-subset",
+		Tags:      []string{"core"},
+	}, state.Metadata{Entries: []state.Record{{
+		Target: target, Source: "configs/codex/config.toml", Strategy: "copy",
+	}}}, "codegraph")
+
+	if action.Status != plan.StatusUpdate {
+		t.Fatalf("Status = %q, want %q", action.Status, plan.StatusUpdate)
+	}
+	if action.Source != "configs/codex/config-codegraph.toml" {
+		t.Fatalf("Source = %q, want CodeGraph override", action.Source)
+	}
+	if action.Ownership != "toml-subset" {
+		t.Fatalf("Ownership = %q, want toml-subset", action.Ownership)
 	}
 }
 

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -94,6 +94,7 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options) (Report, erro
 			continue
 		}
 
+		defaultSource := entry.Source
 		source := manifest.EntrySource(entry, tags)
 		evaluated := Entry{Source: source, Target: entry.Target, Strategy: entry.Strategy}
 		if !manifest.MatchesOS(entry.OS, opts.OS) {
@@ -112,7 +113,7 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options) (Report, erro
 		}
 
 		entry.Source = source
-		st, err := evaluate(entry, target, meta, opts.SourceRoot)
+		st, err := evaluate(entry, target, meta, opts.SourceRoot, defaultSource)
 		if err != nil {
 			return Report{}, err
 		}
@@ -123,7 +124,7 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options) (Report, erro
 	return report, nil
 }
 
-func evaluate(entry manifest.Entry, target string, meta state.Metadata, sourceRoot string) (State, error) {
+func evaluate(entry manifest.Entry, target string, meta state.Metadata, sourceRoot string, defaultSource string) (State, error) {
 	if _, err := os.Lstat(target); err != nil {
 		if os.IsNotExist(err) {
 			return StateMissing, nil
@@ -163,6 +164,9 @@ func evaluate(entry manifest.Entry, target string, meta state.Metadata, sourceRo
 			return StateOK, nil
 		}
 	}
+	if entry.Ownership == "toml-subset" && targetContainsCompatibleRecordedSource(entry, target, sourceRoot, meta, defaultSource) {
+		return StateDrifted, nil
+	}
 
 	// The target diverges from the Source of Truth. Installation Metadata is the
 	// discriminator: if dots installed this target, the divergence is Drift; if
@@ -176,6 +180,34 @@ func evaluate(entry manifest.Entry, target string, meta state.Metadata, sourceRo
 func metadataMatchesEntry(meta state.Metadata, target, source, strategy string) bool {
 	rec, ok := meta.FindByTarget(target)
 	return ok && rec.Source == source && rec.Strategy == strategy
+}
+
+func targetContainsCompatibleRecordedSource(entry manifest.Entry, target, sourceRoot string, meta state.Metadata, defaultSource string) bool {
+	rec, ok := meta.FindByTarget(target)
+	if !ok || rec.Strategy != entry.Strategy || !compatibleEntrySource(entry, defaultSource, rec.Source) {
+		return false
+	}
+	sourceAbs, err := plan.ResolveSource(rec.Source, sourceRoot)
+	if err != nil {
+		return false
+	}
+	if err := plan.ValidateResolvedSource(sourceAbs, sourceRoot); err != nil {
+		return false
+	}
+	subset, err := subsetContent(entry.Ownership, target, sourceAbs)
+	return err == nil && subset
+}
+
+func compatibleEntrySource(entry manifest.Entry, defaultSource, source string) bool {
+	if source == entry.Source || source == defaultSource {
+		return true
+	}
+	for _, override := range entry.SourceOverrides {
+		if source == override {
+			return true
+		}
+	}
+	return false
 }
 
 func matchesSource(strategy, target, sourceAbs string) (bool, error) {

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -282,6 +282,56 @@ func TestBuildReportsDriftedForChangedDotsOwnedCodexConfigValues(t *testing.T) {
 	}
 }
 
+func TestBuildReportsDriftedForTOMLSubsetSourceOverrideFromCompatibleManagedTarget(t *testing.T) {
+	entry := manifest.Entry{
+		Source: "configs/codex/config.toml",
+		SourceOverrides: map[string]string{
+			"codegraph": "configs/codex/config-codegraph.toml",
+		},
+		Target:    "~/.codex/config.toml",
+		Strategy:  "copy",
+		Ownership: "toml-subset",
+		Tags:      []string{"core"},
+	}
+	f := newFixture(entry)
+	f.sourceRoot = t.TempDir()
+	f.home = t.TempDir()
+	writeSource(t, f.sourceRoot, "configs/codex/config.toml", "sandbox_mode = \"danger-full-access\"\napproval_policy = \"never\"\n")
+	writeSource(t, f.sourceRoot, "configs/codex/config-codegraph.toml", `sandbox_mode = "danger-full-access"
+approval_policy = "never"
+
+[[hooks.SessionStart]]
+matcher = "startup|resume"
+
+[[hooks.SessionStart.hooks]]
+type = "command"
+command = "codegraph init"
+timeout = 120
+`)
+	target := filepath.Join(f.home, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target parent: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("model = \"gpt-5.5\"\nsandbox_mode = \"danger-full-access\"\napproval_policy = \"never\"\n"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	meta := state.Metadata{Version: 1, Entries: []state.Record{{
+		Target: target, Source: "configs/codex/config.toml", Strategy: "copy", Hash: "installed-hash",
+	}}}
+
+	report, err := status.Build(manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}},
+		Entries:  []manifest.Entry{entry},
+	}, meta, status.Options{Profile: "default", ExtraTags: []string{"codegraph"}, OS: "darwin", SourceRoot: f.sourceRoot, Home: f.home})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if got := onlyEntry(t, report).State; got != status.StateDrifted {
+		t.Fatalf("state = %q, want drifted because the managed target needs the CodeGraph hook update", got)
+	}
+}
+
 func TestBuildReportsMissingWhenTargetAbsent(t *testing.T) {
 	f := newFixture(manifest.Entry{Source: "configs/git/gitconfig", Target: "~/.gitconfig", Strategy: "copy", Tags: []string{"core"}})
 	f.sourceRoot = t.TempDir()


### PR DESCRIPTION
Closes #307

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds an Install Plan `update` status for safe TOML subset-owned migrations.
- Migrates a previously managed base Codex config to the CodeGraph source override by appending the missing `SessionStart` hook while preserving Codex/user-owned settings.
- Documents the new update/backup/output-contract behavior and adds sandboxed regression coverage.

## Changes

| File | Change |
|------|--------|
| `internal/plan/plan.go` | Classifies compatible TOML subset source-overrides as `update` instead of `conflict`. |
| `internal/install/install.go` | Applies `update` by backing up then merging missing TOML array-of-table blocks; rejects symlink leaf targets. |
| `internal/configsubset/subset.go` | Supports source `[[array-of-table]]` TOML subset comparison and narrow append-only TOML merge. |
| `internal/status/status.go` | Reports compatible managed source-override drift instead of untrusted conflict. |
| `internal/cli/render.go` | Renders/counts update actions when present. |
| `internal/*_test.go` | Covers CodeGraph migration, arrays-of-tables, metadata, backups, and symlink safety. |
| `README.md`, `docs/update.md`, `docs/backups.md`, `docs/agents/output-contract.md` | Documents `update` semantics, Backup Set behavior, and JSON plan status meaning. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile agents --tag codegraph --source-root "$PWD" --home <tmp>/home --state-root <tmp>/state`

Additional validation:
- [x] `go run ./cmd/dots plan --file dots.yaml --profile workstation --tag codex-spark-delegation --tag codegraph --source-root "$PWD"` showed the real Codex config as `update` (read-only; no real HOME writes).
- [x] `$review` Standards and Spec axes: 0 hard Standards findings, 0 Spec findings. Remaining Standards note is a non-blocking duplicated-code judgement call between plan/status compatibility helpers.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #307`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
