### PR TITLE
feat(selection): record installed selection

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -117,8 +117,12 @@ The current alignment between a workstation and the repository-owned Source of T
 _Avoid_: health, sync state, installed state
 
 **Installation Metadata**:
-The state file stored under `~/.local/state/dots/installed.json` that records what the Dotfiles CLI installed, including managed entries, strategies, hashes, and timestamps. It lets the CLI detect drift for copied and templated targets.
+The state file stored under `~/.local/state/dots/installed.json` that records what the Dotfiles CLI installed, including Managed Entries, Provisioners, strategies, hashes, timestamps, and an optional Installed Selection. It lets the CLI detect Drift for copied and templated targets while preserving machine-level selection intent separately from historical inventory.
 _Avoid_: install log, state file, tracking file
+
+**Installed Selection**:
+The authoritative machine-level installation intent recorded after a successful explicit install. It preserves the ordered Profiles and explicit extra Tags selected by the operator, the ordered resolved Tag snapshot, Source of Truth provenance, and recording time. Profiles and explicit extra Tags are intent; resolved Tags are an audit snapshot. Per-Managed-Entry and per-Provisioner Profiles and Tags remain historical inventory and ownership evidence, not a substitute for an Installed Selection.
+_Avoid_: inferred selection, installed profile, tag inventory
 
 **Dependency Installation Metadata**:
 The state record of Dependencies the Dotfiles CLI installed through executable providers, including the dependency name, provider, installed path, artifact version or checksum when applicable, and timestamp. It is separate from Installation Metadata because dependency tools are external workstation capabilities, not Managed Entries.

--- a/docs/adr/0014-record-authoritative-installed-selection.md
+++ b/docs/adr/0014-record-authoritative-installed-selection.md
@@ -1,0 +1,42 @@
+# Record authoritative Installed Selection
+
+Installation Metadata historically recorded Profiles and Tags only on individual
+Managed Entries and Provisioners. Those records describe what earlier runs
+installed, but their union cannot identify one current machine-level intent:
+records can survive partial runs and can represent different selections over
+time.
+
+We add an optional top-level Installed Selection to Installation Metadata v3.
+It records, in deterministic order, the selected Profile names, explicit extra
+Tags, the resolved Tag snapshot, Source of Truth provenance, and recording time.
+Profile names and explicit extra Tags are the authoritative intent. The resolved
+Tags are an audit snapshot of what that intent selected at recording time; they
+do not replace the named Profiles or explicit extra Tags.
+
+The Installed Selection is committed only at terminal success, after Managed
+Entries, required Provisioners, and final convergence work complete. The commit
+reloads and merges with current Installation Metadata so inventory written
+during the run is retained. A failed or canceled run, including a failure to
+write the new selection, preserves the previously recorded Installed Selection.
+
+Installation Metadata v1 and v2 remain readable. Because the new field is
+optional, their Managed Entry and Provisioner records are not promoted or
+inferred into an authoritative Installed Selection. `dots installed` therefore
+reports the Installed Selection separately from represented Tags and recorded
+or inferred Profile coverage, and clearly reports when authoritative selection
+metadata is absent.
+
+ADR 0013 still governs first installation from the repository manifest:
+`dots install` requires an explicit Profile and fails before Dependencies,
+Managed Entries, Provisioners, home mutation, or state creation when none is
+provided. Legacy fixtures may retain their existing `default` Profile
+compatibility. This slice records Installed Selection but does not reuse it as
+an implicit input to a later install, and it does not introduce a repository
+`default` or `core` selection.
+
+Consequences: a completed explicit install leaves one durable statement of the
+operator's chosen Profiles and extra Tags, while per-record Profiles and Tags
+remain historical inventory and ownership evidence. This ADR does not authorize
+other commands to reuse the Installed Selection, migrate legacy metadata,
+interpret future Profile changes, report selection deltas, or remove items that
+are no longer selected.

--- a/docs/agents/output-contract.md
+++ b/docs/agents/output-contract.md
@@ -106,12 +106,23 @@ prose the text surface prints:
   agents can distinguish aligned Managed Entries from an incomplete full-profile
   setup. Read dependency readiness for those commands from `doctor`.
 
-- `installed` is a read-only inventory over Installation Metadata. It reports
-  recorded Managed Entries, represented Tags, recorded or inferred Profiles
-  (including partial coverage), recorded Provisioner runs, and Source of Truth
-  provenance when the metadata contains it. It is informational rather than an
-  alignment diagnostic, so partial profile coverage remains `status: "ok"`;
-  use `status` or `doctor` when an agent needs drift/dependency findings.
+- `installed` is a read-only report over Installation Metadata. Its optional
+  `data.installed_selection` is the authoritative machine-level intent recorded
+  by the last successful explicit install: ordered `profiles`, ordered
+  `extra_tags`, the ordered `resolved_tags` snapshot, Source of Truth
+  `provenance`, and the selection recording time in
+  `provenance.recorded_at`. The text surface renders the same information in a
+  distinct **Installed Selection** section.
+- The existing top-level `data.tags`, `data.profiles`, `data.managed_entries`,
+  and `data.provisioners` remain historical inventory evidence. In particular,
+  represented Tags and recorded or inferred Profile coverage are not an
+  authoritative selection. When v1/v2 or other legacy Installation Metadata has
+  no Installed Selection, JSON omits `data.installed_selection` and text says
+  that no authoritative Installed Selection is recorded; dots does not promote
+  inventory inference. The command is informational rather than an alignment
+  diagnostic, so an absent Installed Selection or partial Profile coverage
+  remains `status: "ok"`; use `status` or `doctor` when an agent needs
+  drift/dependency findings.
 - `plan`'s `resolved_source` (a per-machine absolute path) and `deps`'s
   `probe_detail`/`hint` (unstable human prose) are excluded. Agents key on the
   portable, structured fields (`source`, `present`, `warning`, and the

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -23,6 +23,7 @@ import (
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/provision"
+	"github.com/yersonargotev/dots/internal/selection"
 	"github.com/yersonargotev/dots/internal/state"
 	"github.com/yersonargotev/dots/internal/tui"
 	"github.com/yersonargotev/dots/internal/version"
@@ -33,6 +34,7 @@ var (
 	installHostArch                         = runtime.GOARCH
 	packageManagerDetector                  = pkgmgr.Detector{}
 	packageManagerSetupRunner pkgmgr.Runner = pkgmgr.ExecRunner{}
+	recordInstalledSelection                = selection.Record
 )
 
 func newInstallCommand() *cobra.Command {
@@ -84,7 +86,8 @@ func newInstallCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if _, err := manifest.ResolveSelection(*m, profiles, extraTags); err != nil {
+			installedSelection, err := selection.Resolve(*m, profiles, extraTags)
+			if err != nil {
 				return err
 			}
 
@@ -251,6 +254,10 @@ func newInstallCommand() *cobra.Command {
 				if wantsJSON(cmd) {
 					return installProvisionerError{err: err, report: installReport{DryRun: false, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan, BackupSets: createdBackups, ProvisionerResults: &provResult}}
 				}
+				return err
+			}
+			installedSelection.Provenance = state.CaptureProvenance(paths.SourceRoot, version.Value)
+			if err := recordInstalledSelection(state.Path(paths.StateRoot), installedSelection); err != nil {
 				return err
 			}
 			if wantsJSON(cmd) {
@@ -755,7 +762,9 @@ func recordProvisionerMetadata(stateRoot, sourceRoot string, report provision.Re
 	if err != nil {
 		return err
 	}
-	meta.Version = 2
+	if meta.Version < 2 {
+		meta.Version = 2
+	}
 	meta.Provenance = state.CaptureProvenance(sourceRoot, version.Value)
 	now := time.Now().UTC().Format(time.RFC3339)
 	for _, item := range report.Items {

--- a/internal/cli/install_provision_test.go
+++ b/internal/cli/install_provision_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -1001,6 +1002,19 @@ func TestInstallTUICancelDoesNotRunProvisioners(t *testing.T) {
 	writeExecStub(t, filepath.Join(stubDir, "engram"), "#!/bin/sh\nexit 0\n")
 	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
+	previousSelection := state.InstalledSelection{
+		Profiles:     []string{"old"},
+		ResolvedTags: []string{"old"},
+		Provenance:   state.Provenance{RecordedAt: "2026-01-02T03:04:05Z"},
+	}
+	if err := state.Save(state.Path(stateRoot), state.Metadata{
+		Version:            state.CurrentVersion,
+		Entries:            []state.Record{},
+		InstalledSelection: &previousSelection,
+	}); err != nil {
+		t.Fatalf("seed metadata: %v", err)
+	}
+
 	writeCLISource(t, sourceRoot, "configs/git/gitconfig", "managed\n")
 	if err := os.WriteFile(filepath.Join(sandboxHome, ".gitconfig"), []byte("local\n"), 0o600); err != nil {
 		t.Fatalf("write local target: %v", err)
@@ -1031,7 +1045,7 @@ provisioners:
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
 	cmd.SetIn(strings.NewReader("q"))
-	cmd.SetArgs([]string{"install", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot})
+	cmd.SetArgs([]string{"install", "--profile", "default", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
@@ -1052,6 +1066,13 @@ provisioners:
 	}
 	if !strings.Contains(out.String(), "Conflict resolution canceled; no changes applied.") {
 		t.Fatalf("cancel output missing abort message\noutput:\n%s", out.String())
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if meta.InstalledSelection == nil || !reflect.DeepEqual(*meta.InstalledSelection, previousSelection) {
+		t.Fatalf("InstalledSelection = %#v, want previous %#v", meta.InstalledSelection, previousSelection)
 	}
 }
 

--- a/internal/cli/install_selection_internal_test.go
+++ b/internal/cli/install_selection_internal_test.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/state"
+)
+
+func TestInstallSelectionCommitFailurePreservesPreviousSelection(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	source := filepath.Join(sourceRoot, "configs", "zsh", "zshrc")
+	if err := os.MkdirAll(filepath.Dir(source), 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	if err := os.WriteFile(source, []byte("managed\n"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	manifestPath := filepath.Join(home, "dots.yaml")
+	if err := os.WriteFile(manifestPath, []byte(`version: 1
+profiles:
+  core:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+`), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	previous := state.InstalledSelection{
+		Profiles:     []string{"old"},
+		ResolvedTags: []string{"old"},
+		Provenance:   state.Provenance{RecordedAt: "2026-01-02T03:04:05Z"},
+	}
+	if err := state.Save(state.Path(stateRoot), state.Metadata{
+		Version:            state.CurrentVersion,
+		Entries:            []state.Record{},
+		InstalledSelection: &previous,
+	}); err != nil {
+		t.Fatalf("seed metadata: %v", err)
+	}
+
+	originalRecord := recordInstalledSelection
+	recordInstalledSelection = func(string, state.InstalledSelection) error {
+		return errors.New("injected Installed Selection commit failure")
+	}
+	t.Cleanup(func() { recordInstalledSelection = originalRecord })
+
+	cmd := newInstallCommand()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{
+		"--yes", "--skip-deps", "--profile", "core",
+		"--file", manifestPath,
+		"--home", home,
+		"--source-root", sourceRoot,
+		"--state-root", stateRoot,
+	})
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("Execute() error = nil, want selection commit failure\noutput:\n%s", output.String())
+	}
+	if _, err := os.Lstat(filepath.Join(home, ".zshrc")); err != nil {
+		t.Fatalf("Managed Entry was not applied before terminal selection commit: %v", err)
+	}
+
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if meta.InstalledSelection == nil || !reflect.DeepEqual(*meta.InstalledSelection, previous) {
+		t.Fatalf("InstalledSelection = %#v, want previous %#v", meta.InstalledSelection, previous)
+	}
+}

--- a/internal/cli/install_selection_test.go
+++ b/internal/cli/install_selection_test.go
@@ -1,0 +1,282 @@
+package cli_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/cli"
+	"github.com/yersonargotev/dots/internal/state"
+)
+
+func TestInstallRecordsAuthoritativeSelectionAfterSuccessfulApply(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	writeCLISource(t, sourceRoot, "configs/zsh/zshrc", "managed\n")
+	manifestPath := writeCLIManifest(t, home, `version: 1
+profiles:
+  core:
+    tags: [core, shared]
+  agents:
+    tags: [agents, shared]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+`)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"install", "--yes", "--skip-deps",
+		"--profile", "core", "--profile", "agents",
+		"--tag", "shared", "--tag", "adaptive-theme", "--tag", "adaptive-theme",
+		"--file", manifestPath,
+		"--home", home,
+		"--source-root", sourceRoot,
+		"--state-root", stateRoot,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if meta.Version != state.CurrentVersion {
+		t.Fatalf("metadata version = %d, want %d", meta.Version, state.CurrentVersion)
+	}
+	if meta.InstalledSelection == nil {
+		t.Fatal("InstalledSelection = nil after successful install")
+	}
+	got := meta.InstalledSelection
+	if want := []string{"core", "agents"}; !reflect.DeepEqual(got.Profiles, want) {
+		t.Fatalf("Profiles = %#v, want %#v", got.Profiles, want)
+	}
+	if want := []string{"shared", "adaptive-theme"}; !reflect.DeepEqual(got.ExtraTags, want) {
+		t.Fatalf("ExtraTags = %#v, want %#v", got.ExtraTags, want)
+	}
+	if want := []string{"core", "shared", "agents", "adaptive-theme"}; !reflect.DeepEqual(got.ResolvedTags, want) {
+		t.Fatalf("ResolvedTags = %#v, want %#v", got.ResolvedTags, want)
+	}
+	if got.Provenance.SourceRoot != sourceRoot {
+		t.Fatalf("SourceRoot = %q, want %q", got.Provenance.SourceRoot, sourceRoot)
+	}
+	if got.Provenance.RecordedAt == "" {
+		t.Fatal("RecordedAt is empty")
+	}
+	if len(meta.Entries) != 1 {
+		t.Fatalf("Entries = %#v, want the Managed Entry inventory preserved", meta.Entries)
+	}
+}
+
+func TestInstallFailurePreservesPreviousInstalledSelection(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	stubDir := t.TempDir()
+	writeExecStub(t, filepath.Join(stubDir, "gentle-ai"), "#!/bin/sh\nexit 7\n")
+	writeExecStub(t, filepath.Join(stubDir, "engram"), "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	previous := state.InstalledSelection{
+		Profiles:     []string{"old"},
+		ExtraTags:    []string{"old-extra"},
+		ResolvedTags: []string{"old", "old-extra"},
+		Provenance:   state.Provenance{SourceRoot: "/old/source", RecordedAt: "2026-01-02T03:04:05Z"},
+	}
+	if err := state.Save(state.Path(stateRoot), state.Metadata{
+		Version:            state.CurrentVersion,
+		Entries:            []state.Record{},
+		InstalledSelection: &previous,
+	}); err != nil {
+		t.Fatalf("seed metadata: %v", err)
+	}
+
+	writeCLISource(t, sourceRoot, "configs/zsh/zshrc", "managed\n")
+	manifestPath := writeCLIManifest(t, home, `version: 1
+profiles:
+  new:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+provisioners:
+  - tool: gentle-ai
+    tags: [core]
+    spec:
+      scope: global
+      persona: neutral
+      agents: [codex]
+    dependencies:
+      - name: gentle-ai
+      - name: engram
+`)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"install", "--yes", "--skip-deps", "--profile", "new",
+		"--file", manifestPath,
+		"--home", home,
+		"--source-root", sourceRoot,
+		"--state-root", stateRoot,
+	})
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("Execute() error = nil, want failing provisioner\noutput:\n%s", out.String())
+	}
+
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if meta.Version != state.CurrentVersion {
+		t.Fatalf("metadata version = %d, want preserved v%d", meta.Version, state.CurrentVersion)
+	}
+	if meta.InstalledSelection == nil || !reflect.DeepEqual(*meta.InstalledSelection, previous) {
+		t.Fatalf("InstalledSelection = %#v, want previous %#v", meta.InstalledSelection, previous)
+	}
+	if len(meta.Entries) != 1 {
+		t.Fatalf("Entries = %#v, want partial Managed Entry inventory retained", meta.Entries)
+	}
+	if len(meta.Provisioners) != 1 || meta.Provisioners[0].Status != "failed" {
+		t.Fatalf("Provisioners = %#v, want failed inventory retained", meta.Provisioners)
+	}
+}
+
+func TestInstallPostProvisionerConvergenceFailurePreservesPreviousSelection(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	stubDir := t.TempDir()
+	writeExecStub(t, filepath.Join(stubDir, "codegraph"), "#!/bin/sh\nmkdir -p \"$HOME/.codex/AGENTS.md\"\n")
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	previous := state.InstalledSelection{
+		Profiles:     []string{"old"},
+		ResolvedTags: []string{"old"},
+		Provenance:   state.Provenance{RecordedAt: "2026-01-02T03:04:05Z"},
+	}
+	if err := state.Save(state.Path(stateRoot), state.Metadata{
+		Version:            state.CurrentVersion,
+		Entries:            []state.Record{},
+		InstalledSelection: &previous,
+	}); err != nil {
+		t.Fatalf("seed metadata: %v", err)
+	}
+
+	writeCLISource(t, sourceRoot, "configs/zsh/zshrc", "managed\n")
+	manifestPath := writeCLIManifest(t, home, `version: 1
+profiles:
+  new:
+    tags: [core, codegraph]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+provisioners:
+  - tool: codegraph
+    tags: [codegraph]
+    spec:
+      scope: global
+      agents: [codex]
+      yes: true
+`)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"install", "--yes", "--skip-deps", "--profile", "new",
+		"--file", manifestPath,
+		"--home", home,
+		"--source-root", sourceRoot,
+		"--state-root", stateRoot,
+	})
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("Execute() error = nil, want post-Provisioner convergence failure\noutput:\n%s", out.String())
+	}
+
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if meta.InstalledSelection == nil || !reflect.DeepEqual(*meta.InstalledSelection, previous) {
+		t.Fatalf("InstalledSelection = %#v, want previous %#v", meta.InstalledSelection, previous)
+	}
+	if len(meta.Provisioners) != 1 || meta.Provisioners[0].Status != "provisioned" {
+		t.Fatalf("Provisioners = %#v, want successful inventory before convergence failure", meta.Provisioners)
+	}
+}
+
+func TestInstallWithoutExplicitProfileMutatesNothing(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := filepath.Join(t.TempDir(), "state")
+	t.Setenv("HOME", t.TempDir())
+
+	writeCLISource(t, sourceRoot, "configs/zsh/zshrc", "managed\n")
+	manifestPath := writeCLIManifest(t, home, `version: 1
+profiles:
+  core:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+    dependencies:
+      - name: must-not-run
+        command: definitely-missing-profile-guard-probe
+provisioners:
+  - tool: gentle-ai
+    tags: [core]
+    spec:
+      scope: global
+      persona: neutral
+      agents: [codex]
+`)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"install", "--yes",
+		"--file", manifestPath,
+		"--home", home,
+		"--source-root", sourceRoot,
+		"--state-root", stateRoot,
+	})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "at least one --profile is required") {
+		t.Fatalf("Execute() error = %v, want explicit Profile guidance\noutput:\n%s", err, out.String())
+	}
+	if _, err := os.Lstat(filepath.Join(home, ".zshrc")); !os.IsNotExist(err) {
+		t.Fatalf("target mutated without Profile; lstat err = %v", err)
+	}
+	if _, err := os.Stat(stateRoot); !os.IsNotExist(err) {
+		t.Fatalf("state root created without Profile; stat err = %v", err)
+	}
+}

--- a/internal/cli/installed.go
+++ b/internal/cli/installed.go
@@ -72,25 +72,26 @@ func renderInstalled(w io.Writer, report inst.Report) {
 	}
 	fmt.Fprintln(w)
 	if !report.Provenance.Empty() {
-		parts := []string{}
-		if report.Provenance.SourceRoot != "" {
-			parts = append(parts, "source="+report.Provenance.SourceRoot)
-		}
-		if report.Provenance.SourceRevision != "" {
-			parts = append(parts, "commit="+report.Provenance.SourceRevision)
-		}
-		if report.Provenance.DotsVersion != "" {
-			parts = append(parts, "dots="+report.Provenance.DotsVersion)
-		}
-		if report.Provenance.RecordedAt != "" {
-			parts = append(parts, "recorded="+report.Provenance.RecordedAt)
-		}
-		fmt.Fprintf(w, "Provenance: %s\n", strings.Join(parts, ", "))
+		fmt.Fprintf(w, "Provenance: %s\n", renderProvenance(report.Provenance, true))
 	} else {
 		fmt.Fprintln(w, "Provenance: unknown (metadata predates provenance capture)")
 	}
 
 	fmt.Fprintln(w)
+	if report.InstalledSelection == nil {
+		fmt.Fprintln(w, "Installed Selection: none recorded (historical inventory below is non-authoritative)")
+	} else {
+		selection := report.InstalledSelection
+		fmt.Fprintln(w, "Installed Selection (authoritative)")
+		fmt.Fprintf(w, "  Profiles: %s\n", renderListOrNone(selection.Profiles))
+		fmt.Fprintf(w, "  Extra Tags: %s\n", renderListOrNone(selection.ExtraTags))
+		fmt.Fprintf(w, "  Resolved Tags: %s\n", renderListOrNone(selection.ResolvedTags))
+		fmt.Fprintf(w, "  Source of Truth: %s\n", renderProvenance(selection.Provenance, false))
+		fmt.Fprintf(w, "  Recorded At: %s\n", renderValueOrUnknown(selection.Provenance.RecordedAt))
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Historical inventory (non-authoritative)")
 	if len(report.ManagedEntries) == 0 {
 		fmt.Fprintln(w, "Managed Entries: none recorded")
 	} else {
@@ -170,4 +171,31 @@ func renderListOrNone(values []string) string {
 		return "none"
 	}
 	return strings.Join(values, ", ")
+}
+
+func renderProvenance(provenance state.Provenance, includeRecordedAt bool) string {
+	parts := []string{}
+	if provenance.SourceRoot != "" {
+		parts = append(parts, "source="+provenance.SourceRoot)
+	}
+	if provenance.SourceRevision != "" {
+		parts = append(parts, "commit="+provenance.SourceRevision)
+	}
+	if provenance.DotsVersion != "" {
+		parts = append(parts, "dots="+provenance.DotsVersion)
+	}
+	if includeRecordedAt && provenance.RecordedAt != "" {
+		parts = append(parts, "recorded="+provenance.RecordedAt)
+	}
+	if len(parts) == 0 {
+		return "unknown"
+	}
+	return strings.Join(parts, ", ")
+}
+
+func renderValueOrUnknown(value string) string {
+	if value == "" {
+		return "unknown"
+	}
+	return value
 }

--- a/internal/cli/installed_test.go
+++ b/internal/cli/installed_test.go
@@ -70,7 +70,60 @@ func TestInstalledTextExplainsPartialProfile(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit code = %d, want 0\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
 	}
-	for _, want := range []string{"Installed inventory", "Managed Entries (1)", "Tags represented: core", "Profiles", "Notes", "inferred-from-manifest"} {
+	for _, want := range []string{"Installed inventory", "Installed Selection: none recorded", "Historical inventory (non-authoritative)", "Managed Entries (1)", "Tags represented: core", "Profiles", "Notes", "inferred-from-manifest"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("text output missing %q\noutput:\n%s", want, out.String())
+		}
+	}
+}
+
+func TestInstalledTextShowsAuthoritativeSelectionSeparately(t *testing.T) {
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	manifestPath, sourceRoot := writeStatusManifest(t, home, "core")
+	if err := state.Save(state.Path(stateRoot), state.Metadata{
+		Version: 3,
+		InstalledSelection: &state.InstalledSelection{
+			Profiles:     []string{"default"},
+			ExtraTags:    []string{"agents"},
+			ResolvedTags: []string{"core", "agents"},
+			Provenance: state.Provenance{
+				SourceRoot:     sourceRoot,
+				SourceRevision: "abc123",
+				DotsVersion:    "v0.test",
+				RecordedAt:     "2026-07-23T12:00:00Z",
+			},
+		},
+		Entries: []state.Record{{
+			Target:   filepath.Join(home, ".zshrc"),
+			Source:   "configs/zsh/zshrc",
+			Strategy: "symlink",
+			Profiles: []string{"default"},
+			Tags:     []string{"core"},
+		}},
+	}); err != nil {
+		t.Fatalf("save metadata: %v", err)
+	}
+
+	var out, errOut bytes.Buffer
+	code := cli.Run([]string{
+		"installed", "--file", manifestPath,
+		"--source-root", sourceRoot, "--home", home, "--state-root", stateRoot,
+	}, &out, &errOut)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
+	}
+	for _, want := range []string{
+		"Installed Selection (authoritative)",
+		"Profiles: default",
+		"Extra Tags: agents",
+		"Resolved Tags: core, agents",
+		"Source of Truth: source=" + sourceRoot + ", commit=abc123, dots=v0.test",
+		"Recorded At: 2026-07-23T12:00:00Z",
+		"Historical inventory (non-authoritative)",
+		"Tags represented: core",
+	} {
 		if !strings.Contains(out.String(), want) {
 			t.Fatalf("text output missing %q\noutput:\n%s", want, out.String())
 		}

--- a/internal/cli/output_golden_test.go
+++ b/internal/cli/output_golden_test.go
@@ -62,8 +62,14 @@ func TestEnvelopeGolden(t *testing.T) {
 				Command:       "installed",
 				Status:        statusOK,
 				Data: inst.Report{
-					Metadata:       inst.MetadataSummary{Path: "/home/user/.local/state/dots/installed.json", Version: 2},
-					Provenance:     state.Provenance{SourceRoot: "/src/dots", SourceRevision: "abc123", DotsVersion: "v0.test", RecordedAt: "2026-07-08T12:00:00Z"},
+					Metadata:   inst.MetadataSummary{Path: "/home/user/.local/state/dots/installed.json", Version: 3},
+					Provenance: state.Provenance{SourceRoot: "/src/dots", SourceRevision: "abc123", DotsVersion: "v0.test", RecordedAt: "2026-07-08T12:00:00Z"},
+					InstalledSelection: &state.InstalledSelection{
+						Profiles:     []string{"core", "agents"},
+						ExtraTags:    []string{"work"},
+						ResolvedTags: []string{"core", "agents", "work"},
+						Provenance:   state.Provenance{SourceRoot: "/src/dots", SourceRevision: "abc123", DotsVersion: "v0.test", RecordedAt: "2026-07-08T12:00:00Z"},
+					},
 					ManagedEntries: []inst.ManagedEntry{{Source: "configs/zsh/zshrc", Target: "/home/user/.zshrc", Strategy: "symlink", InstalledAt: "2026-07-08T12:00:00Z", Tags: []string{"core"}, TagsSource: "recorded", Profiles: []string{"core"}, ProfilesSource: "recorded", ManifestMatched: true}},
 					Tags:           []string{"core"},
 					Profiles:       []inst.ProfileCoverage{{Name: "core", Source: "recorded+inferred", State: inst.CoverageComplete, CoveredTags: []string{"core"}, CoveredEntries: 1, TotalEntries: 1}},

--- a/internal/cli/testdata/envelope_installed.golden
+++ b/internal/cli/testdata/envelope_installed.golden
@@ -5,13 +5,33 @@
   "data": {
     "metadata": {
       "path": "/home/user/.local/state/dots/installed.json",
-      "version": 2
+      "version": 3
     },
     "provenance": {
       "source_root": "/src/dots",
       "source_revision": "abc123",
       "dots_version": "v0.test",
       "recorded_at": "2026-07-08T12:00:00Z"
+    },
+    "installed_selection": {
+      "profiles": [
+        "core",
+        "agents"
+      ],
+      "extra_tags": [
+        "work"
+      ],
+      "resolved_tags": [
+        "core",
+        "agents",
+        "work"
+      ],
+      "provenance": {
+        "source_root": "/src/dots",
+        "source_revision": "abc123",
+        "dots_version": "v0.test",
+        "recorded_at": "2026-07-08T12:00:00Z"
+      }
     },
     "managed_entries": [
       {

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -90,7 +90,9 @@ func recordMetadata(p plan.Plan, resolvedSources []string, opts Options) error {
 	if err != nil {
 		return err
 	}
-	meta.Version = 2
+	if meta.Version < 2 {
+		meta.Version = 2
+	}
 	meta.Provenance = state.CaptureProvenance(opts.SourceRoot, version.Value)
 
 	now := time.Now().UTC().Format(time.RFC3339)

--- a/internal/installed/installed.go
+++ b/internal/installed/installed.go
@@ -76,13 +76,14 @@ type ProvisionerRun struct {
 // Report is the official installed inventory. It is a read-only informational
 // report, so HasFindings always returns false.
 type Report struct {
-	Metadata       MetadataSummary   `json:"metadata"`
-	Provenance     state.Provenance  `json:"provenance,omitempty"`
-	ManagedEntries []ManagedEntry    `json:"managed_entries"`
-	Tags           []string          `json:"tags"`
-	Profiles       []ProfileCoverage `json:"profiles"`
-	Provisioners   []ProvisionerRun  `json:"provisioners"`
-	Notes          []string          `json:"notes,omitempty"`
+	Metadata           MetadataSummary           `json:"metadata"`
+	Provenance         state.Provenance          `json:"provenance,omitempty"`
+	InstalledSelection *state.InstalledSelection `json:"installed_selection,omitempty"`
+	ManagedEntries     []ManagedEntry            `json:"managed_entries"`
+	Tags               []string                  `json:"tags"`
+	Profiles           []ProfileCoverage         `json:"profiles"`
+	Provisioners       []ProvisionerRun          `json:"provisioners"`
+	Notes              []string                  `json:"notes,omitempty"`
 }
 
 func (r Report) HasFindings() bool { return false }
@@ -98,12 +99,13 @@ type Options struct {
 // represented Tags and Profile coverage without touching managed targets.
 func Build(m manifest.Manifest, meta state.Metadata, opts Options) (Report, error) {
 	report := Report{
-		Metadata:       MetadataSummary{Path: opts.StatePath, Version: meta.Version},
-		Provenance:     meta.Provenance,
-		ManagedEntries: []ManagedEntry{},
-		Tags:           []string{},
-		Profiles:       []ProfileCoverage{},
-		Provisioners:   []ProvisionerRun{},
+		Metadata:           MetadataSummary{Path: opts.StatePath, Version: meta.Version},
+		Provenance:         meta.Provenance,
+		InstalledSelection: meta.InstalledSelection,
+		ManagedEntries:     []ManagedEntry{},
+		Tags:               []string{},
+		Profiles:           []ProfileCoverage{},
+		Provisioners:       []ProvisionerRun{},
 	}
 
 	matchedEntryKeys := map[string]bool{}

--- a/internal/installed/installed_test.go
+++ b/internal/installed/installed_test.go
@@ -90,6 +90,62 @@ func TestBuildUsesRecordedProfilesAndTags(t *testing.T) {
 	}
 }
 
+func TestBuildExposesAuthoritativeInstalledSelectionSeparatelyFromInventory(t *testing.T) {
+	home := t.TempDir()
+	selection := &state.InstalledSelection{
+		Profiles:     []string{"core", "agents"},
+		ExtraTags:    []string{"work"},
+		ResolvedTags: []string{"core", "agents", "work"},
+		Provenance: state.Provenance{
+			SourceRoot:     "/src",
+			SourceRevision: "abc123",
+			DotsVersion:    "v0.test",
+			RecordedAt:     "2026-07-23T12:00:00Z",
+		},
+	}
+	meta := state.Metadata{
+		Version:            3,
+		InstalledSelection: selection,
+		Entries: []state.Record{{
+			Target:   filepath.Join(home, ".zshrc"),
+			Source:   "configs/zsh/zshrc",
+			Strategy: "symlink",
+			Profiles: []string{"core"},
+			Tags:     []string{"core"},
+		}},
+	}
+
+	report, err := inst.Build(inventoryManifest(), meta, inst.Options{StatePath: filepath.Join(home, "installed.json"), Home: home, OS: "linux"})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if report.InstalledSelection != selection {
+		t.Fatalf("InstalledSelection = %#v, want authoritative metadata selection %#v", report.InstalledSelection, selection)
+	}
+	if got, want := report.Tags, []string{"core"}; !sameStrings(got, want) {
+		t.Fatalf("inventory Tags = %v, want %v; resolved Installed Selection Tags must remain separate", got, want)
+	}
+}
+
+func TestBuildDoesNotPromoteLegacyInventoryToInstalledSelection(t *testing.T) {
+	home := t.TempDir()
+	meta := state.Metadata{Version: 2, Entries: []state.Record{{
+		Target:   filepath.Join(home, ".zshrc"),
+		Source:   "configs/zsh/zshrc",
+		Strategy: "symlink",
+		Profiles: []string{"core"},
+		Tags:     []string{"core"},
+	}}}
+
+	report, err := inst.Build(inventoryManifest(), meta, inst.Options{StatePath: filepath.Join(home, "installed.json"), Home: home, OS: "linux"})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if report.InstalledSelection != nil {
+		t.Fatalf("InstalledSelection = %#v, want nil for legacy metadata", report.InstalledSelection)
+	}
+}
+
 func TestBuildReturnsEmptyListsForEmptyMetadata(t *testing.T) {
 	home := t.TempDir()
 	report, err := inst.Build(inventoryManifest(), state.Metadata{}, inst.Options{StatePath: filepath.Join(home, "installed.json"), Home: home, OS: "linux"})

--- a/internal/selection/selection.go
+++ b/internal/selection/selection.go
@@ -1,0 +1,47 @@
+// Package selection resolves and persists authoritative Installed Selection.
+package selection
+
+import (
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/state"
+)
+
+// Resolve validates the requested Profiles and retains both explicit intent and
+// the resulting ordered Tag snapshot.
+func Resolve(m manifest.Manifest, profiles, extraTags []string) (state.InstalledSelection, error) {
+	resolved, err := manifest.ResolveSelection(m, profiles, extraTags)
+	if err != nil {
+		return state.InstalledSelection{}, err
+	}
+	return state.InstalledSelection{
+		Profiles:     append([]string(nil), resolved.Profiles...),
+		ExtraTags:    orderedUnique(extraTags),
+		ResolvedTags: append([]string(nil), resolved.Tags...),
+	}, nil
+}
+
+// Record reloads the latest Installation Metadata and commits only the
+// authoritative Installed Selection, preserving Managed Entry and Provisioner
+// inventory written earlier in the install.
+func Record(path string, installed state.InstalledSelection) error {
+	meta, err := state.Load(path)
+	if err != nil {
+		return err
+	}
+	meta.Version = state.CurrentVersion
+	meta.InstalledSelection = &installed
+	return state.Save(path, meta)
+}
+
+func orderedUnique(values []string) []string {
+	result := make([]string, 0, len(values))
+	seen := make(map[string]bool, len(values))
+	for _, value := range values {
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		result = append(result, value)
+	}
+	return result
+}

--- a/internal/selection/selection_test.go
+++ b/internal/selection/selection_test.go
@@ -1,0 +1,69 @@
+package selection_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/selection"
+	"github.com/yersonargotev/dots/internal/state"
+)
+
+func TestResolvePreservesExplicitSelectionIntent(t *testing.T) {
+	m := manifest.Manifest{Profiles: map[string]manifest.Profile{
+		"core":   {Tags: []string{"core", "shared"}},
+		"agents": {Tags: []string{"agents", "shared"}},
+	}}
+	got, err := selection.Resolve(m, []string{"core", "agents", "core"}, []string{"shared", "web", "shared"})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	want := state.InstalledSelection{
+		Profiles:     []string{"core", "agents"},
+		ExtraTags:    []string{"shared", "web"},
+		ResolvedTags: []string{"core", "shared", "agents", "web"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Resolve() = %+v, want %+v", got, want)
+	}
+}
+
+func TestRecordReloadsLatestInventoryBeforePersistingSelection(t *testing.T) {
+	path := state.Path(t.TempDir())
+	latest := state.Metadata{
+		Version:      2,
+		Entries:      []state.Record{{Target: "/home/user/.zshrc"}},
+		Provisioners: []state.ProvisionerRecord{{Tool: "gentle-ai"}},
+		InstalledSelection: &state.InstalledSelection{
+			Profiles: []string{"old"},
+		},
+	}
+	if err := state.Save(path, latest); err != nil {
+		t.Fatalf("save latest metadata: %v", err)
+	}
+	want := state.InstalledSelection{
+		Profiles:     []string{"core"},
+		ResolvedTags: []string{"core"},
+		Provenance:   state.Provenance{RecordedAt: "2026-07-23T12:00:00Z"},
+	}
+
+	if err := selection.Record(path, want); err != nil {
+		t.Fatalf("Record() error = %v", err)
+	}
+	got, err := state.Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if got.Version != state.CurrentVersion {
+		t.Fatalf("metadata version = %d, want %d", got.Version, state.CurrentVersion)
+	}
+	if !reflect.DeepEqual(got.Entries, latest.Entries) {
+		t.Fatalf("entries = %+v, want %+v", got.Entries, latest.Entries)
+	}
+	if !reflect.DeepEqual(got.Provisioners, latest.Provisioners) {
+		t.Fatalf("provisioners = %+v, want %+v", got.Provisioners, latest.Provisioners)
+	}
+	if got.InstalledSelection == nil || !reflect.DeepEqual(*got.InstalledSelection, want) {
+		t.Fatalf("installed selection = %+v, want %+v", got.InstalledSelection, want)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -17,12 +17,25 @@ import (
 	"time"
 )
 
+// CurrentVersion is the current Installation Metadata schema version.
+const CurrentVersion = 3
+
 // Metadata is the machine-readable record of installed managed targets.
 type Metadata struct {
-	Version      int                 `json:"version"`
-	Provenance   Provenance          `json:"provenance,omitempty"`
-	Entries      []Record            `json:"entries"`
-	Provisioners []ProvisionerRecord `json:"provisioners,omitempty"`
+	Version            int                 `json:"version"`
+	Provenance         Provenance          `json:"provenance,omitempty"`
+	Entries            []Record            `json:"entries"`
+	Provisioners       []ProvisionerRecord `json:"provisioners,omitempty"`
+	InstalledSelection *InstalledSelection `json:"installed_selection,omitempty"`
+}
+
+// InstalledSelection is the authoritative machine-level install intent. It is
+// separate from the historical Profile and Tag evidence on inventory records.
+type InstalledSelection struct {
+	Profiles     []string   `json:"profiles"`
+	ExtraTags    []string   `json:"extra_tags,omitempty"`
+	ResolvedTags []string   `json:"resolved_tags"`
+	Provenance   Provenance `json:"provenance"`
 }
 
 // Provenance records the Source of Truth and dots binary that last updated the
@@ -105,18 +118,36 @@ func Load(path string) (Metadata, error) {
 	return meta, nil
 }
 
-// Save writes Installation Metadata to path, creating the state directory if
-// needed.
+// Save atomically writes Installation Metadata to path, creating the state
+// directory if needed. A failed write leaves any prior metadata file intact.
 func Save(path string, meta Metadata) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return fmt.Errorf("create state directory: %w", err)
-	}
 	data, err := json.MarshalIndent(meta, "", "  ")
 	if err != nil {
 		return fmt.Errorf("encode installation metadata: %w", err)
 	}
 	data = append(data, '\n')
-	if err := os.WriteFile(path, data, 0o600); err != nil {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create state directory: %w", err)
+	}
+	temp, err := os.CreateTemp(dir, ".installed-*.tmp")
+	if err != nil {
+		return fmt.Errorf("write installation metadata: %w", err)
+	}
+	tempPath := temp.Name()
+	defer os.Remove(tempPath)
+	if err := temp.Chmod(0o600); err != nil {
+		temp.Close()
+		return fmt.Errorf("write installation metadata: %w", err)
+	}
+	if _, err := temp.Write(data); err != nil {
+		temp.Close()
+		return fmt.Errorf("write installation metadata: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return fmt.Errorf("write installation metadata: %w", err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
 		return fmt.Errorf("write installation metadata: %w", err)
 	}
 	return nil
@@ -175,7 +206,12 @@ func (m Metadata) Remove(targets ...string) Metadata {
 		drop[t] = struct{}{}
 	}
 
-	pruned := Metadata{Version: m.Version, Provenance: m.Provenance, Provisioners: append([]ProvisionerRecord(nil), m.Provisioners...)}
+	pruned := Metadata{
+		Version:            m.Version,
+		Provenance:         m.Provenance,
+		Provisioners:       append([]ProvisionerRecord(nil), m.Provisioners...),
+		InstalledSelection: cloneInstalledSelection(m.InstalledSelection),
+	}
 	for _, r := range m.Entries {
 		if _, ok := drop[r.Target]; ok {
 			continue
@@ -183,6 +219,17 @@ func (m Metadata) Remove(targets ...string) Metadata {
 		pruned.Entries = append(pruned.Entries, r)
 	}
 	return pruned
+}
+
+func cloneInstalledSelection(installed *InstalledSelection) *InstalledSelection {
+	if installed == nil {
+		return nil
+	}
+	cloned := *installed
+	cloned.Profiles = append([]string(nil), installed.Profiles...)
+	cloned.ExtraTags = append([]string(nil), installed.ExtraTags...)
+	cloned.ResolvedTags = append([]string(nil), installed.ResolvedTags...)
+	return &cloned
 }
 
 // HashFile returns the hex-encoded SHA-256 of a regular file's content.

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,6 +1,7 @@
 package state_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -63,6 +64,99 @@ func TestSaveThenLoadRoundTripsRecords(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("Load() metadata = %+v, want %+v", got, want)
+	}
+}
+
+func TestSaveThenLoadRoundTripsInstalledSelectionV3(t *testing.T) {
+	path := state.Path(t.TempDir())
+	want := state.Metadata{
+		Version: 3,
+		InstalledSelection: &state.InstalledSelection{
+			Profiles:     []string{"core", "agents"},
+			ExtraTags:    []string{"agents", "web"},
+			ResolvedTags: []string{"core", "agents", "web"},
+			Provenance: state.Provenance{
+				SourceRoot:     "/src/dots",
+				SourceRevision: "abc123",
+				DotsVersion:    "v0.test",
+				RecordedAt:     "2026-07-23T12:00:00Z",
+			},
+		},
+		Entries: []state.Record{{Target: "/home/user/.zshrc"}},
+	}
+
+	if err := state.Save(path, want); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	got, err := state.Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Load() metadata = %+v, want %+v", got, want)
+	}
+}
+
+func TestLoadLegacyMetadataHasNoInstalledSelection(t *testing.T) {
+	for _, version := range []int{1, 2} {
+		t.Run(fmt.Sprintf("v%d", version), func(t *testing.T) {
+			path := state.Path(t.TempDir())
+			data := fmt.Sprintf("{\"version\":%d,\"entries\":[]}\n", version)
+			if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+				t.Fatalf("write legacy metadata: %v", err)
+			}
+			got, err := state.Load(path)
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if got.InstalledSelection != nil {
+				t.Fatalf("Load() selection = %+v, want nil", got.InstalledSelection)
+			}
+		})
+	}
+}
+
+func TestSaveFailurePreservesPreviousMetadata(t *testing.T) {
+	dir := t.TempDir()
+	path := state.Path(dir)
+	previous := []byte("{\"version\":2,\"entries\":[]}\n")
+	if err := os.WriteFile(path, previous, 0o600); err != nil {
+		t.Fatalf("write previous metadata: %v", err)
+	}
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("make state directory read-only: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	if err := state.Save(path, state.Metadata{Version: 3}); err == nil {
+		t.Skip("filesystem permits writes to a read-only directory")
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read previous metadata: %v", err)
+	}
+	if !reflect.DeepEqual(got, previous) {
+		t.Fatalf("metadata after failed Save() = %q, want previous %q", got, previous)
+	}
+}
+
+func TestRemovePreservesIndependentInstalledSelection(t *testing.T) {
+	original := state.Metadata{
+		Entries: []state.Record{{Target: "/drop"}, {Target: "/keep"}},
+		InstalledSelection: &state.InstalledSelection{
+			Profiles:     []string{"core"},
+			ExtraTags:    []string{"web"},
+			ResolvedTags: []string{"core", "web"},
+		},
+	}
+
+	pruned := original.Remove("/drop")
+	if pruned.InstalledSelection == nil || !reflect.DeepEqual(pruned.InstalledSelection, original.InstalledSelection) {
+		t.Fatalf("Remove() selection = %+v, want %+v", pruned.InstalledSelection, original.InstalledSelection)
+	}
+	pruned.InstalledSelection.Profiles[0] = "changed"
+	if original.InstalledSelection.Profiles[0] != "core" {
+		t.Fatal("Remove() selection aliases the original metadata")
 	}
 }
 


### PR DESCRIPTION
Closes #340

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- add backward-compatible Installation Metadata v3 with authoritative Installed Selection intent
- commit selection only after the complete explicit install succeeds while preserving prior intent on failure or cancellation
- expose authoritative selection separately from historical inventory in `dots installed` text and JSON

## Changes

| File | Change |
|------|--------|
| `internal/state`, `internal/selection` | Add the v3 schema, atomic metadata replacement, ordered selection resolution, and terminal persistence seam. |
| `internal/install`, `internal/cli/install*` | Record selection after Managed Entries, Provisioners, and convergence complete; preserve it across all tested failure paths. |
| `internal/installed`, `internal/cli/installed*` | Render authoritative selection separately from represented/inferred historical coverage and update JSON goldens. |
| `CONTEXT.md`, `docs/adr/0014-*`, `docs/agents/output-contract.md` | Document the Installed Selection domain and metadata/output contracts. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile core --source-root "$PWD" --home <tmp> --state-root <tmp>`
- [x] `go build ./...`
- [x] Local Standards and Spec review completed with no remaining findings

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #340`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
