### PR TITLE
chore(release): gate Homebrew publishing with environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
   release:
     name: Build and publish release artifacts
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.release.outputs.tag }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
@@ -51,56 +53,12 @@ jobs:
       - name: Build release artifacts and checksums.txt
         run: scripts/build-release-artifacts.sh --version "${{ steps.release.outputs.tag }}" --out-dir dist
 
-      - name: Require Homebrew tap token
-        env:
-          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-        run: |
-          set -euo pipefail
-          if [[ -z "${HOMEBREW_TAP_TOKEN:-}" ]]; then
-            echo "HOMEBREW_TAP_TOKEN is required to update yersonargotev/homebrew-tap before publishing release assets" >&2
-            exit 1
-          fi
-
-      - name: Check out Homebrew tap
-        uses: actions/checkout@v5
+      - name: Preserve release checksums for Homebrew publication
+        uses: actions/upload-artifact@v4
         with:
-          repository: yersonargotev/homebrew-tap
-          path: homebrew-tap
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-
-      - name: Generate Homebrew formula from release checksums
-        run: |
-          scripts/generate-homebrew-formula.sh \
-            --version "${{ steps.release.outputs.tag }}" \
-            --checksums dist/checksums.txt \
-            --out homebrew-tap/Formula/dots.rb \
-            --repo yersonargotev/dots \
-            --homepage https://github.com/yersonargotev/dots \
-            --desc "Safe dotfiles installer"
-
-      - name: Prepare Homebrew tap formula update
-        id: prepare_tap
-        working-directory: homebrew-tap
-        env:
-          RELEASE_TAG: ${{ steps.release.outputs.tag }}
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Formula/dots.rb
-          if git diff --cached --quiet; then
-            echo "Homebrew formula already matches $RELEASE_TAG"
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          git commit -m "feat: update dots formula to ${RELEASE_TAG}"
-          echo "changed=true" >> "$GITHUB_OUTPUT"
-
-      - name: Prove Homebrew tap push permission
-        working-directory: homebrew-tap
-        run: |
-          set -euo pipefail
-          git push --dry-run origin HEAD:main
+          name: release-checksums
+          path: dist/checksums.txt
+          if-no-files-found: error
 
       - name: Create GitHub Release if needed
         env:
@@ -122,10 +80,78 @@ jobs:
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
         run: gh release upload "$RELEASE_TAG" dist/* --clobber
 
+  publish-homebrew-formula:
+    name: Publish Homebrew formula
+    needs: release
+    environment: homebrew
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository at release tag
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.release.outputs.tag }}
+
+      - name: Download release checksums
+        uses: actions/download-artifact@v4
+        with:
+          name: release-checksums
+          path: dist
+
+      - name: Require Homebrew tap token
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${HOMEBREW_TAP_TOKEN:-}" ]]; then
+            echo "HOMEBREW_TAP_TOKEN is required to update yersonargotev/homebrew-tap before publishing release assets" >&2
+            exit 1
+          fi
+
+      - name: Check out Homebrew tap
+        uses: actions/checkout@v5
+        with:
+          repository: yersonargotev/homebrew-tap
+          path: homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+      - name: Generate Homebrew formula from release checksums
+        run: |
+          scripts/generate-homebrew-formula.sh \
+            --version "${{ needs.release.outputs.tag }}" \
+            --checksums dist/checksums.txt \
+            --out homebrew-tap/Formula/dots.rb \
+            --repo yersonargotev/dots \
+            --homepage https://github.com/yersonargotev/dots \
+            --desc "Safe dotfiles installer"
+
+      - name: Prepare Homebrew tap formula update
+        id: prepare_tap
+        working-directory: homebrew-tap
+        env:
+          RELEASE_TAG: ${{ needs.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/dots.rb
+          if git diff --cached --quiet; then
+            echo "Homebrew formula already matches $RELEASE_TAG"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git commit -m "feat: update dots formula to ${RELEASE_TAG}"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Prove Homebrew tap push permission
+        working-directory: homebrew-tap
+        run: |
+          set -euo pipefail
+          git push --dry-run origin HEAD:main
+
       - name: Push prepared Homebrew tap formula update
         working-directory: homebrew-tap
         env:
-          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          RELEASE_TAG: ${{ needs.release.outputs.tag }}
           TAP_UPDATE_CHANGED: ${{ steps.prepare_tap.outputs.changed }}
         run: |
           set -euo pipefail

--- a/docs/release.md
+++ b/docs/release.md
@@ -27,7 +27,8 @@ Use manual dispatch when the tag already exists but the release needs to be rebu
 
 1. Go to **Actions → Release → Run workflow**.
 2. Enter the existing tag, for example `v0.5.1`.
-3. Run the workflow. It checks out that tag, rebuilds the four artifacts, recreates `checksums.txt`, verifies `HOMEBREW_TAP_TOKEN` is present, checks out the Homebrew tap, regenerates and locally commits `Formula/dots.rb` when changed, dry-run pushes that prepared tap state, uploads assets with `--clobber`, and only then pushes the prepared tap commit.
+3. Run the workflow. It checks out that tag, rebuilds the four artifacts, recreates `checksums.txt`, and uploads the GitHub Release assets with `--clobber`.
+4. Approve the pending `homebrew` deployment. The protected job downloads the published checksum manifest, verifies `HOMEBREW_TAP_TOKEN` is present, regenerates and locally commits `Formula/dots.rb` when changed, dry-run proves access, and pushes the prepared tap commit.
 
 ## Checksum Verification contract
 
@@ -83,18 +84,18 @@ brew "yersonargotev/tap/dots", trusted: true
 
 The formula selects the correct Release Artifact for macOS/Linux and amd64/arm64, marks each raw executable URL with `using: :nounzip`, verifies the published SHA-256 checksum from the generated formula, installs the downloaded binary as `dots`, and runs `dots --version` in `brew test`.
 
-The release workflow proves tap write access before it mutates the public GitHub Release, but it does not publish the tap update until the release assets exist:
+The release workflow publishes the GitHub Release first, then gates the separate tap update behind the protected `homebrew` environment:
 
-1. It verifies `HOMEBREW_TAP_TOKEN` is present and checks out `yersonargotev/homebrew-tap`.
-2. It generates `Formula/dots.rb` with `scripts/generate-homebrew-formula.sh`. The script reads `dist/checksums.txt` and requires exactly the four supported artifact entries.
-3. It stages and commits the formula update locally when the tap formula changed.
-4. It dry-run pushes the prepared local tap state before creating or uploading GitHub Release assets.
-5. After the release assets upload succeeds, it pushes the already-prepared tap commit, or no-ops if the formula already matched the tag.
+1. The release job builds and uploads the four binaries plus `checksums.txt`, preserving the checksum manifest as a workflow artifact.
+2. The dependent Homebrew job waits for approval of the `homebrew` environment, then reads its `HOMEBREW_TAP_TOKEN` environment secret and checks out `yersonargotev/homebrew-tap`.
+3. It generates `Formula/dots.rb` with `scripts/generate-homebrew-formula.sh`. The script reads the transferred `dist/checksums.txt` and requires exactly the four supported artifact entries.
+4. It stages and commits the formula update locally when the tap formula changed, dry-run proves that prepared state can be pushed, and then publishes the tap commit.
 
 Maintainer setup:
 
 - Create or maintain the `yersonargotev/homebrew-tap` repository.
-- Store a token with write access to that tap as this repository secret: `HOMEBREW_TAP_TOKEN`.
+- Configure a protected `homebrew` environment that requires maintainer approval and permits `main` plus release tags matching `v0.*`.
+- Store a fine-grained token with write access only to that tap as the environment secret `HOMEBREW_TAP_TOKEN`.
 - Do not use `GITHUB_TOKEN` for the tap push; it is scoped to this repository.
 
 ## Bootstrapper install
@@ -128,12 +129,13 @@ DOTS_VERSION=v0.5.1 DOTS_SOURCE_ROOT="$PWD" bash scripts/install.sh
 | Artifacts | Raw `dots` binaries named `dots_<version>_<goos>_<goarch>`. |
 | Platforms | `darwin/amd64`, `darwin/arm64`, `linux/amd64`, and `linux/arm64`. |
 | Checksums | One `checksums.txt` file covers every Release Artifact. |
-| Homebrew Distribution | `scripts/generate-homebrew-formula.sh` generates `Formula/dots.rb` from the release tag and `checksums.txt`; the workflow locally prepares the tap commit, dry-run proves that prepared state can be pushed, then pushes it to `yersonargotev/homebrew-tap` with `HOMEBREW_TAP_TOKEN` after release assets upload. Users should prefer formula-level Tap Trust through `brew install yersonargotev/tap/dots`, `brew trust --formula yersonargotev/tap/dots`, or Brewfile `trusted: true`. Homebrew installs only the binary, so first-run package-manager installs must run `dots init` to clone the default Installed Repository before `dots status`, `dots doctor`, or `dots install --profile workstation --dry-run`. |
+| Homebrew Distribution | `scripts/generate-homebrew-formula.sh` generates `Formula/dots.rb` from the release tag and transferred `checksums.txt`; after the GitHub Release assets exist, the environment-protected Homebrew job locally prepares the tap commit, dry-run proves that prepared state can be pushed, then publishes it to `yersonargotev/homebrew-tap` with the environment `HOMEBREW_TAP_TOKEN`. Users should prefer formula-level Tap Trust through `brew install yersonargotev/tap/dots`, `brew trust --formula yersonargotev/tap/dots`, or Brewfile `trusted: true`. Homebrew installs only the binary, so first-run package-manager installs must run `dots init` to clone the default Installed Repository before `dots status`, `dots doctor`, or `dots install --profile workstation --dry-run`. |
 
 ## First v0.x checklist
 
 - [ ] The tag is a v0.x tag, such as `v0.5.1`.
 - [ ] The workflow completed from the tag commit.
+- [ ] The pending `homebrew` deployment was approved by the required reviewer.
 - [ ] All four platform artifacts are attached to the GitHub Release.
 - [ ] `checksums.txt` contains one SHA-256 entry for each artifact.
 - [ ] The Bootstrapper maps its detected `goos/goarch` to the matching artifact name.
@@ -141,4 +143,4 @@ DOTS_VERSION=v0.5.1 DOTS_SOURCE_ROOT="$PWD" bash scripts/install.sh
 - [ ] A Homebrew-installed binary can run `dots init` and then read the default Installed Repository manifest.
 - [ ] `Formula/dots.rb` in `yersonargotev/homebrew-tap` points at the same tag and checksums.
 - [ ] A Tap Trust install path has been checked with `HOMEBREW_REQUIRE_TAP_TRUST=1` using the fully-qualified formula or formula-level trust.
-- [ ] `HOMEBREW_TAP_TOKEN` is configured before relying on automatic tap updates.
+- [ ] `HOMEBREW_TAP_TOKEN` is configured as an environment secret before relying on automatic tap updates.

--- a/internal/release/release_automation_test.go
+++ b/internal/release/release_automation_test.go
@@ -83,36 +83,77 @@ func TestReleaseWorkflowCreatesReleaseWithGeneratedNotes(t *testing.T) {
 	}
 }
 
-func TestReleaseWorkflowProvesTapAccessBeforePublishingReleaseAssets(t *testing.T) {
+func TestReleaseWorkflowGatesHomebrewPublishingBehindEnvironment(t *testing.T) {
 	root := repoRoot(t)
 	workflow := readWorkflow(t, filepath.Join(root, ".github", "workflows", "release.yml"))
-	steps := workflowSteps(t, workflow)
+	releaseJob := workflowJob(t, workflow, "release")
+	homebrewJob := workflowJob(t, workflow, "publish-homebrew-formula")
+	releaseSteps := workflowJobSteps(t, releaseJob, "release")
+	homebrewSteps := workflowJobSteps(t, homebrewJob, "publish-homebrew-formula")
 
-	buildIndex := workflowStepIndex(t, steps, "build release artifacts and checksums", func(step map[string]any) bool {
+	if environment := fmt.Sprint(releaseJob["environment"]); environment != "<nil>" {
+		t.Fatalf("release artifact job must not use the protected Homebrew environment; got %q", environment)
+	}
+	if environment := fmt.Sprint(homebrewJob["environment"]); environment != "homebrew" {
+		t.Fatalf("Homebrew publication job should use environment homebrew; got %q", environment)
+	}
+	if needs := fmt.Sprint(homebrewJob["needs"]); needs != "release" {
+		t.Fatalf("Homebrew publication should wait for the release job; got needs %q", needs)
+	}
+	if output := fmt.Sprint(mapAt(t, releaseJob, "outputs")["tag"]); !strings.Contains(output, "steps.release.outputs.tag") {
+		t.Fatalf("release job should expose the resolved tag to Homebrew publication; got %q", output)
+	}
+
+	buildIndex := workflowStepIndex(t, releaseSteps, "build release artifacts and checksums", func(step map[string]any) bool {
 		run := stepRun(step)
 		return strings.Contains(run, "scripts/build-release-artifacts.sh") &&
 			strings.Contains(run, "--out-dir dist")
 	})
-	requireTapTokenIndex := workflowStepIndex(t, steps, "required Homebrew tap token guard", func(step map[string]any) bool {
+	uploadChecksumsIndex := workflowStepIndex(t, releaseSteps, "release checksum workflow artifact upload", func(step map[string]any) bool {
+		with := stepWith(step)
+		return stepUses(step) == "actions/upload-artifact@v4" &&
+			with["name"] == "release-checksums" &&
+			with["path"] == "dist/checksums.txt"
+	})
+	createReleaseIndex := workflowStepIndex(t, releaseSteps, "GitHub Release creation", func(step map[string]any) bool {
+		run := stepRun(step)
+		return strings.Contains(run, "gh release create") &&
+			strings.Contains(fmt.Sprint(stepEnv(step)["GH_TOKEN"]), "github.token")
+	})
+	uploadIndex := workflowStepIndex(t, releaseSteps, "GitHub Release asset upload", func(step map[string]any) bool {
+		run := stepRun(step)
+		return strings.Contains(run, "gh release upload") &&
+			strings.Contains(run, "dist/*") &&
+			strings.Contains(run, "--clobber")
+	})
+
+	downloadChecksumsIndex := workflowStepIndex(t, homebrewSteps, "release checksum workflow artifact download", func(step map[string]any) bool {
+		with := stepWith(step)
+		return stepUses(step) == "actions/download-artifact@v4" &&
+			with["name"] == "release-checksums" &&
+			with["path"] == "dist"
+	})
+	requireTapTokenIndex := workflowStepIndex(t, homebrewSteps, "required Homebrew tap token guard", func(step map[string]any) bool {
 		run := stepRun(step)
 		return strings.Contains(fmt.Sprint(stepEnv(step)["HOMEBREW_TAP_TOKEN"]), "HOMEBREW_TAP_TOKEN") &&
 			strings.Contains(run, "HOMEBREW_TAP_TOKEN is required") &&
 			strings.Contains(run, "yersonargotev/homebrew-tap")
 	})
-	tapCheckoutIndex := workflowStepIndex(t, steps, "token-backed Homebrew tap checkout", func(step map[string]any) bool {
+	tapCheckoutIndex := workflowStepIndex(t, homebrewSteps, "token-backed Homebrew tap checkout", func(step map[string]any) bool {
 		with := stepWith(step)
 		return stepUses(step) == "actions/checkout@v5" &&
 			with["repository"] == "yersonargotev/homebrew-tap" &&
 			with["path"] == "homebrew-tap" &&
 			strings.Contains(fmt.Sprint(with["token"]), "HOMEBREW_TAP_TOKEN")
 	})
-	formulaIndex := workflowStepIndex(t, steps, "Homebrew formula generation from release checksums", func(step map[string]any) bool {
+	formulaIndex := workflowStepIndex(t, homebrewSteps, "Homebrew formula generation from release checksums", func(step map[string]any) bool {
 		run := stepRun(step)
 		return strings.Contains(run, "scripts/generate-homebrew-formula.sh") &&
+			strings.Contains(run, "needs.release.outputs.tag") &&
 			strings.Contains(run, "--checksums dist/checksums.txt") &&
 			strings.Contains(run, "--out homebrew-tap/Formula/dots.rb")
 	})
-	prepareTapIndex := workflowStepIndex(t, steps, "local Homebrew tap formula commit preparation", func(step map[string]any) bool {
+	prepareTapIndex := workflowStepIndex(t, homebrewSteps, "local Homebrew tap formula commit preparation", func(step map[string]any) bool {
 		run := stepRun(step)
 		return stepWorkingDirectory(step) == "homebrew-tap" &&
 			strings.Contains(run, `git config user.name "github-actions[bot]"`) &&
@@ -123,25 +164,14 @@ func TestReleaseWorkflowProvesTapAccessBeforePublishingReleaseAssets(t *testing.
 			strings.Contains(run, `echo "changed=true" >> "$GITHUB_OUTPUT"`) &&
 			strings.Contains(run, `git commit -m "feat: update dots formula to ${RELEASE_TAG}"`)
 	})
-	tapPushAccessProofIndex := workflowStepIndex(t, steps, "non-mutating Homebrew tap push permission proof against prepared local state", func(step map[string]any) bool {
+	tapPushAccessProofIndex := workflowStepIndex(t, homebrewSteps, "non-mutating Homebrew tap push permission proof against prepared local state", func(step map[string]any) bool {
 		run := stepRun(step)
 		return stepWorkingDirectory(step) == "homebrew-tap" &&
 			strings.Contains(run, "git push --dry-run origin HEAD:main") &&
 			!strings.Contains(run, "git commit") &&
 			!strings.Contains(run, "git add Formula/dots.rb")
 	})
-	createReleaseIndex := workflowStepIndex(t, steps, "GitHub Release creation", func(step map[string]any) bool {
-		run := stepRun(step)
-		return strings.Contains(run, "gh release create") &&
-			strings.Contains(fmt.Sprint(stepEnv(step)["GH_TOKEN"]), "github.token")
-	})
-	uploadIndex := workflowStepIndex(t, steps, "GitHub Release asset upload", func(step map[string]any) bool {
-		run := stepRun(step)
-		return strings.Contains(run, "gh release upload") &&
-			strings.Contains(run, "dist/*") &&
-			strings.Contains(run, "--clobber")
-	})
-	pushTapIndex := workflowStepIndex(t, steps, "final Homebrew tap formula push", func(step map[string]any) bool {
+	pushTapIndex := workflowStepIndex(t, homebrewSteps, "final Homebrew tap formula push", func(step map[string]any) bool {
 		run := stepRun(step)
 		return stepWorkingDirectory(step) == "homebrew-tap" &&
 			strings.Contains(fmt.Sprint(stepEnv(step)["TAP_UPDATE_CHANGED"]), "prepare_tap.outputs.changed") &&
@@ -151,18 +181,16 @@ func TestReleaseWorkflowProvesTapAccessBeforePublishingReleaseAssets(t *testing.
 			!strings.Contains(run, "git commit")
 	})
 
-	assertStepBefore(t, steps, buildIndex, formulaIndex, "formula generation must consume freshly built artifacts and dist/checksums.txt")
-	assertStepBefore(t, steps, requireTapTokenIndex, tapCheckoutIndex, "the workflow must reject a missing HOMEBREW_TAP_TOKEN before falling back to anonymous tap checkout")
-	assertStepBefore(t, steps, requireTapTokenIndex, createReleaseIndex, "a missing HOMEBREW_TAP_TOKEN must fail before creating a GitHub Release")
-	assertStepBefore(t, steps, requireTapTokenIndex, uploadIndex, "a missing HOMEBREW_TAP_TOKEN must fail before re-uploading release assets")
-	assertStepBefore(t, steps, tapCheckoutIndex, formulaIndex, "the tap checkout must exist before writing Formula/dots.rb into it")
-	assertStepBefore(t, steps, formulaIndex, prepareTapIndex, "the generated formula must be staged before preparing a local tap commit")
-	assertStepBefore(t, steps, prepareTapIndex, tapPushAccessProofIndex, "the workflow must dry-run push the already-prepared local tap state, not the untouched checkout")
-	assertStepBefore(t, steps, tapPushAccessProofIndex, createReleaseIndex, "token-backed tap push permission must be proven before creating a GitHub Release")
-	assertStepBefore(t, steps, tapPushAccessProofIndex, uploadIndex, "token-backed tap push permission must be proven before re-uploading release assets")
-	assertStepBefore(t, steps, uploadIndex, pushTapIndex, "the tap update must not be published until release assets exist")
-	assertStepBefore(t, steps, tapPushAccessProofIndex, pushTapIndex, "token-backed tap push permission must be proven before the mutating tap push")
-	assertStepBefore(t, steps, prepareTapIndex, pushTapIndex, "the final tap push must publish the already-prepared commit instead of creating a new commit after assets upload")
+	assertStepBefore(t, releaseSteps, buildIndex, uploadChecksumsIndex, "fresh checksums must be transferred to the dependent Homebrew job")
+	assertStepBefore(t, releaseSteps, buildIndex, createReleaseIndex, "release artifacts must be built before creating the GitHub Release")
+	assertStepBefore(t, releaseSteps, createReleaseIndex, uploadIndex, "the GitHub Release must exist before its assets are uploaded")
+	assertStepBefore(t, homebrewSteps, downloadChecksumsIndex, formulaIndex, "formula generation must consume checksums transferred from the release job")
+	assertStepBefore(t, homebrewSteps, requireTapTokenIndex, tapCheckoutIndex, "the workflow must reject a missing HOMEBREW_TAP_TOKEN before falling back to anonymous tap checkout")
+	assertStepBefore(t, homebrewSteps, tapCheckoutIndex, formulaIndex, "the tap checkout must exist before writing Formula/dots.rb into it")
+	assertStepBefore(t, homebrewSteps, formulaIndex, prepareTapIndex, "the generated formula must be staged before preparing a local tap commit")
+	assertStepBefore(t, homebrewSteps, prepareTapIndex, tapPushAccessProofIndex, "the workflow must dry-run push the already-prepared local tap state, not the untouched checkout")
+	assertStepBefore(t, homebrewSteps, tapPushAccessProofIndex, pushTapIndex, "token-backed tap push permission must be proven before the mutating tap push")
+	assertStepBefore(t, homebrewSteps, prepareTapIndex, pushTapIndex, "the final tap push must publish the already-prepared commit")
 }
 
 func TestBuildReleaseArtifactsCreatesChecksummedSupportedPlatforms(t *testing.T) {
@@ -486,22 +514,30 @@ func readWorkflow(t *testing.T, path string) map[string]any {
 
 func workflowSteps(t *testing.T, workflow map[string]any) []map[string]any {
 	t.Helper()
-	jobs := mapAt(t, workflow, "jobs")
-	release := mapAt(t, jobs, "release")
-	value, ok := release["steps"]
+	return workflowJobSteps(t, workflowJob(t, workflow, "release"), "release")
+}
+
+func workflowJob(t *testing.T, workflow map[string]any, name string) map[string]any {
+	t.Helper()
+	return mapAt(t, mapAt(t, workflow, "jobs"), name)
+}
+
+func workflowJobSteps(t *testing.T, job map[string]any, name string) []map[string]any {
+	t.Helper()
+	value, ok := job["steps"]
 	if !ok {
-		t.Fatal("release job should define steps")
+		t.Fatalf("%s job should define steps", name)
 	}
 	items, ok := value.([]any)
 	if !ok {
-		t.Fatalf("release steps should be a list, got %T", value)
+		t.Fatalf("%s steps should be a list, got %T", name, value)
 	}
 
 	steps := make([]map[string]any, 0, len(items))
 	for index, item := range items {
 		step, ok := item.(map[string]any)
 		if !ok {
-			t.Fatalf("release step %d should be a map, got %T", index, item)
+			t.Fatalf("%s step %d should be a map, got %T", name, index, item)
 		}
 		steps = append(steps, step)
 	}


### PR DESCRIPTION
Closes #335

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [x] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Separates GitHub Release publication from Homebrew formula publication.
- Gates only the Homebrew job with the protected `homebrew` environment.
- Transfers the resolved tag and checksums across the job boundary with regression coverage.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Adds a dependent, environment-protected Homebrew publication job. |
| `internal/release/release_automation_test.go` | Verifies environment scoping, job dependency, artifact transfer, and tap update ordering. |
| `docs/release.md` | Documents the approval gate and environment-secret release procedure. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: not applicable; no dotfiles behavior was exercised.

Additional validation:
- [x] `go build ./...`
- [x] `git diff --check`
- [x] Focused release workflow tests

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #335`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed: `docs/release.md` now documents the protected stage and approval flow.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
