### PR TITLE
fix(selection): explain unselected source overrides

### DIFF
--- a/docs/agents/output-contract.md
+++ b/docs/agents/output-contract.md
@@ -150,6 +150,14 @@ prose the text surface prints:
   Entry Ownership proof to safely mutate a previously managed target, creating a
   Backup Set before writing, while preserving the conservative conflict model
   for unmanaged or incompatible targets.
+- Plan actions and Status Managed Entry items may add the optional reason
+  `source-override-not-selected` and a deterministic `matching_tags` array when
+  a conflicting target exactly matches one or more alternate sources whose
+  `source_overrides` tags were not selected. These fields diagnose the omitted
+  selection without replacing the action's `conflict` status or the Status
+  item's `conflict` state. To recover the intended selection, omit explicit
+  selection flags so dots can reuse an available Installed Selection, or supply
+  each intended exact tag with repeated `--tag <tag>`.
 - Dependency provider availability is an internal planning check, not a JSON
   contract field. `deps plan` and dependency install previews expose the stable
   outcome (`status`, selected `provider`, executable action, `manual` guidance)

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -108,6 +108,13 @@ Static apps without a safe optional include seam can use a `source_overrides`
 entry when a whole target must switch sources behind the opt-in. The override
 keeps one Managed Entry/target in the Install Plan while selecting the tagged
 source, so `--tag adaptive-theme` does not create duplicate target actions.
+When none of an entry's override tags is selected, dots uses its base `source`;
+an override does not change the entry's `tags` selection or `os` applicability.
+Override keys match selected tags exactly. When a conflicting target exactly
+matches an alternate source whose tag was not selected, diagnostics retain the
+Conflict and report all such unselected tags in deterministic order. Omit
+explicit `--profile` and `--tag` flags to reuse an available Installed
+Selection, or pass each intended exact tag with repeated `--tag <tag>`.
 Co-owned files are still documented in [`docs/adaptive-theme-audit.md`](adaptive-theme-audit.md)
 when no safe dots-owned source can be selected.
 
@@ -119,7 +126,7 @@ home directory.
 | Field | Required | Supported values |
 |-------|----------|------------------|
 | `source` | Yes | Repository-relative path to Managed Configuration. |
-| `source_overrides` | No | Map of selected tag to alternate repository-relative source for the same target. Used for opt-in variants without duplicate Install Plan targets. |
+| `source_overrides` | No | Map of exact selected tag to alternate repository-relative source for the same target. The base `source` is used when no key matches; overrides do not alter entry tag selection or OS applicability. |
 | `target` | Yes | Home-relative target: `~` or `~/...`. |
 | `strategy` | Yes | `symlink`, `copy`, or `template` in the manifest schema. Current install execution supports `symlink` and `copy`. |
 | `ownership` | No | Empty, `json-subset`, or `toml-subset`. Subset ownership requires `strategy: copy`. |

--- a/internal/cli/output_golden_test.go
+++ b/internal/cli/output_golden_test.go
@@ -77,6 +77,7 @@ func TestEnvelopeGolden(t *testing.T) {
 					Entries: []status.Entry{
 						{Source: "configs/zsh/zshrc", Target: "/home/user/.zshrc", Strategy: "symlink", State: status.StateOK},
 						{Source: "configs/git/config", Target: "/home/user/.gitconfig", Strategy: "copy", State: status.StateMissing},
+						{Source: "configs/zellij/default.kdl", Target: "/home/user/.config/zellij/config.kdl", Strategy: "symlink", State: status.StateConflict, Reason: plan.ConflictReasonSourceOverrideNotSelected, MatchingTags: []string{"adaptive-theme"}},
 					},
 					Provisioners: provision.StatusReport{
 						Profile: "default",
@@ -122,7 +123,7 @@ func TestEnvelopeGolden(t *testing.T) {
 					Source: selection.SourceExplicit, Profiles: []string{"default"}, ExtraTags: []string{"work"}, EffectiveTags: []string{"core", "work"},
 				}, Actions: []plan.Action{
 					{Source: "configs/zsh/zshrc", ResolvedSource: "/abs/machine/local/path/MUST/NOT/APPEAR", Target: "/home/user/.zshrc", Strategy: "symlink", Status: plan.StatusCreate},
-					{Source: "configs/git/config", ResolvedSource: "/abs/x", Target: "/home/user/.gitconfig", Strategy: "copy", Status: plan.StatusConflict},
+					{Source: "configs/git/config", ResolvedSource: "/abs/x", Target: "/home/user/.gitconfig", Strategy: "copy", Status: plan.StatusConflict, Reason: plan.ConflictReasonSourceOverrideNotSelected, MatchingTags: []string{"adaptive-theme"}},
 				}},
 			},
 			golden: "envelope_plan.golden",

--- a/internal/cli/read_selection_test.go
+++ b/internal/cli/read_selection_test.go
@@ -181,6 +181,84 @@ func TestReadOnlySelectionTextReportsSource(t *testing.T) {
 	}
 }
 
+func TestReadOnlyCommandsDiagnoseOverrideOmittedByExplicitSelection(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(sourceRoot, "configs", "zellij"), 0o755); err != nil {
+		t.Fatalf("mkdir sources: %v", err)
+	}
+	defaultSource := filepath.Join(sourceRoot, "configs", "zellij", "default.kdl")
+	adaptiveSource := filepath.Join(sourceRoot, "configs", "zellij", "adaptive.kdl")
+	if err := os.WriteFile(defaultSource, []byte("dark\n"), 0o600); err != nil {
+		t.Fatalf("write default source: %v", err)
+	}
+	if err := os.WriteFile(adaptiveSource, []byte("adaptive\n"), 0o600); err != nil {
+		t.Fatalf("write adaptive source: %v", err)
+	}
+	target := filepath.Join(home, ".config", "zellij", "config.kdl")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target parent: %v", err)
+	}
+	if err := os.Symlink(adaptiveSource, target); err != nil {
+		t.Fatalf("symlink target: %v", err)
+	}
+	manifestPath := filepath.Join(sourceRoot, "dots.yaml")
+	if err := os.WriteFile(manifestPath, []byte(`version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/zellij/default.kdl
+    source_overrides:
+      adaptive-theme: configs/zellij/adaptive.kdl
+    target: ~/.config/zellij/config.kdl
+    strategy: symlink
+    tags: [core]
+`), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	saveInstalledSelection(t, stateRoot, "default", "adaptive-theme")
+
+	for _, command := range []struct {
+		name       string
+		args       []string
+		collection string
+		stateKey   string
+		aligned    string
+	}{
+		{name: "plan", args: []string{"plan"}, collection: "actions", stateKey: "status", aligned: "unchanged"},
+		{name: "status", args: []string{"status"}, collection: "entries", stateKey: "state", aligned: "ok"},
+	} {
+		t.Run(command.name, func(t *testing.T) {
+			recordedArgs := selectionCommandArgs(command.args, manifestPath, home, sourceRoot, stateRoot, false)
+			code, data, envelopeError := runSelectionJSON(t, recordedArgs)
+			if code != 0 {
+				t.Fatalf("recorded selection exit code = %d, want 0; error=%q", code, envelopeError)
+			}
+			assertSelectionJSON(t, data, "recorded", []string{"default"}, []string{"adaptive-theme"}, []string{"core", "adaptive-theme"})
+			items := data[command.collection].([]any)
+			if got := items[0].(map[string]any)[command.stateKey]; got != command.aligned {
+				t.Fatalf("recorded %s = %v, want %q", command.stateKey, got, command.aligned)
+			}
+
+			explicitArgs := append(append([]string{}, command.args...), "--profile", "default")
+			explicitArgs = selectionCommandArgs(explicitArgs, manifestPath, home, sourceRoot, stateRoot, false)
+			code, data, envelopeError = runSelectionJSON(t, explicitArgs)
+			if code != 2 {
+				t.Fatalf("explicit selection exit code = %d, want 2; error=%q", code, envelopeError)
+			}
+			items = data[command.collection].([]any)
+			item := items[0].(map[string]any)
+			if item[command.stateKey] != "conflict" ||
+				item["reason"] != "source-override-not-selected" ||
+				mustJSON(t, item["matching_tags"]) != `["adaptive-theme"]` {
+				t.Fatalf("explicit selection item = %#v, want diagnosed conflict", item)
+			}
+		})
+	}
+}
+
 func TestDepsExplicitSelectionWorksWithoutInstallationMetadata(t *testing.T) {
 	home := t.TempDir()
 	manifestPath := writeCLIManifest(t, home, `version: 1

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -26,6 +26,7 @@ func renderPlan(w io.Writer, p plan.Plan) {
 	}
 	for _, a := range p.Actions {
 		fmt.Fprintf(w, "  %-15s %-9s %s -> %s\n", a.Status, a.Strategy, a.Source, a.Target)
+		renderSourceOverrideSelectionHint(w, a.Reason, a.MatchingTags)
 		switch a.Status {
 		case plan.StatusCreate:
 			counts.create++
@@ -54,6 +55,18 @@ func renderPlan(w io.Writer, p plan.Plan) {
 	if counts.conflict > 0 {
 		renderConflictResolutionGuidance(w)
 	}
+}
+
+func renderSourceOverrideSelectionHint(w io.Writer, reason string, matchingTags []string) {
+	if reason != plan.ConflictReasonSourceOverrideNotSelected || len(matchingTags) == 0 {
+		return
+	}
+	flags := make([]string, 0, len(matchingTags))
+	for _, tag := range matchingTags {
+		flags = append(flags, "--tag "+tag)
+	}
+	fmt.Fprintf(w, "    source override matches omitted tag(s): %s\n", strings.Join(matchingTags, ", "))
+	fmt.Fprintf(w, "    selection: omit explicit selection flags to reuse Installed Selection when available, or add %s\n", strings.Join(flags, " "))
 }
 
 // renderSkippedEntryHint prints a one-line nudge when the active profile omits

--- a/internal/cli/render_golden_test.go
+++ b/internal/cli/render_golden_test.go
@@ -25,7 +25,7 @@ func TestRenderPlanGolden(t *testing.T) {
 				Profile: "work",
 				Actions: []plan.Action{
 					{Source: "configs/zsh/zshrc", Target: "/home/user/.zshrc", Strategy: "symlink", Status: plan.StatusCreate},
-					{Source: "configs/git/gitconfig", Target: "/home/user/.gitconfig", Strategy: "symlink", Status: plan.StatusConflict},
+					{Source: "configs/git/gitconfig", Target: "/home/user/.gitconfig", Strategy: "symlink", Status: plan.StatusConflict, Reason: plan.ConflictReasonSourceOverrideNotSelected, MatchingTags: []string{"adaptive-theme"}},
 					{Source: "configs/starship.toml", Target: "/home/user/.config/starship.toml", Strategy: "copy", Status: plan.StatusUnchanged},
 					{Source: "configs/nvim/init.lua", Target: "/home/user/.config/nvim/init.lua", Strategy: "template", Status: plan.StatusMissingSource},
 				},

--- a/internal/cli/render_status.go
+++ b/internal/cli/render_status.go
@@ -25,6 +25,7 @@ func renderStatus(w io.Writer, report status.Report) {
 	}
 	for _, e := range report.Entries {
 		fmt.Fprintf(w, "  %-12s %-9s %s -> %s\n", e.State, e.Strategy, e.Source, e.Target)
+		renderSourceOverrideSelectionHint(w, e.Reason, e.MatchingTags)
 		switch e.State {
 		case status.StateOK:
 			counts.ok++

--- a/internal/cli/render_status_golden_test.go
+++ b/internal/cli/render_status_golden_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/status"
 )
 
@@ -22,7 +23,7 @@ func TestRenderStatusGolden(t *testing.T) {
 				Entries: []status.Entry{
 					{Source: "configs/zsh/zshrc", Target: "/home/user/.zshrc", Strategy: "symlink", State: status.StateOK},
 					{Source: "configs/git/gitconfig", Target: "/home/user/.gitconfig", Strategy: "copy", State: status.StateMissing},
-					{Source: "configs/tmux/tmux.conf", Target: "/home/user/.tmux.conf", Strategy: "copy", State: status.StateConflict},
+					{Source: "configs/tmux/tmux.conf", Target: "/home/user/.tmux.conf", Strategy: "copy", State: status.StateConflict, Reason: plan.ConflictReasonSourceOverrideNotSelected, MatchingTags: []string{"adaptive-theme", "work-theme"}},
 					{Source: "configs/mac/app", Target: "~/.app", Strategy: "copy", State: status.StateSkipped},
 					{Source: "configs/starship.toml", Target: "/home/user/.config/starship.toml", Strategy: "copy", State: status.StateDrifted},
 					{Source: "configs/nvim/init.lua", Target: "/home/user/.config/nvim/init.lua", Strategy: "template", State: status.StateUnsupported},

--- a/internal/cli/testdata/envelope_plan.golden
+++ b/internal/cli/testdata/envelope_plan.golden
@@ -28,7 +28,11 @@
         "source": "configs/git/config",
         "target": "/home/user/.gitconfig",
         "strategy": "copy",
-        "status": "conflict"
+        "status": "conflict",
+        "reason": "source-override-not-selected",
+        "matching_tags": [
+          "adaptive-theme"
+        ]
       }
     ]
   }

--- a/internal/cli/testdata/envelope_status.golden
+++ b/internal/cli/testdata/envelope_status.golden
@@ -29,6 +29,16 @@
         "target": "/home/user/.gitconfig",
         "strategy": "copy",
         "state": "missing"
+      },
+      {
+        "source": "configs/zellij/default.kdl",
+        "target": "/home/user/.config/zellij/config.kdl",
+        "strategy": "symlink",
+        "state": "conflict",
+        "reason": "source-override-not-selected",
+        "matching_tags": [
+          "adaptive-theme"
+        ]
       }
     ],
     "provisioners": {

--- a/internal/cli/testdata/plan_all_statuses.golden
+++ b/internal/cli/testdata/plan_all_statuses.golden
@@ -2,6 +2,8 @@ Plan for profile "work"
 
   create          symlink   configs/zsh/zshrc -> /home/user/.zshrc
   conflict        symlink   configs/git/gitconfig -> /home/user/.gitconfig
+    source override matches omitted tag(s): adaptive-theme
+    selection: omit explicit selection flags to reuse Installed Selection when available, or add --tag adaptive-theme
   unchanged       copy      configs/starship.toml -> /home/user/.config/starship.toml
   missing-source  template  configs/nvim/init.lua -> /home/user/.config/nvim/init.lua
 

--- a/internal/cli/testdata/status_all_states.golden
+++ b/internal/cli/testdata/status_all_states.golden
@@ -3,6 +3,8 @@ Status for profile "work"
   ok           symlink   configs/zsh/zshrc -> /home/user/.zshrc
   missing      copy      configs/git/gitconfig -> /home/user/.gitconfig
   conflict     copy      configs/tmux/tmux.conf -> /home/user/.tmux.conf
+    source override matches omitted tag(s): adaptive-theme, work-theme
+    selection: omit explicit selection flags to reuse Installed Selection when available, or add --tag adaptive-theme --tag work-theme
   skipped      copy      configs/mac/app -> ~/.app
   drifted      copy      configs/starship.toml -> /home/user/.config/starship.toml
   unsupported  template  configs/nvim/init.lua -> /home/user/.config/nvim/init.lua

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/yersonargotev/dots/internal/configsubset"
@@ -25,6 +26,8 @@ const (
 	StatusMissingSource Status = "missing-source"
 )
 
+const ConflictReasonSourceOverrideNotSelected = "source-override-not-selected"
+
 // Action is a single planned filesystem change for a Managed Entry.
 type Action struct {
 	Source string `json:"source"`
@@ -32,11 +35,13 @@ type Action struct {
 	// of the Agent Output Contract: it differs between machines and install
 	// locations, which would break idempotent envelope comparisons. Agents key on
 	// the portable, manifest-relative Source instead.
-	ResolvedSource string `json:"-"`
-	Target         string `json:"target"`
-	Strategy       string `json:"strategy"`
-	Status         Status `json:"status"`
-	Ownership      string `json:"-"`
+	ResolvedSource string   `json:"-"`
+	Target         string   `json:"target"`
+	Strategy       string   `json:"strategy"`
+	Status         Status   `json:"status"`
+	Reason         string   `json:"reason,omitempty"`
+	MatchingTags   []string `json:"matching_tags,omitempty"`
+	Ownership      string   `json:"-"`
 }
 
 // Plan is the preview of changes the installer would apply for a Profile.
@@ -112,17 +117,100 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 		if err != nil {
 			return Plan{}, err
 		}
+		var reason string
+		var matchingTags []string
+		if actionStatus == StatusConflict {
+			matchingTags, err = MatchingUnselectedSourceOverrideTags(entry, tags, target, opts.SourceRoot)
+			if err != nil {
+				return Plan{}, err
+			}
+			if len(matchingTags) > 0 {
+				reason = ConflictReasonSourceOverrideNotSelected
+			}
+		}
 		plan.Actions = append(plan.Actions, Action{
 			Source:         source,
 			ResolvedSource: sourceAbs,
 			Target:         target,
 			Strategy:       entry.Strategy,
 			Status:         actionStatus,
+			Reason:         reason,
+			MatchingTags:   matchingTags,
 			Ownership:      entry.Ownership,
 		})
 	}
 
 	return plan, nil
+}
+
+// MatchingUnselectedSourceOverrideTags returns the deterministic set of
+// unselected Tags whose declared alternate source exactly matches target.
+// Alternate sources receive the same containment and existence checks as a
+// selected Managed Entry source before they can produce remediation guidance.
+func MatchingUnselectedSourceOverrideTags(entry manifest.Entry, selectedTags []string, target, sourceRoot string) ([]string, error) {
+	if len(entry.SourceOverrides) == 0 || (entry.Strategy != "symlink" && entry.Strategy != "copy") {
+		return nil, nil
+	}
+
+	selected := make(map[string]struct{}, len(selectedTags))
+	for _, tag := range selectedTags {
+		selected[tag] = struct{}{}
+	}
+	overrideTags := make([]string, 0, len(entry.SourceOverrides))
+	for tag := range entry.SourceOverrides {
+		if _, ok := selected[tag]; !ok {
+			overrideTags = append(overrideTags, tag)
+		}
+	}
+	sort.Strings(overrideTags)
+
+	matching := make([]string, 0, len(overrideTags))
+	for _, tag := range overrideTags {
+		sourceAbs, err := ResolveSource(entry.SourceOverrides[tag], sourceRoot)
+		if err != nil {
+			return nil, err
+		}
+		exists, err := safeSourceExists(sourceAbs, sourceRoot)
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			continue
+		}
+		matches, err := targetMatchesSource(entry.Strategy, target, sourceAbs)
+		if err != nil {
+			return nil, err
+		}
+		if matches {
+			matching = append(matching, tag)
+		}
+	}
+	return matching, nil
+}
+
+func targetMatchesSource(strategy, target, sourceAbs string) (bool, error) {
+	info, err := os.Lstat(target)
+	if err != nil {
+		return false, nil
+	}
+	switch strategy {
+	case "symlink":
+		if info.Mode()&os.ModeSymlink == 0 {
+			return false, nil
+		}
+		dest, err := os.Readlink(target)
+		if err != nil {
+			return false, fmt.Errorf("readlink target %s: %w", target, err)
+		}
+		return dest == sourceAbs, nil
+	case "copy":
+		if !info.Mode().IsRegular() {
+			return false, nil
+		}
+		return sameContent(target, sourceAbs)
+	default:
+		return false, nil
+	}
 }
 
 // ResolveTarget resolves a manifest target inside home. Targets are deliberately

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -824,6 +824,110 @@ func TestBuildUsesSourceOverrideForSelectedExtraTag(t *testing.T) {
 	}
 }
 
+func TestBuildDiagnosesUnselectedSourceOverrides(t *testing.T) {
+	sourceRoot := t.TempDir()
+	home := t.TempDir()
+	writeSource(t, sourceRoot, "herdr/default.toml", "dark\n")
+	herdrAdaptive := writeSource(t, sourceRoot, "herdr/adaptive.toml", "adaptive\n")
+	writeSource(t, sourceRoot, "zellij/default.kdl", "dark\n")
+	zellijAdaptive := writeSource(t, sourceRoot, "zellij/adaptive.kdl", "adaptive\n")
+
+	entries := []manifest.Entry{
+		{
+			Source:          "herdr/default.toml",
+			SourceOverrides: map[string]string{"adaptive-theme": "herdr/adaptive.toml"},
+			Target:          "~/.config/herdr/config.toml",
+			Strategy:        "symlink",
+			Tags:            []string{"core"},
+			OS:              []string{"darwin"},
+		},
+		{
+			Source:          "zellij/default.kdl",
+			SourceOverrides: map[string]string{"adaptive-theme": "zellij/adaptive.kdl"},
+			Target:          "~/.config/zellij/config.kdl",
+			Strategy:        "symlink",
+			Tags:            []string{"core"},
+			OS:              []string{"darwin"},
+		},
+	}
+	for target, source := range map[string]string{
+		filepath.Join(home, ".config", "herdr", "config.toml"): herdrAdaptive,
+		filepath.Join(home, ".config", "zellij", "config.kdl"): zellijAdaptive,
+	} {
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			t.Fatalf("mkdir target parent: %v", err)
+		}
+		if err := os.Symlink(source, target); err != nil {
+			t.Fatalf("symlink target: %v", err)
+		}
+	}
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}},
+		Entries:  entries,
+	}
+
+	withoutTag, err := plan.Build(m, plan.Options{Profile: "default", OS: "darwin", SourceRoot: sourceRoot, Home: home})
+	if err != nil {
+		t.Fatalf("Build() without tag error = %v", err)
+	}
+	for _, action := range withoutTag.Actions {
+		if action.Status != plan.StatusConflict {
+			t.Fatalf("Status = %q, want conflict", action.Status)
+		}
+		if action.Reason != plan.ConflictReasonSourceOverrideNotSelected {
+			t.Fatalf("Reason = %q, want %q", action.Reason, plan.ConflictReasonSourceOverrideNotSelected)
+		}
+		if got, want := action.MatchingTags, []string{"adaptive-theme"}; len(got) != 1 || got[0] != want[0] {
+			t.Fatalf("MatchingTags = %v, want %v", got, want)
+		}
+	}
+
+	withTag, err := plan.Build(m, plan.Options{Profile: "default", ExtraTags: []string{"adaptive-theme"}, OS: "darwin", SourceRoot: sourceRoot, Home: home})
+	if err != nil {
+		t.Fatalf("Build() with tag error = %v", err)
+	}
+	for _, action := range withTag.Actions {
+		if action.Status != plan.StatusUnchanged || action.Reason != "" || len(action.MatchingTags) != 0 {
+			t.Fatalf("selected override action = %+v, want unchanged without diagnostic", action)
+		}
+	}
+}
+
+func TestBuildSourceOverrideDiagnosisIsDeterministicAndExact(t *testing.T) {
+	sourceRoot := t.TempDir()
+	home := t.TempDir()
+	writeSource(t, sourceRoot, "default.conf", "default\n")
+	writeSource(t, sourceRoot, "adaptive.conf", "adaptive\n")
+	target := filepath.Join(home, "config")
+	if err := os.WriteFile(target, []byte("adaptive\n"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	e := manifest.Entry{
+		Source: "default.conf",
+		SourceOverrides: map[string]string{
+			"z-last":  "adaptive.conf",
+			"a-first": "adaptive.conf",
+		},
+		Target:   "~/config",
+		Strategy: "copy",
+		Tags:     []string{"core"},
+	}
+
+	action := buildOne(t, sourceRoot, home, e)
+	if got, want := action.MatchingTags, []string{"a-first", "z-last"}; len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("MatchingTags = %v, want %v", got, want)
+	}
+
+	if err := os.WriteFile(target, []byte("local divergence\n"), 0o600); err != nil {
+		t.Fatalf("rewrite target: %v", err)
+	}
+	action = buildOne(t, sourceRoot, home, e)
+	if action.Status != plan.StatusConflict || action.Reason != "" || len(action.MatchingTags) != 0 {
+		t.Fatalf("ordinary conflict = %+v, want no source-override diagnosis", action)
+	}
+}
+
 func TestBuildRejectsUnknownProfile(t *testing.T) {
 	m := manifest.Manifest{
 		Version:  1,

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -42,10 +42,12 @@ const (
 
 // Entry is the evaluated alignment of one Managed Entry.
 type Entry struct {
-	Source   string `json:"source"`
-	Target   string `json:"target"`
-	Strategy string `json:"strategy"`
-	State    State  `json:"state"`
+	Source       string   `json:"source"`
+	Target       string   `json:"target"`
+	Strategy     string   `json:"strategy"`
+	State        State    `json:"state"`
+	Reason       string   `json:"reason,omitempty"`
+	MatchingTags []string `json:"matching_tags,omitempty"`
 }
 
 // Report is the Dotfiles Status for a Profile, in manifest order.
@@ -125,6 +127,16 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options) (Report, erro
 			return Report{}, err
 		}
 		evaluated.State = st
+		if st == StateConflict {
+			matchingTags, err := plan.MatchingUnselectedSourceOverrideTags(entry, tags, target, opts.SourceRoot)
+			if err != nil {
+				return Report{}, err
+			}
+			if len(matchingTags) > 0 {
+				evaluated.Reason = plan.ConflictReasonSourceOverrideNotSelected
+				evaluated.MatchingTags = matchingTags
+			}
+		}
 		report.Entries = append(report.Entries, evaluated)
 	}
 

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/state"
 	"github.com/yersonargotev/dots/internal/status"
 )
@@ -73,6 +74,64 @@ func TestBuildReportsOKForSymlinkPointingAtSource(t *testing.T) {
 
 	if got := onlyEntry(t, f.build(t, state.Metadata{})).State; got != status.StateOK {
 		t.Fatalf("state = %q, want ok", got)
+	}
+}
+
+func TestBuildDiagnosesUnselectedSourceOverrideAndKeepsSelectedOverrideAligned(t *testing.T) {
+	f := newFixture(manifest.Entry{
+		Source:          "configs/zellij/default.kdl",
+		SourceOverrides: map[string]string{"adaptive-theme": "configs/zellij/adaptive.kdl"},
+		Target:          "~/.config/zellij/config.kdl",
+		Strategy:        "symlink",
+		Tags:            []string{"core"},
+		OS:              []string{"linux"},
+	})
+	f.sourceRoot = t.TempDir()
+	f.home = t.TempDir()
+	writeSource(t, f.sourceRoot, "configs/zellij/default.kdl", "dark\n")
+	adaptive := writeSource(t, f.sourceRoot, "configs/zellij/adaptive.kdl", "adaptive\n")
+	target := filepath.Join(f.home, ".config", "zellij", "config.kdl")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target parent: %v", err)
+	}
+	if err := os.Symlink(adaptive, target); err != nil {
+		t.Fatalf("symlink target: %v", err)
+	}
+
+	entry := onlyEntry(t, f.build(t, state.Metadata{}))
+	if entry.State != status.StateConflict ||
+		entry.Reason != plan.ConflictReasonSourceOverrideNotSelected ||
+		len(entry.MatchingTags) != 1 || entry.MatchingTags[0] != "adaptive-theme" {
+		t.Fatalf("entry = %+v, want diagnosed conflict", entry)
+	}
+
+	report, err := status.Build(f.manifest, state.Metadata{}, status.Options{
+		Profile:    "default",
+		ExtraTags:  []string{"adaptive-theme"},
+		OS:         "linux",
+		SourceRoot: f.sourceRoot,
+		Home:       f.home,
+	})
+	if err != nil {
+		t.Fatalf("Build() selected override error = %v", err)
+	}
+	entry = onlyEntry(t, report)
+	if entry.State != status.StateOK || entry.Reason != "" || len(entry.MatchingTags) != 0 {
+		t.Fatalf("selected override entry = %+v, want ok without diagnostic", entry)
+	}
+
+	report, err = status.Build(f.manifest, state.Metadata{}, status.Options{
+		Profile:    "default",
+		OS:         "darwin",
+		SourceRoot: f.sourceRoot,
+		Home:       f.home,
+	})
+	if err != nil {
+		t.Fatalf("Build() OS-filtered error = %v", err)
+	}
+	entry = onlyEntry(t, report)
+	if entry.State != status.StateSkipped || entry.Reason != "" || len(entry.MatchingTags) != 0 {
+		t.Fatalf("OS-filtered entry = %+v, want skipped without diagnostic", entry)
 	}
 }
 


### PR DESCRIPTION
Closes #344

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Keep existing Conflict status/state and exit semantics when explicit selection omits a source-override Tag.
- Add portable `reason: source-override-not-selected` and deterministic `matching_tags` diagnostics to Plan and Status JSON.
- Render exact selection remediation and document the source-override/output contracts.

## Changes

| File | Change |
|------|--------|
| `internal/plan/plan.go` | Detect safe, exact matches to unselected alternate sources and enrich Conflict actions. |
| `internal/status/status.go` | Expose the same diagnosis for Dotfiles Status conflicts without changing Drift/Conflict classification. |
| `internal/cli/` | Render selection-specific guidance and lock text/JSON output with goldens and recorded-selection integration coverage. |
| `docs/manifest.md` | Document omitted override Tags, exact matching, OS applicability, and remediation. |
| `docs/agents/output-contract.md` | Document the additive optional diagnostic fields. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan: `go run ./cmd/dots plan --file dots.yaml --profile core --source-root "$PWD" --home <tmp>/home --state-root <tmp>/state --output json` (exit 0, `status=ok`, 16 actions)

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Risk / Rollback

- Risk is limited to additive optional JSON fields and extra human guidance on diagnosed Conflicts; semantic statuses and exit codes are unchanged.
- Roll back by reverting this commit; ordinary Conflict behavior remains the compatibility baseline.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #344`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
