### PR TITLE
feat(cli): add installed inventory command

### DIFF
--- a/docs/agents/output-contract.md
+++ b/docs/agents/output-contract.md
@@ -13,6 +13,7 @@ default, so human output and Golden Output Tests are unchanged.
 
 ```bash
 dots status --output json
+dots installed --output json
 dots doctor --output json
 dots plan   --output json
 dots deps check --output json
@@ -47,7 +48,7 @@ state.
 | Field            | Meaning                                                              |
 |------------------|---------------------------------------------------------------------|
 | `schema_version` | Envelope version, bumped independently of the CLI binary.           |
-| `command`        | The command that ran (`status`, `plan`, `doctor`, `deps check`).    |
+| `command`        | The command that ran (`status`, `installed`, `plan`, `doctor`, `deps check`). |
 | `status`         | Outcome discriminator: `ok` \| `findings` \| `error`.               |
 | `data`           | The command's domain report (present on `ok` / `findings`; selected action-command errors may include a partial report). |
 | `error`          | Structured error string (present only on `status: "error"`).        |
@@ -104,6 +105,13 @@ prose the text surface prints:
   `data.provisioners.items`. Pending or failed Provisioners are findings so
   agents can distinguish aligned Managed Entries from an incomplete full-profile
   setup. Read dependency readiness for those commands from `doctor`.
+
+- `installed` is a read-only inventory over Installation Metadata. It reports
+  recorded Managed Entries, represented Tags, recorded or inferred Profiles
+  (including partial coverage), recorded Provisioner runs, and Source of Truth
+  provenance when the metadata contains it. It is informational rather than an
+  alignment diagnostic, so partial profile coverage remains `status: "ok"`;
+  use `status` or `doctor` when an agent needs drift/dependency findings.
 - `plan`'s `resolved_source` (a per-machine absolute path) and `deps`'s
   `probe_detail`/`hint` (unstable human prose) are excluded. Agents key on the
   portable, structured fields (`source`, `present`, `warning`, and the

--- a/docs/update.md
+++ b/docs/update.md
@@ -112,6 +112,12 @@ provisioners:
       components: [engram, context7, permissions]
 ```
 
+After installs or updates, use `dots installed` to inspect the read-only
+Installation Metadata inventory: recorded Managed Entries, represented Tags,
+recorded or inferred Profiles, Provisioner runs, and captured Source of Truth
+provenance when available. The command is useful when you need to answer what is
+currently installed without manually reading `~/.local/state/dots/installed.json`.
+
 To keep that requirement discoverable, both `install` and `update` print a one-line hint when the active profile skips provisioners another profile would select on this OS:
 
 ```

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -79,3 +79,8 @@ dots upgrade \
 
 Use temporary `--home`, `--source-root`, and `--state-root` values when testing
 upgrade behavior so real workstation configuration is never modified.
+
+After an upgrade, `dots installed` provides the official read-only inventory for
+what Installation Metadata currently records, including Profile/Tag coverage,
+Provisioner runs, and Source of Truth provenance captured by recent installs or
+updates.

--- a/internal/cli/installed.go
+++ b/internal/cli/installed.go
@@ -1,0 +1,173 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"runtime"
+	"strings"
+
+	"github.com/spf13/cobra"
+	inst "github.com/yersonargotev/dots/internal/installed"
+	"github.com/yersonargotev/dots/internal/state"
+)
+
+func newInstalledCommand() *cobra.Command {
+	var (
+		file       string
+		sourceRoot string
+		home       string
+		stateRoot  string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "installed",
+		Short: "Show what dots has installed from Installation Metadata",
+		Long:  "installed reads Installation Metadata and the Install Manifest to list installed Managed Entries, represented tags, inferred or recorded profiles, Provisioners, and Source of Truth provenance. It is read-only and never evaluates or mutates managed targets.",
+		Args:  cobra.NoArgs,
+		// Domain errors (bad metadata, missing manifest) are user-facing messages,
+		// not command misuse.
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			paths, err := resolvePaths(home, sourceRoot, stateRoot)
+			if err != nil {
+				return err
+			}
+			m, err := loadManifestForCommand(cmd, file, paths.SourceRoot)
+			if err != nil {
+				return err
+			}
+			meta, err := loadInstallationMetadata(paths, stateRoot)
+			if err != nil {
+				return err
+			}
+			report, err := inst.Build(*m, meta, inst.Options{
+				StatePath:  state.Path(paths.StateRoot),
+				SourceRoot: paths.SourceRoot,
+				Home:       paths.Home,
+				OS:         runtime.GOOS,
+			})
+			if err != nil {
+				return err
+			}
+			return renderOrEmit(cmd, report, func() error {
+				renderInstalled(cmd.OutOrStdout(), report)
+				return nil
+			})
+		},
+	}
+
+	cmd.Flags().StringVarP(&file, "file", "f", "dots.yaml", "manifest file to use for tag/profile inference")
+	cmd.Flags().StringVar(&sourceRoot, "source-root", "", "installed repository root (default ~/.local/share/dots)")
+	cmd.Flags().StringVar(&home, "home", "", "home directory for resolving manifest targets (default: the current user's home); use a sandbox path for validation")
+	cmd.Flags().StringVar(&stateRoot, "state-root", "", "state directory for Installation Metadata (default ~/.local/state/dots)")
+	return cmd
+}
+
+func renderInstalled(w io.Writer, report inst.Report) {
+	fmt.Fprintln(w, "Installed inventory")
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "Metadata: %s", report.Metadata.Path)
+	if report.Metadata.Version != 0 {
+		fmt.Fprintf(w, " (version %d)", report.Metadata.Version)
+	}
+	fmt.Fprintln(w)
+	if !report.Provenance.Empty() {
+		parts := []string{}
+		if report.Provenance.SourceRoot != "" {
+			parts = append(parts, "source="+report.Provenance.SourceRoot)
+		}
+		if report.Provenance.SourceRevision != "" {
+			parts = append(parts, "commit="+report.Provenance.SourceRevision)
+		}
+		if report.Provenance.DotsVersion != "" {
+			parts = append(parts, "dots="+report.Provenance.DotsVersion)
+		}
+		if report.Provenance.RecordedAt != "" {
+			parts = append(parts, "recorded="+report.Provenance.RecordedAt)
+		}
+		fmt.Fprintf(w, "Provenance: %s\n", strings.Join(parts, ", "))
+	} else {
+		fmt.Fprintln(w, "Provenance: unknown (metadata predates provenance capture)")
+	}
+
+	fmt.Fprintln(w)
+	if len(report.ManagedEntries) == 0 {
+		fmt.Fprintln(w, "Managed Entries: none recorded")
+	} else {
+		fmt.Fprintf(w, "Managed Entries (%d)\n", len(report.ManagedEntries))
+		for _, entry := range report.ManagedEntries {
+			fmt.Fprintf(w, "  %-8s %s -> %s\n", entry.Strategy, entry.Source, entry.Target)
+			fmt.Fprintf(w, "    tags: %s (%s)\n", renderListOrUnknown(entry.Tags), entry.TagsSource)
+			fmt.Fprintf(w, "    profiles: %s (%s)\n", renderListOrUnknown(entry.Profiles), entry.ProfilesSource)
+			if entry.InstalledAt != "" {
+				fmt.Fprintf(w, "    installed: %s\n", entry.InstalledAt)
+			}
+			if !entry.ManifestMatched {
+				fmt.Fprintln(w, "    manifest: no current match")
+			}
+		}
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "Tags represented: %s\n", renderListOrNone(report.Tags))
+
+	fmt.Fprintln(w)
+	if len(report.Profiles) == 0 {
+		fmt.Fprintln(w, "Profiles: none inferred or recorded")
+	} else {
+		fmt.Fprintln(w, "Profiles")
+		for _, profile := range report.Profiles {
+			fmt.Fprintf(w, "  %-18s %-8s %s\n", profile.Name, profile.State, profile.Source)
+			fmt.Fprintf(w, "    tags: %s", renderListOrNone(profile.CoveredTags))
+			if len(profile.MissingTags) > 0 {
+				fmt.Fprintf(w, " (missing: %s)", strings.Join(profile.MissingTags, ", "))
+			}
+			fmt.Fprintln(w)
+			fmt.Fprintf(w, "    managed entries: %d/%d\n", profile.CoveredEntries, profile.TotalEntries)
+			fmt.Fprintf(w, "    provisioners: %d/%d recorded, %d provisioned\n", profile.RecordedProvisioners, profile.TotalProvisioners, profile.ProvisionedProvisioners)
+		}
+	}
+
+	fmt.Fprintln(w)
+	if len(report.Provisioners) == 0 {
+		fmt.Fprintln(w, "Provisioners: none recorded")
+	} else {
+		fmt.Fprintf(w, "Provisioners (%d)\n", len(report.Provisioners))
+		for _, prov := range report.Provisioners {
+			fmt.Fprintf(w, "  %-22s %s %s\n", prov.Status, prov.Executable, strings.Join(prov.Args, " "))
+			fmt.Fprintf(w, "    tags: %s (%s)\n", renderListOrUnknown(prov.Tags), prov.TagsSource)
+			fmt.Fprintf(w, "    profiles: %s (%s)\n", renderListOrUnknown(prov.Profiles), prov.ProfilesSource)
+			if prov.LastRunAt != "" {
+				fmt.Fprintf(w, "    last run: %s\n", prov.LastRunAt)
+			}
+			if len(prov.Missing) > 0 {
+				fmt.Fprintf(w, "    missing: %s\n", strings.Join(prov.Missing, ", "))
+			}
+			if !prov.ManifestMatched {
+				fmt.Fprintln(w, "    manifest: no current match")
+			}
+		}
+	}
+
+	if len(report.Notes) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Notes")
+		for _, note := range report.Notes {
+			fmt.Fprintf(w, "  - %s\n", note)
+		}
+	}
+}
+
+func renderListOrUnknown(values []string) string {
+	if len(values) == 0 {
+		return "unknown"
+	}
+	return strings.Join(values, ", ")
+}
+
+func renderListOrNone(values []string) string {
+	if len(values) == 0 {
+		return "none"
+	}
+	return strings.Join(values, ", ")
+}

--- a/internal/cli/installed_test.go
+++ b/internal/cli/installed_test.go
@@ -1,0 +1,78 @@
+package cli_test
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/cli"
+	"github.com/yersonargotev/dots/internal/state"
+)
+
+func TestInstalledJSONEnvelope(t *testing.T) {
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	manifestPath, sourceRoot := writeStatusManifest(t, home, "core")
+	target := filepath.Join(home, ".zshrc")
+	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: 2, Provenance: state.Provenance{SourceRoot: sourceRoot, SourceRevision: "abc123", DotsVersion: "v0.test"}, Entries: []state.Record{{
+		Target:   target,
+		Source:   "configs/zsh/zshrc",
+		Strategy: "symlink",
+		Profiles: []string{"default"},
+		Tags:     []string{"core"},
+	}}}); err != nil {
+		t.Fatalf("save metadata: %v", err)
+	}
+
+	var out, errOut bytes.Buffer
+	code := cli.Run([]string{
+		"installed", "--output", "json", "--file", manifestPath,
+		"--source-root", sourceRoot, "--home", home, "--state-root", stateRoot,
+	}, &out, &errOut)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
+	}
+	env := decodeEnvelopeForCommand(t, out.String(), "installed")
+	if env.Status != "ok" {
+		t.Fatalf("status = %q, want ok", env.Status)
+	}
+	data := string(env.Data)
+	for _, want := range []string{`"managed_entries"`, `"tags"`, `"profiles"`, `"provenance"`, `"source_revision": "abc123"`, `"profiles_source": "recorded"`} {
+		if !strings.Contains(data, want) {
+			t.Fatalf("installed JSON missing %s\ndata:\n%s", want, data)
+		}
+	}
+	if strings.Contains(out.String(), "Installed inventory") {
+		t.Fatalf("JSON mode leaked human prose:\n%s", out.String())
+	}
+}
+
+func TestInstalledTextExplainsPartialProfile(t *testing.T) {
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	manifestPath, sourceRoot := writeStatusManifest(t, home, "core")
+	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: 1, Entries: []state.Record{{
+		Target:   filepath.Join(home, ".zshrc"),
+		Source:   "configs/zsh/zshrc",
+		Strategy: "symlink",
+	}}}); err != nil {
+		t.Fatalf("save metadata: %v", err)
+	}
+
+	var out, errOut bytes.Buffer
+	code := cli.Run([]string{
+		"installed", "--file", manifestPath,
+		"--source-root", sourceRoot, "--home", home, "--state-root", stateRoot,
+	}, &out, &errOut)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
+	}
+	for _, want := range []string{"Installed inventory", "Managed Entries (1)", "Tags represented: core", "Profiles", "Notes", "inferred-from-manifest"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("text output missing %q\noutput:\n%s", want, out.String())
+		}
+	}
+}

--- a/internal/cli/output_golden_test.go
+++ b/internal/cli/output_golden_test.go
@@ -8,8 +8,10 @@ import (
 	"github.com/yersonargotev/dots/internal/deps"
 	"github.com/yersonargotev/dots/internal/deps/pkgmgr"
 	"github.com/yersonargotev/dots/internal/doctor"
+	inst "github.com/yersonargotev/dots/internal/installed"
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/provision"
+	"github.com/yersonargotev/dots/internal/state"
 	"github.com/yersonargotev/dots/internal/status"
 )
 
@@ -52,6 +54,23 @@ func TestEnvelopeGolden(t *testing.T) {
 				},
 			},
 			golden: "envelope_status.golden",
+		},
+		{
+			name: "installed",
+			env: envelope{
+				SchemaVersion: schemaVersion,
+				Command:       "installed",
+				Status:        statusOK,
+				Data: inst.Report{
+					Metadata:       inst.MetadataSummary{Path: "/home/user/.local/state/dots/installed.json", Version: 2},
+					Provenance:     state.Provenance{SourceRoot: "/src/dots", SourceRevision: "abc123", DotsVersion: "v0.test", RecordedAt: "2026-07-08T12:00:00Z"},
+					ManagedEntries: []inst.ManagedEntry{{Source: "configs/zsh/zshrc", Target: "/home/user/.zshrc", Strategy: "symlink", InstalledAt: "2026-07-08T12:00:00Z", Tags: []string{"core"}, TagsSource: "recorded", Profiles: []string{"core"}, ProfilesSource: "recorded", ManifestMatched: true}},
+					Tags:           []string{"core"},
+					Profiles:       []inst.ProfileCoverage{{Name: "core", Source: "recorded+inferred", State: inst.CoverageComplete, CoveredTags: []string{"core"}, CoveredEntries: 1, TotalEntries: 1}},
+					Provisioners:   []inst.ProvisionerRun{{Tool: "gentle-ai", Executable: "gentle-ai", Args: []string{"install", "--scope", "global"}, Status: "provisioned", LastRunAt: "2026-07-08T12:00:00Z", Profile: "core", Profiles: []string{"core"}, ProfilesSource: "recorded", Tags: []string{"core"}, TagsSource: "recorded", ManifestMatched: true}},
+				},
+			},
+			golden: "envelope_installed.golden",
 		},
 		{
 			name: "plan",

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -59,6 +59,7 @@ func NewRootCommand() *cobra.Command {
 	root.AddCommand(newUpdateCommand())
 	root.AddCommand(newUpgradeCommand())
 	root.AddCommand(newStatusCommand())
+	root.AddCommand(newInstalledCommand())
 	root.AddCommand(newBackupsCommand())
 	root.AddCommand(newDepsCommand())
 	root.AddCommand(newDoctorCommand())

--- a/internal/cli/testdata/envelope_installed.golden
+++ b/internal/cli/testdata/envelope_installed.golden
@@ -1,0 +1,75 @@
+{
+  "schema_version": "5",
+  "command": "installed",
+  "status": "ok",
+  "data": {
+    "metadata": {
+      "path": "/home/user/.local/state/dots/installed.json",
+      "version": 2
+    },
+    "provenance": {
+      "source_root": "/src/dots",
+      "source_revision": "abc123",
+      "dots_version": "v0.test",
+      "recorded_at": "2026-07-08T12:00:00Z"
+    },
+    "managed_entries": [
+      {
+        "source": "configs/zsh/zshrc",
+        "target": "/home/user/.zshrc",
+        "strategy": "symlink",
+        "installed_at": "2026-07-08T12:00:00Z",
+        "tags": [
+          "core"
+        ],
+        "tags_source": "recorded",
+        "profiles": [
+          "core"
+        ],
+        "profiles_source": "recorded",
+        "manifest_matched": true
+      }
+    ],
+    "tags": [
+      "core"
+    ],
+    "profiles": [
+      {
+        "name": "core",
+        "source": "recorded+inferred",
+        "state": "complete",
+        "covered_tags": [
+          "core"
+        ],
+        "covered_entries": 1,
+        "total_entries": 1,
+        "recorded_provisioners": 0,
+        "provisioned_provisioners": 0,
+        "total_provisioners": 0
+      }
+    ],
+    "provisioners": [
+      {
+        "tool": "gentle-ai",
+        "executable": "gentle-ai",
+        "args": [
+          "install",
+          "--scope",
+          "global"
+        ],
+        "status": "provisioned",
+        "last_run_at": "2026-07-08T12:00:00Z",
+        "profile": "core",
+        "profiles": [
+          "core"
+        ],
+        "profiles_source": "recorded",
+        "tags": [
+          "core"
+        ],
+        "tags_source": "recorded",
+        "manifest_matched": true
+      }
+    ]
+  }
+}

--- a/internal/installed/installed.go
+++ b/internal/installed/installed.go
@@ -98,8 +98,12 @@ type Options struct {
 // represented Tags and Profile coverage without touching managed targets.
 func Build(m manifest.Manifest, meta state.Metadata, opts Options) (Report, error) {
 	report := Report{
-		Metadata:   MetadataSummary{Path: opts.StatePath, Version: meta.Version},
-		Provenance: meta.Provenance,
+		Metadata:       MetadataSummary{Path: opts.StatePath, Version: meta.Version},
+		Provenance:     meta.Provenance,
+		ManagedEntries: []ManagedEntry{},
+		Tags:           []string{},
+		Profiles:       []ProfileCoverage{},
+		Provisioners:   []ProvisionerRun{},
 	}
 
 	matchedEntryKeys := map[string]bool{}
@@ -285,7 +289,7 @@ func profileCoverage(m manifest.Manifest, opts Options, representedTags map[stri
 	}
 	sort.Strings(profileNames)
 
-	var out []ProfileCoverage
+	out := []ProfileCoverage{}
 	for _, name := range profileNames {
 		profile := m.Profiles[name]
 		coveredTags, missingTags := splitTags(profile.Tags, representedTags)
@@ -416,7 +420,9 @@ func (s *orderedSet) add(value string) {
 }
 
 func (s orderedSet) values() []string {
-	return append([]string(nil), s.order...)
+	out := make([]string, len(s.order))
+	copy(out, s.order)
+	return out
 }
 
 func (s orderedSet) set() map[string]bool {

--- a/internal/installed/installed.go
+++ b/internal/installed/installed.go
@@ -1,0 +1,432 @@
+// Package installed builds a read-only inventory from Installation Metadata.
+package installed
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/plan"
+	"github.com/yersonargotev/dots/internal/provision"
+	"github.com/yersonargotev/dots/internal/state"
+)
+
+// CoverageState describes how much of a Profile appears represented by the
+// current Installation Metadata.
+type CoverageState string
+
+const (
+	CoverageComplete CoverageState = "complete"
+	CoveragePartial  CoverageState = "partial"
+)
+
+// MetadataSummary identifies the state file used to build the report.
+type MetadataSummary struct {
+	Path    string `json:"path"`
+	Version int    `json:"version"`
+}
+
+// ManagedEntry is one Managed Entry recorded in Installation Metadata.
+type ManagedEntry struct {
+	Source          string   `json:"source"`
+	Target          string   `json:"target"`
+	Strategy        string   `json:"strategy"`
+	Hash            string   `json:"hash,omitempty"`
+	InstalledAt     string   `json:"installed_at,omitempty"`
+	Tags            []string `json:"tags,omitempty"`
+	TagsSource      string   `json:"tags_source"`
+	Profiles        []string `json:"profiles,omitempty"`
+	ProfilesSource  string   `json:"profiles_source"`
+	ManifestMatched bool     `json:"manifest_matched"`
+}
+
+// ProfileCoverage summarizes whether a Profile is explicit in metadata or can be
+// inferred from represented Tags and how complete its current-OS coverage is.
+type ProfileCoverage struct {
+	Name                    string        `json:"name"`
+	Source                  string        `json:"source"`
+	State                   CoverageState `json:"state"`
+	CoveredTags             []string      `json:"covered_tags,omitempty"`
+	MissingTags             []string      `json:"missing_tags,omitempty"`
+	CoveredEntries          int           `json:"covered_entries"`
+	TotalEntries            int           `json:"total_entries"`
+	RecordedProvisioners    int           `json:"recorded_provisioners"`
+	ProvisionedProvisioners int           `json:"provisioned_provisioners"`
+	TotalProvisioners       int           `json:"total_provisioners"`
+}
+
+// ProvisionerRun is one Provisioner outcome recorded in Installation Metadata.
+type ProvisionerRun struct {
+	Tool            string   `json:"tool"`
+	Executable      string   `json:"executable"`
+	Args            []string `json:"args"`
+	Status          string   `json:"status,omitempty"`
+	Missing         []string `json:"missing,omitempty"`
+	LastRunAt       string   `json:"last_run_at,omitempty"`
+	Profile         string   `json:"profile,omitempty"`
+	Profiles        []string `json:"profiles,omitempty"`
+	ProfilesSource  string   `json:"profiles_source"`
+	Tags            []string `json:"tags,omitempty"`
+	TagsSource      string   `json:"tags_source"`
+	ManifestMatched bool     `json:"manifest_matched"`
+}
+
+// Report is the official installed inventory. It is a read-only informational
+// report, so HasFindings always returns false.
+type Report struct {
+	Metadata       MetadataSummary   `json:"metadata"`
+	Provenance     state.Provenance  `json:"provenance,omitempty"`
+	ManagedEntries []ManagedEntry    `json:"managed_entries"`
+	Tags           []string          `json:"tags"`
+	Profiles       []ProfileCoverage `json:"profiles"`
+	Provisioners   []ProvisionerRun  `json:"provisioners"`
+	Notes          []string          `json:"notes,omitempty"`
+}
+
+func (r Report) HasFindings() bool { return false }
+
+type Options struct {
+	StatePath  string
+	SourceRoot string
+	Home       string
+	OS         string
+}
+
+// Build joins Installation Metadata with the current Install Manifest to infer
+// represented Tags and Profile coverage without touching managed targets.
+func Build(m manifest.Manifest, meta state.Metadata, opts Options) (Report, error) {
+	report := Report{
+		Metadata:   MetadataSummary{Path: opts.StatePath, Version: meta.Version},
+		Provenance: meta.Provenance,
+	}
+
+	matchedEntryKeys := map[string]bool{}
+	representedTags := orderedSet{}
+	explicitProfiles := orderedSet{}
+	legacyTagsInferred := false
+	legacyProfilesInferred := false
+	unmatchedEntries := false
+
+	for _, rec := range meta.Entries {
+		entry, matched, err := matchEntry(m, rec, opts)
+		if err != nil {
+			return Report{}, err
+		}
+		if matched {
+			matchedEntryKeys[entryKey(entry, opts.Home)] = true
+		}
+
+		tags := append([]string(nil), rec.Tags...)
+		tagsSource := "recorded"
+		if len(tags) == 0 && matched {
+			tags = append([]string(nil), entry.Tags...)
+			tagsSource = "inferred-from-manifest"
+			legacyTagsInferred = true
+		} else if len(tags) == 0 {
+			tagsSource = "unknown"
+			unmatchedEntries = true
+		}
+		for _, tag := range tags {
+			representedTags.add(tag)
+		}
+
+		profiles := normalizeProfiles(rec.Profiles, "")
+		profilesSource := "recorded"
+		if len(profiles) == 0 {
+			profiles = normalizeProfiles(nil, "")
+			profilesSource = "unknown"
+			legacyProfilesInferred = true
+		}
+		for _, profile := range profiles {
+			explicitProfiles.add(profile)
+		}
+
+		report.ManagedEntries = append(report.ManagedEntries, ManagedEntry{
+			Source:          rec.Source,
+			Target:          rec.Target,
+			Strategy:        rec.Strategy,
+			Hash:            rec.Hash,
+			InstalledAt:     rec.InstalledAt,
+			Tags:            tags,
+			TagsSource:      tagsSource,
+			Profiles:        profiles,
+			ProfilesSource:  profilesSource,
+			ManifestMatched: matched,
+		})
+	}
+
+	provMatches, err := provisionerMatches(m, opts.OS)
+	if err != nil {
+		return Report{}, err
+	}
+	recordedProvisioners := map[string]state.ProvisionerRecord{}
+	for _, rec := range meta.Provisioners {
+		key := provisionerKey(rec.Tool, rec.Executable, rec.Args)
+		recordedProvisioners[key] = rec
+		matched := provMatches[key]
+		tags := append([]string(nil), rec.Tags...)
+		tagsSource := "recorded"
+		if len(tags) == 0 && len(matched.tags) > 0 {
+			tags = append([]string(nil), matched.tags...)
+			tagsSource = "inferred-from-manifest"
+			legacyTagsInferred = true
+		} else if len(tags) == 0 {
+			tagsSource = "unknown"
+		}
+		for _, tag := range tags {
+			representedTags.add(tag)
+		}
+
+		profiles := normalizeProfiles(rec.Profiles, rec.Profile)
+		profilesSource := "recorded"
+		if len(profiles) == 0 {
+			profilesSource = "unknown"
+			legacyProfilesInferred = true
+		}
+		for _, profile := range profiles {
+			explicitProfiles.add(profile)
+		}
+
+		report.Provisioners = append(report.Provisioners, ProvisionerRun{
+			Tool:            rec.Tool,
+			Executable:      rec.Executable,
+			Args:            append([]string(nil), rec.Args...),
+			Status:          rec.Status,
+			Missing:         append([]string(nil), rec.Missing...),
+			LastRunAt:       rec.LastRunAt,
+			Profile:         rec.Profile,
+			Profiles:        profiles,
+			ProfilesSource:  profilesSource,
+			Tags:            tags,
+			TagsSource:      tagsSource,
+			ManifestMatched: len(matched.tags) > 0,
+		})
+	}
+
+	report.Tags = representedTags.values()
+	report.Profiles = profileCoverage(m, opts, representedTags.set(), explicitProfiles.set(), matchedEntryKeys, recordedProvisioners)
+	if legacyTagsInferred {
+		report.Notes = append(report.Notes, "some metadata predates recorded tags; tags were inferred from the current manifest where possible")
+	}
+	if legacyProfilesInferred {
+		report.Notes = append(report.Notes, "some metadata predates recorded profiles; profile coverage may be inferred from represented tags")
+	}
+	if unmatchedEntries {
+		report.Notes = append(report.Notes, "some installed entries no longer match the current manifest; their tags and profile coverage are unknown")
+	}
+	if meta.Provenance.Empty() {
+		report.Notes = append(report.Notes, "metadata does not record Source of Truth provenance; run a future install/update to capture source revision and dots version")
+	}
+	return report, nil
+}
+
+func matchEntry(m manifest.Manifest, rec state.Record, opts Options) (manifest.Entry, bool, error) {
+	for _, entry := range m.Entries {
+		if !manifest.MatchesOS(entry.OS, opts.OS) {
+			continue
+		}
+		target, err := plan.ResolveTarget(entry.Target, opts.Home)
+		if err != nil {
+			return manifest.Entry{}, false, err
+		}
+		if filepath.Clean(target) != filepath.Clean(rec.Target) || entry.Strategy != rec.Strategy {
+			continue
+		}
+		if compatibleEntrySource(entry, rec.Source) {
+			return entry, true, nil
+		}
+	}
+	return manifest.Entry{}, false, nil
+}
+
+func compatibleEntrySource(entry manifest.Entry, source string) bool {
+	if source == entry.Source {
+		return true
+	}
+	for _, override := range entry.SourceOverrides {
+		if source == override {
+			return true
+		}
+	}
+	return false
+}
+
+func entryKey(entry manifest.Entry, home string) string {
+	target, err := plan.ResolveTarget(entry.Target, home)
+	if err != nil {
+		return entry.Target + "\x00" + entry.Strategy
+	}
+	return filepath.Clean(target) + "\x00" + entry.Strategy
+}
+
+type provisionerMatch struct{ tags []string }
+
+func provisionerMatches(m manifest.Manifest, osName string) (map[string]provisionerMatch, error) {
+	matches := map[string]provisionerMatch{}
+	for _, prov := range m.Provisioners {
+		if !manifest.MatchesOS(prov.OS, osName) {
+			continue
+		}
+		executable, args := provision.RenderCommand(prov)
+		key := provisionerKey(prov.Tool, executable, args)
+		match := matches[key]
+		match.tags = appendUnique(match.tags, prov.Tags...)
+		matches[key] = match
+	}
+	return matches, nil
+}
+
+func profileCoverage(m manifest.Manifest, opts Options, representedTags map[string]bool, explicitProfiles map[string]bool, matchedEntryKeys map[string]bool, recordedProvisioners map[string]state.ProvisionerRecord) []ProfileCoverage {
+	profileNames := make([]string, 0, len(m.Profiles))
+	for name := range m.Profiles {
+		profileNames = append(profileNames, name)
+	}
+	sort.Strings(profileNames)
+
+	var out []ProfileCoverage
+	for _, name := range profileNames {
+		profile := m.Profiles[name]
+		coveredTags, missingTags := splitTags(profile.Tags, representedTags)
+		if len(coveredTags) == 0 && !explicitProfiles[name] {
+			continue
+		}
+
+		coverage := ProfileCoverage{Name: name, CoveredTags: coveredTags, MissingTags: missingTags}
+		coverage.Source = "inferred"
+		if explicitProfiles[name] && len(coveredTags) > 0 {
+			coverage.Source = "recorded+inferred"
+		} else if explicitProfiles[name] {
+			coverage.Source = "recorded"
+		}
+
+		coverage.TotalEntries, coverage.CoveredEntries = entryCoverageForProfile(m, name, opts, matchedEntryKeys)
+		coverage.TotalProvisioners, coverage.RecordedProvisioners, coverage.ProvisionedProvisioners = provisionerCoverageForProfile(m, name, opts.OS, recordedProvisioners)
+		coverage.State = CoverageComplete
+		if len(missingTags) > 0 || coverage.CoveredEntries < coverage.TotalEntries || coverage.RecordedProvisioners < coverage.TotalProvisioners {
+			coverage.State = CoveragePartial
+		}
+		out = append(out, coverage)
+	}
+	return out
+}
+
+func entryCoverageForProfile(m manifest.Manifest, profileName string, opts Options, matchedEntryKeys map[string]bool) (int, int) {
+	profile := m.Profiles[profileName]
+	total, covered := 0, 0
+	for _, entry := range m.Entries {
+		if !manifest.SharesTag(entry.Tags, profile.Tags) || !manifest.MatchesOS(entry.OS, opts.OS) {
+			continue
+		}
+		total++
+		if matchedEntryKeys[entryKey(entry, opts.Home)] {
+			covered++
+		}
+	}
+	return total, covered
+}
+
+func provisionerCoverageForProfile(m manifest.Manifest, profileName, osName string, records map[string]state.ProvisionerRecord) (int, int, int) {
+	profile := m.Profiles[profileName]
+	total, recorded, provisioned := 0, 0, 0
+	seen := map[string]bool{}
+	for _, prov := range m.Provisioners {
+		if !manifest.SharesTag(prov.Tags, profile.Tags) || !manifest.MatchesOS(prov.OS, osName) {
+			continue
+		}
+		executable, args := provision.RenderCommand(prov)
+		key := provisionerKey(prov.Tool, executable, args)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		total++
+		if rec, ok := records[key]; ok {
+			recorded++
+			if rec.Status == string(provision.RunStatusProvisioned) {
+				provisioned++
+			}
+		}
+	}
+	return total, recorded, provisioned
+}
+
+func splitTags(profileTags []string, represented map[string]bool) ([]string, []string) {
+	var covered, missing []string
+	for _, tag := range profileTags {
+		if represented[tag] {
+			covered = append(covered, tag)
+		} else {
+			missing = append(missing, tag)
+		}
+	}
+	return covered, missing
+}
+
+func provisionerKey(tool, executable string, args []string) string {
+	return tool + "\x00" + executable + "\x00" + strings.Join(args, "\x00")
+}
+
+func normalizeProfiles(profiles []string, legacy string) []string {
+	set := orderedSet{}
+	for _, profile := range profiles {
+		set.add(profile)
+	}
+	for _, profile := range strings.Split(legacy, ",") {
+		set.add(profile)
+	}
+	return set.values()
+}
+
+func appendUnique(values []string, additions ...string) []string {
+	seen := map[string]bool{}
+	for _, value := range values {
+		seen[value] = true
+	}
+	for _, value := range additions {
+		value = strings.TrimSpace(value)
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		values = append(values, value)
+	}
+	return values
+}
+
+type orderedSet struct {
+	order []string
+	seen  map[string]bool
+}
+
+func (s *orderedSet) add(value string) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return
+	}
+	if s.seen == nil {
+		s.seen = map[string]bool{}
+	}
+	if s.seen[value] {
+		return
+	}
+	s.seen[value] = true
+	s.order = append(s.order, value)
+}
+
+func (s orderedSet) values() []string {
+	return append([]string(nil), s.order...)
+}
+
+func (s orderedSet) set() map[string]bool {
+	out := map[string]bool{}
+	for _, value := range s.order {
+		out[value] = true
+	}
+	return out
+}
+
+func (r Report) String() string {
+	return fmt.Sprintf("%d managed entries, %d tags, %d profiles, %d provisioners", len(r.ManagedEntries), len(r.Tags), len(r.Profiles), len(r.Provisioners))
+}

--- a/internal/installed/installed_test.go
+++ b/internal/installed/installed_test.go
@@ -1,0 +1,130 @@
+package installed_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	inst "github.com/yersonargotev/dots/internal/installed"
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/provision"
+	"github.com/yersonargotev/dots/internal/state"
+)
+
+func TestBuildInfersLegacyMetadataAndPartialProfiles(t *testing.T) {
+	home := t.TempDir()
+	m := inventoryManifest()
+	prov := m.Provisioners[0]
+	executable, args := provision.RenderCommand(prov)
+	meta := state.Metadata{
+		Version: 1,
+		Entries: []state.Record{{
+			Target:   filepath.Join(home, ".zshrc"),
+			Source:   "configs/zsh/zshrc",
+			Strategy: "symlink",
+		}},
+		Provisioners: []state.ProvisionerRecord{{
+			Profile:    "agents",
+			Tool:       prov.Tool,
+			Executable: executable,
+			Args:       args,
+			Status:     string(provision.RunStatusProvisioned),
+		}},
+	}
+
+	report, err := inst.Build(m, meta, inst.Options{StatePath: filepath.Join(home, ".local/state/dots/installed.json"), Home: home, OS: "linux"})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	if got, want := report.Tags, []string{"core", "agents"}; !sameStrings(got, want) {
+		t.Fatalf("Tags = %v, want %v", got, want)
+	}
+	if len(report.ManagedEntries) != 1 || report.ManagedEntries[0].TagsSource != "inferred-from-manifest" || report.ManagedEntries[0].ProfilesSource != "unknown" {
+		t.Fatalf("legacy entry inference = %+v", report.ManagedEntries)
+	}
+	if len(report.Provisioners) != 1 || report.Provisioners[0].ProfilesSource != "recorded" || report.Provisioners[0].TagsSource != "inferred-from-manifest" {
+		t.Fatalf("provisioner inference = %+v", report.Provisioners)
+	}
+
+	workstation := findProfile(t, report.Profiles, "workstation")
+	if workstation.Source != "inferred" || workstation.State != inst.CoveragePartial {
+		t.Fatalf("workstation coverage = %+v, want inferred partial", workstation)
+	}
+	if got, want := workstation.CoveredTags, []string{"core", "agents"}; !sameStrings(got, want) {
+		t.Fatalf("workstation covered tags = %v, want %v", got, want)
+	}
+	if got, want := workstation.MissingTags, []string{"desktop"}; !sameStrings(got, want) {
+		t.Fatalf("workstation missing tags = %v, want %v", got, want)
+	}
+
+	agents := findProfile(t, report.Profiles, "agents")
+	if agents.Source != "recorded+inferred" || agents.State != inst.CoverageComplete || agents.ProvisionedProvisioners != 1 {
+		t.Fatalf("agents coverage = %+v, want recorded+inferred complete with provisioner", agents)
+	}
+	if len(report.Notes) == 0 {
+		t.Fatal("legacy metadata should produce explanatory notes")
+	}
+}
+
+func TestBuildUsesRecordedProfilesAndTags(t *testing.T) {
+	home := t.TempDir()
+	m := inventoryManifest()
+	meta := state.Metadata{Version: 2, Provenance: state.Provenance{SourceRoot: "/src", SourceRevision: "abc123", DotsVersion: "v0.test"}, Entries: []state.Record{{
+		Target:   filepath.Join(home, ".zshrc"),
+		Source:   "configs/zsh/zshrc",
+		Strategy: "symlink",
+		Profiles: []string{"core"},
+		Tags:     []string{"core"},
+	}}}
+
+	report, err := inst.Build(m, meta, inst.Options{StatePath: filepath.Join(home, "installed.json"), Home: home, OS: "linux"})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	core := findProfile(t, report.Profiles, "core")
+	if core.Source != "recorded+inferred" || core.State != inst.CoverageComplete {
+		t.Fatalf("core coverage = %+v, want recorded+inferred complete", core)
+	}
+	if report.Provenance.SourceRevision != "abc123" {
+		t.Fatalf("provenance = %+v", report.Provenance)
+	}
+}
+
+func inventoryManifest() manifest.Manifest {
+	return manifest.Manifest{
+		Profiles: map[string]manifest.Profile{
+			"core":        {Tags: []string{"core"}},
+			"desktop":     {Tags: []string{"desktop"}},
+			"agents":      {Tags: []string{"agents"}},
+			"workstation": {Tags: []string{"core", "desktop", "agents"}},
+		},
+		Entries: []manifest.Entry{
+			{Source: "configs/zsh/zshrc", Target: "~/.zshrc", Strategy: "symlink", Tags: []string{"core"}},
+			{Source: "configs/ghostty/config", Target: "~/.config/ghostty/config", Strategy: "symlink", Tags: []string{"desktop"}},
+		},
+		Provisioners: []manifest.Provisioner{{Tool: "gentle-ai", Tags: []string{"agents"}, Spec: manifest.ProvisionerSpec{Scope: "global", Agents: []string{"codex"}}}},
+	}
+}
+
+func findProfile(t *testing.T, profiles []inst.ProfileCoverage, name string) inst.ProfileCoverage {
+	t.Helper()
+	for _, profile := range profiles {
+		if profile.Name == name {
+			return profile
+		}
+	}
+	t.Fatalf("profile %q not found in %+v", name, profiles)
+	return inst.ProfileCoverage{}
+}
+
+func sameStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/installed/installed_test.go
+++ b/internal/installed/installed_test.go
@@ -90,6 +90,26 @@ func TestBuildUsesRecordedProfilesAndTags(t *testing.T) {
 	}
 }
 
+func TestBuildReturnsEmptyListsForEmptyMetadata(t *testing.T) {
+	home := t.TempDir()
+	report, err := inst.Build(inventoryManifest(), state.Metadata{}, inst.Options{StatePath: filepath.Join(home, "installed.json"), Home: home, OS: "linux"})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if report.ManagedEntries == nil {
+		t.Fatal("ManagedEntries = nil, want empty list for stable JSON output")
+	}
+	if report.Tags == nil {
+		t.Fatal("Tags = nil, want empty list for stable JSON output")
+	}
+	if report.Profiles == nil {
+		t.Fatal("Profiles = nil, want empty list for stable JSON output")
+	}
+	if report.Provisioners == nil {
+		t.Fatal("Provisioners = nil, want empty list for stable JSON output")
+	}
+}
+
 func inventoryManifest() manifest.Manifest {
 	return manifest.Manifest{
 		Profiles: map[string]manifest.Profile{


### PR DESCRIPTION
Closes #315

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds `dots installed`, a read-only inventory command over Installation Metadata.
- Reports Managed Entries, represented Tags, recorded vs inferred Profile coverage, recorded Provisioners, and Source of Truth provenance when available.
- Supports `--output json` through the Agent Output Contract and documents the new machine-readable surface.

## Changes

| File | Change |
|------|--------|
| `internal/installed/` | New inventory builder that joins `installed.json` with `dots.yaml` without touching managed targets. |
| `internal/cli/installed.go` | New `dots installed` command and human text renderer. |
| `internal/cli/root.go` | Registers the new command. |
| `internal/cli/installed_test.go` / `internal/installed/installed_test.go` | Focused coverage for JSON output, text output, legacy metadata inference, explicit profile/tag metadata, partial profile coverage, and Provisioner reporting. |
| `internal/cli/output_golden_test.go` / `internal/cli/testdata/envelope_installed.golden` | Locks the Agent Output Contract shape for `dots installed --output json`. |
| `docs/agents/output-contract.md`, `docs/update.md`, `docs/upgrade.md` | Documents the installed inventory UX and JSON contract. |

## Chain Context

- Strategy: stacked PRs to protect review size.
- Parent issue: #315.
- Depends on: PR #317 (`feat/installed-metadata`), now merged into `main`, for future installs to record explicit Profiles/Tags and provenance.
- This PR is slice 2/2 and closes #315 now that #317 has merged and this PR targets `main`.
- Dependency diagram:

```text
main (includes merged PR #317 metadata provenance/selection capture)
└── 📍 PR 2: feat/installed-inventory — read-only installed inventory command
```

Review budget note: this slice is 954 changed lines after the empty-list JSON fix, including focused tests and a 75-line JSON golden. I am requesting `size:exception` for this slice because the builder, CLI, docs, and contract fixture form one user-visible command surface; splitting further would leave non-user-visible internals without the UX that proves them.

## Test Plan

- [x] `go test ./internal/installed ./internal/cli ./internal/install`
- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile core --source-root "$PWD" --home <tmp>`
- [x] Smoke: `go run ./cmd/dots installed --output json --file dots.yaml --source-root "$PWD" --home <tmp>/home --state-root <tmp>/state`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #315`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit; see `size:exception` note above for the cohesive command-surface rationale.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

