### PR TITLE
fix(config): enable Herdr mouse capture

### DIFF
--- a/configs/herdr/config-adaptive.toml
+++ b/configs/herdr/config-adaptive.toml
@@ -24,6 +24,7 @@ light_name = "catppuccin-latte"
 [ui]
 confirm_close = true
 prompt_new_tab_name = true
+mouse_capture = true
 pane_borders = true
 pane_gaps = true
 

--- a/configs/herdr/config.toml
+++ b/configs/herdr/config.toml
@@ -18,6 +18,7 @@ name = "catppuccin"
 [ui]
 confirm_close = true
 prompt_new_tab_name = true
+mouse_capture = true
 pane_borders = true
 pane_gaps = true
 

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -3602,6 +3602,7 @@ func TestRepositoryHerdrConfigSupportsAdaptiveThemeOverride(t *testing.T) {
 		`next_workspace = "prefix+alt+j"`,
 		`previous_agent = "prefix+alt+h"`,
 		`next_agent = "prefix+alt+l"`,
+		`mouse_capture = true`,
 		`previous_tab = ["prefix+p", "ctrl+alt+["]`,
 		`next_tab = ["prefix+n", "ctrl+alt+]"]`,
 		`focus_pane_left = ["prefix+h", "ctrl+alt+h"]`,


### PR DESCRIPTION
Closes #325

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Enables Herdr mouse capture from the dots Source of Truth.
- Keeps the default and adaptive Herdr configs synchronized outside their theme section.
- Adds a manifest regression guard for the new Herdr UI setting.

## Changes

| File | Change |
|------|--------|
| `configs/herdr/config.toml` | Adds `[ui] mouse_capture = true` to the default managed Herdr config. |
| `configs/herdr/config-adaptive.toml` | Adds the same UI setting to the adaptive-theme Herdr config. |
| `internal/manifest/manifest_test.go` | Guards that the default Herdr config contains the mouse capture setting and that adaptive non-theme sections stay synchronized. |

## Test Plan

- [x] `go test ./internal/manifest -run TestRepositoryHerdrConfigSupportsAdaptiveThemeOverride`
- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile core --source-root "$PWD" --home <tmp> --state-root <tmp> --output json`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #325`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
