### PR TITLE
feat(state): record install metadata provenance

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -246,7 +246,7 @@ func newInstallCommand() *cobra.Command {
 				return nil
 			}
 
-			provResult, err := runProvisioners(cmd, *m, profiles, extraTags, paths.Home, paths.StateRoot)
+			provResult, err := runProvisioners(cmd, *m, profiles, extraTags, paths.Home, paths.StateRoot, paths.SourceRoot)
 			if err != nil {
 				if wantsJSON(cmd) {
 					return installProvisionerError{err: err, report: installReport{DryRun: false, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan, BackupSets: createdBackups, ProvisionerResults: &provResult}}
@@ -430,7 +430,7 @@ func runInstallDependencies(cmd *cobra.Command, m manifest.Manifest, options dep
 // temporary home. Apply stops at the first failing provisioner and returns the
 // error, which the caller surfaces; the tool's own stdout/stderr are streamed
 // through so its progress is visible.
-func runProvisioners(cmd *cobra.Command, m manifest.Manifest, profiles []string, extraTags []string, home string, stateRoot string) (provision.Report, error) {
+func runProvisioners(cmd *cobra.Command, m manifest.Manifest, profiles []string, extraTags []string, home string, stateRoot string, sourceRoot string) (provision.Report, error) {
 	ctx := cmd.Context()
 	if ctx == nil {
 		ctx = context.Background()
@@ -455,7 +455,7 @@ func runProvisioners(cmd *cobra.Command, m manifest.Manifest, profiles []string,
 	if !wantsJSON(cmd) {
 		renderProvisionReport(cmd.OutOrStdout(), report)
 	}
-	if recordErr := recordProvisionerMetadata(stateRoot, report); recordErr != nil {
+	if recordErr := recordProvisionerMetadata(stateRoot, sourceRoot, report); recordErr != nil {
 		return report, recordErr
 	}
 	if gentleAIProvisionerRan(report) {
@@ -746,7 +746,7 @@ func writeFileForPromptDiff(w interface{ Write([]byte) (int, error) }, path, lab
 	_, _ = w.Write(data)
 }
 
-func recordProvisionerMetadata(stateRoot string, report provision.Report) error {
+func recordProvisionerMetadata(stateRoot, sourceRoot string, report provision.Report) error {
 	if stateRoot == "" || len(report.Items) == 0 {
 		return nil
 	}
@@ -755,13 +755,14 @@ func recordProvisionerMetadata(stateRoot string, report provision.Report) error 
 	if err != nil {
 		return err
 	}
-	if meta.Version == 0 {
-		meta.Version = 1
-	}
+	meta.Version = 2
+	meta.Provenance = state.CaptureProvenance(sourceRoot, version.Value)
 	now := time.Now().UTC().Format(time.RFC3339)
 	for _, item := range report.Items {
 		meta.UpsertProvisioner(state.ProvisionerRecord{
 			Profile:    report.Profile,
+			Profiles:   append([]string(nil), report.Profiles...),
+			Tags:       append([]string(nil), report.Tags...),
 			Tool:       item.Tool,
 			Executable: item.Executable,
 			Args:       append([]string(nil), item.Args...),

--- a/internal/cli/provision_runner_test.go
+++ b/internal/cli/provision_runner_test.go
@@ -153,7 +153,7 @@ printf 'npm-local' > "$HOME/gentle-ai-npm-mode"
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
 
-	if _, err := runProvisioners(cmd, m, []string{"workstation"}, nil, home, t.TempDir()); err != nil {
+	if _, err := runProvisioners(cmd, m, []string{"workstation"}, nil, home, t.TempDir(), t.TempDir()); err != nil {
 		t.Fatalf("runProvisioners() error = %v\noutput:\n%s", err, out.String())
 	}
 	got, err := os.ReadFile(filepath.Join(home, "gentle-ai-npm-mode"))
@@ -213,7 +213,7 @@ EOF
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
 
-	_, err := runProvisioners(cmd, m, []string{"default"}, nil, home, t.TempDir())
+	_, err := runProvisioners(cmd, m, []string{"default"}, nil, home, t.TempDir(), t.TempDir())
 	if err == nil {
 		t.Fatal("runProvisioners() error = nil, want second provisioner failure")
 	}
@@ -278,7 +278,7 @@ printf '%s\n' "$*" > "$HOME/skills-args"
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
 
-	if _, err := runProvisioners(cmd, m, []string{"default"}, nil, home, t.TempDir()); err != nil {
+	if _, err := runProvisioners(cmd, m, []string{"default"}, nil, home, t.TempDir(), t.TempDir()); err != nil {
 		t.Fatalf("runProvisioners() error = %v\noutput:\n%s", err, out.String())
 	}
 
@@ -340,7 +340,7 @@ done
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
 
-	if _, err := runProvisioners(cmd, m, []string{"default"}, []string{"codegraph"}, home, t.TempDir()); err != nil {
+	if _, err := runProvisioners(cmd, m, []string{"default"}, []string{"codegraph"}, home, t.TempDir(), t.TempDir()); err != nil {
 		t.Fatalf("runProvisioners() error = %v\noutput:\n%s", err, out.String())
 	}
 

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -215,7 +215,7 @@ func runUpdateWorkflow(cmd *cobra.Command, opts updateOptions, emit bool) (updat
 		return updateReport{}, err
 	}
 	if applied {
-		if _, err := runProvisioners(cmd, *m, opts.profiles, opts.extraTags, paths.Home, paths.StateRoot); err != nil {
+		if _, err := runProvisioners(cmd, *m, opts.profiles, opts.extraTags, paths.Home, paths.StateRoot, paths.SourceRoot); err != nil {
 			return updateReport{}, err
 		}
 	}

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -10,6 +10,7 @@ import (
 	"github.com/yersonargotev/dots/internal/configsubset"
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/state"
+	"github.com/yersonargotev/dots/internal/version"
 )
 
 // ConflictDecision describes the explicit per-target action selected for a
@@ -89,7 +90,8 @@ func recordMetadata(p plan.Plan, resolvedSources []string, opts Options) error {
 	if err != nil {
 		return err
 	}
-	meta.Version = 1
+	meta.Version = 2
+	meta.Provenance = state.CaptureProvenance(opts.SourceRoot, version.Value)
 
 	now := time.Now().UTC().Format(time.RFC3339)
 	for i, action := range p.Actions {
@@ -110,6 +112,8 @@ func recordMetadata(p plan.Plan, resolvedSources []string, opts Options) error {
 			Strategy:    action.Strategy,
 			Hash:        hash,
 			InstalledAt: now,
+			Profiles:    append([]string(nil), p.Profiles...),
+			Tags:        append([]string(nil), p.Tags...),
 		})
 	}
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -11,31 +11,52 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
+	"time"
 )
 
 // Metadata is the machine-readable record of installed managed targets.
 type Metadata struct {
 	Version      int                 `json:"version"`
+	Provenance   Provenance          `json:"provenance,omitempty"`
 	Entries      []Record            `json:"entries"`
 	Provisioners []ProvisionerRecord `json:"provisioners,omitempty"`
+}
+
+// Provenance records the Source of Truth and dots binary that last updated the
+// Installation Metadata. Fields are optional so older metadata remains valid.
+type Provenance struct {
+	SourceRoot     string `json:"source_root,omitempty"`
+	SourceRevision string `json:"source_revision,omitempty"`
+	DotsVersion    string `json:"dots_version,omitempty"`
+	RecordedAt     string `json:"recorded_at,omitempty"`
+}
+
+func (p Provenance) Empty() bool {
+	return p.SourceRoot == "" && p.SourceRevision == "" && p.DotsVersion == "" && p.RecordedAt == ""
 }
 
 // Record describes a single managed target the CLI installed. Copy-like
 // strategies may record a source content hash; symlink records leave Hash empty
 // because drift is detected from the link destination.
 type Record struct {
-	Target      string `json:"target"`
-	Source      string `json:"source"`
-	Strategy    string `json:"strategy"`
-	Hash        string `json:"hash"`
-	InstalledAt string `json:"installedAt"`
+	Target      string   `json:"target"`
+	Source      string   `json:"source"`
+	Strategy    string   `json:"strategy"`
+	Hash        string   `json:"hash"`
+	InstalledAt string   `json:"installedAt"`
+	Profiles    []string `json:"profiles,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
 }
 
 // ProvisionerRecord describes the last known result for one selected
 // Provisioner command in a profile.
 type ProvisionerRecord struct {
 	Profile    string   `json:"profile"`
+	Profiles   []string `json:"profiles,omitempty"`
+	Tags       []string `json:"tags,omitempty"`
 	Tool       string   `json:"tool"`
 	Executable string   `json:"executable"`
 	Args       []string `json:"args"`
@@ -47,6 +68,22 @@ type ProvisionerRecord struct {
 // Path returns the location of installed.json under a state root.
 func Path(stateRoot string) string {
 	return filepath.Join(stateRoot, "installed.json")
+}
+
+// CaptureProvenance best-effort captures the current Source of Truth revision
+// and dots binary version without failing the install path when Git metadata is
+// unavailable.
+func CaptureProvenance(sourceRoot, dotsVersion string) Provenance {
+	prov := Provenance{SourceRoot: sourceRoot, DotsVersion: dotsVersion, RecordedAt: time.Now().UTC().Format(time.RFC3339)}
+	if abs, err := filepath.Abs(sourceRoot); err == nil {
+		prov.SourceRoot = filepath.Clean(abs)
+	}
+	cmd := exec.Command("git", "-C", sourceRoot, "rev-parse", "--short", "HEAD")
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL="+os.DevNull, "GIT_CONFIG_NOSYSTEM=1")
+	if out, err := cmd.Output(); err == nil {
+		prov.SourceRevision = strings.TrimSpace(string(out))
+	}
+	return prov
 }
 
 // Load reads Installation Metadata from path. A missing file is not an error:
@@ -138,7 +175,7 @@ func (m Metadata) Remove(targets ...string) Metadata {
 		drop[t] = struct{}{}
 	}
 
-	pruned := Metadata{Version: m.Version}
+	pruned := Metadata{Version: m.Version, Provenance: m.Provenance, Provisioners: append([]ProvisionerRecord(nil), m.Provisioners...)}
 	for _, r := range m.Entries {
 		if _, ok := drop[r.Target]; ok {
 			continue

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -3,6 +3,7 @@ package state_test
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -26,13 +27,26 @@ func TestSaveThenLoadRoundTripsRecords(t *testing.T) {
 	path := state.Path(stateRoot)
 
 	want := state.Metadata{
-		Version: 1,
+		Version:    2,
+		Provenance: state.Provenance{SourceRoot: "/src/dots", SourceRevision: "abc123", DotsVersion: "v0.test", RecordedAt: "2026-06-06T00:00:00Z"},
 		Entries: []state.Record{{
 			Target:      "/home/user/.zshrc",
 			Source:      "configs/zsh/zshrc",
 			Strategy:    "symlink",
 			Hash:        "abc123",
 			InstalledAt: "2026-06-06T00:00:00Z",
+			Profiles:    []string{"core"},
+			Tags:        []string{"core"},
+		}},
+		Provisioners: []state.ProvisionerRecord{{
+			Profile:    "core",
+			Profiles:   []string{"core"},
+			Tags:       []string{"core"},
+			Tool:       "gentle-ai",
+			Executable: "gentle-ai",
+			Args:       []string{"install"},
+			Status:     "provisioned",
+			LastRunAt:  "2026-06-06T00:00:00Z",
 		}},
 	}
 
@@ -47,8 +61,8 @@ func TestSaveThenLoadRoundTripsRecords(t *testing.T) {
 	if len(got.Entries) != 1 {
 		t.Fatalf("Load() entries = %d, want 1", len(got.Entries))
 	}
-	if got.Entries[0] != want.Entries[0] {
-		t.Fatalf("Load() record = %+v, want %+v", got.Entries[0], want.Entries[0])
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Load() metadata = %+v, want %+v", got, want)
 	}
 }
 


### PR DESCRIPTION
Closes #316

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Records selected Profiles and Tags in Installation Metadata for Managed Entries and Provisioner runs.
- Adds best-effort Source of Truth provenance capture: source root, Git revision, dots version, and timestamp.
- Keeps old metadata compatible by adding optional fields only.

## Changes

| File | Change |
|------|--------|
| `internal/state/state.go` | Adds optional provenance, profile, and tag metadata fields plus best-effort provenance capture. |
| `internal/install/install.go` | Persists metadata schema v2, provenance, selected Profiles, and Tags for Managed Entries. |
| `internal/cli/install.go` / `internal/cli/update.go` | Threads Source of Truth into Provisioner metadata recording and persists selected Profiles/Tags. |
| `internal/state/state_test.go` | Extends metadata round-trip coverage for provenance, Profiles, Tags, and Provisioners. |
| `internal/cli/provision_runner_test.go` | Updates internal helper calls for the new source-root argument. |

## Chain Context

- Strategy: stacked PRs to protect review size.
- Parent issue: #315.
- This PR is slice 1/2: metadata capture only.
- Next PR: `feat/installed-inventory` targets this branch and adds `dots installed` UX + docs/tests.
- Dependency diagram:

```text
main
└── 📍 PR 1: feat/installed-metadata — metadata provenance/selection capture
    └── PR 2: feat/installed-inventory — read-only installed inventory command
```

## Test Plan

- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile core --source-root "$PWD" --home <tmp>`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #316`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed. Not applicable; this slice is internal metadata capture only.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
