### PR TITLE
feat(config): preserve Claude proxy harness

### DIFF
--- a/configs/zsh/rc.d/post/60-ai.zsh
+++ b/configs/zsh/rc.d/post/60-ai.zsh
@@ -9,6 +9,11 @@ export CLAUDE_CODE_NO_FLICKER=1
 # Engram: opt into tool-search behavior.
 export ENABLE_TOOL_SEARCH=true
 
+# Claude Code harness backed by GPT-5.6 Sol through the local CLIProxyAPI.
+if command -v claude >/dev/null 2>&1 && command -v cliproxyapi >/dev/null 2>&1; then
+  alias claudex='ANTHROPIC_BASE_URL=http://127.0.0.1:8317 ANTHROPIC_AUTH_TOKEN=sk-dummy CLAUDE_CODE_SUBAGENT_MODEL=gpt-5.6-sol CLAUDE_CODE_ALWAYS_ENABLE_EFFORT=1 CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY=3 ENABLE_TOOL_SEARCH=false claude --model gpt-5.6-sol'
+fi
+
 # GitHub Copilot CLI: start interactive sessions in Autopilot mode by default.
 if [[ -o interactive ]] && command -v copilot >/dev/null 2>&1; then
   copilot() {

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -2603,6 +2603,30 @@ func TestRepositoryManagedConfigsExposeLocalExtensionPoints(t *testing.T) {
 	}
 }
 
+func TestRepositoryManagedZshExposesClaudeProxyHarness(t *testing.T) {
+	path := filepath.Clean(filepath.Join("..", "..", "configs", "zsh", "rc.d", "post", "60-ai.zsh"))
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+
+	for _, want := range []string{
+		"command -v claude >/dev/null 2>&1 && command -v cliproxyapi >/dev/null 2>&1",
+		"alias claudex=",
+		"ANTHROPIC_BASE_URL=http://127.0.0.1:8317",
+		"ANTHROPIC_AUTH_TOKEN=sk-dummy",
+		"CLAUDE_CODE_SUBAGENT_MODEL=gpt-5.6-sol",
+		"CLAUDE_CODE_ALWAYS_ENABLE_EFFORT=1",
+		"CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY=3",
+		"ENABLE_TOOL_SEARCH=false",
+		"claude --model gpt-5.6-sol",
+	} {
+		if !strings.Contains(string(content), want) {
+			t.Errorf("%s missing %q", path, want)
+		}
+	}
+}
+
 func TestRepositoryGitConfigClassifiesPortableAndLocalConcerns(t *testing.T) {
 	root := filepath.Clean(filepath.Join("..", ".."))
 


### PR DESCRIPTION
Closes #333

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Preserve the local Claude-through-CLIProxyAPI harness in the repository-owned Zsh configuration.
- Expose `claudex` only when both `claude` and `cliproxyapi` are installed.
- Guard the complete proxy/model contract with a focused repository test.

## Changes

| File | Change |
|------|--------|
| `configs/zsh/rc.d/post/60-ai.zsh` | Add the guarded GPT-5.6 Sol `claudex` alias using the loopback proxy and dummy local auth placeholder. |
| `internal/manifest/manifest_test.go` | Assert the managed harness retains its guards, proxy settings, model, effort, concurrency, and tool-search behavior. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go build ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile core --source-root "$PWD" --home <tmp>`
- [x] `zsh -n configs/zsh/zshrc configs/zsh/rc.d/pre/*.zsh configs/zsh/rc.d/post/*.zsh`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [ ] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

The operator explicitly authorized a separate migration of the machine-specific Pi/Node PATH from the dirty Installed Repository into the unmanaged Local Extension Point `~/.zshrc.local`. The PR itself does not manage that file.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #333`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed (not applicable; no workflow behavior changed).
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
