### PR TITLE
fix(config): use prefix Herdr navigation shortcuts

### DIFF
--- a/configs/herdr/config-adaptive.toml
+++ b/configs/herdr/config-adaptive.toml
@@ -52,8 +52,12 @@ goto = "prefix+g"
 new_workspace = "prefix+shift+n"
 rename_workspace = "prefix+shift+w"
 close_workspace = "prefix+alt+d"
-previous_workspace = "ctrl+alt+shift+k"
-next_workspace = "ctrl+alt+shift+j"
+# Keep workspace cycling behind prefix: many terminals collapse Ctrl+Alt+Shift+j/k
+# to Ctrl+Alt+j/k, which conflicts with the direct pane-focus bindings below.
+previous_workspace = "prefix+alt+k"
+next_workspace = "prefix+alt+j"
+previous_agent = "prefix+alt+h"
+next_agent = "prefix+alt+l"
 toggle_sidebar = "prefix+b"
 
 # Tabs: prefix-first tmux-like core plus explicit direct tab navigation.

--- a/configs/herdr/config.toml
+++ b/configs/herdr/config.toml
@@ -46,8 +46,12 @@ goto = "prefix+g"
 new_workspace = "prefix+shift+n"
 rename_workspace = "prefix+shift+w"
 close_workspace = "prefix+alt+d"
-previous_workspace = "ctrl+alt+shift+k"
-next_workspace = "ctrl+alt+shift+j"
+# Keep workspace cycling behind prefix: many terminals collapse Ctrl+Alt+Shift+j/k
+# to Ctrl+Alt+j/k, which conflicts with the direct pane-focus bindings below.
+previous_workspace = "prefix+alt+k"
+next_workspace = "prefix+alt+j"
+previous_agent = "prefix+alt+h"
+next_agent = "prefix+alt+l"
 toggle_sidebar = "prefix+b"
 
 # Tabs: prefix-first tmux-like core plus explicit direct tab navigation.

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -3598,8 +3598,10 @@ func TestRepositoryHerdrConfigSupportsAdaptiveThemeOverride(t *testing.T) {
 
 	defaultText := string(defaultConfig)
 	for _, want := range []string{
-		`previous_workspace = "ctrl+alt+shift+k"`,
-		`next_workspace = "ctrl+alt+shift+j"`,
+		`previous_workspace = "prefix+alt+k"`,
+		`next_workspace = "prefix+alt+j"`,
+		`previous_agent = "prefix+alt+h"`,
+		`next_agent = "prefix+alt+l"`,
 		`previous_tab = ["prefix+p", "ctrl+alt+["]`,
 		`next_tab = ["prefix+n", "ctrl+alt+]"]`,
 		`focus_pane_left = ["prefix+h", "ctrl+alt+h"]`,


### PR DESCRIPTION
Closes #323

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Replaces unreliable direct Herdr workspace cycling chords with prefix-mode `prefix+alt+k/j`.
- Adds prefix-mode previous/next agent navigation on `prefix+alt+h/l`.
- Keeps the adaptive Herdr config and repository manifest guard aligned with the default config.

## Changes

| File | Change |
|------|--------|
| `configs/herdr/config.toml` | Moves previous/next workspace to `prefix+alt+k/j`, adds previous/next agent on `prefix+alt+h/l`, and documents the Ctrl+Alt+Shift terminal-collapse gotcha. |
| `configs/herdr/config-adaptive.toml` | Mirrors the same keybinding changes for the adaptive theme override. |
| `internal/manifest/manifest_test.go` | Updates the Herdr repository guard to expect the prefix workspace and agent shortcuts. |

## Test Plan

- [x] `go test ./internal/manifest -run TestRepositoryHerdrConfigSupportsAdaptiveThemeOverride -count=1`
- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile core --source-root "$PWD" --home <tmp> --state-root <tmp>`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #323`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
