### PR TITLE
fix(config): remove Herdr command shortcuts

### DIFF
--- a/configs/ghostty/config.ghostty
+++ b/configs/ghostty/config.ghostty
@@ -28,7 +28,4 @@ keybind = super+shift+h=esc:H
 keybind = super+shift+j=esc:J
 keybind = super+shift+k=esc:K
 keybind = super+shift+l=esc:L
-# Let terminal multiplexers such as Herdr receive direct workspace navigation.
-keybind = cmd+j=unbind
-keybind = cmd+k=unbind
 keybind = alt+s=write_screen_file:paste

--- a/configs/herdr/config-adaptive.toml
+++ b/configs/herdr/config-adaptive.toml
@@ -52,23 +52,23 @@ goto = "prefix+g"
 new_workspace = "prefix+shift+n"
 rename_workspace = "prefix+shift+w"
 close_workspace = "prefix+alt+d"
-previous_workspace = "cmd+k"
-next_workspace = "cmd+j"
+previous_workspace = "ctrl+alt+shift+k"
+next_workspace = "ctrl+alt+shift+j"
 toggle_sidebar = "prefix+b"
 
 # Tabs: prefix-first tmux-like core plus explicit direct tab navigation.
 new_tab = "prefix+c"
 rename_tab = ["prefix+shift+t", "prefix+comma"]
-previous_tab = ["prefix+p", "ctrl+alt+[", "cmd+h"]
-next_tab = ["prefix+n", "ctrl+alt+]", "cmd+l"]
+previous_tab = ["prefix+p", "ctrl+alt+["]
+next_tab = ["prefix+n", "ctrl+alt+]"]
 switch_tab = "prefix+1..9"
 close_tab = "prefix+shift+x"
 
 # Panes: mirror dots tmux/Zellij intent and add direct pane focus chords.
-focus_pane_left = ["prefix+h", "ctrl+alt+h", "cmd+shift+h"]
-focus_pane_down = ["prefix+j", "ctrl+alt+j", "cmd+shift+j"]
-focus_pane_up = ["prefix+k", "ctrl+alt+k", "cmd+shift+k"]
-focus_pane_right = ["prefix+l", "ctrl+alt+l", "cmd+shift+l"]
+focus_pane_left = ["prefix+h", "ctrl+alt+h"]
+focus_pane_down = ["prefix+j", "ctrl+alt+j"]
+focus_pane_up = ["prefix+k", "ctrl+alt+k"]
+focus_pane_right = ["prefix+l", "ctrl+alt+l"]
 swap_pane_left = "prefix+shift+h"
 swap_pane_down = "prefix+shift+j"
 swap_pane_up = "prefix+shift+k"

--- a/configs/herdr/config.toml
+++ b/configs/herdr/config.toml
@@ -46,23 +46,23 @@ goto = "prefix+g"
 new_workspace = "prefix+shift+n"
 rename_workspace = "prefix+shift+w"
 close_workspace = "prefix+alt+d"
-previous_workspace = "cmd+k"
-next_workspace = "cmd+j"
+previous_workspace = "ctrl+alt+shift+k"
+next_workspace = "ctrl+alt+shift+j"
 toggle_sidebar = "prefix+b"
 
 # Tabs: prefix-first tmux-like core plus explicit direct tab navigation.
 new_tab = "prefix+c"
 rename_tab = ["prefix+shift+t", "prefix+comma"]
-previous_tab = ["prefix+p", "ctrl+alt+[", "cmd+h"]
-next_tab = ["prefix+n", "ctrl+alt+]", "cmd+l"]
+previous_tab = ["prefix+p", "ctrl+alt+["]
+next_tab = ["prefix+n", "ctrl+alt+]"]
 switch_tab = "prefix+1..9"
 close_tab = "prefix+shift+x"
 
 # Panes: mirror dots tmux/Zellij intent and add direct pane focus chords.
-focus_pane_left = ["prefix+h", "ctrl+alt+h", "cmd+shift+h"]
-focus_pane_down = ["prefix+j", "ctrl+alt+j", "cmd+shift+j"]
-focus_pane_up = ["prefix+k", "ctrl+alt+k", "cmd+shift+k"]
-focus_pane_right = ["prefix+l", "ctrl+alt+l", "cmd+shift+l"]
+focus_pane_left = ["prefix+h", "ctrl+alt+h"]
+focus_pane_down = ["prefix+j", "ctrl+alt+j"]
+focus_pane_up = ["prefix+k", "ctrl+alt+k"]
+focus_pane_right = ["prefix+l", "ctrl+alt+l"]
 swap_pane_left = "prefix+shift+h"
 swap_pane_down = "prefix+shift+j"
 swap_pane_up = "prefix+shift+k"

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -3598,15 +3598,27 @@ func TestRepositoryHerdrConfigSupportsAdaptiveThemeOverride(t *testing.T) {
 
 	defaultText := string(defaultConfig)
 	for _, want := range []string{
-		`previous_workspace = "cmd+k"`,
-		`next_workspace = "cmd+j"`,
+		`previous_workspace = "ctrl+alt+shift+k"`,
+		`next_workspace = "ctrl+alt+shift+j"`,
+		`previous_tab = ["prefix+p", "ctrl+alt+["]`,
+		`next_tab = ["prefix+n", "ctrl+alt+]"]`,
+		`focus_pane_left = ["prefix+h", "ctrl+alt+h"]`,
+		`focus_pane_down = ["prefix+j", "ctrl+alt+j"]`,
+		`focus_pane_up = ["prefix+k", "ctrl+alt+k"]`,
+		`focus_pane_right = ["prefix+l", "ctrl+alt+l"]`,
 	} {
 		if !strings.Contains(defaultText, want) {
 			t.Fatalf("default Herdr config missing workspace shortcut %q:\n%s", want, defaultText)
 		}
 	}
+	if strings.Contains(defaultText, `cmd+`) {
+		t.Fatalf("default Herdr config contains unreliable Command shortcut:\n%s", defaultText)
+	}
 
 	adaptiveText := string(adaptiveConfig)
+	if strings.Contains(adaptiveText, `cmd+`) {
+		t.Fatalf("adaptive Herdr config contains unreliable Command shortcut:\n%s", adaptiveText)
+	}
 	if got, want := herdrConfigWithoutTheme(t, adaptiveText), herdrConfigWithoutTheme(t, defaultText); got != want {
 		t.Fatalf("adaptive Herdr config non-theme sections drifted from default; got:\n%s\nwant:\n%s", got, want)
 	}
@@ -3632,7 +3644,7 @@ func herdrConfigWithoutTheme(t *testing.T, config string) string {
 	return body[:themeStart] + body[themeEnd:]
 }
 
-func TestRepositoryGhosttyConfigForwardsHerdrWorkspaceShortcuts(t *testing.T) {
+func TestRepositoryGhosttyConfigDoesNotForwardObsoleteHerdrCommandShortcuts(t *testing.T) {
 	root := filepath.Clean(filepath.Join("..", ".."))
 	configPath := filepath.Join(root, "configs/ghostty/config.ghostty")
 
@@ -3642,16 +3654,9 @@ func TestRepositoryGhosttyConfigForwardsHerdrWorkspaceShortcuts(t *testing.T) {
 	}
 	config := string(configBytes)
 
-	for _, want := range []string{
+	for _, notWant := range []string{
 		`keybind = cmd+j=unbind`,
 		`keybind = cmd+k=unbind`,
-	} {
-		if !strings.Contains(config, want) {
-			t.Fatalf("Ghostty config missing Herdr workspace passthrough %q:\n%s", want, config)
-		}
-	}
-
-	for _, notWant := range []string{
 		`keybind = cmd+j=scroll_to_selection`,
 		`keybind = cmd+k=clear_screen`,
 		`keybind = super+j=scroll_to_selection`,


### PR DESCRIPTION
Closes #321

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Replaces unreliable Herdr Command workspace shortcuts with `ctrl+alt+shift+k/j`.
- Removes `cmd+...` aliases from dots-managed Herdr tab and pane navigation.
- Drops obsolete Ghostty `cmd+j/k` passthrough and updates repository guards.

## Changes

| File | Change |
|------|--------|
| `configs/herdr/config.toml` | Uses safe `ctrl+alt+shift+k/j` workspace navigation and removes all `cmd+...` Herdr movement aliases. |
| `configs/herdr/config-adaptive.toml` | Mirrors the default non-theme Herdr keybinding changes for adaptive theme installs. |
| `configs/ghostty/config.ghostty` | Removes obsolete `cmd+j/k` unbind passthrough lines that were only for Herdr Command workspace shortcuts. |
| `internal/manifest/manifest_test.go` | Asserts safe Herdr direct bindings, no Herdr `cmd+` bindings, adaptive sync, and no obsolete Ghostty passthrough. |

## Test Plan

- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile core --source-root "$PWD" --home <tmp>`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #321`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
