### PR TITLE
feat(config): add Herdr cmd tab shortcuts

### DIFF
--- a/configs/herdr/config-adaptive.toml
+++ b/configs/herdr/config-adaptive.toml
@@ -57,8 +57,8 @@ toggle_sidebar = "prefix+b"
 # Tabs: prefix-first tmux-like core plus explicit direct tab navigation.
 new_tab = "prefix+c"
 rename_tab = ["prefix+shift+t", "prefix+comma"]
-previous_tab = ["prefix+p", "ctrl+alt+["]
-next_tab = ["prefix+n", "ctrl+alt+]"]
+previous_tab = ["prefix+p", "ctrl+alt+[", "cmd+h"]
+next_tab = ["prefix+n", "ctrl+alt+]", "cmd+l"]
 switch_tab = "prefix+1..9"
 close_tab = "prefix+shift+x"
 

--- a/configs/herdr/config.toml
+++ b/configs/herdr/config.toml
@@ -51,8 +51,8 @@ toggle_sidebar = "prefix+b"
 # Tabs: prefix-first tmux-like core plus explicit direct tab navigation.
 new_tab = "prefix+c"
 rename_tab = ["prefix+shift+t", "prefix+comma"]
-previous_tab = ["prefix+p", "ctrl+alt+["]
-next_tab = ["prefix+n", "ctrl+alt+]"]
+previous_tab = ["prefix+p", "ctrl+alt+[", "cmd+h"]
+next_tab = ["prefix+n", "ctrl+alt+]", "cmd+l"]
 switch_tab = "prefix+1..9"
 close_tab = "prefix+shift+x"
 


### PR DESCRIPTION
Closes #311

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds macOS-friendly direct Herdr tab navigation aliases.
- Preserves existing prefix-first and `ctrl+alt` tab navigation bindings.
- Keeps the default and adaptive Herdr configs synchronized outside theme settings.

## Changes

| File | Change |
|------|--------|
| `configs/herdr/config.toml` | Adds `cmd+h` / `cmd+l` aliases for previous/next tab. |
| `configs/herdr/config-adaptive.toml` | Mirrors the same tab aliases so the adaptive variant stays synchronized. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile core --source-root "$PWD" --home <tmp> --state-root <tmp>`
- [x] `go test ./internal/manifest -run TestRepositoryHerdrConfigSupportsAdaptiveThemeOverride`
- [x] Sandboxed install/status: `go run ./cmd/dots install --file dots.yaml --source-root "$PWD" --home <tmp>/home --state-root <tmp>/state --profile core --yes` then `go run ./cmd/dots status --file dots.yaml --source-root "$PWD" --home <tmp>/home --state-root <tmp>/state --profile core --output json`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #311`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed. Not applicable; no workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
