### PR TITLE
feat(config): add Herdr cmd workspace shortcuts

### DIFF
--- a/configs/ghostty/README.md
+++ b/configs/ghostty/README.md
@@ -29,7 +29,7 @@ The live `~/.config/ghostty/config` file was classified before adoption:
 
 | Category | Examples | Repository decision |
 | --- | --- | --- |
-| **Portable** | font family, font size, Catppuccin Mocha fallback theme, optional `adaptive-theme` native light/dark include, intentional keybindings for terminal workflow and Zellij/tmux forwarding | Managed in `configs/ghostty/config.ghostty`. |
+| **Portable** | font family, font size, Catppuccin Mocha fallback theme, optional `adaptive-theme` native light/dark include, intentional keybindings for terminal workflow and Zellij/tmux/Herdr forwarding | Managed in `configs/ghostty/config.ghostty`. |
 | **Machine-specific** | window dimensions, opacity/blur, window padding ergonomics, explicit shell/command paths, initial working directories, OS integrations, display/GPU/host-dependent behavior | Excluded from the shared file; document deliberate host-specific exceptions in `configs/ghostty/config.local.ghostty.example`. |
 | **Generated** | logs, caches, sessions, backups, temporary files, generated state, local shaders | Never committed. |
 | **Private** | secrets, authenticated state, private paths, hostnames, machine IDs | Excluded. |

--- a/configs/ghostty/config.ghostty
+++ b/configs/ghostty/config.ghostty
@@ -28,5 +28,7 @@ keybind = super+shift+h=esc:H
 keybind = super+shift+j=esc:J
 keybind = super+shift+k=esc:K
 keybind = super+shift+l=esc:L
-keybind = cmd+k=clear_screen
+# Let terminal multiplexers such as Herdr receive direct workspace navigation.
+keybind = cmd+j=unbind
+keybind = cmd+k=unbind
 keybind = alt+s=write_screen_file:paste

--- a/configs/herdr/config-adaptive.toml
+++ b/configs/herdr/config-adaptive.toml
@@ -52,6 +52,8 @@ goto = "prefix+g"
 new_workspace = "prefix+shift+n"
 rename_workspace = "prefix+shift+w"
 close_workspace = "prefix+alt+d"
+previous_workspace = "cmd+k"
+next_workspace = "cmd+j"
 toggle_sidebar = "prefix+b"
 
 # Tabs: prefix-first tmux-like core plus explicit direct tab navigation.

--- a/configs/herdr/config.toml
+++ b/configs/herdr/config.toml
@@ -46,6 +46,8 @@ goto = "prefix+g"
 new_workspace = "prefix+shift+n"
 rename_workspace = "prefix+shift+w"
 close_workspace = "prefix+alt+d"
+previous_workspace = "cmd+k"
+next_workspace = "cmd+j"
 toggle_sidebar = "prefix+b"
 
 # Tabs: prefix-first tmux-like core plus explicit direct tab navigation.

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -3597,6 +3597,15 @@ func TestRepositoryHerdrConfigSupportsAdaptiveThemeOverride(t *testing.T) {
 	}
 
 	defaultText := string(defaultConfig)
+	for _, want := range []string{
+		`previous_workspace = "cmd+k"`,
+		`next_workspace = "cmd+j"`,
+	} {
+		if !strings.Contains(defaultText, want) {
+			t.Fatalf("default Herdr config missing workspace shortcut %q:\n%s", want, defaultText)
+		}
+	}
+
 	adaptiveText := string(adaptiveConfig)
 	if got, want := herdrConfigWithoutTheme(t, adaptiveText), herdrConfigWithoutTheme(t, defaultText); got != want {
 		t.Fatalf("adaptive Herdr config non-theme sections drifted from default; got:\n%s\nwant:\n%s", got, want)
@@ -3621,6 +3630,37 @@ func herdrConfigWithoutTheme(t *testing.T, config string) string {
 	}
 	themeEnd := themeStart + len("[theme]") + nextSection + 1
 	return body[:themeStart] + body[themeEnd:]
+}
+
+func TestRepositoryGhosttyConfigForwardsHerdrWorkspaceShortcuts(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", ".."))
+	configPath := filepath.Join(root, "configs/ghostty/config.ghostty")
+
+	configBytes, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read Ghostty config: %v", err)
+	}
+	config := string(configBytes)
+
+	for _, want := range []string{
+		`keybind = cmd+j=unbind`,
+		`keybind = cmd+k=unbind`,
+	} {
+		if !strings.Contains(config, want) {
+			t.Fatalf("Ghostty config missing Herdr workspace passthrough %q:\n%s", want, config)
+		}
+	}
+
+	for _, notWant := range []string{
+		`keybind = cmd+j=scroll_to_selection`,
+		`keybind = cmd+k=clear_screen`,
+		`keybind = super+j=scroll_to_selection`,
+		`keybind = super+k=clear_screen`,
+	} {
+		if strings.Contains(config, notWant) {
+			t.Fatalf("Ghostty config consumes Herdr workspace shortcut %q:\n%s", notWant, config)
+		}
+	}
 }
 
 func TestAgentStatuslinePalettesUseAdaptiveHelper(t *testing.T) {


### PR DESCRIPTION
Closes #319

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds direct Herdr workspace navigation: `cmd+j` for next/down and `cmd+k` for previous/up.
- Keeps the default and adaptive Herdr configs synchronized outside theme-only differences.
- Releases Ghostty's default `cmd+j` / `cmd+k` key consumption so the chords can reach terminal multiplexers such as Herdr.

## Changes

| File | Change |
|------|--------|
| `configs/herdr/config.toml` | Adds `previous_workspace = "cmd+k"` and `next_workspace = "cmd+j"`. |
| `configs/herdr/config-adaptive.toml` | Mirrors the same non-theme workspace shortcuts. |
| `configs/ghostty/config.ghostty` | Unbinds `cmd+j` / `cmd+k` so Ghostty does not consume Herdr workspace shortcuts. |
| `configs/ghostty/README.md` | Documents Herdr forwarding as part of the portable keyboard behavior. |
| `internal/manifest/manifest_test.go` | Guards Herdr workspace shortcuts, adaptive config sync, and Ghostty passthrough. |

## Test Plan

- [x] `go test ./internal/manifest -run 'TestRepositoryHerdrConfigSupportsAdaptiveThemeOverride|TestRepositoryGhosttyConfigForwardsHerdrWorkspaceShortcuts'`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] `ghostty +validate-config --config-file=configs/ghostty/config.ghostty`
- [x] `herdr --default-config | rg -n "previous_workspace|next_workspace|cmd\+k|cmd\+j"`
- [x] Sandboxed install/status with explicit temp `--home`, `--source-root`, `--state-root`, and `--skip-deps`
- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `git diff --check`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

Note: an initial sandboxed `dots install` attempt omitted `--skip-deps`; it did not target the real home directory, but Homebrew dependency behavior ran before I stopped using that pattern. Final install/status validation used `--skip-deps`.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #319`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
