### PR TITLE
feat(selection): reuse Installed Selection in read-only commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ dots status
 dots doctor
 ```
 
+After a successful explicit install, `status`, `doctor`, `plan`, `deps check`,
+and `deps plan` reuse the recorded Installed Selection when no `--profile` or
+`--tag` is supplied. Supplying either flag makes that invocation's complete
+explicit selection win without changing Installation Metadata. A machine with
+no recorded selection must pass an explicit `--profile` or `--tag`; read-only
+commands never invent an implicit Profile.
+
 ### Machine-readable output
 
 Scripts and agents can request a stable JSON envelope from result-producing
@@ -111,7 +118,9 @@ dots deps install --yes  # execute installable actions without prompting
 
 `dots deps install` executes package managers with direct argv only after confirmation. It does not bypass `sudo`, does not run manual-only guidance, and does not promise rollback, version constraints, reinstall, or upgrade behavior.
 
-For honest fresh-machine validation, `deps check` and `deps plan` accept `--home` to root font detection at a sandbox instead of your real home:
+For honest fresh-machine validation, `deps check` and `deps plan` accept
+`--home` to root font detection and Installed Selection lookup at a sandbox
+instead of your real home:
 
 ```bash
 tmp=$(mktemp -d); mkdir -p "$tmp/home"
@@ -119,7 +128,10 @@ dots deps check --file dots.yaml --home "$tmp/home"
 dots deps plan  --file dots.yaml --home "$tmp/home"
 ```
 
-Unlike `doctor`/`install`, deps commands manage system-global tools rather than `$HOME` files, so they intentionally do not offer `--source-root`/`--state-root` (inert and misleading here), and `deps install` takes no `--home` (it would only relabel font detection while the real install still touches the system).
+Unlike `doctor`/`install`, deps commands manage system-global tools rather than
+`$HOME` files, so read-only deps commands derive both the Installed Repository
+and Installation Metadata locations from `--home` instead of offering separate
+`--source-root`/`--state-root` flags.
 
 List Backup Metadata created by safe installs or restores:
 

--- a/docs/adr/0014-record-authoritative-installed-selection.md
+++ b/docs/adr/0014-record-authoritative-installed-selection.md
@@ -40,3 +40,18 @@ remain historical inventory and ownership evidence. This ADR does not authorize
 other commands to reuse the Installed Selection, migrate legacy metadata,
 interpret future Profile changes, report selection deltas, or remove items that
 are no longer selected.
+
+## Read-only reuse amendment
+
+Issue #341 authorizes `status`, `doctor`, `plan`, `deps check`, and `deps plan`
+to reuse the Installed Selection when the invocation supplies neither
+`--profile` nor `--tag`. Any explicit selection is complete for that invocation,
+wins over recorded intent, and never rewrites Installation Metadata. Recorded
+Profile names and explicit extra Tags are resolved again against the current
+Install Manifest; the stored resolved Tag snapshot remains audit-only.
+
+If neither explicit nor recorded intent exists, these commands return consistent
+selection guidance and do not fall back to a manifest `default` or infer intent
+from historical inventory. Human and machine reports identify whether the
+effective selection was `explicit` or `recorded`. This amendment does not change
+install, update, upgrade, migration, selection-delta, or removal policy.

--- a/docs/agents/output-contract.md
+++ b/docs/agents/output-contract.md
@@ -105,6 +105,15 @@ prose the text surface prints:
   `data.provisioners.items`. Pending or failed Provisioners are findings so
   agents can distinguish aligned Managed Entries from an incomplete full-profile
   setup. Read dependency readiness for those commands from `doctor`.
+- `status`, `doctor`, `plan`, `deps check`, and `deps plan` include
+  `data.selection` with `source` (`explicit` or `recorded`), ordered `profiles`,
+  explicit `extra_tags`, and recomputed `effective_tags`. When no selection
+  flags are supplied, these commands resolve the recorded Profile names and
+  extra Tags against the current Install Manifest; the stored `resolved_tags`
+  remains audit-only. Any explicit Profile or Tag selection wins completely for
+  that invocation and is never merged into or persisted over recorded intent.
+  If neither source exists, the command returns an execution error (`1`) with
+  selection guidance rather than falling back to a manifest `default`.
 
 - `installed` is a read-only report over Installation Metadata. Its optional
   `data.installed_selection` is the authoritative machine-level intent recorded
@@ -162,11 +171,10 @@ prose the text surface prints:
   `data.backup_sets` lists the Backup Sets created by that run, including each
   set ID, target list, and state-root path.
 
-Profile-aware reports expose both the compatibility `profile` label and the
-first-class composed selection: `profiles` is the ordered list supplied with
-repeatable `--profile`, and `tags` is the resolved, de-duplicated tag union after
-explicit `--tag` values are applied. Agents should prefer `profiles` and `tags`
-when branching on composed selections.
+Profile-aware reports retain the compatibility `profile`, `profiles`, and
+`tags` fields. For read-only selection-aware commands, agents should prefer the
+portable `selection` object because it distinguishes invocation intent from
+recorded machine intent and separates explicit extra Tags from effective Tags.
 
 The domain reports' `json:` field names are part of the public contract.
 Renaming, removing, or changing the meaning of an existing field is a

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -29,11 +29,14 @@ Unknown YAML fields are rejected during manifest loading.
 
 ## Profiles
 
-A Profile is selected explicitly by commands such as `dots plan`, `dots install`,
-`dots status`, and `dots deps check`. Repeat `--profile` to compose multiple
-Profiles by the ordered union of their tags. Commands that expose `--tag` can add
-optional capability tags on top of the selected Profile set without creating another
-Profile. For example, `--tag adaptive-theme` installs the opt-in marker and
+A Profile is selected explicitly during install. Read-only selection-aware
+commands (`status`, `doctor`, `plan`, `deps check`, and `deps plan`) reuse the
+authoritative Installed Selection when both `--profile` and `--tag` are omitted.
+Any explicit selection flag makes the current invocation's complete selection
+win without rewriting Installation Metadata. Repeat `--profile` to compose
+multiple Profiles by the ordered union of their tags. Commands that expose
+`--tag` can add optional capability tags on top of the selected Profile set
+without creating another Profile. For example, `--tag adaptive-theme` installs the opt-in marker and
 app-specific fragments used by managed configs to follow macOS light appearance
 where the app has a safe seam.
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -99,7 +99,7 @@ entries:
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"plan", "--file", manifestPath, "--source-root", sourceRoot})
+	cmd.SetArgs([]string{"plan", "--profile", "default", "--file", manifestPath, "--source-root", sourceRoot})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
@@ -155,7 +155,7 @@ entries:
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"plan", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot})
+	cmd.SetArgs([]string{"plan", "--profile", "default", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
@@ -197,7 +197,7 @@ entries:
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"plan", "--file", manifestPath})
+	cmd.SetArgs([]string{"plan", "--profile", "default", "--file", manifestPath})
 
 	// A declared source the Installed Repository does not provide is a finding.
 	requireFindings(t, cmd.Execute())
@@ -243,7 +243,7 @@ entries:
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"doctor", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
+	cmd.SetArgs([]string{"doctor", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
@@ -299,7 +299,7 @@ entries:
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"doctor", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
+	cmd.SetArgs([]string{"doctor", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
 
 	// doctor surfaces warning diagnostics (a missing dependency), so it now
 	// returns findings.
@@ -382,7 +382,7 @@ entries:
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"doctor", "--file", manifestPath, "--profile", "desktop", "--home", home, "--source-root", sourceRoot})
+	cmd.SetArgs([]string{"doctor", "--profile", "desktop", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
 	}
@@ -965,7 +965,7 @@ entries:
 	var out bytes.Buffer
 	statusCmd.SetOut(&out)
 	statusCmd.SetErr(&out)
-	statusCmd.SetArgs([]string{"status", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+	statusCmd.SetArgs([]string{"status", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
 	if err := statusCmd.Execute(); err != nil {
 		t.Fatalf("status Execute() error = %v", err)
 	}
@@ -1128,7 +1128,7 @@ entries:
 	var out bytes.Buffer
 	statusCmd.SetOut(&out)
 	statusCmd.SetErr(&out)
-	statusCmd.SetArgs([]string{"status", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+	statusCmd.SetArgs([]string{"status", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
 	// The foreign target is a Conflict, so status now returns findings.
 	requireFindings(t, statusCmd.Execute())
 
@@ -1170,7 +1170,7 @@ entries:
 	var out bytes.Buffer
 	statusCmd.SetOut(&out)
 	statusCmd.SetErr(&out)
-	statusCmd.SetArgs([]string{"status", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
+	statusCmd.SetArgs([]string{"status", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
 	if err := statusCmd.Execute(); err == nil {
 		t.Fatal("status Execute() error = nil, want default state-root symlink escape error")
 	}
@@ -1210,7 +1210,7 @@ entries:
 	var out bytes.Buffer
 	statusCmd.SetOut(&out)
 	statusCmd.SetErr(&out)
-	statusCmd.SetArgs([]string{"status", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
+	statusCmd.SetArgs([]string{"status", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
 	if err := statusCmd.Execute(); err == nil {
 		t.Fatal("status Execute() error = nil, want metadata leaf symlink escape error")
 	}
@@ -1268,7 +1268,7 @@ entries:
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"deps", "check", "--file", manifestPath})
+	cmd.SetArgs([]string{"deps", "check", "--profile", "default", "--file", manifestPath})
 	// A missing Dependency is a finding.
 	requireFindings(t, cmd.Execute())
 
@@ -1311,7 +1311,7 @@ entries:
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"deps", "check", "--file", manifestPath})
+	cmd.SetArgs([]string{"deps", "check", "--profile", "default", "--file", manifestPath})
 	// A missing Dependency is a finding.
 	requireFindings(t, cmd.Execute())
 
@@ -1365,7 +1365,7 @@ entries:
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"deps", "check", "--file", manifestPath})
+	cmd.SetArgs([]string{"deps", "check", "--profile", "default", "--file", manifestPath})
 	// The fallback font is present, so every Dependency is satisfied: no findings.
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
@@ -1415,13 +1415,13 @@ entries:
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
 	// --tier makes the guidance deterministic regardless of the test host.
-	cmd.SetArgs([]string{"deps", "plan", "--file", manifestPath, "--tier", "debian"})
+	cmd.SetArgs([]string{"deps", "plan", "--profile", "default", "--file", manifestPath, "--tier", "debian"})
 	// The plan lists missing Dependencies, which is a finding.
 	requireFindings(t, cmd.Execute())
 
 	got := out.String()
 	for _, want := range []string{
-		`Dependency plan for profile "default" (tags: core) (debian)`,
+		`Dependency plan for profile "default" (tags: core) [selection: explicit] (debian)`,
 		"starship",
 		"sudo apt-get install starship",
 		"Summary: 1 dependency to install",
@@ -1458,7 +1458,7 @@ entries:
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"deps", "plan", "--file", manifestPath, "--tier", "Debian"})
+	cmd.SetArgs([]string{"deps", "plan", "--profile", "default", "--file", manifestPath, "--tier", "Debian"})
 	// The plan lists missing Dependencies, which is a finding.
 	requireFindings(t, cmd.Execute())
 
@@ -1486,7 +1486,7 @@ entries:
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"deps", "plan", "--file", manifestPath, "--tier", "windows"})
+	cmd.SetArgs([]string{"deps", "plan", "--profile", "default", "--file", manifestPath, "--tier", "windows"})
 	if err := cmd.Execute(); err == nil {
 		t.Fatal("Execute() error = nil, want error for unknown tier")
 	}
@@ -1772,7 +1772,7 @@ entries:
 	}{
 		{
 			name: "plan",
-			args: []string{"plan", "--home", home},
+			args: []string{"plan", "--profile", "default", "--home", home},
 			want: "Summary: 1 create, 0 conflict, 0 unchanged, 0 missing-source",
 		},
 		{
@@ -1782,13 +1782,13 @@ entries:
 		},
 		{
 			name:         "status",
-			args:         []string{"status", "--home", home},
+			args:         []string{"status", "--profile", "default", "--home", home},
 			want:         "missing",
 			wantFindings: true,
 		},
 		{
 			name:         "doctor",
-			args:         []string{"doctor", "--home", home},
+			args:         []string{"doctor", "--profile", "default", "--home", home},
 			want:         `Doctor for profile "default" (tags: core)`,
 			wantFindings: true,
 		},
@@ -1840,12 +1840,12 @@ entries:
 	}{
 		{
 			name: "check",
-			args: []string{"deps", "check", "--home", home},
+			args: []string{"deps", "check", "--profile", "default", "--home", home},
 			want: "missing  absenttool",
 		},
 		{
 			name: "plan",
-			args: []string{"deps", "plan", "--home", home},
+			args: []string{"deps", "plan", "--profile", "default", "--home", home},
 			want: "absenttool",
 		},
 	} {

--- a/internal/cli/deps.go
+++ b/internal/cli/deps.go
@@ -14,6 +14,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/yersonargotev/dots/internal/deps"
 	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/selection"
+	"github.com/yersonargotev/dots/internal/state"
 )
 
 func newDepsCommand() *cobra.Command {
@@ -54,14 +56,21 @@ func newDepsCheckCommand(profiles *[]string, extraTags *[]string) *cobra.Command
 				return err
 			}
 
+			effective, err := resolveDepsReadOnlySelection(*m, resolvedHome, *profiles, *extraTags)
+			if err != nil {
+				return err
+			}
+
 			report, err := deps.CheckWithToolProbes(*m, deps.Options{
-				Profiles:  *profiles,
-				ExtraTags: *extraTags,
+				Profiles:  effective.Profiles,
+				ExtraTags: effective.ExtraTags,
+				Selection: &effective.Selection,
 				OS:        runtime.GOOS,
 			}, lookupCommand, fontInstalled(runtime.GOOS, resolvedHome), commandOutput)
 			if err != nil {
 				return err
 			}
+			report.Selection = &effective.Report
 
 			return renderOrEmit(cmd, report, func() error {
 				renderDepsCheck(cmd.OutOrStdout(), report)
@@ -96,19 +105,26 @@ func newDepsPlanCommand(profiles *[]string, extraTags *[]string) *cobra.Command 
 				return err
 			}
 
+			effective, err := resolveDepsReadOnlySelection(*m, resolvedHome, *profiles, *extraTags)
+			if err != nil {
+				return err
+			}
+
 			resolvedTier, err := resolveTier(tier)
 			if err != nil {
 				return err
 			}
 
 			report, err := deps.Plan(*m, deps.Options{
-				Profiles:  *profiles,
-				ExtraTags: *extraTags,
+				Profiles:  effective.Profiles,
+				ExtraTags: effective.ExtraTags,
+				Selection: &effective.Selection,
 				OS:        runtime.GOOS,
 			}, lookupCommand, fontInstalled(runtime.GOOS, resolvedHome), resolvedTier)
 			if err != nil {
 				return err
 			}
+			report.Selection = &effective.Report
 
 			return renderOrEmit(cmd, report, func() error {
 				renderDepsPlan(cmd.OutOrStdout(), report)
@@ -219,6 +235,22 @@ func newDepsInstallCommand(profiles *[]string, extraTags *[]string) *cobra.Comma
 
 func loadDepsManifest(cmd *cobra.Command, file, home string) (*manifest.Manifest, error) {
 	return loadManifestForCommand(cmd, file, defaultSourceRoot(home))
+}
+
+func resolveDepsReadOnlySelection(m manifest.Manifest, home string, profiles, extraTags []string) (selection.Effective, error) {
+	var recorded *state.InstalledSelection
+	if len(profiles) == 0 && len(extraTags) == 0 {
+		paths, err := resolvePaths(home, "", "")
+		if err != nil {
+			return selection.Effective{}, err
+		}
+		meta, err := loadInstallationMetadata(paths, "")
+		if err != nil {
+			return selection.Effective{}, err
+		}
+		recorded = meta.InstalledSelection
+	}
+	return selection.ResolveReadOnly(m, profiles, extraTags, recorded)
 }
 
 func runDepsInstall(cmd *cobra.Command, m manifest.Manifest, options deps.Options, tier deps.Tier) error {

--- a/internal/cli/deps_home_test.go
+++ b/internal/cli/deps_home_test.go
@@ -61,7 +61,7 @@ func TestDepsCheckHomeFlagDetectsSandboxFont(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"deps", "check", "--file", manifestPath, "--home", sandbox})
+	cmd.SetArgs([]string{"deps", "check", "--profile", "default", "--file", manifestPath, "--home", sandbox})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
@@ -90,7 +90,7 @@ func TestDepsCheckHomeFlagIgnoresRealHomeFont(t *testing.T) {
 
 	// A missing dependency is a finding, so deps check exits with code 2.
 	var out, errOut bytes.Buffer
-	code := cli.Run([]string{"deps", "check", "--file", manifestPath, "--home", sandbox}, &out, &errOut)
+	code := cli.Run([]string{"deps", "check", "--profile", "default", "--file", manifestPath, "--home", sandbox}, &out, &errOut)
 	if code != 2 {
 		t.Fatalf("exit code = %d, want 2 (findings)\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
 	}
@@ -118,7 +118,7 @@ func TestDepsPlanHomeFlagDetectsSandboxFont(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"deps", "plan", "--file", manifestPath, "--home", sandbox, "--tier", "homebrew"})
+	cmd.SetArgs([]string{"deps", "plan", "--profile", "default", "--file", manifestPath, "--home", sandbox, "--tier", "homebrew"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())

--- a/internal/cli/deps_install_test.go
+++ b/internal/cli/deps_install_test.go
@@ -572,7 +572,7 @@ func TestDepsInstallDryRunClassifiesMissingFNMToolchainLikePlan(t *testing.T) {
 	var planOut bytes.Buffer
 	planCmd.SetOut(&planOut)
 	planCmd.SetErr(&planOut)
-	planCmd.SetArgs([]string{"deps", "plan", "--file", manifestPath, "--tier", "generic"})
+	planCmd.SetArgs([]string{"deps", "plan", "--profile", "default", "--file", manifestPath, "--tier", "generic"})
 	if err := planCmd.Execute(); err == nil {
 		t.Fatalf("deps plan error = nil, want findings exit")
 	}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/yersonargotev/dots/internal/doctor"
 	"github.com/yersonargotev/dots/internal/plan"
+	"github.com/yersonargotev/dots/internal/selection"
 	"github.com/yersonargotev/dots/internal/state"
 )
 
@@ -51,9 +52,15 @@ func newDoctorCommand() *cobra.Command {
 				return err
 			}
 
+			effective, err := selection.ResolveReadOnly(*m, profiles, extraTags, meta.InstalledSelection)
+			if err != nil {
+				return err
+			}
+
 			report, err := doctor.Build(*m, meta, doctor.Options{
-				Profiles:   profiles,
-				ExtraTags:  extraTags,
+				Profiles:   effective.Profiles,
+				ExtraTags:  effective.ExtraTags,
+				Selection:  &effective.Selection,
 				OS:         runtime.GOOS,
 				SourceRoot: paths.SourceRoot,
 				Home:       paths.Home,
@@ -62,6 +69,7 @@ func newDoctorCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			report.Selection = &effective.Report
 
 			return renderOrEmit(cmd, report, func() error {
 				renderDoctor(cmd.OutOrStdout(), report)

--- a/internal/cli/install_provision_test.go
+++ b/internal/cli/install_provision_test.go
@@ -1117,7 +1117,7 @@ func TestInstallPersistsFailedProvisionerForStatusResumeGuidance(t *testing.T) {
 	var statusOut bytes.Buffer
 	statusCmd.SetOut(&statusOut)
 	statusCmd.SetErr(&statusOut)
-	statusCmd.SetArgs([]string{"status", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot})
+	statusCmd.SetArgs([]string{"status", "--profile", "default", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot})
 	requireFindings(t, statusCmd.Execute())
 	got := statusOut.String()
 	for _, want := range []string{

--- a/internal/cli/json_reports.go
+++ b/internal/cli/json_reports.go
@@ -8,6 +8,7 @@ import (
 	"github.com/yersonargotev/dots/internal/gitrepo"
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/provision"
+	"github.com/yersonargotev/dots/internal/selection"
 	"github.com/yersonargotev/dots/internal/status"
 	"github.com/yersonargotev/dots/internal/uninstall"
 	"github.com/yersonargotev/dots/internal/upgrade"
@@ -19,6 +20,7 @@ type statusReport struct {
 	Profile      string                 `json:"profile,omitempty"`
 	Profiles     []string               `json:"profiles,omitempty"`
 	Tags         []string               `json:"tags,omitempty"`
+	Selection    *selection.Report      `json:"selection,omitempty"`
 	Entries      []status.Entry         `json:"entries"`
 	Provisioners provision.StatusReport `json:"provisioners"`
 }

--- a/internal/cli/output_golden_test.go
+++ b/internal/cli/output_golden_test.go
@@ -11,6 +11,7 @@ import (
 	inst "github.com/yersonargotev/dots/internal/installed"
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/provision"
+	"github.com/yersonargotev/dots/internal/selection"
 	"github.com/yersonargotev/dots/internal/state"
 	"github.com/yersonargotev/dots/internal/status"
 )
@@ -40,6 +41,9 @@ func TestEnvelopeGolden(t *testing.T) {
 				Status:        statusFindings,
 				Data: statusReport{
 					Profile: "default",
+					Selection: &selection.Report{
+						Source: selection.SourceExplicit, Profiles: []string{"default"}, ExtraTags: []string{"work"}, EffectiveTags: []string{"core", "work"},
+					},
 					Entries: []status.Entry{
 						{Source: "configs/zsh/zshrc", Target: "/home/user/.zshrc", Strategy: "symlink", State: status.StateOK},
 						{Source: "configs/git/config", Target: "/home/user/.gitconfig", Strategy: "copy", State: status.StateMissing},
@@ -84,7 +88,9 @@ func TestEnvelopeGolden(t *testing.T) {
 				SchemaVersion: schemaVersion,
 				Command:       "plan",
 				Status:        statusFindings,
-				Data: plan.Plan{Profile: "default", Actions: []plan.Action{
+				Data: plan.Plan{Profile: "default", Selection: &selection.Report{
+					Source: selection.SourceExplicit, Profiles: []string{"default"}, ExtraTags: []string{"work"}, EffectiveTags: []string{"core", "work"},
+				}, Actions: []plan.Action{
 					{Source: "configs/zsh/zshrc", ResolvedSource: "/abs/machine/local/path/MUST/NOT/APPEAR", Target: "/home/user/.zshrc", Strategy: "symlink", Status: plan.StatusCreate},
 					{Source: "configs/git/config", ResolvedSource: "/abs/x", Target: "/home/user/.gitconfig", Strategy: "copy", Status: plan.StatusConflict},
 				}},
@@ -98,7 +104,10 @@ func TestEnvelopeGolden(t *testing.T) {
 				Command:       "doctor",
 				Status:        statusFindings,
 				Data: doctor.Report{
-					Profile:  "default",
+					Profile: "default",
+					Selection: &selection.Report{
+						Source: selection.SourceExplicit, Profiles: []string{"default"}, ExtraTags: []string{"work"}, EffectiveTags: []string{"core", "work"},
+					},
 					OS:       "darwin",
 					Platform: doctor.Platform{Supported: true, OS: "darwin"},
 					Dependencies: deps.CheckReport{Profile: "default", Results: []deps.Result{
@@ -124,7 +133,9 @@ func TestEnvelopeGolden(t *testing.T) {
 				SchemaVersion: schemaVersion,
 				Command:       "deps check",
 				Status:        statusFindings,
-				Data: deps.CheckReport{Profile: "default", Results: []deps.Result{
+				Data: deps.CheckReport{Profile: "default", Selection: &selection.Report{
+					Source: selection.SourceExplicit, Profiles: []string{"default"}, ExtraTags: []string{"work"}, EffectiveTags: []string{"core", "work"},
+				}, Results: []deps.Result{
 					{Name: "git", Requirement: "required", Command: "git", Present: true, ProbeDetail: "MUST NOT APPEAR", Hint: "MUST NOT APPEAR"},
 					{Name: "rg", Requirement: "optional", Command: "rg", Present: false},
 				}},
@@ -139,7 +150,10 @@ func TestEnvelopeGolden(t *testing.T) {
 				Status:        statusFindings,
 				Data: deps.PlanReport{
 					Profile: "default",
-					Tier:    deps.Tier("debian"),
+					Selection: &selection.Report{
+						Source: selection.SourceExplicit, Profiles: []string{"default"}, ExtraTags: []string{"work"}, EffectiveTags: []string{"core", "work"},
+					},
+					Tier: deps.Tier("debian"),
 					Actions: []deps.InstallAction{
 						{Dependency: "rg", Requirement: "optional", Status: deps.InstallActionStatusInstallable, Provider: deps.TierDebian, Package: "ripgrep", Executable: "apt-get", Args: []string{"install", "-y", "ripgrep"}, Candidates: []deps.ProviderCandidate{{Provider: deps.TierDebian, Package: "ripgrep", Executable: "apt-get", Args: []string{"install", "ripgrep"}}}},
 					},

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -159,7 +159,7 @@ func TestStatusJSONEnvelopeAligned(t *testing.T) {
 
 	var out, errOut bytes.Buffer
 	code := cli.Run([]string{
-		"status", "--output", "json", "--file", manifestPath,
+		"status", "--profile", "default", "--output", "json", "--file", manifestPath,
 		"--source-root", sourceRoot, "--home", home, "--state-root", stateRoot,
 	}, &out, &errOut)
 
@@ -181,7 +181,7 @@ func TestStatusJSONEnvelopeFindings(t *testing.T) {
 
 	var out, errOut bytes.Buffer
 	code := cli.Run([]string{
-		"status", "--output", "json", "--file", manifestPath,
+		"status", "--profile", "default", "--output", "json", "--file", manifestPath,
 		"--source-root", sourceRoot, "--home", home, "--state-root", stateRoot,
 	}, &out, &errOut)
 
@@ -202,7 +202,7 @@ func TestStatusJSONEnvelopeFindings(t *testing.T) {
 func TestJSONErrorEnvelopeOnStdout(t *testing.T) {
 	var out, errOut bytes.Buffer
 	code := cli.Run([]string{
-		"status", "--output", "json", "--file", filepath.Join(t.TempDir(), "missing.yaml"),
+		"status", "--profile", "default", "--output", "json", "--file", filepath.Join(t.TempDir(), "missing.yaml"),
 	}, &out, &errOut)
 
 	if code != 1 {
@@ -242,7 +242,7 @@ func TestTextModeRemainsDefault(t *testing.T) {
 
 	var out, errOut bytes.Buffer
 	cli.Run([]string{
-		"status", "--file", manifestPath,
+		"status", "--profile", "default", "--file", manifestPath,
 		"--source-root", sourceRoot, "--home", home, "--state-root", stateRoot,
 	}, &out, &errOut)
 

--- a/internal/cli/plan.go
+++ b/internal/cli/plan.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/yersonargotev/dots/internal/plan"
+	"github.com/yersonargotev/dots/internal/selection"
 )
 
 func newPlanCommand() *cobra.Command {
@@ -40,12 +41,18 @@ func newPlanCommand() *cobra.Command {
 				return err
 			}
 
+			effective, err := selection.ResolveReadOnly(*m, profiles, extraTags, meta.InstalledSelection)
+			if err != nil {
+				return err
+			}
+
 			// TODO: add an --os flag to preview a cross-platform install
 			// (e.g. plan a Linux install from macOS); for now the OS is locked
 			// to the host so the dry-run reflects this machine.
 			p, err := plan.Build(*m, plan.Options{
-				Profiles:   profiles,
-				ExtraTags:  extraTags,
+				Profiles:   effective.Profiles,
+				ExtraTags:  effective.ExtraTags,
+				Selection:  &effective.Selection,
 				OS:         runtime.GOOS,
 				SourceRoot: paths.SourceRoot,
 				Home:       paths.Home,
@@ -54,6 +61,7 @@ func newPlanCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			p.Selection = &effective.Report
 
 			return renderOrEmit(cmd, p, func() error {
 				renderPlan(cmd.OutOrStdout(), p)

--- a/internal/cli/read_selection_test.go
+++ b/internal/cli/read_selection_test.go
@@ -1,0 +1,333 @@
+package cli_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/cli"
+	"github.com/yersonargotev/dots/internal/state"
+)
+
+func TestReadOnlyCommandsResolveSelectionWithoutDefaultFallback(t *testing.T) {
+	sourceRoot := t.TempDir()
+	manifestPath := filepath.Join(sourceRoot, "dots.yaml")
+	if err := os.WriteFile(manifestPath, []byte(`version: 1
+profiles:
+  default:
+    tags: [core]
+  alternate:
+    tags: [alternate]
+entries:
+  - source: configs/missing
+    target: ~/.missing
+    strategy: symlink
+    tags: [core]
+    dependencies:
+      - name: definitely-missing-selection-test-tool
+`), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("PATH", t.TempDir())
+
+	commands := []struct {
+		name   string
+		args   []string
+		isDeps bool
+	}{
+		{name: "status", args: []string{"status"}},
+		{name: "doctor", args: []string{"doctor"}},
+		{name: "plan", args: []string{"plan"}},
+		{name: "deps check", args: []string{"deps", "check"}, isDeps: true},
+		{name: "deps plan", args: []string{"deps", "plan", "--tier", "homebrew"}, isDeps: true},
+	}
+
+	for _, command := range commands {
+		t.Run(command.name, func(t *testing.T) {
+			var golden []selectionGoldenOutcome
+			commandHome := t.TempDir()
+			stateRoot := filepath.Join(commandHome, ".local", "state", "dots")
+			saveInstalledSelection(t, stateRoot, "default", "extra")
+
+			recordedArgs := selectionCommandArgs(command.args, manifestPath, commandHome, sourceRoot, stateRoot, command.isDeps)
+			code, data, envelopeError := runSelectionJSON(t, recordedArgs)
+			if code != 2 {
+				t.Fatalf("recorded selection exit code = %d, want 2; error=%q", code, envelopeError)
+			}
+			assertSelectionJSON(t, data, "recorded", []string{"default"}, []string{"extra"}, []string{"core", "extra"})
+			golden = append(golden, selectionOutcome("recorded", code, data, envelopeError))
+
+			explicitArgs := append(append([]string{}, command.args...), "--profile", "alternate")
+			explicitArgs = selectionCommandArgs(explicitArgs, manifestPath, commandHome, sourceRoot, stateRoot, command.isDeps)
+			code, data, envelopeError = runSelectionJSON(t, explicitArgs)
+			if code != 0 {
+				t.Fatalf("explicit selection exit code = %d, want 0; error=%q", code, envelopeError)
+			}
+			assertSelectionJSON(t, data, "explicit", []string{"alternate"}, nil, []string{"alternate"})
+			golden = append(golden, selectionOutcome("explicit", code, data, envelopeError))
+
+			tagOnlyArgs := append(append([]string{}, command.args...), "--tag", "alternate")
+			tagOnlyArgs = selectionCommandArgs(tagOnlyArgs, manifestPath, commandHome, sourceRoot, stateRoot, command.isDeps)
+			code, data, envelopeError = runSelectionJSON(t, tagOnlyArgs)
+			if code != 0 {
+				t.Fatalf("tag-only explicit selection exit code = %d, want 0; error=%q", code, envelopeError)
+			}
+			assertSelectionJSON(t, data, "explicit", nil, []string{"alternate"}, []string{"alternate"})
+			golden = append(golden, selectionOutcome("tag-only explicit", code, data, envelopeError))
+
+			missingHome := t.TempDir()
+			missingArgs := selectionCommandArgs(command.args, manifestPath, missingHome, sourceRoot, filepath.Join(missingHome, "state"), command.isDeps)
+			code, _, envelopeError = runSelectionJSON(t, missingArgs)
+			if code != 1 || !strings.Contains(envelopeError, "selection required") {
+				t.Fatalf("missing selection = code %d error %q, want code 1 selection-required error", code, envelopeError)
+			}
+			golden = append(golden, selectionOutcome("missing", code, nil, envelopeError))
+
+			invalidHome := t.TempDir()
+			invalidStateRoot := filepath.Join(invalidHome, ".local", "state", "dots")
+			saveInstalledSelection(t, invalidStateRoot, "removed-profile")
+			invalidArgs := selectionCommandArgs(command.args, manifestPath, invalidHome, sourceRoot, invalidStateRoot, command.isDeps)
+			code, _, envelopeError = runSelectionJSON(t, invalidArgs)
+			if code != 1 || !strings.Contains(envelopeError, "recorded selection") || !strings.Contains(envelopeError, `profile "removed-profile" not found`) {
+				t.Fatalf("invalid recorded selection = code %d error %q", code, envelopeError)
+			}
+			golden = append(golden, selectionOutcome("invalid recorded", code, nil, envelopeError))
+
+			invalidExplicitArgs := append(append([]string{}, command.args...), "--profile", "removed-profile")
+			invalidExplicitArgs = selectionCommandArgs(invalidExplicitArgs, manifestPath, commandHome, sourceRoot, stateRoot, command.isDeps)
+			code, _, envelopeError = runSelectionJSON(t, invalidExplicitArgs)
+			if code != 1 || !strings.Contains(envelopeError, "explicit selection") || !strings.Contains(envelopeError, `profile "removed-profile" not found`) {
+				t.Fatalf("invalid explicit selection = code %d error %q", code, envelopeError)
+			}
+			golden = append(golden, selectionOutcome("invalid explicit", code, nil, envelopeError))
+
+			emptyRecordedHome := t.TempDir()
+			emptyRecordedStateRoot := filepath.Join(emptyRecordedHome, ".local", "state", "dots")
+			saveEmptyInstalledSelection(t, emptyRecordedStateRoot)
+			emptyRecordedArgs := selectionCommandArgs(command.args, manifestPath, emptyRecordedHome, sourceRoot, emptyRecordedStateRoot, command.isDeps)
+			code, _, envelopeError = runSelectionJSON(t, emptyRecordedArgs)
+			if code != 1 || envelopeError != "recorded selection: at least one Profile or extra Tag is required" {
+				t.Fatalf("empty recorded selection = code %d error %q", code, envelopeError)
+			}
+			golden = append(golden, selectionOutcome("empty recorded", code, nil, envelopeError))
+
+			emptyExplicitArgs := append(append([]string{}, command.args...), "--profile", "")
+			emptyExplicitArgs = selectionCommandArgs(emptyExplicitArgs, manifestPath, commandHome, sourceRoot, stateRoot, command.isDeps)
+			code, _, envelopeError = runSelectionJSON(t, emptyExplicitArgs)
+			if code != 1 || envelopeError != "explicit selection: profile names must not be empty" {
+				t.Fatalf("empty explicit selection = code %d error %q", code, envelopeError)
+			}
+			golden = append(golden, selectionOutcome("empty explicit", code, nil, envelopeError))
+
+			whitespaceRecordedHome := t.TempDir()
+			whitespaceRecordedStateRoot := filepath.Join(whitespaceRecordedHome, ".local", "state", "dots")
+			saveWhitespaceInstalledSelection(t, whitespaceRecordedStateRoot)
+			whitespaceRecordedArgs := selectionCommandArgs(command.args, manifestPath, whitespaceRecordedHome, sourceRoot, whitespaceRecordedStateRoot, command.isDeps)
+			code, _, envelopeError = runSelectionJSON(t, whitespaceRecordedArgs)
+			if code != 1 || envelopeError != "recorded selection: tags must not be empty" {
+				t.Fatalf("whitespace recorded selection = code %d error %q", code, envelopeError)
+			}
+			golden = append(golden, selectionOutcome("whitespace recorded", code, nil, envelopeError))
+
+			whitespaceExplicitArgs := append(append([]string{}, command.args...), "--tag", " ")
+			whitespaceExplicitArgs = selectionCommandArgs(whitespaceExplicitArgs, manifestPath, commandHome, sourceRoot, stateRoot, command.isDeps)
+			code, _, envelopeError = runSelectionJSON(t, whitespaceExplicitArgs)
+			if code != 1 || envelopeError != "explicit selection: tags must not be empty" {
+				t.Fatalf("whitespace explicit selection = code %d error %q", code, envelopeError)
+			}
+			golden = append(golden, selectionOutcome("whitespace explicit", code, nil, envelopeError))
+
+			assertReadSelectionGolden(t, strings.ReplaceAll(command.name, " ", "_"), golden)
+		})
+	}
+}
+
+func TestReadOnlySelectionTextReportsSource(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	manifestPath, sourceRoot := writeStatusManifest(t, home, "other")
+	saveInstalledSelection(t, stateRoot, "default")
+
+	for _, tt := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "recorded",
+			args: []string{"status", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot},
+			want: "[selection: recorded]",
+		},
+		{
+			name: "explicit",
+			args: []string{"status", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot},
+			want: "[selection: explicit]",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if code := cli.Run(tt.args, &stdout, &stderr); code != 0 {
+				t.Fatalf("exit code = %d, want 0\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stdout.String(), tt.want) {
+				t.Fatalf("output missing %q:\n%s", tt.want, stdout.String())
+			}
+		})
+	}
+}
+
+func TestDepsExplicitSelectionWorksWithoutInstallationMetadata(t *testing.T) {
+	home := t.TempDir()
+	manifestPath := writeCLIManifest(t, home, `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/unused
+    target: ~/.unused
+    strategy: symlink
+    tags: [other]
+`)
+	for _, args := range [][]string{
+		{"deps", "check", "--profile", "default"},
+		{"deps", "plan", "--profile", "default", "--tier", "homebrew"},
+	} {
+		args = append(args, "--output", "json", "--file", manifestPath, "--home", home)
+		code, data, envelopeError := runSelectionJSON(t, args)
+		if code != 0 {
+			t.Fatalf("%v exit code = %d, want 0; error=%q", args[:2], code, envelopeError)
+		}
+		assertSelectionJSON(t, data, "explicit", []string{"default"}, nil, []string{"core"})
+	}
+}
+
+func selectionCommandArgs(args []string, manifestPath, home, sourceRoot, stateRoot string, isDeps bool) []string {
+	result := append(append([]string{}, args...), "--output", "json", "--file", manifestPath, "--home", home)
+	if !isDeps {
+		result = append(result, "--source-root", sourceRoot, "--state-root", stateRoot)
+	}
+	return result
+}
+
+func saveInstalledSelection(t *testing.T, stateRoot, profile string, extraTags ...string) {
+	t.Helper()
+	if err := state.Save(state.Path(stateRoot), state.Metadata{
+		Version: state.CurrentVersion,
+		InstalledSelection: &state.InstalledSelection{
+			Profiles:     []string{profile},
+			ExtraTags:    extraTags,
+			ResolvedTags: append([]string{profile}, extraTags...),
+		},
+	}); err != nil {
+		t.Fatalf("save Installed Selection: %v", err)
+	}
+}
+
+func saveEmptyInstalledSelection(t *testing.T, stateRoot string) {
+	t.Helper()
+	if err := state.Save(state.Path(stateRoot), state.Metadata{
+		Version:            state.CurrentVersion,
+		InstalledSelection: &state.InstalledSelection{},
+	}); err != nil {
+		t.Fatalf("save empty Installed Selection: %v", err)
+	}
+}
+
+func saveWhitespaceInstalledSelection(t *testing.T, stateRoot string) {
+	t.Helper()
+	if err := state.Save(state.Path(stateRoot), state.Metadata{
+		Version: state.CurrentVersion,
+		InstalledSelection: &state.InstalledSelection{
+			ExtraTags: []string{" "},
+		},
+	}); err != nil {
+		t.Fatalf("save whitespace Installed Selection: %v", err)
+	}
+}
+
+func runSelectionJSON(t *testing.T, args []string) (int, map[string]any, string) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	code := cli.Run(args, &stdout, &stderr)
+	var env struct {
+		Data  map[string]any `json:"data"`
+		Error string         `json:"error"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("decode envelope: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+	return code, env.Data, env.Error
+}
+
+func assertSelectionJSON(t *testing.T, data map[string]any, source string, profiles, extraTags, effectiveTags []string) {
+	t.Helper()
+	got, ok := data["selection"].(map[string]any)
+	if !ok {
+		t.Fatalf("data.selection = %#v, want object", data["selection"])
+	}
+	want := map[string]any{
+		"source":         source,
+		"profiles":       stringSliceToAny(profiles),
+		"extra_tags":     stringSliceToAny(extraTags),
+		"effective_tags": stringSliceToAny(effectiveTags),
+	}
+	for key, value := range want {
+		if gotJSON, wantJSON := mustJSON(t, got[key]), mustJSON(t, value); gotJSON != wantJSON {
+			t.Fatalf("selection.%s = %s, want %s", key, gotJSON, wantJSON)
+		}
+	}
+}
+
+func stringSliceToAny(values []string) []any {
+	result := make([]any, len(values))
+	for i, value := range values {
+		result[i] = value
+	}
+	return result
+}
+
+func mustJSON(t *testing.T, value any) string {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+type selectionGoldenOutcome struct {
+	Scenario  string `json:"scenario"`
+	ExitCode  int    `json:"exit_code"`
+	Selection any    `json:"selection,omitempty"`
+	Error     string `json:"error,omitempty"`
+}
+
+func selectionOutcome(scenario string, exitCode int, data map[string]any, envelopeError string) selectionGoldenOutcome {
+	var reported any
+	if data != nil {
+		reported = data["selection"]
+	}
+	return selectionGoldenOutcome{Scenario: scenario, ExitCode: exitCode, Selection: reported, Error: envelopeError}
+}
+
+func assertReadSelectionGolden(t *testing.T, command string, outcomes []selectionGoldenOutcome) {
+	t.Helper()
+	got, err := json.MarshalIndent(outcomes, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal selection golden: %v", err)
+	}
+	got = append(got, '\n')
+	path := filepath.Join("testdata", "selection_"+command+".golden")
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read selection golden %s: %v\ngot:\n%s", path, err, got)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("selection golden mismatch for %s\ngot:\n%s\nwant:\n%s", command, got, want)
+	}
+}

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -7,13 +7,14 @@ import (
 
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/plan"
+	"github.com/yersonargotev/dots/internal/selection"
 )
 
 // renderPlan writes a human-readable, deterministic preview of an Install Plan.
 // The output is stable for a given Plan so it can be locked with a golden test
 // and read predictably by the user during a dry run.
 func renderPlan(w io.Writer, p plan.Plan) {
-	fmt.Fprintf(w, "Plan for %s\n\n", renderProfileSelection(p.Profile, p.Profiles, p.Tags))
+	fmt.Fprintf(w, "Plan for %s\n\n", renderEffectiveSelection(p.Profile, p.Profiles, p.Tags, p.Selection))
 
 	if len(p.Actions) == 0 {
 		fmt.Fprintln(w, "Nothing to do.")
@@ -89,7 +90,9 @@ func renderSkippedEntryHint(w io.Writer, m manifest.Manifest, profiles []string,
 
 func renderProfileSelection(profile string, profiles []string, tags []string) string {
 	var selection string
-	if len(profiles) == 0 {
+	if len(profiles) == 0 && profile == "" {
+		selection = "tags only"
+	} else if len(profiles) == 0 {
 		selection = fmt.Sprintf("profile %q", profile)
 	} else if len(profiles) == 1 {
 		selection = fmt.Sprintf("profile %q", profiles[0])
@@ -104,6 +107,14 @@ func renderProfileSelection(profile string, profiles []string, tags []string) st
 		return selection
 	}
 	return selection + " (tags: " + strings.Join(tags, ", ") + ")"
+}
+
+func renderEffectiveSelection(profile string, profiles, tags []string, report *selection.Report) string {
+	rendered := renderProfileSelection(profile, profiles, tags)
+	if report == nil {
+		return rendered
+	}
+	return fmt.Sprintf("%s [selection: %s]", rendered, report.Source)
 }
 
 func renderProfileFlags(profiles []string) string {

--- a/internal/cli/render_deps.go
+++ b/internal/cli/render_deps.go
@@ -11,7 +11,7 @@ import (
 // renderDepsCheck writes a deterministic Dependency presence report so it can be
 // locked with a golden test and read predictably by the user.
 func renderDepsCheck(w io.Writer, report deps.CheckReport) {
-	fmt.Fprintf(w, "Dependencies for %s\n\n", renderProfileSelection(report.Profile, report.Profiles, report.Tags))
+	fmt.Fprintf(w, "Dependencies for %s\n\n", renderEffectiveSelection(report.Profile, report.Profiles, report.Tags, report.Selection))
 
 	if len(report.Results) == 0 {
 		fmt.Fprintln(w, "No dependencies declared for this profile.")
@@ -45,7 +45,7 @@ func renderDepsCheck(w io.Writer, report deps.CheckReport) {
 // renderDepsPlan writes a deterministic, advisory Dependency Plan: OS-aware
 // installation guidance for the missing Dependencies under the active Tier.
 func renderDepsPlan(w io.Writer, report deps.PlanReport) {
-	fmt.Fprintf(w, "Dependency plan for %s (%s)\n\n", renderProfileSelection(report.Profile, report.Profiles, report.Tags), report.Tier)
+	fmt.Fprintf(w, "Dependency plan for %s (%s)\n\n", renderEffectiveSelection(report.Profile, report.Profiles, report.Tags, report.Selection), report.Tier)
 
 	if len(report.Items) == 0 {
 		fmt.Fprintln(w, "All declared dependencies are already installed.")

--- a/internal/cli/render_doctor.go
+++ b/internal/cli/render_doctor.go
@@ -11,7 +11,7 @@ import (
 )
 
 func renderDoctor(w io.Writer, report doctor.Report) {
-	fmt.Fprintf(w, "Doctor for %s\n\n", renderProfileSelection(report.Profile, report.Profiles, report.Tags))
+	fmt.Fprintf(w, "Doctor for %s\n\n", renderEffectiveSelection(report.Profile, report.Profiles, report.Tags, report.Selection))
 
 	if report.Platform.Supported {
 		fmt.Fprintf(w, "Platform: ok (%s)\n", report.Platform.OS)

--- a/internal/cli/render_status.go
+++ b/internal/cli/render_status.go
@@ -13,7 +13,7 @@ import (
 // The output is stable for a given Report so it can be locked with a golden test
 // and read predictably by the user.
 func renderStatus(w io.Writer, report status.Report) {
-	fmt.Fprintf(w, "Status for %s\n\n", renderProfileSelection(report.Profile, report.Profiles, report.Tags))
+	fmt.Fprintf(w, "Status for %s\n\n", renderEffectiveSelection(report.Profile, report.Profiles, report.Tags, report.Selection))
 
 	if len(report.Entries) == 0 {
 		fmt.Fprintln(w, "No managed entries for this profile.")

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -61,7 +61,7 @@ func TestRunReturnsZeroWhenAligned(t *testing.T) {
 
 	var out, errOut bytes.Buffer
 	code := cli.Run([]string{
-		"status", "--file", manifestPath,
+		"status", "--profile", "default", "--file", manifestPath,
 		"--source-root", sourceRoot, "--home", home, "--state-root", stateRoot,
 	}, &out, &errOut)
 
@@ -79,7 +79,7 @@ func TestRunReturnsTwoOnFindings(t *testing.T) {
 
 	var out, errOut bytes.Buffer
 	code := cli.Run([]string{
-		"status", "--file", manifestPath,
+		"status", "--profile", "default", "--file", manifestPath,
 		"--source-root", sourceRoot, "--home", home, "--state-root", stateRoot,
 	}, &out, &errOut)
 
@@ -90,7 +90,7 @@ func TestRunReturnsTwoOnFindings(t *testing.T) {
 
 func TestRunReturnsOneOnError(t *testing.T) {
 	var out, errOut bytes.Buffer
-	code := cli.Run([]string{"status", "--file", filepath.Join(t.TempDir(), "missing.yaml")}, &out, &errOut)
+	code := cli.Run([]string{"status", "--profile", "default", "--file", filepath.Join(t.TempDir(), "missing.yaml")}, &out, &errOut)
 
 	if code != 1 {
 		t.Fatalf("status with bad manifest exit code = %d, want 1", code)

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/provision"
+	"github.com/yersonargotev/dots/internal/selection"
 	"github.com/yersonargotev/dots/internal/state"
 	"github.com/yersonargotev/dots/internal/status"
 )
@@ -52,9 +53,15 @@ func newStatusCommand() *cobra.Command {
 				return err
 			}
 
+			effective, err := selection.ResolveReadOnly(*m, profiles, extraTags, meta.InstalledSelection)
+			if err != nil {
+				return err
+			}
+
 			report, err := status.Build(*m, meta, status.Options{
-				Profiles:   profiles,
-				ExtraTags:  extraTags,
+				Profiles:   effective.Profiles,
+				ExtraTags:  effective.ExtraTags,
+				Selection:  &effective.Selection,
 				OS:         runtime.GOOS,
 				SourceRoot: paths.SourceRoot,
 				Home:       paths.Home,
@@ -62,8 +69,9 @@ func newStatusCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			report.Selection = &effective.Report
 
-			provPlan, err := provision.Build(*m, provision.Options{Profiles: profiles, ExtraTags: extraTags, OS: runtime.GOOS})
+			provPlan, err := provision.Build(*m, provision.Options{Profiles: effective.Profiles, ExtraTags: effective.ExtraTags, Selection: &effective.Selection, OS: runtime.GOOS})
 			if err != nil {
 				return err
 			}
@@ -71,6 +79,7 @@ func newStatusCommand() *cobra.Command {
 				Profile:      report.Profile,
 				Profiles:     report.Profiles,
 				Tags:         report.Tags,
+				Selection:    report.Selection,
 				Entries:      report.Entries,
 				Provisioners: provision.BuildStatus(provPlan, meta),
 			}

--- a/internal/cli/status_provision_test.go
+++ b/internal/cli/status_provision_test.go
@@ -24,7 +24,7 @@ func TestStatusListsDeclaredProvisioners(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"status", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+	cmd.SetArgs([]string{"status", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
 
 	// The managed entries are not installed in this sandbox, so status reports
 	// them as missing: a finding.

--- a/internal/cli/testdata/envelope_deps_check.golden
+++ b/internal/cli/testdata/envelope_deps_check.golden
@@ -4,6 +4,19 @@
   "status": "findings",
   "data": {
     "profile": "default",
+    "selection": {
+      "source": "explicit",
+      "profiles": [
+        "default"
+      ],
+      "extra_tags": [
+        "work"
+      ],
+      "effective_tags": [
+        "core",
+        "work"
+      ]
+    },
     "results": [
       {
         "name": "git",

--- a/internal/cli/testdata/envelope_deps_plan.golden
+++ b/internal/cli/testdata/envelope_deps_plan.golden
@@ -4,6 +4,19 @@
   "status": "findings",
   "data": {
     "profile": "default",
+    "selection": {
+      "source": "explicit",
+      "profiles": [
+        "default"
+      ],
+      "extra_tags": [
+        "work"
+      ],
+      "effective_tags": [
+        "core",
+        "work"
+      ]
+    },
     "tier": "debian",
     "actions": [
       {

--- a/internal/cli/testdata/envelope_doctor.golden
+++ b/internal/cli/testdata/envelope_doctor.golden
@@ -4,6 +4,19 @@
   "status": "findings",
   "data": {
     "profile": "default",
+    "selection": {
+      "source": "explicit",
+      "profiles": [
+        "default"
+      ],
+      "extra_tags": [
+        "work"
+      ],
+      "effective_tags": [
+        "core",
+        "work"
+      ]
+    },
     "os": "darwin",
     "platform": {
       "supported": true,

--- a/internal/cli/testdata/envelope_plan.golden
+++ b/internal/cli/testdata/envelope_plan.golden
@@ -4,6 +4,19 @@
   "status": "findings",
   "data": {
     "profile": "default",
+    "selection": {
+      "source": "explicit",
+      "profiles": [
+        "default"
+      ],
+      "extra_tags": [
+        "work"
+      ],
+      "effective_tags": [
+        "core",
+        "work"
+      ]
+    },
     "actions": [
       {
         "source": "configs/zsh/zshrc",

--- a/internal/cli/testdata/envelope_status.golden
+++ b/internal/cli/testdata/envelope_status.golden
@@ -4,6 +4,19 @@
   "status": "findings",
   "data": {
     "profile": "default",
+    "selection": {
+      "source": "explicit",
+      "profiles": [
+        "default"
+      ],
+      "extra_tags": [
+        "work"
+      ],
+      "effective_tags": [
+        "core",
+        "work"
+      ]
+    },
     "entries": [
       {
         "source": "configs/zsh/zshrc",

--- a/internal/cli/testdata/selection_deps_check.golden
+++ b/internal/cli/testdata/selection_deps_check.golden
@@ -1,0 +1,82 @@
+[
+  {
+    "scenario": "recorded",
+    "exit_code": 2,
+    "selection": {
+      "effective_tags": [
+        "core",
+        "extra"
+      ],
+      "extra_tags": [
+        "extra"
+      ],
+      "profiles": [
+        "default"
+      ],
+      "source": "recorded"
+    }
+  },
+  {
+    "scenario": "explicit",
+    "exit_code": 0,
+    "selection": {
+      "effective_tags": [
+        "alternate"
+      ],
+      "extra_tags": [],
+      "profiles": [
+        "alternate"
+      ],
+      "source": "explicit"
+    }
+  },
+  {
+    "scenario": "tag-only explicit",
+    "exit_code": 0,
+    "selection": {
+      "effective_tags": [
+        "alternate"
+      ],
+      "extra_tags": [
+        "alternate"
+      ],
+      "profiles": [],
+      "source": "explicit"
+    }
+  },
+  {
+    "scenario": "missing",
+    "exit_code": 1,
+    "error": "selection required: provide --profile or --tag, or run dots install to record an Installed Selection"
+  },
+  {
+    "scenario": "invalid recorded",
+    "exit_code": 1,
+    "error": "recorded selection: profile \"removed-profile\" not found"
+  },
+  {
+    "scenario": "invalid explicit",
+    "exit_code": 1,
+    "error": "explicit selection: profile \"removed-profile\" not found"
+  },
+  {
+    "scenario": "empty recorded",
+    "exit_code": 1,
+    "error": "recorded selection: at least one Profile or extra Tag is required"
+  },
+  {
+    "scenario": "empty explicit",
+    "exit_code": 1,
+    "error": "explicit selection: profile names must not be empty"
+  },
+  {
+    "scenario": "whitespace recorded",
+    "exit_code": 1,
+    "error": "recorded selection: tags must not be empty"
+  },
+  {
+    "scenario": "whitespace explicit",
+    "exit_code": 1,
+    "error": "explicit selection: tags must not be empty"
+  }
+]

--- a/internal/cli/testdata/selection_deps_plan.golden
+++ b/internal/cli/testdata/selection_deps_plan.golden
@@ -1,0 +1,82 @@
+[
+  {
+    "scenario": "recorded",
+    "exit_code": 2,
+    "selection": {
+      "effective_tags": [
+        "core",
+        "extra"
+      ],
+      "extra_tags": [
+        "extra"
+      ],
+      "profiles": [
+        "default"
+      ],
+      "source": "recorded"
+    }
+  },
+  {
+    "scenario": "explicit",
+    "exit_code": 0,
+    "selection": {
+      "effective_tags": [
+        "alternate"
+      ],
+      "extra_tags": [],
+      "profiles": [
+        "alternate"
+      ],
+      "source": "explicit"
+    }
+  },
+  {
+    "scenario": "tag-only explicit",
+    "exit_code": 0,
+    "selection": {
+      "effective_tags": [
+        "alternate"
+      ],
+      "extra_tags": [
+        "alternate"
+      ],
+      "profiles": [],
+      "source": "explicit"
+    }
+  },
+  {
+    "scenario": "missing",
+    "exit_code": 1,
+    "error": "selection required: provide --profile or --tag, or run dots install to record an Installed Selection"
+  },
+  {
+    "scenario": "invalid recorded",
+    "exit_code": 1,
+    "error": "recorded selection: profile \"removed-profile\" not found"
+  },
+  {
+    "scenario": "invalid explicit",
+    "exit_code": 1,
+    "error": "explicit selection: profile \"removed-profile\" not found"
+  },
+  {
+    "scenario": "empty recorded",
+    "exit_code": 1,
+    "error": "recorded selection: at least one Profile or extra Tag is required"
+  },
+  {
+    "scenario": "empty explicit",
+    "exit_code": 1,
+    "error": "explicit selection: profile names must not be empty"
+  },
+  {
+    "scenario": "whitespace recorded",
+    "exit_code": 1,
+    "error": "recorded selection: tags must not be empty"
+  },
+  {
+    "scenario": "whitespace explicit",
+    "exit_code": 1,
+    "error": "explicit selection: tags must not be empty"
+  }
+]

--- a/internal/cli/testdata/selection_doctor.golden
+++ b/internal/cli/testdata/selection_doctor.golden
@@ -1,0 +1,82 @@
+[
+  {
+    "scenario": "recorded",
+    "exit_code": 2,
+    "selection": {
+      "effective_tags": [
+        "core",
+        "extra"
+      ],
+      "extra_tags": [
+        "extra"
+      ],
+      "profiles": [
+        "default"
+      ],
+      "source": "recorded"
+    }
+  },
+  {
+    "scenario": "explicit",
+    "exit_code": 0,
+    "selection": {
+      "effective_tags": [
+        "alternate"
+      ],
+      "extra_tags": [],
+      "profiles": [
+        "alternate"
+      ],
+      "source": "explicit"
+    }
+  },
+  {
+    "scenario": "tag-only explicit",
+    "exit_code": 0,
+    "selection": {
+      "effective_tags": [
+        "alternate"
+      ],
+      "extra_tags": [
+        "alternate"
+      ],
+      "profiles": [],
+      "source": "explicit"
+    }
+  },
+  {
+    "scenario": "missing",
+    "exit_code": 1,
+    "error": "selection required: provide --profile or --tag, or run dots install to record an Installed Selection"
+  },
+  {
+    "scenario": "invalid recorded",
+    "exit_code": 1,
+    "error": "recorded selection: profile \"removed-profile\" not found"
+  },
+  {
+    "scenario": "invalid explicit",
+    "exit_code": 1,
+    "error": "explicit selection: profile \"removed-profile\" not found"
+  },
+  {
+    "scenario": "empty recorded",
+    "exit_code": 1,
+    "error": "recorded selection: at least one Profile or extra Tag is required"
+  },
+  {
+    "scenario": "empty explicit",
+    "exit_code": 1,
+    "error": "explicit selection: profile names must not be empty"
+  },
+  {
+    "scenario": "whitespace recorded",
+    "exit_code": 1,
+    "error": "recorded selection: tags must not be empty"
+  },
+  {
+    "scenario": "whitespace explicit",
+    "exit_code": 1,
+    "error": "explicit selection: tags must not be empty"
+  }
+]

--- a/internal/cli/testdata/selection_plan.golden
+++ b/internal/cli/testdata/selection_plan.golden
@@ -1,0 +1,82 @@
+[
+  {
+    "scenario": "recorded",
+    "exit_code": 2,
+    "selection": {
+      "effective_tags": [
+        "core",
+        "extra"
+      ],
+      "extra_tags": [
+        "extra"
+      ],
+      "profiles": [
+        "default"
+      ],
+      "source": "recorded"
+    }
+  },
+  {
+    "scenario": "explicit",
+    "exit_code": 0,
+    "selection": {
+      "effective_tags": [
+        "alternate"
+      ],
+      "extra_tags": [],
+      "profiles": [
+        "alternate"
+      ],
+      "source": "explicit"
+    }
+  },
+  {
+    "scenario": "tag-only explicit",
+    "exit_code": 0,
+    "selection": {
+      "effective_tags": [
+        "alternate"
+      ],
+      "extra_tags": [
+        "alternate"
+      ],
+      "profiles": [],
+      "source": "explicit"
+    }
+  },
+  {
+    "scenario": "missing",
+    "exit_code": 1,
+    "error": "selection required: provide --profile or --tag, or run dots install to record an Installed Selection"
+  },
+  {
+    "scenario": "invalid recorded",
+    "exit_code": 1,
+    "error": "recorded selection: profile \"removed-profile\" not found"
+  },
+  {
+    "scenario": "invalid explicit",
+    "exit_code": 1,
+    "error": "explicit selection: profile \"removed-profile\" not found"
+  },
+  {
+    "scenario": "empty recorded",
+    "exit_code": 1,
+    "error": "recorded selection: at least one Profile or extra Tag is required"
+  },
+  {
+    "scenario": "empty explicit",
+    "exit_code": 1,
+    "error": "explicit selection: profile names must not be empty"
+  },
+  {
+    "scenario": "whitespace recorded",
+    "exit_code": 1,
+    "error": "recorded selection: tags must not be empty"
+  },
+  {
+    "scenario": "whitespace explicit",
+    "exit_code": 1,
+    "error": "explicit selection: tags must not be empty"
+  }
+]

--- a/internal/cli/testdata/selection_status.golden
+++ b/internal/cli/testdata/selection_status.golden
@@ -1,0 +1,82 @@
+[
+  {
+    "scenario": "recorded",
+    "exit_code": 2,
+    "selection": {
+      "effective_tags": [
+        "core",
+        "extra"
+      ],
+      "extra_tags": [
+        "extra"
+      ],
+      "profiles": [
+        "default"
+      ],
+      "source": "recorded"
+    }
+  },
+  {
+    "scenario": "explicit",
+    "exit_code": 0,
+    "selection": {
+      "effective_tags": [
+        "alternate"
+      ],
+      "extra_tags": [],
+      "profiles": [
+        "alternate"
+      ],
+      "source": "explicit"
+    }
+  },
+  {
+    "scenario": "tag-only explicit",
+    "exit_code": 0,
+    "selection": {
+      "effective_tags": [
+        "alternate"
+      ],
+      "extra_tags": [
+        "alternate"
+      ],
+      "profiles": [],
+      "source": "explicit"
+    }
+  },
+  {
+    "scenario": "missing",
+    "exit_code": 1,
+    "error": "selection required: provide --profile or --tag, or run dots install to record an Installed Selection"
+  },
+  {
+    "scenario": "invalid recorded",
+    "exit_code": 1,
+    "error": "recorded selection: profile \"removed-profile\" not found"
+  },
+  {
+    "scenario": "invalid explicit",
+    "exit_code": 1,
+    "error": "explicit selection: profile \"removed-profile\" not found"
+  },
+  {
+    "scenario": "empty recorded",
+    "exit_code": 1,
+    "error": "recorded selection: at least one Profile or extra Tag is required"
+  },
+  {
+    "scenario": "empty explicit",
+    "exit_code": 1,
+    "error": "explicit selection: profile names must not be empty"
+  },
+  {
+    "scenario": "whitespace recorded",
+    "exit_code": 1,
+    "error": "recorded selection: tags must not be empty"
+  },
+  {
+    "scenario": "whitespace explicit",
+    "exit_code": 1,
+    "error": "explicit selection: tags must not be empty"
+  }
+]

--- a/internal/deps/deps.go
+++ b/internal/deps/deps.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/selection"
 )
 
 // Lookup reports whether a command is available on the workstation. It is the
@@ -28,6 +29,7 @@ type Options struct {
 	Profile   string
 	Profiles  []string
 	ExtraTags []string
+	Selection *manifest.Selection
 	OS        string
 	Arch      string
 	Home      string
@@ -51,10 +53,11 @@ type Result struct {
 
 // CheckReport is the Dependency presence report for a Profile.
 type CheckReport struct {
-	Profile  string   `json:"profile,omitempty"`
-	Profiles []string `json:"profiles,omitempty"`
-	Tags     []string `json:"tags,omitempty"`
-	Results  []Result `json:"results"`
+	Profile   string            `json:"profile,omitempty"`
+	Profiles  []string          `json:"profiles,omitempty"`
+	Tags      []string          `json:"tags,omitempty"`
+	Selection *selection.Report `json:"selection,omitempty"`
+	Results   []Result          `json:"results"`
 }
 
 // HasFindings reports whether any declared Dependency is absent from the
@@ -84,7 +87,7 @@ func CheckWithToolProbes(m manifest.Manifest, opts Options, look Lookup, fontLoo
 		return CheckReport{}, err
 	}
 
-	selection, _ := manifest.ResolveSelection(m, manifest.SelectedProfileNames(opts.Profile, opts.Profiles), opts.ExtraTags)
+	selection, _ := resolveOptionsSelection(m, opts)
 	report := CheckReport{Profile: selection.Profile, Profiles: selection.Profiles, Tags: selection.Tags}
 	for _, dep := range selected {
 		result := checkResult(dep, look, fontLook)
@@ -223,7 +226,7 @@ func fontProbeLabel(matches []string) string {
 // first-declared order.
 
 func selectDependencies(m manifest.Manifest, opts Options) ([]manifest.Dependency, error) {
-	selection, err := manifest.ResolveSelection(m, manifest.SelectedProfileNames(opts.Profile, opts.Profiles), opts.ExtraTags)
+	selection, err := resolveOptionsSelection(m, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -283,4 +286,11 @@ func selectDependencies(m manifest.Manifest, opts Options) ([]manifest.Dependenc
 		addDependencies(prov.Dependencies)
 	}
 	return selected, nil
+}
+
+func resolveOptionsSelection(m manifest.Manifest, opts Options) (manifest.Selection, error) {
+	if opts.Selection != nil {
+		return *opts.Selection, nil
+	}
+	return manifest.ResolveSelection(m, manifest.SelectedProfileNames(opts.Profile, opts.Profiles), opts.ExtraTags)
 }

--- a/internal/deps/plan.go
+++ b/internal/deps/plan.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/selection"
 )
 
 // ProviderCandidate is one ordered installation provider considered for a
@@ -76,12 +77,13 @@ type Guidance struct {
 // PlanReport is the Dependency Plan for a Profile: OS-aware guidance for the
 // missing Dependencies under the active Tier. It is advisory only.
 type PlanReport struct {
-	Profile  string          `json:"profile,omitempty"`
-	Profiles []string        `json:"profiles,omitempty"`
-	Tags     []string        `json:"tags,omitempty"`
-	Tier     Tier            `json:"tier"`
-	Actions  []InstallAction `json:"actions"`
-	Items    []Guidance      `json:"items"`
+	Profile   string            `json:"profile,omitempty"`
+	Profiles  []string          `json:"profiles,omitempty"`
+	Tags      []string          `json:"tags,omitempty"`
+	Selection *selection.Report `json:"selection,omitempty"`
+	Tier      Tier              `json:"tier"`
+	Actions   []InstallAction   `json:"actions"`
+	Items     []Guidance        `json:"items"`
 }
 
 // HasFindings reports whether the Dependency Plan lists any missing Dependency.
@@ -94,7 +96,7 @@ func (r PlanReport) HasFindings() bool {
 // Plan computes advisory installation guidance for the Dependencies that the
 // Profile needs but the workstation is missing, tailored to the active Tier.
 func Plan(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup, tier Tier) (PlanReport, error) {
-	selection, err := manifest.ResolveSelection(m, manifest.SelectedProfileNames(opts.Profile, opts.Profiles), opts.ExtraTags)
+	selection, err := resolveOptionsSelection(m, opts)
 	if err != nil {
 		return PlanReport{}, err
 	}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/provision"
+	"github.com/yersonargotev/dots/internal/selection"
 	"github.com/yersonargotev/dots/internal/state"
 	"github.com/yersonargotev/dots/internal/status"
 )
@@ -25,6 +26,7 @@ type Options struct {
 	Profile    string
 	Profiles   []string
 	ExtraTags  []string
+	Selection  *manifest.Selection
 	OS         string
 	SourceRoot string
 	Home       string
@@ -36,6 +38,7 @@ type Report struct {
 	Profile       string                `json:"profile,omitempty"`
 	Profiles      []string              `json:"profiles,omitempty"`
 	Tags          []string              `json:"tags,omitempty"`
+	Selection     *selection.Report     `json:"selection,omitempty"`
 	OS            string                `json:"os"`
 	Platform      Platform              `json:"platform"`
 	Dependencies  deps.CheckReport      `json:"dependencies"`
@@ -87,19 +90,23 @@ var secretPatterns = []secretPattern{
 
 // Build runs all doctor diagnostics without mutating the filesystem.
 func Build(m manifest.Manifest, meta state.Metadata, opts Options, look deps.Lookup, fontLook deps.FontLookup) (Report, error) {
-	selection, err := manifest.ResolveSelection(m, manifest.SelectedProfileNames(opts.Profile, opts.Profiles), opts.ExtraTags)
-	if err != nil {
-		return Report{}, err
+	resolved := opts.Selection
+	if resolved == nil {
+		selection, err := manifest.ResolveSelection(m, manifest.SelectedProfileNames(opts.Profile, opts.Profiles), opts.ExtraTags)
+		if err != nil {
+			return Report{}, err
+		}
+		resolved = &selection
 	}
 	report := Report{
-		Profile:  selection.Profile,
-		Profiles: selection.Profiles,
-		Tags:     selection.Tags,
+		Profile:  resolved.Profile,
+		Profiles: resolved.Profiles,
+		Tags:     resolved.Tags,
 		OS:       opts.OS,
 		Platform: Platform{Supported: supportedOS(opts.OS), OS: opts.OS},
 	}
 
-	depReport, err := deps.CheckWithToolProbes(m, deps.Options{Profile: opts.Profile, Profiles: opts.Profiles, ExtraTags: opts.ExtraTags, OS: opts.OS}, look, fontLook, opts.ToolRunner)
+	depReport, err := deps.CheckWithToolProbes(m, deps.Options{Profile: opts.Profile, Profiles: opts.Profiles, ExtraTags: opts.ExtraTags, Selection: resolved, OS: opts.OS}, look, fontLook, opts.ToolRunner)
 	if err != nil {
 		return Report{}, err
 	}
@@ -109,6 +116,7 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options, look deps.Loo
 		Profile:    opts.Profile,
 		Profiles:   opts.Profiles,
 		ExtraTags:  opts.ExtraTags,
+		Selection:  resolved,
 		OS:         opts.OS,
 		SourceRoot: opts.SourceRoot,
 		Home:       opts.Home,
@@ -118,7 +126,7 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options, look deps.Loo
 	}
 	report.Configuration = statusReport
 
-	provReport, err := provision.Check(m, provision.Options{Profile: opts.Profile, Profiles: opts.Profiles, ExtraTags: opts.ExtraTags, OS: opts.OS}, look, fontLook)
+	provReport, err := provision.Check(m, provision.Options{Profile: opts.Profile, Profiles: opts.Profiles, ExtraTags: opts.ExtraTags, Selection: resolved, OS: opts.OS}, look, fontLook)
 	if err != nil {
 		return Report{}, err
 	}
@@ -136,11 +144,15 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options, look deps.Loo
 // ScanSecrets scans selected repository-managed source files for obvious secret
 // patterns. It is intentionally conservative scope-wise and advisory in meaning.
 func ScanSecrets(m manifest.Manifest, opts Options) (SecretReport, error) {
-	selection, err := manifest.ResolveSelection(m, manifest.SelectedProfileNames(opts.Profile, opts.Profiles), opts.ExtraTags)
-	if err != nil {
-		return SecretReport{}, err
+	resolved := opts.Selection
+	if resolved == nil {
+		selection, err := manifest.ResolveSelection(m, manifest.SelectedProfileNames(opts.Profile, opts.Profiles), opts.ExtraTags)
+		if err != nil {
+			return SecretReport{}, err
+		}
+		resolved = &selection
 	}
-	tags := selection.Tags
+	tags := resolved.Tags
 
 	var report SecretReport
 	seen := map[string]bool{}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -824,6 +824,17 @@ func SelectedProfileNames(profile string, profiles []string) []string {
 // de-duplicated tag union. Repository manifests without a legacy default Profile
 // require an explicit Profile so install never falls back to an implicit baseline.
 func ResolveSelection(m Manifest, profileNames []string, extraTags []string) (Selection, error) {
+	return resolveSelection(m, profileNames, extraTags, true)
+}
+
+// ResolveReadOnlySelection validates a read-only command selection without
+// inferring a legacy default Profile. Explicit Tags may form the complete
+// selection when no Profile was supplied.
+func ResolveReadOnlySelection(m Manifest, profileNames []string, extraTags []string) (Selection, error) {
+	return resolveSelection(m, profileNames, extraTags, false)
+}
+
+func resolveSelection(m Manifest, profileNames []string, extraTags []string, allowDefault bool) (Selection, error) {
 	profiles := make([]string, 0, len(profileNames))
 	profileSeen := make(map[string]bool, len(profileNames))
 	tags := make([]string, 0, len(extraTags))
@@ -849,7 +860,7 @@ func ResolveSelection(m Manifest, profileNames []string, extraTags []string) (Se
 			addTag(tag)
 		}
 	}
-	if len(profiles) == 0 {
+	if len(profiles) == 0 && allowDefault {
 		if profile, ok := m.Profiles["default"]; ok {
 			profiles = append(profiles, "default")
 			for _, tag := range profile.Tags {

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -3776,6 +3776,23 @@ func TestResolveSelectionComposesProfilesInOrder(t *testing.T) {
 	}
 }
 
+func TestResolveReadOnlySelectionAllowsTagsWithoutInferringDefault(t *testing.T) {
+	m := manifest.Manifest{Profiles: map[string]manifest.Profile{
+		"default": {Tags: []string{"default"}},
+	}}
+
+	got, err := manifest.ResolveReadOnlySelection(m, nil, []string{"web", "web"})
+	if err != nil {
+		t.Fatalf("ResolveReadOnlySelection() error = %v", err)
+	}
+	if got.Profile != "" || len(got.Profiles) != 0 {
+		t.Fatalf("selection = %+v, want no inferred Profile", got)
+	}
+	if want := []string{"web"}; !reflect.DeepEqual(got.Tags, want) {
+		t.Fatalf("Tags = %#v, want %#v", got.Tags, want)
+	}
+}
+
 func TestRepositoryManifestRequiresExplicitProfileSelection(t *testing.T) {
 	root := filepath.Clean(filepath.Join("..", ".."))
 	got, err := manifest.LoadFile(filepath.Join(root, "dots.yaml"))

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/yersonargotev/dots/internal/configsubset"
 	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/selection"
 	"github.com/yersonargotev/dots/internal/state"
 )
 
@@ -40,10 +41,11 @@ type Action struct {
 
 // Plan is the preview of changes the installer would apply for a Profile.
 type Plan struct {
-	Profile  string   `json:"profile,omitempty"`
-	Profiles []string `json:"profiles,omitempty"`
-	Tags     []string `json:"tags,omitempty"`
-	Actions  []Action `json:"actions"`
+	Profile   string            `json:"profile,omitempty"`
+	Profiles  []string          `json:"profiles,omitempty"`
+	Tags      []string          `json:"tags,omitempty"`
+	Selection *selection.Report `json:"selection,omitempty"`
+	Actions   []Action          `json:"actions"`
 }
 
 // HasFindings reports whether the Install Plan contains an action the caller
@@ -64,6 +66,7 @@ type Options struct {
 	Profile    string
 	Profiles   []string
 	ExtraTags  []string
+	Selection  *manifest.Selection
 	OS         string
 	SourceRoot string
 	Home       string
@@ -75,13 +78,17 @@ type Options struct {
 // Profile's tags and that pass the OS filter, then determines each target's
 // status against the current workstation state.
 func Build(m manifest.Manifest, opts Options) (Plan, error) {
-	selection, err := manifest.ResolveSelection(m, manifest.SelectedProfileNames(opts.Profile, opts.Profiles), opts.ExtraTags)
-	if err != nil {
-		return Plan{}, err
+	resolved := opts.Selection
+	if resolved == nil {
+		selection, err := manifest.ResolveSelection(m, manifest.SelectedProfileNames(opts.Profile, opts.Profiles), opts.ExtraTags)
+		if err != nil {
+			return Plan{}, err
+		}
+		resolved = &selection
 	}
-	tags := selection.Tags
+	tags := resolved.Tags
 
-	plan := Plan{Profile: selection.Profile, Profiles: selection.Profiles, Tags: selection.Tags}
+	plan := Plan{Profile: resolved.Profile, Profiles: resolved.Profiles, Tags: resolved.Tags}
 	for _, entry := range m.Entries {
 		if !manifest.SharesTag(entry.Tags, tags) {
 			continue

--- a/internal/provision/check.go
+++ b/internal/provision/check.go
@@ -46,7 +46,7 @@ func Check(m manifest.Manifest, opts Options, look deps.Lookup, fontLook deps.Fo
 		return CheckReport{}, err
 	}
 
-	selection, _ := manifest.ResolveSelection(m, manifest.SelectedProfileNames(opts.Profile, opts.Profiles), opts.ExtraTags)
+	selection, _ := resolveOptionsSelection(m, opts)
 	report := CheckReport{Profile: selection.Profile, Profiles: selection.Profiles, Tags: selection.Tags}
 	for _, prov := range selected {
 		executable, args := RenderCommand(prov)

--- a/internal/provision/plan.go
+++ b/internal/provision/plan.go
@@ -12,6 +12,7 @@ type Options struct {
 	Profile   string
 	Profiles  []string
 	ExtraTags []string
+	Selection *manifest.Selection
 	OS        string
 }
 
@@ -39,10 +40,11 @@ type Plan struct {
 // intersect the Profile's tags) and pass the OS filter, preserving manifest
 // order. It mirrors the Entry selection used by deps, plan, and status.
 func Select(m manifest.Manifest, opts Options) ([]manifest.Provisioner, error) {
-	indices, err := selectedIndices(m, manifest.SelectedProfileNames(opts.Profile, opts.Profiles), opts.OS, opts.ExtraTags)
+	selection, err := resolveOptionsSelection(m, opts)
 	if err != nil {
 		return nil, err
 	}
+	indices := selectedIndicesForSelection(m, selection, opts.OS)
 
 	var selected []manifest.Provisioner
 	for i, prov := range m.Provisioners {
@@ -63,15 +65,17 @@ func selectedIndices(m manifest.Manifest, profileNames []string, os string, extr
 	if err != nil {
 		return nil, err
 	}
-	tags := selection.Tags
+	return selectedIndicesForSelection(m, selection, os), nil
+}
 
+func selectedIndicesForSelection(m manifest.Manifest, selection manifest.Selection, os string) map[int]bool {
 	indices := make(map[int]bool)
 	for i, prov := range m.Provisioners {
-		if manifest.SharesTag(prov.Tags, tags) && manifest.MatchesOS(prov.OS, os) {
+		if manifest.SharesTag(prov.Tags, selection.Tags) && manifest.MatchesOS(prov.OS, os) {
 			indices[i] = true
 		}
 	}
-	return indices, nil
+	return indices
 }
 
 // SkippedProvisioners reports whether the active profile omits provisioners that
@@ -101,7 +105,7 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 		return Plan{}, err
 	}
 
-	selection, _ := manifest.ResolveSelection(m, manifest.SelectedProfileNames(opts.Profile, opts.Profiles), opts.ExtraTags)
+	selection, _ := resolveOptionsSelection(m, opts)
 	plan := Plan{Profile: selection.Profile, Profiles: selection.Profiles, Tags: selection.Tags}
 	for _, prov := range selected {
 		executable, args := RenderCommand(prov)
@@ -114,6 +118,13 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 		})
 	}
 	return plan, nil
+}
+
+func resolveOptionsSelection(m manifest.Manifest, opts Options) (manifest.Selection, error) {
+	if opts.Selection != nil {
+		return *opts.Selection, nil
+	}
+	return manifest.ResolveSelection(m, manifest.SelectedProfileNames(opts.Profile, opts.Profiles), opts.ExtraTags)
 }
 
 // managedRoots returns the well-known HOME-relative roots an allowlisted tool

--- a/internal/selection/selection.go
+++ b/internal/selection/selection.go
@@ -2,9 +2,104 @@
 package selection
 
 import (
+	"errors"
+	"fmt"
+	"strings"
+
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/state"
 )
+
+// Source identifies where a read-only command obtained its selection.
+type Source string
+
+const (
+	SourceExplicit Source = "explicit"
+	SourceRecorded Source = "recorded"
+)
+
+// ErrSelectionRequired means that neither invocation arguments nor Installation
+// Metadata supplied a selection. Read-only commands must not silently use a
+// manifest's default Profile in this case.
+var ErrSelectionRequired = errors.New("selection required: provide --profile or --tag, or run dots install to record an Installed Selection")
+
+// Report is the stable, read-only description of the selection used by a
+// command.
+type Report struct {
+	Source        Source   `json:"source"`
+	Profiles      []string `json:"profiles"`
+	ExtraTags     []string `json:"extra_tags"`
+	EffectiveTags []string `json:"effective_tags"`
+}
+
+// Effective contains the validated inputs for downstream command builders and
+// their corresponding report.
+type Effective struct {
+	Profiles  []string
+	ExtraTags []string
+	Selection manifest.Selection
+	Report    Report
+}
+
+// ResolveReadOnly chooses and validates the selection for a read-only command.
+// Any explicit Profile or tag wins over the recorded Installed Selection.
+func ResolveReadOnly(m manifest.Manifest, explicitProfiles, explicitTags []string, recorded *state.InstalledSelection) (Effective, error) {
+	source := SourceExplicit
+	profiles := explicitProfiles
+	extraTags := explicitTags
+	if len(explicitProfiles) == 0 && len(explicitTags) == 0 {
+		if recorded == nil {
+			return Effective{}, ErrSelectionRequired
+		}
+		source = SourceRecorded
+		profiles = recorded.Profiles
+		extraTags = recorded.ExtraTags
+	}
+	if err := validateIntent(source, profiles, extraTags); err != nil {
+		return Effective{}, err
+	}
+
+	resolved, err := manifest.ResolveReadOnlySelection(m, profiles, extraTags)
+	if err != nil {
+		return Effective{}, fmt.Errorf("%s selection: %w", source, err)
+	}
+
+	orderedProfiles := cloneStrings(resolved.Profiles)
+	orderedExtraTags := orderedUnique(extraTags)
+	effectiveTags := cloneStrings(resolved.Tags)
+	return Effective{
+		Profiles:  cloneStrings(orderedProfiles),
+		ExtraTags: cloneStrings(orderedExtraTags),
+		Selection: manifest.Selection{
+			Profile:  resolved.Profile,
+			Profiles: cloneStrings(orderedProfiles),
+			Tags:     cloneStrings(effectiveTags),
+		},
+		Report: Report{
+			Source:        source,
+			Profiles:      orderedProfiles,
+			ExtraTags:     orderedExtraTags,
+			EffectiveTags: effectiveTags,
+		},
+	}, nil
+}
+
+func validateIntent(source Source, profiles, extraTags []string) error {
+	for _, profile := range profiles {
+		if strings.TrimSpace(profile) == "" {
+			return fmt.Errorf("%s selection: profile names must not be empty", source)
+		}
+	}
+	for _, tag := range extraTags {
+		if strings.TrimSpace(tag) == "" {
+			return fmt.Errorf("%s selection: tags must not be empty", source)
+		}
+	}
+	if len(profiles) == 0 && len(extraTags) == 0 {
+		return fmt.Errorf("%s selection: at least one Profile or extra Tag is required", source)
+	}
+	return nil
+}
 
 // Resolve validates the requested Profiles and retains both explicit intent and
 // the resulting ordered Tag snapshot.
@@ -44,4 +139,8 @@ func orderedUnique(values []string) []string {
 		result = append(result, value)
 	}
 	return result
+}
+
+func cloneStrings(values []string) []string {
+	return append(make([]string, 0, len(values)), values...)
 }

--- a/internal/selection/selection_test.go
+++ b/internal/selection/selection_test.go
@@ -1,13 +1,184 @@
 package selection_test
 
 import (
+	"errors"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/selection"
 	"github.com/yersonargotev/dots/internal/state"
 )
+
+func TestResolveReadOnlyExplicitSelectionWinsCompletely(t *testing.T) {
+	m := manifest.Manifest{Profiles: map[string]manifest.Profile{
+		"core": {Tags: []string{"core", "shared"}},
+		"web":  {Tags: []string{"web"}},
+	}}
+	recorded := &state.InstalledSelection{
+		Profiles:     []string{"core"},
+		ExtraTags:    []string{"recorded-extra"},
+		ResolvedTags: []string{"stale", "snapshot"},
+	}
+
+	got, err := selection.ResolveReadOnly(m, []string{"web", "web"}, []string{"explicit", "explicit"}, recorded)
+	if err != nil {
+		t.Fatalf("ResolveReadOnly() error = %v", err)
+	}
+	want := selection.Effective{
+		Profiles:  []string{"web"},
+		ExtraTags: []string{"explicit"},
+		Selection: manifest.Selection{
+			Profile:  "web",
+			Profiles: []string{"web"},
+			Tags:     []string{"web", "explicit"},
+		},
+		Report: selection.Report{
+			Source:        selection.SourceExplicit,
+			Profiles:      []string{"web"},
+			ExtraTags:     []string{"explicit"},
+			EffectiveTags: []string{"web", "explicit"},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ResolveReadOnly() = %#v, want %#v", got, want)
+	}
+}
+
+func TestResolveReadOnlyTagOnlySelectionDoesNotInferDefaultProfile(t *testing.T) {
+	m := manifest.Manifest{Profiles: map[string]manifest.Profile{
+		"default": {Tags: []string{"must-not-be-used"}},
+	}}
+
+	got, err := selection.ResolveReadOnly(m, nil, []string{"web", "web"}, nil)
+	if err != nil {
+		t.Fatalf("ResolveReadOnly() error = %v", err)
+	}
+	if len(got.Selection.Profiles) != 0 || got.Selection.Profile != "" {
+		t.Fatalf("Selection Profiles = %#v, Profile = %q; want no inferred Profile", got.Selection.Profiles, got.Selection.Profile)
+	}
+	if want := []string{"web"}; !reflect.DeepEqual(got.Selection.Tags, want) {
+		t.Fatalf("Selection Tags = %#v, want %#v", got.Selection.Tags, want)
+	}
+	if got.Report.Source != selection.SourceExplicit {
+		t.Fatalf("Source = %q, want %q", got.Report.Source, selection.SourceExplicit)
+	}
+}
+
+func TestResolveReadOnlyRecomputesRecordedSelection(t *testing.T) {
+	m := manifest.Manifest{Profiles: map[string]manifest.Profile{
+		"core": {Tags: []string{"current", "shared"}},
+	}}
+	recorded := &state.InstalledSelection{
+		Profiles:     []string{"core"},
+		ExtraTags:    []string{"shared", "extra", "extra"},
+		ResolvedTags: []string{"stale"},
+	}
+
+	got, err := selection.ResolveReadOnly(m, nil, nil, recorded)
+	if err != nil {
+		t.Fatalf("ResolveReadOnly() error = %v", err)
+	}
+	if got.Report.Source != selection.SourceRecorded {
+		t.Fatalf("Source = %q, want %q", got.Report.Source, selection.SourceRecorded)
+	}
+	if want := []string{"current", "shared", "extra"}; !reflect.DeepEqual(got.Report.EffectiveTags, want) {
+		t.Fatalf("EffectiveTags = %#v, want %#v", got.Report.EffectiveTags, want)
+	}
+	if want := []string{"shared", "extra"}; !reflect.DeepEqual(got.ExtraTags, want) {
+		t.Fatalf("ExtraTags = %#v, want %#v", got.ExtraTags, want)
+	}
+}
+
+func TestResolveReadOnlyRequiresInvocationOrRecordedSelection(t *testing.T) {
+	m := manifest.Manifest{Profiles: map[string]manifest.Profile{
+		"default": {Tags: []string{"must-not-be-used"}},
+	}}
+
+	_, err := selection.ResolveReadOnly(m, nil, nil, nil)
+	if !errors.Is(err, selection.ErrSelectionRequired) {
+		t.Fatalf("ResolveReadOnly() error = %v, want ErrSelectionRequired", err)
+	}
+	if !strings.Contains(err.Error(), "--profile") || !strings.Contains(err.Error(), "dots install") {
+		t.Fatalf("ResolveReadOnly() error = %q, want actionable guidance", err)
+	}
+}
+
+func TestResolveReadOnlyValidatesSelectedSource(t *testing.T) {
+	m := manifest.Manifest{Profiles: map[string]manifest.Profile{
+		"core": {Tags: []string{"core"}},
+	}}
+	tests := []struct {
+		name     string
+		profiles []string
+		recorded *state.InstalledSelection
+		source   selection.Source
+	}{
+		{name: "explicit", profiles: []string{"missing"}, source: selection.SourceExplicit},
+		{name: "recorded", recorded: &state.InstalledSelection{Profiles: []string{"missing"}}, source: selection.SourceRecorded},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := selection.ResolveReadOnly(m, tt.profiles, nil, tt.recorded)
+			if err == nil {
+				t.Fatal("ResolveReadOnly() error = nil")
+			}
+			if !strings.Contains(err.Error(), string(tt.source)+" selection") || !strings.Contains(err.Error(), `profile "missing" not found`) {
+				t.Fatalf("ResolveReadOnly() error = %q, want source and validation context", err)
+			}
+		})
+	}
+}
+
+func TestResolveReadOnlyRejectsEmptyIntentValues(t *testing.T) {
+	m := manifest.Manifest{Profiles: map[string]manifest.Profile{
+		"core": {Tags: []string{"core"}},
+	}}
+	tests := []struct {
+		name     string
+		profiles []string
+		tags     []string
+		recorded *state.InstalledSelection
+		want     string
+	}{
+		{name: "explicit empty profile", profiles: []string{""}, want: "explicit selection: profile names must not be empty"},
+		{name: "explicit empty tag", tags: []string{""}, want: "explicit selection: tags must not be empty"},
+		{name: "explicit whitespace profile", profiles: []string{" \t"}, want: "explicit selection: profile names must not be empty"},
+		{name: "explicit whitespace tag", tags: []string{" \t"}, want: "explicit selection: tags must not be empty"},
+		{name: "recorded empty", recorded: &state.InstalledSelection{}, want: "recorded selection: at least one Profile or extra Tag is required"},
+		{name: "recorded whitespace tag", recorded: &state.InstalledSelection{ExtraTags: []string{" "}}, want: "recorded selection: tags must not be empty"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := selection.ResolveReadOnly(m, tt.profiles, tt.tags, tt.recorded)
+			if err == nil || err.Error() != tt.want {
+				t.Fatalf("ResolveReadOnly() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveReadOnlyClonesSlices(t *testing.T) {
+	m := manifest.Manifest{Profiles: map[string]manifest.Profile{
+		"core": {Tags: []string{"core"}},
+	}}
+	profiles := []string{"core"}
+	tags := []string{"extra"}
+	got, err := selection.ResolveReadOnly(m, profiles, tags, nil)
+	if err != nil {
+		t.Fatalf("ResolveReadOnly() error = %v", err)
+	}
+
+	profiles[0], tags[0] = "changed", "changed"
+	got.Profiles[0], got.ExtraTags[0] = "effective-changed", "effective-changed"
+	if got.Report.Profiles[0] != "core" || got.Report.ExtraTags[0] != "extra" {
+		t.Fatalf("Report aliases input or Effective slices: %#v", got.Report)
+	}
+	if got.Selection.Profiles[0] != "core" || got.Selection.Tags[1] != "extra" {
+		t.Fatalf("Selection aliases Effective slices: %#v", got.Selection)
+	}
+}
 
 func TestResolvePreservesExplicitSelectionIntent(t *testing.T) {
 	m := manifest.Manifest{Profiles: map[string]manifest.Profile{

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -14,6 +14,7 @@ import (
 	"github.com/yersonargotev/dots/internal/configsubset"
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/plan"
+	"github.com/yersonargotev/dots/internal/selection"
 	"github.com/yersonargotev/dots/internal/state"
 )
 
@@ -49,10 +50,11 @@ type Entry struct {
 
 // Report is the Dotfiles Status for a Profile, in manifest order.
 type Report struct {
-	Profile  string   `json:"profile,omitempty"`
-	Profiles []string `json:"profiles,omitempty"`
-	Tags     []string `json:"tags,omitempty"`
-	Entries  []Entry  `json:"entries"`
+	Profile   string            `json:"profile,omitempty"`
+	Profiles  []string          `json:"profiles,omitempty"`
+	Tags      []string          `json:"tags,omitempty"`
+	Selection *selection.Report `json:"selection,omitempty"`
+	Entries   []Entry           `json:"entries"`
 }
 
 // HasFindings reports whether the Dotfiles Status contains any entry that
@@ -74,6 +76,7 @@ type Options struct {
 	Profile    string
 	Profiles   []string
 	ExtraTags  []string
+	Selection  *manifest.Selection
 	OS         string
 	SourceRoot string
 	Home       string
@@ -82,13 +85,17 @@ type Options struct {
 // Build evaluates the Dotfiles Status for the selected Profile. It does not
 // mutate the filesystem.
 func Build(m manifest.Manifest, meta state.Metadata, opts Options) (Report, error) {
-	selection, err := manifest.ResolveSelection(m, manifest.SelectedProfileNames(opts.Profile, opts.Profiles), opts.ExtraTags)
-	if err != nil {
-		return Report{}, err
+	resolved := opts.Selection
+	if resolved == nil {
+		selection, err := manifest.ResolveSelection(m, manifest.SelectedProfileNames(opts.Profile, opts.Profiles), opts.ExtraTags)
+		if err != nil {
+			return Report{}, err
+		}
+		resolved = &selection
 	}
-	tags := selection.Tags
+	tags := resolved.Tags
 
-	report := Report{Profile: selection.Profile, Profiles: selection.Profiles, Tags: selection.Tags}
+	report := Report{Profile: resolved.Profile, Profiles: resolved.Profiles, Tags: resolved.Tags}
 	for _, entry := range m.Entries {
 		if !manifest.SharesTag(entry.Tags, tags) {
 			continue


### PR DESCRIPTION
Closes #341

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Reuse authoritative Installed Selection across status, doctor, plan, deps check, and deps plan when flags are omitted.
- Keep explicit Profile/Tag intent complete and invocation-local, including tag-only selections without implicit default fallback.
- Expose stable selection source and effective intent in text/JSON, with sandboxed cross-command and golden coverage.

## Changes

| File | Change |
|------|--------|
| `internal/selection/` | Added shared explicit-versus-recorded read-only resolution, validation, and portable reporting. |
| `internal/{status,doctor,plan,deps,provision}/` | Accepted and reused one already-resolved selection across every diagnostic builder. |
| `internal/cli/` | Loaded recorded intent safely, rendered selection source, and updated schema-v5 goldens. |
| `internal/cli/read_selection_test.go` | Covered recorded, explicit, tag-only, missing, invalid, empty, and whitespace intent for all five commands. |
| `README.md`, `docs/manifest.md`, `docs/agents/output-contract.md`, `docs/adr/0014-record-authoritative-installed-selection.md` | Documented read-only precedence and reporting policy. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile core --source-root "$PWD" --home <tmp> --state-root <tmp>`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #341`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
