### PR TITLE
feat(config): add Herdr pane shortcuts

### DIFF
--- a/configs/herdr/config-adaptive.toml
+++ b/configs/herdr/config-adaptive.toml
@@ -63,10 +63,10 @@ switch_tab = "prefix+1..9"
 close_tab = "prefix+shift+x"
 
 # Panes: mirror dots tmux/Zellij intent and add direct pane focus chords.
-focus_pane_left = ["prefix+h", "ctrl+alt+h"]
-focus_pane_down = ["prefix+j", "ctrl+alt+j"]
-focus_pane_up = ["prefix+k", "ctrl+alt+k"]
-focus_pane_right = ["prefix+l", "ctrl+alt+l"]
+focus_pane_left = ["prefix+h", "ctrl+alt+h", "cmd+shift+h"]
+focus_pane_down = ["prefix+j", "ctrl+alt+j", "cmd+shift+j"]
+focus_pane_up = ["prefix+k", "ctrl+alt+k", "cmd+shift+k"]
+focus_pane_right = ["prefix+l", "ctrl+alt+l", "cmd+shift+l"]
 swap_pane_left = "prefix+shift+h"
 swap_pane_down = "prefix+shift+j"
 swap_pane_up = "prefix+shift+k"

--- a/configs/herdr/config.toml
+++ b/configs/herdr/config.toml
@@ -57,10 +57,10 @@ switch_tab = "prefix+1..9"
 close_tab = "prefix+shift+x"
 
 # Panes: mirror dots tmux/Zellij intent and add direct pane focus chords.
-focus_pane_left = ["prefix+h", "ctrl+alt+h"]
-focus_pane_down = ["prefix+j", "ctrl+alt+j"]
-focus_pane_up = ["prefix+k", "ctrl+alt+k"]
-focus_pane_right = ["prefix+l", "ctrl+alt+l"]
+focus_pane_left = ["prefix+h", "ctrl+alt+h", "cmd+shift+h"]
+focus_pane_down = ["prefix+j", "ctrl+alt+j", "cmd+shift+j"]
+focus_pane_up = ["prefix+k", "ctrl+alt+k", "cmd+shift+k"]
+focus_pane_right = ["prefix+l", "ctrl+alt+l", "cmd+shift+l"]
 swap_pane_left = "prefix+shift+h"
 swap_pane_down = "prefix+shift+j"
 swap_pane_up = "prefix+shift+k"


### PR DESCRIPTION
Closes #313

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds direct Vim-style `cmd+shift+h/j/k/l` pane focus aliases to the dots-managed Herdr config.
- Preserves the existing `prefix+h/j/k/l` and `ctrl+alt+h/j/k/l` pane focus fallbacks.
- Keeps the adaptive-theme Herdr variant synchronized with the default config outside theme-only settings.

## Changes

| File | Change |
|------|--------|
| `configs/herdr/config.toml` | Adds `cmd+shift+h/j/k/l` aliases to Herdr pane focus bindings. |
| `configs/herdr/config-adaptive.toml` | Mirrors the same pane focus aliases for the adaptive-theme variant. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go build ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] `go test ./internal/manifest -run TestRepositoryHerdrConfigSupportsAdaptiveThemeOverride`
- [x] Sandboxed plan/status/install with temporary `--home`, `--source-root "$PWD"`, and `--state-root`.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #313`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed. (N/A: no workflow behavior changed.)
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
