### PR TITLE
chore(github): restrict triage controls

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,6 @@
 name: Bug report
 description: Report something that is broken or behaving unexpectedly.
 title: "fix: "
-labels: ["needs-triage", "bug"]
 body:
   - type: checkboxes
     id: preflight

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,6 @@
 name: Feature request
 description: Propose an improvement or new capability.
 title: "feat: "
-labels: ["needs-triage", "enhancement"]
 body:
   - type: checkboxes
     id: preflight

--- a/.github/ISSUE_TEMPLATE/prd.yml
+++ b/.github/ISSUE_TEMPLATE/prd.yml
@@ -1,7 +1,6 @@
 name: PRD / agent-ready work
 description: Define product requirements for implementation by an agent or contributor.
 title: "feat: "
-labels: ["needs-triage"]
 body:
   - type: checkboxes
     id: preflight

--- a/.github/workflows/maintainer-governance.yml
+++ b/.github/workflows/maintainer-governance.yml
@@ -1,0 +1,133 @@
+name: Maintainer governance
+
+on:
+  issues:
+    types:
+      - labeled
+  pull_request_target:
+    types:
+      - labeled
+      - closed
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: maintainer-governance-${{ github.event_name }}-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  enforce:
+    name: Restrict triage controls
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce maintainer-only labels and PR closing
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const actor = context.actor;
+
+            async function actorCanGovern() {
+              try {
+                const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner,
+                  repo,
+                  username: actor,
+                });
+
+                const roleName = String(data.role_name || '').toLowerCase();
+                const permissions = data.user?.permissions || {};
+
+                return roleName === 'admin' ||
+                  roleName === 'maintain' ||
+                  permissions.admin === true ||
+                  permissions.maintain === true;
+              } catch (error) {
+                if (error.status === 404) {
+                  return false;
+                }
+                throw error;
+              }
+            }
+
+            async function comment(issue_number, body) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
+
+            const allowed = await actorCanGovern();
+            if (allowed) {
+              core.info(`${actor} is allowed to manage labels and pull request state.`);
+              return;
+            }
+
+            if (context.eventName === 'issues' && context.payload.action === 'labeled') {
+              const issue = context.payload.issue;
+              const label = context.payload.label?.name;
+
+              if (!label) {
+                core.warning('Issue labeled event did not include a label name.');
+                return;
+              }
+
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: issue.number,
+                name: label,
+              });
+              await comment(
+                issue.number,
+                `Removed label \`${label}\` because only maintainers and admins can label issues in this repository.`
+              );
+              return;
+            }
+
+            if (context.eventName === 'pull_request_target' && context.payload.action === 'labeled') {
+              const pull = context.payload.pull_request;
+              const label = context.payload.label?.name;
+
+              if (!label) {
+                core.warning('Pull request labeled event did not include a label name.');
+                return;
+              }
+
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: pull.number,
+                name: label,
+              });
+              await comment(
+                pull.number,
+                `Removed label \`${label}\` because only maintainers and admins can label pull requests in this repository.`
+              );
+              return;
+            }
+
+            if (context.eventName === 'pull_request_target' && context.payload.action === 'closed') {
+              const pull = context.payload.pull_request;
+
+              if (pull.merged) {
+                core.info('Pull request was merged; merged pull requests cannot be reopened.');
+                return;
+              }
+
+              await github.rest.pulls.update({
+                owner,
+                repo,
+                pull_number: pull.number,
+                state: 'open',
+              });
+              await comment(
+                pull.number,
+                'Reopened this pull request because only maintainers and admins can close pull requests in this repository.'
+              );
+            }

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -11,6 +11,8 @@ This repository tracks work in GitHub Issues.
 
 - Product requirements and implementation-ready work should be published as GitHub Issues.
 - PRD issues should use the `ready-for-agent` label once they are sufficiently specified for an agent to implement without additional human context.
+- Public issue templates intentionally do not auto-apply labels; maintainers/admins apply triage labels after creation.
+- The `Maintainer governance` workflow removes issue/PR labels added by non-maintainers and reopens PRs closed without merge by non-maintainers.
 - Use the GitHub CLI (`gh`) when creating or updating issues from automation.
 - Authenticate before agent work that touches GitHub: run `gh auth login` for an interactive workstation, or export `GH_TOKEN`/`GITHUB_TOKEN` in non-interactive environments.
 


### PR DESCRIPTION
Closes #327

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [x] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Removes automatic labels from public issue templates so issue reporters cannot apply triage labels through template metadata.
- Adds a `Maintainer governance` workflow that removes issue/PR labels added by non-maintainers/admins.
- Reopens non-merged PRs closed by non-maintainers/admins and documents the policy.

## Changes

| File | Change |
|------|--------|
| `.github/ISSUE_TEMPLATE/bug_report.yml` | Removed automatic `needs-triage`/`bug` labels. |
| `.github/ISSUE_TEMPLATE/feature_request.yml` | Removed automatic `needs-triage`/`enhancement` labels. |
| `.github/ISSUE_TEMPLATE/prd.yml` | Removed automatic `needs-triage` label. |
| `.github/workflows/maintainer-governance.yml` | Added label and PR-close enforcement for maintainers/admins only. |
| `docs/agents/issue-tracker.md` | Documented maintainer/admin-only triage controls. |

## Test Plan

- [x] `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/ISSUE_TEMPLATE/bug_report.yml .github/ISSUE_TEMPLATE/feature_request.yml .github/ISSUE_TEMPLATE/prd.yml .github/workflows/maintainer-governance.yml`
- [x] `node --check /tmp/maintainer-governance-script.js`
- [x] `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/maintainer-governance.yml`
- [x] `git diff --check`
- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`
- [ ] `go run ./cmd/dots manifest validate --file dots.yaml` (not needed; GitHub workflow/template policy only)
- [ ] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile core --source-root "$PWD" --home <tmp>` (not needed; no dotfiles install/plan behavior changed)

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #327`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
