### PR TITLE
feat(selection): report Install Manifest evolution

### DIFF
--- a/docs/adr/0014-record-authoritative-installed-selection.md
+++ b/docs/adr/0014-record-authoritative-installed-selection.md
@@ -77,6 +77,27 @@ After terminal success, update/upgrade refreshes the Installed Selection,
 including its current resolved Tag snapshot and provenance. A dry run,
 cancellation, invalid refreshed selection, Managed Entry failure, Provisioner
 failure, continuation failure, or metadata-write failure does not replace the
-previous Installed Selection. This amendment does not introduce legacy
-inference, selection-delta or reduction policy, or automatic removal of
-previously selected inventory.
+previous Installed Selection.
+
+## Selection evolution amendment
+
+Issue #343 authorizes update and upgrade to compare the selection resolved
+before Source of Truth refresh with the same authoritative Profile and explicit
+extra Tag intent resolved afterward. The deterministic delta reports previous
+and current intent and effective Tags, plus added and removed Managed Entries,
+Dependencies, and Provisioners. Binary continuation preserves the intent and
+recomputes the pre-refresh comparison basis before advancing the Installed
+Repository.
+
+A saved Profile missing from the refreshed Install Manifest, or an explicit
+extra Tag no longer declared by any Managed Entry, Dependency Set, or
+Provisioner, blocks Managed Configuration and Provisioner application. The
+structured error retains the delta and the stale intent; dots does not silently
+rewrite it. Successful text and JSON output expose the same delta before
+application.
+
+Removed surfaces are informational. Selection evolution does not authorize
+dots to unlink targets, delete ownership or Dependency metadata, uninstall
+Provisioners or capabilities, or otherwise prune historical inventory.
+Explicit selection replacement, reduction acknowledgement, legacy inference,
+and automatic removal remain separate policy.

--- a/docs/agents/output-contract.md
+++ b/docs/agents/output-contract.md
@@ -112,6 +112,12 @@ prose the text surface prints:
   extra Tags against the current Install Manifest; the stored `resolved_tags`
   remains audit-only. Update and upgrade resolve the same intent again after
   Source of Truth refresh and preserve its source across binary continuation.
+  Their selection report also includes `delta` with deterministic `previous`
+  and `current` snapshots; `added` and `removed` effective Tags, Managed
+  Entries, Dependencies, and Provisioners; and ordered `missing_profiles` and
+  `stale_extra_tags` arrays. Empty arrays remain present whenever `delta` is
+  emitted. A blocking evolution error returns the same delta as
+  `data.selection_delta`.
   Any explicit Profile or Tag selection wins completely for that invocation and
   is never merged with recorded intent.
   If neither source exists, the command returns an execution error (`1`) with

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -430,6 +430,17 @@ would leave agents pointing at commands that may not exist.
 5. If `os` is set, the item only matches the current OS (`darwin` or `linux`).
 6. Selected Managed Entries are installed before selected Provisioners run.
 
+During `dots update` and `dots upgrade`, dots resolves the same authoritative
+Profile and explicit extra Tag intent before and after Source of Truth refresh.
+It reports effective Tag and selected Managed Entry, Dependency, and Provisioner
+additions and removals before application. A saved Profile that no longer
+exists, or an explicit extra Tag no longer declared by any Managed Entry,
+Dependency Set, or Provisioner, blocks application without rewriting the
+Installed Selection. Dots-owned selection modifiers and their documented legacy
+aliases remain valid even though they affect installation behavior rather than
+selecting a manifest surface. Removed surfaces are reported only; they are not
+automatically deleted or uninstalled.
+
 ## Related docs
 
 - [`CONTEXT.md`](../CONTEXT.md) defines the domain vocabulary.

--- a/docs/update.md
+++ b/docs/update.md
@@ -86,11 +86,15 @@ dots update --yes
 Any supplied `--profile` or `--tag` makes the complete explicit selection win
 for that invocation; dots never merges it with recorded intent. The selection
 is validated before the Installed Repository changes and resolved again against
-the refreshed manifest before Managed Configuration is applied. Missing or
-invalid recorded intent stops application with remediation instead of choosing
-an implicit default. Only terminal success refreshes the Installed Selection,
-so dry runs, cancellations, and failed Managed Entry or Provisioner work
-preserve the previous intent.
+the refreshed manifest before Managed Configuration is applied. Update reports
+the resulting effective Tag and selected Managed Entry, Dependency, and
+Provisioner additions and removals before application. A missing saved Profile
+or explicit extra Tag no longer declared by any selectable manifest surface
+stops application with remediation and structured delta data instead of
+choosing an implicit default or silently rewriting intent. Removed surfaces are
+informational and are never automatically deleted or uninstalled. Only terminal
+success refreshes the Installed Selection, so dry runs, cancellations, and
+failed Managed Entry or Provisioner work preserve the previous intent.
 
 ## Profiles and provisioners
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -66,10 +66,14 @@ dots upgrade --yes
 ```
 
 Selection is validated before binary replacement and re-resolved against the
-refreshed manifest before Managed Configuration is applied. Missing or invalid
-intent stops the mutating phase without an implicit default. Only terminal
-success refreshes Installed Selection metadata; binary, update, Provisioner, or
-continuation failures preserve the previous selection.
+refreshed manifest before Managed Configuration is applied. Upgrade reports
+effective Tag and selected Managed Entry, Dependency, and Provisioner additions
+and removals before application. Missing Profiles and explicit extra Tags no
+longer declared by selectable manifest surfaces stop the mutating phase without
+an implicit default or automatic intent rewrite. Removed surfaces are never
+automatically deleted or uninstalled. Only terminal success refreshes Installed
+Selection metadata; binary, update, Provisioner, or continuation failures
+preserve the previous selection.
 
 ## Source of Truth flags
 

--- a/internal/cli/output_golden_test.go
+++ b/internal/cli/output_golden_test.go
@@ -46,6 +46,18 @@ func TestEnvelopeGolden(t *testing.T) {
 		Source: selection.SourceRecorded, Profiles: []string{"core"}, ExtraTags: []string{"work"},
 		EffectiveTags: []string{"core", "desktop", "work"}, Delta: &selectionDelta,
 	}
+	blockingDelta := selection.Delta{
+		Previous: selection.Snapshot{Profiles: []string{"core"}, ExtraTags: []string{"retired"}, EffectiveTags: []string{"core", "retired"}},
+		Current:  selection.Snapshot{Profiles: []string{"core"}, ExtraTags: []string{"retired"}, EffectiveTags: []string{"core", "retired"}},
+		Added: selection.Changes{
+			EffectiveTags: []string{}, ManagedEntries: []string{}, Dependencies: []string{}, Provisioners: []string{},
+		},
+		Removed: selection.Changes{
+			EffectiveTags: []string{}, ManagedEntries: []string{"~/.retired"}, Dependencies: []string{}, Provisioners: []string{},
+		},
+		MissingProfiles: []string{},
+		StaleExtraTags:  []string{"retired"},
+	}
 	tests := []struct {
 		name   string
 		env    envelope
@@ -238,6 +250,19 @@ func TestEnvelopeGolden(t *testing.T) {
 				},
 			},
 			golden: "envelope_update.golden",
+		},
+		{
+			name: "update blocking selection evolution",
+			env: envelope{
+				SchemaVersion: schemaVersion,
+				Command:       "update",
+				Status:        statusError,
+				Data: struct {
+					SelectionDelta selection.Delta `json:"selection_delta"`
+				}{SelectionDelta: blockingDelta},
+				Error: `recorded selection: extra Tag "retired" is no longer declared; update the selection before refreshing`,
+			},
+			golden: "envelope_update_selection_error.golden",
 		},
 		{
 			name: "upgrade",

--- a/internal/cli/output_golden_test.go
+++ b/internal/cli/output_golden_test.go
@@ -30,6 +30,22 @@ func TestEnvelopeGolden(t *testing.T) {
 	installResult := deps.InstallReport{Profile: "default", Tier: deps.TierHomebrew, Items: []deps.InstallItem{
 		{Dependency: "starship", Requirement: "required", Status: deps.InstallStatusInstalled, Provider: deps.TierHomebrew, Package: "starship", Executable: "brew", Args: []string{"install", "starship"}},
 	}}
+	selectionDelta := selection.Delta{
+		Previous: selection.Snapshot{Profiles: []string{"core"}, ExtraTags: []string{"work"}, EffectiveTags: []string{"core", "work"}},
+		Current:  selection.Snapshot{Profiles: []string{"core"}, ExtraTags: []string{"work"}, EffectiveTags: []string{"core", "desktop", "work"}},
+		Added: selection.Changes{
+			EffectiveTags: []string{"desktop"}, ManagedEntries: []string{"~/.config/ghostty/config"}, Dependencies: []string{}, Provisioners: []string{},
+		},
+		Removed: selection.Changes{
+			EffectiveTags: []string{}, ManagedEntries: []string{}, Dependencies: []string{}, Provisioners: []string{},
+		},
+		MissingProfiles: []string{},
+		StaleExtraTags:  []string{},
+	}
+	evolvedSelection := selection.Report{
+		Source: selection.SourceRecorded, Profiles: []string{"core"}, ExtraTags: []string{"work"},
+		EffectiveTags: []string{"core", "desktop", "work"}, Delta: &selectionDelta,
+	}
 	tests := []struct {
 		name   string
 		env    envelope
@@ -213,12 +229,12 @@ func TestEnvelopeGolden(t *testing.T) {
 				Status:        statusOK,
 				Data: updateReport{
 					DryRun:    false,
-					Selection: selection.Report{Source: selection.SourceRecorded, Profiles: []string{"core"}, ExtraTags: []string{"work"}, EffectiveTags: []string{"core", "work"}},
+					Selection: evolvedSelection,
 					Update:    gitrepo.Update{OldRev: "abc123", NewRev: "def456", Incoming: []string{"def456 update managed config"}},
-					Plan: plan.Plan{Profile: "core", Profiles: []string{"core"}, Tags: []string{"core", "work"}, Selection: &selection.Report{
-						Source: selection.SourceRecorded, Profiles: []string{"core"}, ExtraTags: []string{"work"}, EffectiveTags: []string{"core", "work"},
-					}, Actions: []plan.Action{}},
-					Provisioners: provision.Plan{Profile: "core", Profiles: []string{"core"}, Tags: []string{"core", "work"}, Steps: []provision.Step{}},
+					Plan:      plan.Plan{Profile: "core", Profiles: []string{"core"}, Tags: []string{"core", "desktop", "work"}, Selection: &evolvedSelection, Actions: []plan.Action{}},
+					Provisioners: provision.Plan{
+						Profile: "core", Profiles: []string{"core"}, Tags: []string{"core", "desktop", "work"}, Steps: []provision.Step{},
+					},
 				},
 			},
 			golden: "envelope_update.golden",
@@ -231,13 +247,13 @@ func TestEnvelopeGolden(t *testing.T) {
 				Status:        statusOK,
 				Data: upgradeReport{
 					DryRun:    false,
-					Selection: selection.Report{Source: selection.SourceRecorded, Profiles: []string{"core"}, ExtraTags: []string{"work"}, EffectiveTags: []string{"core", "work"}},
+					Selection: evolvedSelection,
 					Binary:    upgrade.Plan{Channel: upgrade.ChannelHomebrew, CurrentVersion: "v0.63.0", LatestVersion: "v0.64.0", Action: upgrade.ActionHomebrewUpgrade, Executable: "/opt/homebrew/bin/dots"},
 					Update:    gitrepo.Update{OldRev: "abc123", NewRev: "def456", Incoming: []string{"def456 update managed config"}},
-					Plan: plan.Plan{Profile: "core", Profiles: []string{"core"}, Tags: []string{"core", "work"}, Selection: &selection.Report{
-						Source: selection.SourceRecorded, Profiles: []string{"core"}, ExtraTags: []string{"work"}, EffectiveTags: []string{"core", "work"},
-					}, Actions: []plan.Action{}},
-					Provisioners: provision.Plan{Profile: "core", Profiles: []string{"core"}, Tags: []string{"core", "work"}, Steps: []provision.Step{}},
+					Plan:      plan.Plan{Profile: "core", Profiles: []string{"core"}, Tags: []string{"core", "desktop", "work"}, Selection: &evolvedSelection, Actions: []plan.Action{}},
+					Provisioners: provision.Plan{
+						Profile: "core", Profiles: []string{"core"}, Tags: []string{"core", "desktop", "work"}, Steps: []provision.Step{},
+					},
 				},
 			},
 			golden: "envelope_upgrade.golden",

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -120,6 +120,21 @@ func renderEffectiveSelection(profile string, profiles, tags []string, report *s
 func renderSelectionReport(w io.Writer, report selection.Report) {
 	fmt.Fprintf(w, "Selection: source=%s profiles=%s extra-tags=%s effective-tags=%s\n\n",
 		report.Source, renderSelectionValues(report.Profiles), renderSelectionValues(report.ExtraTags), renderSelectionValues(report.EffectiveTags))
+	if report.Delta == nil {
+		return
+	}
+	delta := report.Delta
+	fmt.Fprintln(w, "Selection evolution:")
+	fmt.Fprintf(w, "  Previous: profiles=%s extra-tags=%s effective-tags=%s\n",
+		renderSelectionValues(delta.Previous.Profiles), renderSelectionValues(delta.Previous.ExtraTags), renderSelectionValues(delta.Previous.EffectiveTags))
+	fmt.Fprintf(w, "  Current: profiles=%s extra-tags=%s effective-tags=%s\n",
+		renderSelectionValues(delta.Current.Profiles), renderSelectionValues(delta.Current.ExtraTags), renderSelectionValues(delta.Current.EffectiveTags))
+	fmt.Fprintf(w, "  Added: effective-tags=%s managed-entries=%s dependencies=%s provisioners=%s\n",
+		renderSelectionValues(delta.Added.EffectiveTags), renderSelectionValues(delta.Added.ManagedEntries),
+		renderSelectionValues(delta.Added.Dependencies), renderSelectionValues(delta.Added.Provisioners))
+	fmt.Fprintf(w, "  Removed: effective-tags=%s managed-entries=%s dependencies=%s provisioners=%s\n\n",
+		renderSelectionValues(delta.Removed.EffectiveTags), renderSelectionValues(delta.Removed.ManagedEntries),
+		renderSelectionValues(delta.Removed.Dependencies), renderSelectionValues(delta.Removed.Provisioners))
 }
 
 func renderSelectionValues(values []string) string {

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -123,7 +123,10 @@ func renderSelectionReport(w io.Writer, report selection.Report) {
 	if report.Delta == nil {
 		return
 	}
-	delta := report.Delta
+	renderSelectionEvolution(w, *report.Delta)
+}
+
+func renderSelectionEvolution(w io.Writer, delta selection.Delta) {
 	fmt.Fprintln(w, "Selection evolution:")
 	fmt.Fprintf(w, "  Previous: profiles=%s extra-tags=%s effective-tags=%s\n",
 		renderSelectionValues(delta.Previous.Profiles), renderSelectionValues(delta.Previous.ExtraTags), renderSelectionValues(delta.Previous.EffectiveTags))
@@ -132,9 +135,15 @@ func renderSelectionReport(w io.Writer, report selection.Report) {
 	fmt.Fprintf(w, "  Added: effective-tags=%s managed-entries=%s dependencies=%s provisioners=%s\n",
 		renderSelectionValues(delta.Added.EffectiveTags), renderSelectionValues(delta.Added.ManagedEntries),
 		renderSelectionValues(delta.Added.Dependencies), renderSelectionValues(delta.Added.Provisioners))
-	fmt.Fprintf(w, "  Removed: effective-tags=%s managed-entries=%s dependencies=%s provisioners=%s\n\n",
+	fmt.Fprintf(w, "  Removed: effective-tags=%s managed-entries=%s dependencies=%s provisioners=%s\n",
 		renderSelectionValues(delta.Removed.EffectiveTags), renderSelectionValues(delta.Removed.ManagedEntries),
 		renderSelectionValues(delta.Removed.Dependencies), renderSelectionValues(delta.Removed.Provisioners))
+	if len(delta.MissingProfiles) > 0 || len(delta.StaleExtraTags) > 0 {
+		fmt.Fprintf(w, "  Blocking validation: missing-profiles=%s stale-extra-tags=%s\n\n",
+			renderSelectionValues(delta.MissingProfiles), renderSelectionValues(delta.StaleExtraTags))
+	} else {
+		fmt.Fprintln(w)
+	}
 }
 
 func renderSelectionValues(values []string) string {

--- a/internal/cli/render_golden_test.go
+++ b/internal/cli/render_golden_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/yersonargotev/dots/internal/plan"
+	"github.com/yersonargotev/dots/internal/selection"
 )
 
 var update = flag.Bool("update", false, "update golden files")
@@ -63,6 +64,54 @@ func TestRenderPlanGolden(t *testing.T) {
 			if got := out.Bytes(); !bytes.Equal(got, want) {
 				t.Fatalf("golden mismatch for %s\n got:\n%s\nwant:\n%s", tt.golden, got, want)
 			}
+		})
+	}
+}
+
+func TestRenderSelectionEvolutionGolden(t *testing.T) {
+	tests := []struct {
+		name   string
+		delta  selection.Delta
+		golden string
+	}{
+		{
+			name: "changes",
+			delta: selection.Delta{
+				Previous: selection.Snapshot{Profiles: []string{"core"}, ExtraTags: []string{}, EffectiveTags: []string{"core", "retired"}},
+				Current:  selection.Snapshot{Profiles: []string{"core"}, ExtraTags: []string{}, EffectiveTags: []string{"core", "desktop"}},
+				Added: selection.Changes{
+					EffectiveTags: []string{"desktop"}, ManagedEntries: []string{"~/.config/ghostty/config"}, Dependencies: []string{"ghostty"}, Provisioners: []string{},
+				},
+				Removed: selection.Changes{
+					EffectiveTags: []string{"retired"}, ManagedEntries: []string{"~/.retired"}, Dependencies: []string{}, Provisioners: []string{"gentle-ai"},
+				},
+				MissingProfiles: []string{},
+				StaleExtraTags:  []string{},
+			},
+			golden: "selection_evolution.golden",
+		},
+		{
+			name: "blocking validation",
+			delta: selection.Delta{
+				Previous: selection.Snapshot{Profiles: []string{"core"}, ExtraTags: []string{"retired"}, EffectiveTags: []string{"core", "retired"}},
+				Current:  selection.Snapshot{Profiles: []string{"core"}, ExtraTags: []string{"retired"}, EffectiveTags: []string{"core", "retired"}},
+				Added: selection.Changes{
+					EffectiveTags: []string{}, ManagedEntries: []string{}, Dependencies: []string{}, Provisioners: []string{},
+				},
+				Removed: selection.Changes{
+					EffectiveTags: []string{}, ManagedEntries: []string{"~/.retired"}, Dependencies: []string{}, Provisioners: []string{},
+				},
+				MissingProfiles: []string{},
+				StaleExtraTags:  []string{"retired"},
+			},
+			golden: "selection_evolution_blocking.golden",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			renderSelectionEvolution(&out, tt.delta)
+			assertGolden(t, tt.golden, out.Bytes())
 		})
 	}
 }

--- a/internal/cli/testdata/envelope_update.golden
+++ b/internal/cli/testdata/envelope_update.golden
@@ -14,8 +14,54 @@
       ],
       "effective_tags": [
         "core",
+        "desktop",
         "work"
-      ]
+      ],
+      "delta": {
+        "previous": {
+          "profiles": [
+            "core"
+          ],
+          "extra_tags": [
+            "work"
+          ],
+          "effective_tags": [
+            "core",
+            "work"
+          ]
+        },
+        "current": {
+          "profiles": [
+            "core"
+          ],
+          "extra_tags": [
+            "work"
+          ],
+          "effective_tags": [
+            "core",
+            "desktop",
+            "work"
+          ]
+        },
+        "added": {
+          "effective_tags": [
+            "desktop"
+          ],
+          "managed_entries": [
+            "~/.config/ghostty/config"
+          ],
+          "dependencies": [],
+          "provisioners": []
+        },
+        "removed": {
+          "effective_tags": [],
+          "managed_entries": [],
+          "dependencies": [],
+          "provisioners": []
+        },
+        "missing_profiles": [],
+        "stale_extra_tags": []
+      }
     },
     "update": {
       "old_rev": "abc123",
@@ -31,6 +77,7 @@
       ],
       "tags": [
         "core",
+        "desktop",
         "work"
       ],
       "selection": {
@@ -43,8 +90,54 @@
         ],
         "effective_tags": [
           "core",
+          "desktop",
           "work"
-        ]
+        ],
+        "delta": {
+          "previous": {
+            "profiles": [
+              "core"
+            ],
+            "extra_tags": [
+              "work"
+            ],
+            "effective_tags": [
+              "core",
+              "work"
+            ]
+          },
+          "current": {
+            "profiles": [
+              "core"
+            ],
+            "extra_tags": [
+              "work"
+            ],
+            "effective_tags": [
+              "core",
+              "desktop",
+              "work"
+            ]
+          },
+          "added": {
+            "effective_tags": [
+              "desktop"
+            ],
+            "managed_entries": [
+              "~/.config/ghostty/config"
+            ],
+            "dependencies": [],
+            "provisioners": []
+          },
+          "removed": {
+            "effective_tags": [],
+            "managed_entries": [],
+            "dependencies": [],
+            "provisioners": []
+          },
+          "missing_profiles": [],
+          "stale_extra_tags": []
+        }
       },
       "actions": []
     },
@@ -55,6 +148,7 @@
       ],
       "tags": [
         "core",
+        "desktop",
         "work"
       ],
       "steps": []

--- a/internal/cli/testdata/envelope_update_selection_error.golden
+++ b/internal/cli/testdata/envelope_update_selection_error.golden
@@ -1,0 +1,52 @@
+{
+  "schema_version": "5",
+  "command": "update",
+  "status": "error",
+  "data": {
+    "selection_delta": {
+      "previous": {
+        "profiles": [
+          "core"
+        ],
+        "extra_tags": [
+          "retired"
+        ],
+        "effective_tags": [
+          "core",
+          "retired"
+        ]
+      },
+      "current": {
+        "profiles": [
+          "core"
+        ],
+        "extra_tags": [
+          "retired"
+        ],
+        "effective_tags": [
+          "core",
+          "retired"
+        ]
+      },
+      "added": {
+        "effective_tags": [],
+        "managed_entries": [],
+        "dependencies": [],
+        "provisioners": []
+      },
+      "removed": {
+        "effective_tags": [],
+        "managed_entries": [
+          "~/.retired"
+        ],
+        "dependencies": [],
+        "provisioners": []
+      },
+      "missing_profiles": [],
+      "stale_extra_tags": [
+        "retired"
+      ]
+    }
+  },
+  "error": "recorded selection: extra Tag \"retired\" is no longer declared; update the selection before refreshing"
+}

--- a/internal/cli/testdata/envelope_upgrade.golden
+++ b/internal/cli/testdata/envelope_upgrade.golden
@@ -14,8 +14,54 @@
       ],
       "effective_tags": [
         "core",
+        "desktop",
         "work"
-      ]
+      ],
+      "delta": {
+        "previous": {
+          "profiles": [
+            "core"
+          ],
+          "extra_tags": [
+            "work"
+          ],
+          "effective_tags": [
+            "core",
+            "work"
+          ]
+        },
+        "current": {
+          "profiles": [
+            "core"
+          ],
+          "extra_tags": [
+            "work"
+          ],
+          "effective_tags": [
+            "core",
+            "desktop",
+            "work"
+          ]
+        },
+        "added": {
+          "effective_tags": [
+            "desktop"
+          ],
+          "managed_entries": [
+            "~/.config/ghostty/config"
+          ],
+          "dependencies": [],
+          "provisioners": []
+        },
+        "removed": {
+          "effective_tags": [],
+          "managed_entries": [],
+          "dependencies": [],
+          "provisioners": []
+        },
+        "missing_profiles": [],
+        "stale_extra_tags": []
+      }
     },
     "binary": {
       "channel": "homebrew",
@@ -38,6 +84,7 @@
       ],
       "tags": [
         "core",
+        "desktop",
         "work"
       ],
       "selection": {
@@ -50,8 +97,54 @@
         ],
         "effective_tags": [
           "core",
+          "desktop",
           "work"
-        ]
+        ],
+        "delta": {
+          "previous": {
+            "profiles": [
+              "core"
+            ],
+            "extra_tags": [
+              "work"
+            ],
+            "effective_tags": [
+              "core",
+              "work"
+            ]
+          },
+          "current": {
+            "profiles": [
+              "core"
+            ],
+            "extra_tags": [
+              "work"
+            ],
+            "effective_tags": [
+              "core",
+              "desktop",
+              "work"
+            ]
+          },
+          "added": {
+            "effective_tags": [
+              "desktop"
+            ],
+            "managed_entries": [
+              "~/.config/ghostty/config"
+            ],
+            "dependencies": [],
+            "provisioners": []
+          },
+          "removed": {
+            "effective_tags": [],
+            "managed_entries": [],
+            "dependencies": [],
+            "provisioners": []
+          },
+          "missing_profiles": [],
+          "stale_extra_tags": []
+        }
       },
       "actions": []
     },
@@ -62,6 +155,7 @@
       ],
       "tags": [
         "core",
+        "desktop",
         "work"
       ],
       "steps": []

--- a/internal/cli/testdata/selection_evolution.golden
+++ b/internal/cli/testdata/selection_evolution.golden
@@ -1,0 +1,6 @@
+Selection evolution:
+  Previous: profiles=core extra-tags=(none) effective-tags=core,retired
+  Current: profiles=core extra-tags=(none) effective-tags=core,desktop
+  Added: effective-tags=desktop managed-entries=~/.config/ghostty/config dependencies=ghostty provisioners=(none)
+  Removed: effective-tags=retired managed-entries=~/.retired dependencies=(none) provisioners=gentle-ai
+

--- a/internal/cli/testdata/selection_evolution_blocking.golden
+++ b/internal/cli/testdata/selection_evolution_blocking.golden
@@ -1,0 +1,7 @@
+Selection evolution:
+  Previous: profiles=core extra-tags=retired effective-tags=core,retired
+  Current: profiles=core extra-tags=retired effective-tags=core,retired
+  Added: effective-tags=(none) managed-entries=(none) dependencies=(none) provisioners=(none)
+  Removed: effective-tags=(none) managed-entries=~/.retired dependencies=(none) provisioners=(none)
+  Blocking validation: missing-profiles=(none) stale-extra-tags=retired
+

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -131,19 +131,21 @@ func renderUpdate(out io.Writer, upd gitrepo.Update, dryRun bool) {
 	fmt.Fprintln(out)
 }
 
-func resolveUpdateSelection(manifestPath string, paths resolvedPaths, opts updateOptions) (selection.Effective, error) {
+func resolveUpdateSelection(manifestPath string, paths resolvedPaths, opts updateOptions) (*manifest.Manifest, selection.Effective, error) {
 	m, err := manifest.LoadFile(manifestPath)
 	if err != nil {
-		return selection.Effective{}, err
+		return nil, selection.Effective{}, err
 	}
 	if opts.selectionIntent != nil {
-		return selection.ResolveIntent(*m, *opts.selectionIntent)
+		effective, err := selection.ResolveIntent(*m, *opts.selectionIntent)
+		return m, effective, err
 	}
 	meta, err := loadInstallationMetadata(paths, opts.stateRoot)
 	if err != nil {
-		return selection.Effective{}, err
+		return nil, selection.Effective{}, err
 	}
-	return selection.ResolveEffective(*m, opts.profiles, opts.extraTags, meta.InstalledSelection)
+	effective, err := selection.ResolveEffective(*m, opts.profiles, opts.extraTags, meta.InstalledSelection)
+	return m, effective, err
 }
 
 func runUpdateWorkflow(cmd *cobra.Command, opts updateOptions, emit bool) (updateReport, error) {
@@ -158,7 +160,7 @@ func runUpdateWorkflow(cmd *cobra.Command, opts updateOptions, emit bool) (updat
 	if !cmd.Flags().Changed("file") {
 		manifestPath = filepath.Join(paths.SourceRoot, opts.file)
 	}
-	effective, err := resolveUpdateSelection(manifestPath, paths, opts)
+	previousManifest, effective, err := resolveUpdateSelection(manifestPath, paths, opts)
 	if err != nil {
 		return updateReport{}, err
 	}
@@ -191,7 +193,7 @@ func runUpdateWorkflow(cmd *cobra.Command, opts updateOptions, emit bool) (updat
 	if err != nil {
 		return updateReport{}, err
 	}
-	effective, err = selection.ResolveIntent(*m, effective.Intent())
+	effective, err = selection.CompareEvolution(*previousManifest, *m, effective, runtime.GOOS)
 	if err != nil {
 		return updateReport{}, err
 	}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -195,6 +195,10 @@ func runUpdateWorkflow(cmd *cobra.Command, opts updateOptions, emit bool) (updat
 	}
 	effective, err = selection.CompareEvolution(*previousManifest, *m, effective, runtime.GOOS)
 	if err != nil {
+		var evolutionErr *selection.EvolutionError
+		if !wantsJSON(cmd) && errors.As(err, &evolutionErr) {
+			renderSelectionEvolution(out, evolutionErr.SelectionDelta)
+		}
 		return updateReport{}, err
 	}
 	meta, err := loadInstallationMetadata(paths, opts.stateRoot)

--- a/internal/cli/update_selection_test.go
+++ b/internal/cli/update_selection_test.go
@@ -193,6 +193,14 @@ entries:
 	if err == nil || !strings.Contains(err.Error(), `recorded selection: profile "core" not found`) {
 		t.Fatalf("error = %v, want invalid refreshed selection\noutput:\n%s", err, out.String())
 	}
+	for _, want := range []string{
+		"Selection evolution:",
+		"Blocking validation: missing-profiles=core stale-extra-tags=(none)",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output missing %q:\n%s", want, out.String())
+		}
+	}
 	if _, err := os.Stat(filepath.Join(sourceRoot, "configs/work")); err != nil {
 		t.Fatalf("Source of Truth did not refresh before stale selection was detected: %v", err)
 	}
@@ -205,6 +213,83 @@ entries:
 	}
 	if meta.InstalledSelection == nil || !reflect.DeepEqual(*meta.InstalledSelection, previous) {
 		t.Fatalf("InstalledSelection = %#v, want previous %#v", meta.InstalledSelection, previous)
+	}
+}
+
+func TestUpdateReportsProfileTagRemovalsWithoutDeletingRetiredSurfaces(t *testing.T) {
+	requireGitCLI(t)
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	origin, sourceRoot := newInstalledRepo(t, map[string]string{
+		"configs/core":    "core\n",
+		"configs/retired": "retired\n",
+		"dots.yaml": `version: 1
+profiles:
+  core:
+    tags: [core, retired]
+dependencies:
+  - tags: [retired]
+    dependencies:
+      - name: retired-tool
+entries:
+  - source: configs/core
+    target: ~/.core
+    strategy: symlink
+    tags: [core]
+  - source: configs/retired
+    target: ~/.retired
+    strategy: symlink
+    tags: [retired]
+provisioners:
+  - tool: gentle-ai
+    tags: [retired]
+    spec:
+      scope: global
+      agents: [codex]
+`,
+	})
+	previous := state.InstalledSelection{Profiles: []string{"core"}, ResolvedTags: []string{"core", "retired"}}
+	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, InstalledSelection: &previous}); err != nil {
+		t.Fatalf("save metadata: %v", err)
+	}
+	retiredTarget := filepath.Join(home, ".retired")
+	if err := os.WriteFile(retiredTarget, []byte("keep me\n"), 0o600); err != nil {
+		t.Fatalf("write retired target: %v", err)
+	}
+	advanceUpstream(t, origin, "remove retired profile tag", map[string]string{
+		"configs/core": "core\n",
+		"dots.yaml": `version: 1
+profiles:
+  core:
+    tags: [core]
+entries:
+  - source: configs/core
+    target: ~/.core
+    strategy: symlink
+    tags: [core]
+`,
+	})
+
+	out := runBareUpdate(t, "--yes", "--file", filepath.Join(sourceRoot, "dots.yaml"),
+		"--home", home, "--source-root", sourceRoot, "--state-root", stateRoot)
+	if want := "Removed: effective-tags=retired managed-entries=~/.retired dependencies=retired-tool provisioners=gentle-ai"; !strings.Contains(out, want) {
+		t.Fatalf("output missing retired surfaces %q:\n%s", want, out)
+	}
+	got, err := os.ReadFile(retiredTarget)
+	if err != nil {
+		t.Fatalf("retired target was deleted: %v", err)
+	}
+	if string(got) != "keep me\n" {
+		t.Fatalf("retired target changed to %q", got)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load metadata: %v", err)
+	}
+	if got, want := meta.InstalledSelection.ResolvedTags, []string{"core"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ResolvedTags = %#v, want %#v", got, want)
 	}
 }
 
@@ -250,13 +335,14 @@ func TestUpdateProvisionerFailurePreservesPreviousInstalledSelection(t *testing.
 
 func TestUpdateStaleExtraTagReturnsStructuredDeltaAndPreservesIntent(t *testing.T) {
 	requireGitCLI(t)
-	home := t.TempDir()
-	stateRoot := t.TempDir()
 	t.Setenv("HOME", t.TempDir())
 
-	origin, sourceRoot := newInstalledRepo(t, map[string]string{
-		"configs/retired": "retired\n",
-		"dots.yaml": `version: 1
+	setup := func() (home, stateRoot, sourceRoot string, previous state.InstalledSelection) {
+		home = t.TempDir()
+		stateRoot = t.TempDir()
+		origin, sourceRoot := newInstalledRepo(t, map[string]string{
+			"configs/retired": "retired\n",
+			"dots.yaml": `version: 1
 profiles:
   core:
     tags: [core]
@@ -266,16 +352,16 @@ entries:
     strategy: symlink
     tags: [retired]
 `,
-	})
-	previous := state.InstalledSelection{
-		Profiles: []string{"core"}, ExtraTags: []string{"retired"}, ResolvedTags: []string{"core", "retired"},
-	}
-	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, InstalledSelection: &previous}); err != nil {
-		t.Fatalf("save metadata: %v", err)
-	}
-	advanceUpstream(t, origin, "retire optional surface", map[string]string{
-		"configs/core": "core\n",
-		"dots.yaml": `version: 1
+		})
+		previous = state.InstalledSelection{
+			Profiles: []string{"core"}, ExtraTags: []string{"retired"}, ResolvedTags: []string{"core", "retired"},
+		}
+		if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, InstalledSelection: &previous}); err != nil {
+			t.Fatalf("save metadata: %v", err)
+		}
+		advanceUpstream(t, origin, "retire optional surface", map[string]string{
+			"configs/core": "core\n",
+			"dots.yaml": `version: 1
 profiles:
   core:
     tags: [core]
@@ -285,8 +371,32 @@ entries:
     strategy: symlink
     tags: [core]
 `,
-	})
+		})
+		return home, stateRoot, sourceRoot, previous
+	}
 
+	home, stateRoot, sourceRoot, _ := setup()
+	textCmd := cli.NewRootCommand()
+	var textOut bytes.Buffer
+	textCmd.SetOut(&textOut)
+	textCmd.SetErr(&textOut)
+	textCmd.SetArgs([]string{"update", "--yes",
+		"--file", filepath.Join(sourceRoot, "dots.yaml"),
+		"--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+	if err := textCmd.Execute(); err == nil {
+		t.Fatalf("text update error = nil, want stale extra Tag\noutput:\n%s", textOut.String())
+	}
+	for _, want := range []string{
+		"Selection evolution:",
+		"Removed: effective-tags=(none) managed-entries=~/.retired dependencies=(none) provisioners=(none)",
+		"Blocking validation: missing-profiles=(none) stale-extra-tags=retired",
+	} {
+		if !strings.Contains(textOut.String(), want) {
+			t.Fatalf("text output missing %q:\n%s", want, textOut.String())
+		}
+	}
+
+	home, stateRoot, sourceRoot, previous := setup()
 	var out, errOut bytes.Buffer
 	code := cli.Run([]string{"update", "--yes", "--output", "json",
 		"--file", filepath.Join(sourceRoot, "dots.yaml"),

--- a/internal/cli/update_selection_test.go
+++ b/internal/cli/update_selection_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/yersonargotev/dots/internal/cli"
+	"github.com/yersonargotev/dots/internal/selection"
 	"github.com/yersonargotev/dots/internal/state"
 )
 
@@ -29,7 +30,7 @@ entries:
   - source: configs/core
     target: ~/.core
     strategy: symlink
-    tags: [core]
+    tags: [core, extra]
 `,
 	})
 	saveInstalledSelection(t, stateRoot, "core", "extra")
@@ -43,7 +44,7 @@ entries:
   - source: configs/core
     target: ~/.core
     strategy: symlink
-    tags: [core]
+    tags: [core, extra]
   - source: configs/new
     target: ~/.new
     strategy: symlink
@@ -56,6 +57,16 @@ entries:
 
 	if want := "Selection: source=recorded profiles=core extra-tags=extra effective-tags=core,new,extra"; !strings.Contains(out, want) {
 		t.Fatalf("output missing selection report %q:\n%s", want, out)
+	}
+	for _, want := range []string{
+		"Selection evolution:",
+		"Previous: profiles=core extra-tags=extra effective-tags=core,extra",
+		"Current: profiles=core extra-tags=extra effective-tags=core,new,extra",
+		"Added: effective-tags=new managed-entries=~/.new dependencies=(none) provisioners=(none)",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing evolution report %q:\n%s", want, out)
+		}
 	}
 	if _, err := os.Readlink(filepath.Join(home, ".new")); err != nil {
 		t.Fatalf("recorded selection did not apply post-refresh Profile tags: %v", err)
@@ -151,7 +162,7 @@ entries:
   - source: configs/core
     target: ~/.core
     strategy: symlink
-    tags: [core]
+    tags: [core, extra]
 `,
 	})
 	previous := state.InstalledSelection{Profiles: []string{"core"}, ResolvedTags: []string{"core"}}
@@ -237,6 +248,82 @@ func TestUpdateProvisionerFailurePreservesPreviousInstalledSelection(t *testing.
 	}
 }
 
+func TestUpdateStaleExtraTagReturnsStructuredDeltaAndPreservesIntent(t *testing.T) {
+	requireGitCLI(t)
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	origin, sourceRoot := newInstalledRepo(t, map[string]string{
+		"configs/retired": "retired\n",
+		"dots.yaml": `version: 1
+profiles:
+  core:
+    tags: [core]
+entries:
+  - source: configs/retired
+    target: ~/.retired
+    strategy: symlink
+    tags: [retired]
+`,
+	})
+	previous := state.InstalledSelection{
+		Profiles: []string{"core"}, ExtraTags: []string{"retired"}, ResolvedTags: []string{"core", "retired"},
+	}
+	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, InstalledSelection: &previous}); err != nil {
+		t.Fatalf("save metadata: %v", err)
+	}
+	advanceUpstream(t, origin, "retire optional surface", map[string]string{
+		"configs/core": "core\n",
+		"dots.yaml": `version: 1
+profiles:
+  core:
+    tags: [core]
+entries:
+  - source: configs/core
+    target: ~/.core
+    strategy: symlink
+    tags: [core]
+`,
+	})
+
+	var out, errOut bytes.Buffer
+	code := cli.Run([]string{"update", "--yes", "--output", "json",
+		"--file", filepath.Join(sourceRoot, "dots.yaml"),
+		"--home", home, "--source-root", sourceRoot, "--state-root", stateRoot}, &out, &errOut)
+	if code != cli.ExitError {
+		t.Fatalf("exit code = %d, want %d\nstdout:\n%s\nstderr:\n%s", code, cli.ExitError, out.String(), errOut.String())
+	}
+	var env struct {
+		Data struct {
+			SelectionDelta selection.Delta `json:"selection_delta"`
+		} `json:"data"`
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal JSON: %v\n%s", err, out.String())
+	}
+	if !strings.Contains(env.Error, `recorded selection: extra Tag "retired" is no longer declared`) {
+		t.Fatalf("error = %q", env.Error)
+	}
+	if got, want := env.Data.SelectionDelta.StaleExtraTags, []string{"retired"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("stale_extra_tags = %#v, want %#v", got, want)
+	}
+	if got, want := env.Data.SelectionDelta.Removed.ManagedEntries, []string{"~/.retired"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("removed managed_entries = %#v, want %#v", got, want)
+	}
+	if _, err := os.Lstat(filepath.Join(home, ".core")); !os.IsNotExist(err) {
+		t.Fatalf("Managed Configuration applied after stale extra Tag: %v", err)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load metadata: %v", err)
+	}
+	if meta.InstalledSelection == nil || !reflect.DeepEqual(*meta.InstalledSelection, previous) {
+		t.Fatalf("InstalledSelection = %#v, want previous %#v", meta.InstalledSelection, previous)
+	}
+}
+
 func TestUpdateJSONReportsRecordedSelection(t *testing.T) {
 	requireGitCLI(t)
 	home := t.TempDir()
@@ -252,7 +339,7 @@ entries:
   - source: configs/core
     target: ~/.core
     strategy: symlink
-    tags: [core]
+    tags: [core, extra]
 `,
 	})
 	saveInstalledSelection(t, stateRoot, "core", "extra")
@@ -267,10 +354,11 @@ entries:
 	var env struct {
 		Data struct {
 			Selection struct {
-				Source        string   `json:"source"`
-				Profiles      []string `json:"profiles"`
-				ExtraTags     []string `json:"extra_tags"`
-				EffectiveTags []string `json:"effective_tags"`
+				Source        string           `json:"source"`
+				Profiles      []string         `json:"profiles"`
+				ExtraTags     []string         `json:"extra_tags"`
+				EffectiveTags []string         `json:"effective_tags"`
+				Delta         *selection.Delta `json:"delta"`
 			} `json:"selection"`
 		} `json:"data"`
 	}
@@ -282,5 +370,14 @@ entries:
 		!reflect.DeepEqual(env.Data.Selection.ExtraTags, []string{"extra"}) ||
 		!reflect.DeepEqual(env.Data.Selection.EffectiveTags, []string{"core", "extra"}) {
 		t.Fatalf("selection = %#v", env.Data.Selection)
+	}
+	if env.Data.Selection.Delta == nil {
+		t.Fatalf("selection delta = nil\n%s", out.String())
+	}
+	if env.Data.Selection.Delta.Added.EffectiveTags == nil ||
+		env.Data.Selection.Delta.Removed.ManagedEntries == nil ||
+		env.Data.Selection.Delta.MissingProfiles == nil ||
+		env.Data.Selection.Delta.StaleExtraTags == nil {
+		t.Fatalf("selection delta omitted required empty arrays: %#v", env.Data.Selection.Delta)
 	}
 }

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -170,7 +170,8 @@ func resolveUpgradeSelection(cmd *cobra.Command, opts updateOptions) (selection.
 	if !cmd.Flags().Changed("file") {
 		manifestPath = filepath.Join(paths.SourceRoot, opts.file)
 	}
-	return resolveUpdateSelection(manifestPath, paths, opts)
+	_, effective, err := resolveUpdateSelection(manifestPath, paths, opts)
+	return effective, err
 }
 
 func upgradeContinuationArgs(file string, fileChanged bool, intent selection.Intent, sourceRoot, home, stateRoot string, yes, noTUI, json bool, binPlan upgrade.Plan) []string {

--- a/internal/cli/upgrade_continuation_test.go
+++ b/internal/cli/upgrade_continuation_test.go
@@ -33,7 +33,7 @@ func TestUpgradeBinaryReplacementContinuationPreservesRecordedSelection(t *testi
 		t.Run(tt.name, func(t *testing.T) {
 			home := t.TempDir()
 			stateRoot := t.TempDir()
-			sourceRoot := newContinuationRepo(t)
+			origin, sourceRoot := newContinuationRepo(t)
 			t.Setenv("HOME", t.TempDir())
 
 			previous := state.InstalledSelection{
@@ -92,6 +92,7 @@ func TestUpgradeBinaryReplacementContinuationPreservesRecordedSelection(t *testi
 			if meta.InstalledSelection == nil || !reflect.DeepEqual(*meta.InstalledSelection, previous) {
 				t.Fatalf("exec failure changed InstalledSelection = %#v, want %#v", meta.InstalledSelection, previous)
 			}
+			advanceContinuationRepo(t, origin)
 
 			continued := NewRootCommand()
 			var continuedOut bytes.Buffer
@@ -101,7 +102,7 @@ func TestUpgradeBinaryReplacementContinuationPreservesRecordedSelection(t *testi
 			if err := continued.Execute(); err != nil {
 				t.Fatalf("continued upgrade error = %v\noutput:\n%s", err, continuedOut.String())
 			}
-			for _, target := range []string{".core", ".extra"} {
+			for _, target := range []string{".core", ".extra", ".new"} {
 				if _, err := os.Readlink(filepath.Join(home, target)); err != nil {
 					t.Fatalf("continuation did not apply %s: %v", target, err)
 				}
@@ -117,8 +118,13 @@ func TestUpgradeBinaryReplacementContinuationPreservesRecordedSelection(t *testi
 			if env.Data.Selection.Source != selection.SourceRecorded ||
 				!reflect.DeepEqual(env.Data.Selection.Profiles, previous.Profiles) ||
 				!reflect.DeepEqual(env.Data.Selection.ExtraTags, previous.ExtraTags) ||
-				!reflect.DeepEqual(env.Data.Selection.EffectiveTags, previous.ResolvedTags) {
+				!reflect.DeepEqual(env.Data.Selection.EffectiveTags, []string{"core", "new", "extra"}) {
 				t.Fatalf("continuation selection = %#v, want recorded intent %#v", env.Data.Selection, previous)
+			}
+			if env.Data.Selection.Delta == nil ||
+				!reflect.DeepEqual(env.Data.Selection.Delta.Added.EffectiveTags, []string{"new"}) ||
+				!reflect.DeepEqual(env.Data.Selection.Delta.Added.ManagedEntries, []string{"~/.new"}) {
+				t.Fatalf("continuation selection delta = %#v", env.Data.Selection.Delta)
 			}
 		})
 	}
@@ -141,7 +147,7 @@ func assertContinuationSelectionArgs(t *testing.T, args []string) {
 	}
 }
 
-func newContinuationRepo(t *testing.T) string {
+func newContinuationRepo(t *testing.T) (string, string) {
 	t.Helper()
 	origin := t.TempDir()
 	runContinuationGit(t, origin, "init", "-b", "main")
@@ -180,7 +186,37 @@ entries:
 	runContinuationGit(t, "", "clone", origin, clone)
 	runContinuationGit(t, clone, "config", "user.email", "tests@example.com")
 	runContinuationGit(t, clone, "config", "user.name", "dots tests")
-	return clone
+	return origin, clone
+}
+
+func advanceContinuationRepo(t *testing.T, origin string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(origin, "configs", "new"), []byte("new\n"), 0o600); err != nil {
+		t.Fatalf("write new continuation config: %v", err)
+	}
+	manifest := `version: 1
+profiles:
+  core:
+    tags: [core, new]
+entries:
+  - source: configs/core
+    target: ~/.core
+    strategy: symlink
+    tags: [core]
+  - source: configs/new
+    target: ~/.new
+    strategy: symlink
+    tags: [new]
+  - source: configs/extra
+    target: ~/.extra
+    strategy: symlink
+    tags: [extra]
+`
+	if err := os.WriteFile(filepath.Join(origin, "dots.yaml"), []byte(manifest), 0o600); err != nil {
+		t.Fatalf("write continuation manifest: %v", err)
+	}
+	runContinuationGit(t, origin, "add", "-A")
+	runContinuationGit(t, origin, "commit", "-m", "expand core selection")
 }
 
 func runContinuationGit(t *testing.T, dir string, args ...string) {

--- a/internal/selection/selection.go
+++ b/internal/selection/selection.go
@@ -30,6 +30,49 @@ type Report struct {
 	Profiles      []string `json:"profiles"`
 	ExtraTags     []string `json:"extra_tags"`
 	EffectiveTags []string `json:"effective_tags"`
+	Delta         *Delta   `json:"delta,omitempty"`
+}
+
+// Snapshot is the portable selection state on one side of an evolution.
+type Snapshot struct {
+	Profiles      []string `json:"profiles"`
+	ExtraTags     []string `json:"extra_tags"`
+	EffectiveTags []string `json:"effective_tags"`
+}
+
+// Changes describes an ordered change to the selected manifest surface.
+type Changes struct {
+	EffectiveTags  []string `json:"effective_tags"`
+	ManagedEntries []string `json:"managed_entries"`
+	Dependencies   []string `json:"dependencies"`
+	Provisioners   []string `json:"provisioners"`
+}
+
+// Delta describes how the same selection intent evolves between Install
+// Manifest revisions.
+type Delta struct {
+	Previous        Snapshot `json:"previous"`
+	Current         Snapshot `json:"current"`
+	Added           Changes  `json:"added"`
+	Removed         Changes  `json:"removed"`
+	MissingProfiles []string `json:"missing_profiles"`
+	StaleExtraTags  []string `json:"stale_extra_tags"`
+}
+
+// EvolutionError is an actionable, machine-readable blocking validation error.
+type EvolutionError struct {
+	Message        string `json:"message"`
+	SelectionDelta Delta  `json:"selection_delta"`
+}
+
+func (e *EvolutionError) Error() string { return e.Message }
+
+// JSONErrorData supplies the stable machine-readable payload used by the CLI
+// error envelope.
+func (e *EvolutionError) JSONErrorData() any {
+	return struct {
+		SelectionDelta Delta `json:"selection_delta"`
+	}{SelectionDelta: e.SelectionDelta}
 }
 
 // Effective contains the validated inputs for downstream command builders and
@@ -111,6 +154,192 @@ func (e Effective) Intent() Intent {
 		Profiles:  cloneStrings(e.Profiles),
 		ExtraTags: cloneStrings(e.ExtraTags),
 	}
+}
+
+// CompareEvolution re-resolves the same authoritative intent against a newer
+// Install Manifest and reports deterministic changes to its selected surface.
+// It is pure: it performs no filesystem or state mutation.
+func CompareEvolution(previousManifest, currentManifest manifest.Manifest, previous Effective, osName string) (Effective, error) {
+	intent := previous.Intent()
+	delta := emptyDelta(snapshot(previous), Snapshot{
+		Profiles:      cloneStrings(intent.Profiles),
+		ExtraTags:     cloneStrings(intent.ExtraTags),
+		EffectiveTags: make([]string, 0),
+	})
+	delta.MissingProfiles = missingProfiles(currentManifest, intent.Profiles)
+	delta.StaleExtraTags = staleExtraTags(currentManifest, intent.ExtraTags)
+	if len(delta.MissingProfiles) == 0 {
+		current, err := ResolveIntent(currentManifest, intent)
+		if err != nil {
+			return Effective{}, err
+		}
+		delta.Current = snapshot(current)
+		previousSurface := selectedSurface(previousManifest, previous.Selection, osName)
+		currentSurface := selectedSurface(currentManifest, current.Selection, osName)
+		delta.Added = surfaceDifference(currentSurface, previousSurface)
+		delta.Removed = surfaceDifference(previousSurface, currentSurface)
+		if len(delta.StaleExtraTags) == 0 {
+			current.Report.Delta = &delta
+			return current, nil
+		}
+	}
+
+	var problems []string
+	for _, profile := range delta.MissingProfiles {
+		problems = append(problems, fmt.Sprintf(`%s selection: profile %q not found`, intent.Source, profile))
+	}
+	for _, tag := range delta.StaleExtraTags {
+		problems = append(problems, fmt.Sprintf(`%s selection: extra Tag %q is no longer declared`, intent.Source, tag))
+	}
+	return Effective{}, &EvolutionError{
+		Message:        strings.Join(problems, "; ") + "; update the selection before refreshing",
+		SelectionDelta: delta,
+	}
+}
+
+func snapshot(e Effective) Snapshot {
+	return Snapshot{
+		Profiles:      cloneStrings(e.Profiles),
+		ExtraTags:     cloneStrings(e.ExtraTags),
+		EffectiveTags: cloneStrings(e.Selection.Tags),
+	}
+}
+
+func emptyDelta(previous, current Snapshot) Delta {
+	return Delta{
+		Previous: previous,
+		Current:  current,
+		Added: Changes{
+			EffectiveTags:  make([]string, 0),
+			ManagedEntries: make([]string, 0),
+			Dependencies:   make([]string, 0),
+			Provisioners:   make([]string, 0),
+		},
+		Removed: Changes{
+			EffectiveTags:  make([]string, 0),
+			ManagedEntries: make([]string, 0),
+			Dependencies:   make([]string, 0),
+			Provisioners:   make([]string, 0),
+		},
+		MissingProfiles: make([]string, 0),
+		StaleExtraTags:  make([]string, 0),
+	}
+}
+
+func missingProfiles(m manifest.Manifest, profiles []string) []string {
+	var missing []string
+	for _, name := range orderedUnique(profiles) {
+		if _, ok := m.Profiles[name]; !ok {
+			missing = append(missing, name)
+		}
+	}
+	return cloneStrings(missing)
+}
+
+func staleExtraTags(m manifest.Manifest, extraTags []string) []string {
+	declared := make(map[string]bool)
+	for _, entry := range m.Entries {
+		for _, tag := range entry.Tags {
+			declared[tag] = true
+		}
+	}
+	for _, set := range m.Dependencies {
+		for _, tag := range set.Tags {
+			declared[tag] = true
+		}
+	}
+	for _, provisioner := range m.Provisioners {
+		for _, tag := range provisioner.Tags {
+			declared[tag] = true
+		}
+	}
+	var stale []string
+	for _, tag := range orderedUnique(extraTags) {
+		if !declared[tag] && !supportedSelectionModifier(tag) {
+			stale = append(stale, tag)
+		}
+	}
+	return cloneStrings(stale)
+}
+
+func supportedSelectionModifier(tag string) bool {
+	switch tag {
+	case "codex-delegation", "without-codex-delegation",
+		"codex-spark-delegation", "without-codex-spark-delegation":
+		return true
+	default:
+		return false
+	}
+}
+
+func selectedSurface(m manifest.Manifest, selected manifest.Selection, osName string) Changes {
+	result := Changes{
+		EffectiveTags:  cloneStrings(selected.Tags),
+		ManagedEntries: make([]string, 0),
+		Dependencies:   make([]string, 0),
+		Provisioners:   make([]string, 0),
+	}
+	seenEntries := make(map[string]bool)
+	seenDependencies := make(map[string]bool)
+	seenProvisioners := make(map[string]bool)
+	addDependencies := func(dependencies []manifest.Dependency) {
+		for _, dependency := range dependencies {
+			if !seenDependencies[dependency.Name] {
+				seenDependencies[dependency.Name] = true
+				result.Dependencies = append(result.Dependencies, dependency.Name)
+			}
+		}
+	}
+	for _, profileName := range selected.Profiles {
+		addDependencies(m.Profiles[profileName].Dependencies)
+	}
+	for _, set := range m.Dependencies {
+		if manifest.SharesTag(set.Tags, selected.Tags) && manifest.MatchesOS(set.OS, osName) {
+			addDependencies(set.Dependencies)
+		}
+	}
+	for _, entry := range m.Entries {
+		if manifest.SharesTag(entry.Tags, selected.Tags) && manifest.MatchesOS(entry.OS, osName) {
+			if !seenEntries[entry.Target] {
+				seenEntries[entry.Target] = true
+				result.ManagedEntries = append(result.ManagedEntries, entry.Target)
+			}
+			addDependencies(entry.Dependencies)
+		}
+	}
+	for _, provisioner := range m.Provisioners {
+		if manifest.SharesTag(provisioner.Tags, selected.Tags) && manifest.MatchesOS(provisioner.OS, osName) {
+			if !seenProvisioners[provisioner.Tool] {
+				seenProvisioners[provisioner.Tool] = true
+				result.Provisioners = append(result.Provisioners, provisioner.Tool)
+			}
+			addDependencies(provisioner.Dependencies)
+		}
+	}
+	return result
+}
+
+func surfaceDifference(left, right Changes) Changes {
+	return Changes{
+		EffectiveTags:  difference(left.EffectiveTags, right.EffectiveTags),
+		ManagedEntries: difference(left.ManagedEntries, right.ManagedEntries),
+		Dependencies:   difference(left.Dependencies, right.Dependencies),
+		Provisioners:   difference(left.Provisioners, right.Provisioners),
+	}
+}
+
+func difference(left, right []string) []string {
+	excluded := make(map[string]bool, len(right))
+	for _, value := range right {
+		excluded[value] = true
+	}
+	result := make([]string, 0)
+	for _, value := range left {
+		if !excluded[value] {
+			result = append(result, value)
+		}
+	}
+	return result
 }
 
 func validateIntent(source Source, profiles, extraTags []string) error {

--- a/internal/selection/selection_test.go
+++ b/internal/selection/selection_test.go
@@ -1,6 +1,7 @@
 package selection_test
 
 import (
+	"encoding/json"
 	"errors"
 	"reflect"
 	"strings"
@@ -10,6 +11,186 @@ import (
 	"github.com/yersonargotev/dots/internal/selection"
 	"github.com/yersonargotev/dots/internal/state"
 )
+
+func TestCompareEvolutionReportsSelectedSurfaceChangesInManifestOrder(t *testing.T) {
+	oldManifest := manifest.Manifest{
+		Profiles: map[string]manifest.Profile{
+			"core": {
+				Tags:         []string{"core"},
+				Dependencies: []manifest.Dependency{{Name: "profile-old"}, {Name: "shared"}},
+			},
+		},
+		Entries: []manifest.Entry{
+			{Target: ".old", Tags: []string{"core"}, Dependencies: []manifest.Dependency{{Name: "entry-old"}}},
+			{Target: ".shared", Tags: []string{"core"}, Dependencies: []manifest.Dependency{{Name: "shared"}}},
+		},
+		Provisioners: []manifest.Provisioner{{Tool: "old-tool", Tags: []string{"core"}}},
+	}
+	newManifest := manifest.Manifest{
+		Profiles: map[string]manifest.Profile{
+			"core": {
+				Tags:         []string{"core", "new"},
+				Dependencies: []manifest.Dependency{{Name: "shared"}, {Name: "profile-new"}},
+			},
+		},
+		Dependencies: []manifest.DependencySet{{
+			Tags: []string{"new"}, Dependencies: []manifest.Dependency{{Name: "set-new"}, {Name: "shared"}},
+		}},
+		Entries: []manifest.Entry{
+			{Target: ".shared", Tags: []string{"core"}, Dependencies: []manifest.Dependency{{Name: "shared"}}},
+			{Target: ".new", Tags: []string{"new"}, Dependencies: []manifest.Dependency{{Name: "entry-new"}}},
+		},
+		Provisioners: []manifest.Provisioner{{
+			Tool: "new-tool", Tags: []string{"new"}, Dependencies: []manifest.Dependency{{Name: "provisioner-new"}},
+		}},
+	}
+	previous, err := selection.ResolveIntent(oldManifest, selection.Intent{
+		Source: selection.SourceRecorded, Profiles: []string{"core"},
+	})
+	if err != nil {
+		t.Fatalf("ResolveIntent() error = %v", err)
+	}
+
+	got, err := selection.CompareEvolution(oldManifest, newManifest, previous, "darwin")
+	if err != nil {
+		t.Fatalf("CompareEvolution() error = %v", err)
+	}
+	delta := got.Report.Delta
+	if delta == nil {
+		t.Fatal("SelectionDelta = nil")
+	}
+	if want := []string{"new"}; !reflect.DeepEqual(delta.Added.EffectiveTags, want) {
+		t.Fatalf("added effective Tags = %#v, want %#v", delta.Added.EffectiveTags, want)
+	}
+	if want := []string{".new"}; !reflect.DeepEqual(delta.Added.ManagedEntries, want) {
+		t.Fatalf("added Managed Entries = %#v, want %#v", delta.Added.ManagedEntries, want)
+	}
+	if want := []string{"profile-new", "set-new", "entry-new", "provisioner-new"}; !reflect.DeepEqual(delta.Added.Dependencies, want) {
+		t.Fatalf("added Dependencies = %#v, want %#v", delta.Added.Dependencies, want)
+	}
+	if want := []string{"new-tool"}; !reflect.DeepEqual(delta.Added.Provisioners, want) {
+		t.Fatalf("added Provisioners = %#v, want %#v", delta.Added.Provisioners, want)
+	}
+	if want := []string{".old"}; !reflect.DeepEqual(delta.Removed.ManagedEntries, want) {
+		t.Fatalf("removed Managed Entries = %#v, want %#v", delta.Removed.ManagedEntries, want)
+	}
+	if want := []string{"profile-old", "entry-old"}; !reflect.DeepEqual(delta.Removed.Dependencies, want) {
+		t.Fatalf("removed Dependencies = %#v, want %#v", delta.Removed.Dependencies, want)
+	}
+	if want := []string{"old-tool"}; !reflect.DeepEqual(delta.Removed.Provisioners, want) {
+		t.Fatalf("removed Provisioners = %#v, want %#v", delta.Removed.Provisioners, want)
+	}
+}
+
+func TestCompareEvolutionRejectsMissingProfileWithStructuredDelta(t *testing.T) {
+	oldManifest := manifest.Manifest{Profiles: map[string]manifest.Profile{"core": {Tags: []string{"core"}}}}
+	previous, err := selection.ResolveIntent(oldManifest, selection.Intent{
+		Source: selection.SourceRecorded, Profiles: []string{"core"},
+	})
+	if err != nil {
+		t.Fatalf("ResolveIntent() error = %v", err)
+	}
+
+	_, err = selection.CompareEvolution(oldManifest, manifest.Manifest{}, previous, "linux")
+	var evolutionErr *selection.EvolutionError
+	if !errors.As(err, &evolutionErr) {
+		t.Fatalf("CompareEvolution() error = %T %v, want *EvolutionError", err, err)
+	}
+	if want := []string{"core"}; !reflect.DeepEqual(evolutionErr.SelectionDelta.MissingProfiles, want) {
+		t.Fatalf("missing Profiles = %#v, want %#v", evolutionErr.SelectionDelta.MissingProfiles, want)
+	}
+	if !strings.Contains(err.Error(), "update the selection") {
+		t.Fatalf("error = %q, want actionable guidance", err)
+	}
+}
+
+func TestCompareEvolutionRejectsStaleExplicitExtraTag(t *testing.T) {
+	oldManifest := manifest.Manifest{
+		Entries: []manifest.Entry{{Target: ".old", Tags: []string{"retired"}}},
+	}
+	previous, err := selection.ResolveIntent(oldManifest, selection.Intent{
+		Source: selection.SourceExplicit, ExtraTags: []string{"retired"},
+	})
+	if err != nil {
+		t.Fatalf("ResolveIntent() error = %v", err)
+	}
+
+	_, err = selection.CompareEvolution(oldManifest, manifest.Manifest{
+		Entries: []manifest.Entry{{Target: ".new", Tags: []string{"current"}}},
+	}, previous, "linux")
+	var evolutionErr *selection.EvolutionError
+	if !errors.As(err, &evolutionErr) {
+		t.Fatalf("CompareEvolution() error = %T %v, want *EvolutionError", err, err)
+	}
+	if want := []string{"retired"}; !reflect.DeepEqual(evolutionErr.SelectionDelta.StaleExtraTags, want) {
+		t.Fatalf("stale extra Tags = %#v, want %#v", evolutionErr.SelectionDelta.StaleExtraTags, want)
+	}
+	if want := []string{".old"}; !reflect.DeepEqual(evolutionErr.SelectionDelta.Removed.ManagedEntries, want) {
+		t.Fatalf("removed Managed Entries = %#v, want %#v", evolutionErr.SelectionDelta.Removed.ManagedEntries, want)
+	}
+	if !strings.Contains(err.Error(), `explicit selection: extra Tag "retired" is no longer declared`) {
+		t.Fatalf("error = %q, want source and actionable stale Tag", err)
+	}
+	data, marshalErr := json.Marshal(evolutionErr.JSONErrorData())
+	if marshalErr != nil || !strings.Contains(string(data), `"selection_delta"`) {
+		t.Fatalf("JSONErrorData() = %s, %v; want selection_delta", data, marshalErr)
+	}
+}
+
+func TestCompareEvolutionPreservesSupportedSelectionModifiers(t *testing.T) {
+	m := manifest.Manifest{
+		Profiles: map[string]manifest.Profile{"core": {Tags: []string{"core"}}},
+		Entries:  []manifest.Entry{{Target: "~/.core", Tags: []string{"core"}}},
+	}
+	for _, tag := range []string{
+		"codex-delegation",
+		"without-codex-delegation",
+		"codex-spark-delegation",
+		"without-codex-spark-delegation",
+	} {
+		t.Run(tag, func(t *testing.T) {
+			previous, err := selection.ResolveIntent(m, selection.Intent{
+				Source: selection.SourceExplicit, Profiles: []string{"core"}, ExtraTags: []string{tag},
+			})
+			if err != nil {
+				t.Fatalf("resolve previous: %v", err)
+			}
+			if _, err := selection.CompareEvolution(m, m, previous, "linux"); err != nil {
+				t.Fatalf("CompareEvolution() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestCompareEvolutionDeltaJSONUsesDeterministicEmptyArrays(t *testing.T) {
+	m := manifest.Manifest{
+		Profiles: map[string]manifest.Profile{"core": {Tags: []string{"core"}}},
+		Entries:  []manifest.Entry{{Target: ".shared", Tags: []string{"core"}}},
+	}
+	previous, err := selection.ResolveIntent(m, selection.Intent{
+		Source: selection.SourceRecorded, Profiles: []string{"core"},
+	})
+	if err != nil {
+		t.Fatalf("ResolveIntent() error = %v", err)
+	}
+	got, err := selection.CompareEvolution(m, m, previous, "darwin")
+	if err != nil {
+		t.Fatalf("CompareEvolution() error = %v", err)
+	}
+
+	data, err := json.Marshal(got.Report)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	for _, want := range []string{
+		`"effective_tags":[]`, `"managed_entries":[]`, `"dependencies":[]`,
+		`"provisioners":[]`, `"missing_profiles":[]`, `"stale_extra_tags":[]`,
+	} {
+		if !strings.Contains(string(data), want) {
+			t.Fatalf("JSON = %s, want %s", data, want)
+		}
+	}
+}
 
 func TestResolveReadOnlyExplicitSelectionWinsCompletely(t *testing.T) {
 	m := manifest.Manifest{Profiles: map[string]manifest.Profile{


### PR DESCRIPTION
Closes #343

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Compare authoritative Installed Selection before and after Source of Truth refresh.
- Report deterministic Tag, Managed Entry, Dependency, and Provisioner additions/removals in text and JSON.
- Block missing Profiles and stale extra Tags without rewriting intent or pruning retired surfaces.

## Changes

| File | Change |
|------|--------|
| `internal/selection/selection.go` | Add the pure evolution comparator, stable delta model, and structured blocking validation errors. |
| `internal/cli/update.go`, `internal/cli/upgrade.go`, `internal/cli/render.go` | Integrate pre/post-refresh comparison and human rendering across update, upgrade, and continuation. |
| `internal/cli/*test.go`, `internal/cli/testdata/*` | Cover additions, removals, stale/missing intent, no-prune safety, binary continuation, and text/JSON contracts. |
| `docs/adr/0014-record-authoritative-installed-selection.md`, `docs/manifest.md`, `docs/update.md`, `docs/upgrade.md`, `docs/agents/output-contract.md` | Document evolution semantics, blocking validation, stable output, and no automatic removal policy. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile core --source-root "$PWD" --home <tmp>`
- [x] `go build ./...`
- [x] Independent Standards and Spec reviews returned no remaining findings.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #343`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
