### PR TITLE
feat(selection): migrate legacy metadata safely

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -121,8 +121,12 @@ The state file stored under `~/.local/state/dots/installed.json` that records wh
 _Avoid_: install log, state file, tracking file
 
 **Installed Selection**:
-The authoritative machine-level installation intent recorded after a successful explicit install. It preserves the ordered Profiles and explicit extra Tags selected by the operator, the ordered resolved Tag snapshot, Source of Truth provenance, and recording time. Profiles and explicit extra Tags are intent; resolved Tags are an audit snapshot. Per-Managed-Entry and per-Provisioner Profiles and Tags remain historical inventory and ownership evidence, not a substitute for an Installed Selection.
+The authoritative machine-level installation intent recorded only after terminal success of an explicit install, update, or upgrade, including an operator-confirmed Selection Migration Candidate. It preserves the ordered Profiles and explicit extra Tags selected by the operator, the ordered resolved Tag snapshot, Source of Truth provenance, and recording time. Profiles and explicit extra Tags are intent; resolved Tags are an audit snapshot. Per-Managed-Entry and per-Provisioner Profiles and Tags remain historical inventory and ownership evidence, not a substitute for an Installed Selection.
 _Avoid_: inferred selection, installed profile, tag inventory
+
+**Selection Migration Candidate**:
+A non-authoritative selection proposed for Installation Metadata v1 or v2 from historical Managed Entry and Provisioner records plus current Install Manifest, target, and Source of Truth evidence. It reports ordered Profiles, explicit extra Tags, effective Tags, confidence, and ambiguity reasons. Only an unambiguous candidate can become an Installed Selection, and only after interactive operator confirmation and terminal success; ambiguous or absent evidence requires an explicit selection.
+_Avoid_: inferred selection, migrated selection, implicit default
 
 **Dependency Installation Metadata**:
 The state record of Dependencies the Dotfiles CLI installed through executable providers, including the dependency name, provider, installed path, artifact version or checksum when applicable, and timestamp. It is separate from Installation Metadata because dependency tools are external workstation capabilities, not Managed Entries.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,18 @@ after Managed Entries and Provisioners finish. A machine with no recorded
 selection must pass an explicit `--profile` or `--tag`; selection-aware commands
 never invent an implicit Profile.
 
+Machines with Installation Metadata v1/v2 may receive a non-authoritative
+Selection Migration Candidate derived from historical Managed Entry and
+Provisioner records plus current manifest, target, and Source of Truth evidence.
+Only an unambiguous candidate can be confirmed during an interactive `update` or
+`upgrade`. Ambiguous or absent evidence requires repeated `--profile`/`--tag`
+flags for the complete selection. `--yes` and JSON/non-interactive runs instead
+return `selection-migration-required`, with a recommended explicit command when
+possible. The Installed Selection is recorded only after terminal success;
+legacy ownership inventory is preserved, and no implicit default is chosen.
+Use `dots installed` to inspect the authoritative selection, migration
+candidate, and historical inventory as separate sections.
+
 ### Machine-readable output
 
 Scripts and agents can request a stable JSON envelope from result-producing

--- a/docs/adr/0014-record-authoritative-installed-selection.md
+++ b/docs/adr/0014-record-authoritative-installed-selection.md
@@ -101,3 +101,37 @@ dots to unlink targets, delete ownership or Dependency metadata, uninstall
 Provisioners or capabilities, or otherwise prune historical inventory.
 Explicit selection replacement, reduction acknowledgement, legacy inference,
 and automatic removal remain separate policy.
+
+## Legacy selection migration amendment
+
+Issue #345 authorizes a conservative migration path for Installation Metadata
+v1 and v2. Historical Managed Entry and Provisioner records are combined with
+the current Install Manifest and current target/Source of Truth evidence to
+produce a non-authoritative Selection Migration Candidate. The candidate
+reports ordered Profiles, explicit extra Tags, effective Tags, confidence, and
+deterministic ambiguity reasons. Historical inventory remains evidence only:
+the analysis does not promote its union to authoritative intent, delete legacy
+ownership records, or choose an implicit manifest default.
+
+Only an unambiguous candidate may be offered for interactive confirmation by
+`update` or `upgrade`. Confirmation authorizes that candidate for the current
+run; it does not record an Installed Selection immediately. The selection is
+recorded only after terminal success, under the same commit rule as an explicit
+selection. Declining confirmation, cancellation, dry run, Managed Entry or
+Provisioner failure, continuation failure, or metadata-write failure leaves
+legacy metadata and any previous Installed Selection unchanged.
+
+Ambiguous candidates and metadata with no usable evidence require the operator
+to repeat `--profile` and `--tag` as needed to state the complete selection.
+`--yes`, JSON output, and any other non-interactive execution never confirm a
+candidate. They fail before mutation with the stable
+`selection-migration-required` structured error and include a recommended
+explicit command when the evidence supports one. Explicit selection always
+wins and, after terminal success, records the Installed Selection without
+pruning the historical Managed Entry or Provisioner inventory.
+
+`dots installed` keeps three concerns visibly separate: the authoritative
+Installed Selection, the non-authoritative Selection Migration Candidate, and
+historical inventory. Read-only selection-aware commands likewise do not
+silently consume a migration candidate; until migration succeeds, callers must
+provide an explicit selection.

--- a/docs/agents/output-contract.md
+++ b/docs/agents/output-contract.md
@@ -121,7 +121,9 @@ prose the text surface prints:
   Any explicit Profile or Tag selection wins completely for that invocation and
   is never merged with recorded intent.
   If neither source exists, the command returns an execution error (`1`) with
-  selection guidance rather than falling back to a manifest `default`.
+  selection guidance rather than falling back to a manifest `default`. For
+  Installation Metadata v1/v2, historical evidence may be reported as a
+  non-authoritative migration candidate, but is never consumed implicitly.
 
 - `installed` is a read-only report over Installation Metadata. Its optional
   `data.installed_selection` is the authoritative machine-level intent recorded
@@ -140,6 +142,19 @@ prose the text surface prints:
   diagnostic, so an absent Installed Selection or partial Profile coverage
   remains `status: "ok"`; use `status` or `doctor` when an agent needs
   drift/dependency findings.
+- For Installation Metadata v1/v2 without an Installed Selection, `installed`
+  may add `data.selection_migration` alongside (never inside) the historical
+  inventory. It contains stable arrays `profiles`, `extra_tags`,
+  `effective_tags`, and `ambiguity_reasons`, plus `confidence` and, only when
+  available, `recommended_command`. This candidate is non-authoritative and
+  does not change `data.installed_selection`.
+- When selection migration cannot proceed non-interactively, selection-aware
+  commands return exit `1`, `status: "error"`, and error code
+  `selection-migration-required`. Error `data` contains `code`, nullable
+  `candidate`, and `remediation`; candidate arrays remain present even when
+  empty, and `remediation.recommended_command` is included when the evidence
+  supports an explicit command. `--yes` and JSON output never confirm a
+  candidate.
 - `plan`'s `resolved_source` (a per-machine absolute path) and `deps`'s
   `probe_detail`/`hint` (unstable human prose) are excluded. Agents key on the
   portable, structured fields (`source`, `present`, `warning`, and the

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -40,6 +40,13 @@ without creating another Profile. For example, `--tag adaptive-theme` installs t
 app-specific fragments used by managed configs to follow macOS light appearance
 where the app has a safe seam.
 
+When v1/v2 Installation Metadata has no authoritative Installed Selection,
+these read-only commands return `selection-migration-required` rather than
+silently consuming historical Profile or Tag evidence. Inspect the
+non-authoritative candidate with `dots installed`, then run one complete
+explicit `--profile`/`--tag` selection; an interactive `update` or `upgrade`
+may instead offer an unambiguous candidate for confirmation.
+
 | Field | Required | Supported values |
 |-------|----------|------------------|
 | `tags` | Yes | Non-empty strings. Entries and Provisioners are selected when at least one tag matches. Optional CLI `--tag` values join this set at runtime. |

--- a/docs/update.md
+++ b/docs/update.md
@@ -83,6 +83,16 @@ Installed Selection:
 dots update --yes
 ```
 
+For Installation Metadata v1/v2 without an Installed Selection, update first
+builds a non-authoritative Selection Migration Candidate from historical
+Managed Entry and Provisioner records plus the current manifest, target, and
+Source of Truth evidence. An interactive update may confirm only an
+unambiguous candidate. Ambiguous or absent evidence requires the complete
+selection to be repeated with `--profile` and `--tag`. `--yes`, JSON output,
+and other non-interactive runs return `selection-migration-required` before
+mutation, with a recommended explicit command when one can be constructed.
+There is no implicit default.
+
 Any supplied `--profile` or `--tag` makes the complete explicit selection win
 for that invocation; dots never merges it with recorded intent. The selection
 is validated before the Installed Repository changes and resolved again against
@@ -93,7 +103,8 @@ or explicit extra Tag no longer declared by any selectable manifest surface
 stops application with remediation and structured delta data instead of
 choosing an implicit default or silently rewriting intent. Removed surfaces are
 informational and are never automatically deleted or uninstalled. Only terminal
-success refreshes the Installed Selection, so dry runs, cancellations, and
+success records or refreshes the Installed Selection, so dry runs, declined
+migration confirmation, cancellations, and
 failed Managed Entry or Provisioner work preserve the previous intent.
 
 ## Profiles and provisioners
@@ -127,10 +138,11 @@ provisioners:
 ```
 
 After installs or updates, use `dots installed` to inspect the read-only
-Installation Metadata inventory: recorded Managed Entries, represented Tags,
-recorded or inferred Profiles, Provisioner runs, and captured Source of Truth
-provenance when available. The command is useful when you need to answer what is
-currently installed without manually reading `~/.local/state/dots/installed.json`.
+Installation Metadata inventory: the authoritative Installed Selection, any
+non-authoritative Selection Migration Candidate, and historical recorded
+Managed Entries, represented Tags, Profile coverage, Provisioner runs, and
+captured Source of Truth provenance. These sections remain separate; inspecting
+a candidate never records it or deletes legacy ownership records.
 
 To keep that requirement discoverable, both `install` and `update` print a one-line hint when the active profile skips provisioners another profile would select on this OS:
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -65,15 +65,26 @@ reuse the Installed Selection:
 dots upgrade --yes
 ```
 
+For Installation Metadata v1/v2 without an Installed Selection, upgrade derives
+a non-authoritative Selection Migration Candidate from historical Managed Entry
+and Provisioner records plus current manifest, target, and Source of Truth
+evidence. Only an unambiguous candidate can be confirmed interactively.
+Ambiguous or absent evidence requires repeated `--profile` and `--tag` flags
+that state the complete selection. `--yes`, JSON output, and other
+non-interactive runs fail before binary or repository mutation with the stable
+`selection-migration-required` error and a recommended explicit command when
+possible. Upgrade never chooses an implicit default.
+
 Selection is validated before binary replacement and re-resolved against the
 refreshed manifest before Managed Configuration is applied. Upgrade reports
 effective Tag and selected Managed Entry, Dependency, and Provisioner additions
 and removals before application. Missing Profiles and explicit extra Tags no
 longer declared by selectable manifest surfaces stop the mutating phase without
 an implicit default or automatic intent rewrite. Removed surfaces are never
-automatically deleted or uninstalled. Only terminal success refreshes Installed
-Selection metadata; binary, update, Provisioner, or continuation failures
-preserve the previous selection.
+automatically deleted or uninstalled. Only terminal success records or refreshes
+Installed Selection metadata; declined migration confirmation, binary, update,
+Provisioner, or continuation failures preserve the previous state and legacy
+ownership records.
 
 ## Source of Truth flags
 
@@ -94,7 +105,8 @@ dots upgrade \
 Use temporary `--home`, `--source-root`, and `--state-root` values when testing
 upgrade behavior so real workstation configuration is never modified.
 
-After an upgrade, `dots installed` provides the official read-only inventory for
-what Installation Metadata currently records, including Profile/Tag coverage,
-Provisioner runs, and Source of Truth provenance captured by recent installs or
-updates.
+After an upgrade, `dots installed` provides the official read-only report for
+what Installation Metadata currently records. It keeps the authoritative
+Installed Selection, any non-authoritative Selection Migration Candidate, and
+historical Profile/Tag coverage, Managed Entries, Provisioner runs, and Source
+of Truth provenance separate.

--- a/internal/cli/deps.go
+++ b/internal/cli/deps.go
@@ -238,19 +238,20 @@ func loadDepsManifest(cmd *cobra.Command, file, home string) (*manifest.Manifest
 }
 
 func resolveDepsReadOnlySelection(m manifest.Manifest, home string, profiles, extraTags []string) (selection.Effective, error) {
-	var recorded *state.InstalledSelection
-	if len(profiles) == 0 && len(extraTags) == 0 {
-		paths, err := resolvePaths(home, "", "")
-		if err != nil {
-			return selection.Effective{}, err
-		}
-		meta, err := loadInstallationMetadata(paths, "")
-		if err != nil {
-			return selection.Effective{}, err
-		}
-		recorded = meta.InstalledSelection
+	if len(profiles) > 0 || len(extraTags) > 0 {
+		return selection.ResolveReadOnly(m, profiles, extraTags, nil)
 	}
-	return selection.ResolveReadOnly(m, profiles, extraTags, recorded)
+	paths, err := resolvePaths(home, "", "")
+	if err != nil {
+		return selection.Effective{}, err
+	}
+	meta, err := loadInstallationMetadata(paths, "")
+	if err != nil {
+		return selection.Effective{}, err
+	}
+	return resolveReadOnlySelection(m, meta, profiles, extraTags, readOnlySelectionOptions{
+		Home: paths.Home, SourceRoot: paths.SourceRoot, StatePath: state.Path(paths.StateRoot),
+	})
 }
 
 func runDepsInstall(cmd *cobra.Command, m manifest.Manifest, options deps.Options, tier deps.Tier) error {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -6,7 +6,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/yersonargotev/dots/internal/doctor"
 	"github.com/yersonargotev/dots/internal/plan"
-	"github.com/yersonargotev/dots/internal/selection"
 	"github.com/yersonargotev/dots/internal/state"
 )
 
@@ -52,7 +51,9 @@ func newDoctorCommand() *cobra.Command {
 				return err
 			}
 
-			effective, err := selection.ResolveReadOnly(*m, profiles, extraTags, meta.InstalledSelection)
+			effective, err := resolveReadOnlySelection(*m, meta, profiles, extraTags, readOnlySelectionOptions{
+				Home: paths.Home, SourceRoot: paths.SourceRoot, StatePath: state.Path(paths.StateRoot),
+			})
 			if err != nil {
 				return err
 			}

--- a/internal/cli/installed.go
+++ b/internal/cli/installed.go
@@ -8,8 +8,16 @@ import (
 
 	"github.com/spf13/cobra"
 	inst "github.com/yersonargotev/dots/internal/installed"
+	"github.com/yersonargotev/dots/internal/selectionmigration"
 	"github.com/yersonargotev/dots/internal/state"
 )
+
+type installedReport struct {
+	inst.Report
+	SelectionMigration *selectionMigrationCandidate `json:"selection_migration,omitempty"`
+}
+
+func (r installedReport) HasFindings() bool { return false }
 
 func newInstalledCommand() *cobra.Command {
 	var (
@@ -49,8 +57,19 @@ func newInstalledCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return renderOrEmit(cmd, report, func() error {
+			analysis, err := selectionmigration.Analyze(*m, meta, selectionmigration.Options{
+				OS: runtime.GOOS, Home: paths.Home, SourceRoot: paths.SourceRoot, StatePath: state.Path(paths.StateRoot),
+			})
+			if err != nil {
+				return err
+			}
+			fullReport := installedReport{Report: report}
+			if analysis.Required {
+				fullReport.SelectionMigration = migrationCandidate(analysis.Candidate)
+			}
+			return renderOrEmit(cmd, fullReport, func() error {
 				renderInstalled(cmd.OutOrStdout(), report)
+				renderSelectionMigration(cmd.OutOrStdout(), fullReport.SelectionMigration)
 				return nil
 			})
 		},
@@ -61,6 +80,22 @@ func newInstalledCommand() *cobra.Command {
 	cmd.Flags().StringVar(&home, "home", "", "home directory for resolving manifest targets (default: the current user's home); use a sandbox path for validation")
 	cmd.Flags().StringVar(&stateRoot, "state-root", "", "state directory for Installation Metadata (default ~/.local/state/dots)")
 	return cmd
+}
+
+func renderSelectionMigration(w io.Writer, candidate *selectionMigrationCandidate) {
+	if candidate == nil {
+		return
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Selection migration candidate (non-authoritative)")
+	fmt.Fprintf(w, "  Profiles: %s\n", renderListOrNone(candidate.Profiles))
+	fmt.Fprintf(w, "  Extra Tags: %s\n", renderListOrNone(candidate.ExtraTags))
+	fmt.Fprintf(w, "  Effective Tags: %s\n", renderListOrNone(candidate.EffectiveTags))
+	fmt.Fprintf(w, "  Confidence: %s\n", candidate.Confidence)
+	fmt.Fprintf(w, "  Ambiguity Reasons: %s\n", renderListOrNone(candidate.AmbiguityReasons))
+	if candidate.RecommendedCommand != "" {
+		fmt.Fprintf(w, "  Recommended Command: %s\n", candidate.RecommendedCommand)
+	}
 }
 
 func renderInstalled(w io.Writer, report inst.Report) {

--- a/internal/cli/installed.go
+++ b/internal/cli/installed.go
@@ -14,7 +14,7 @@ import (
 
 type installedReport struct {
 	inst.Report
-	SelectionMigration *selectionMigrationCandidate `json:"selection_migration,omitempty"`
+	SelectionMigration *selectionmigration.Candidate `json:"selection_migration,omitempty"`
 }
 
 func (r installedReport) HasFindings() bool { return false }
@@ -65,7 +65,7 @@ func newInstalledCommand() *cobra.Command {
 			}
 			fullReport := installedReport{Report: report}
 			if analysis.Required {
-				fullReport.SelectionMigration = migrationCandidate(analysis.Candidate)
+				fullReport.SelectionMigration = analysis.Candidate
 			}
 			return renderOrEmit(cmd, fullReport, func() error {
 				renderInstalled(cmd.OutOrStdout(), report)
@@ -82,7 +82,7 @@ func newInstalledCommand() *cobra.Command {
 	return cmd
 }
 
-func renderSelectionMigration(w io.Writer, candidate *selectionMigrationCandidate) {
+func renderSelectionMigration(w io.Writer, candidate *selectionmigration.Candidate) {
 	if candidate == nil {
 		return
 	}
@@ -92,7 +92,7 @@ func renderSelectionMigration(w io.Writer, candidate *selectionMigrationCandidat
 	fmt.Fprintf(w, "  Extra Tags: %s\n", renderListOrNone(candidate.ExtraTags))
 	fmt.Fprintf(w, "  Effective Tags: %s\n", renderListOrNone(candidate.EffectiveTags))
 	fmt.Fprintf(w, "  Confidence: %s\n", candidate.Confidence)
-	fmt.Fprintf(w, "  Ambiguity Reasons: %s\n", renderListOrNone(candidate.AmbiguityReasons))
+	fmt.Fprintf(w, "  Ambiguity Reasons: %s\n", renderListOrNone(candidate.AmbiguityReasonStrings()))
 	if candidate.RecommendedCommand != "" {
 		fmt.Fprintf(w, "  Recommended Command: %s\n", candidate.RecommendedCommand)
 	}

--- a/internal/cli/installed_test.go
+++ b/internal/cli/installed_test.go
@@ -39,7 +39,7 @@ func TestInstalledJSONEnvelope(t *testing.T) {
 		t.Fatalf("status = %q, want ok", env.Status)
 	}
 	data := string(env.Data)
-	for _, want := range []string{`"managed_entries"`, `"tags"`, `"profiles"`, `"provenance"`, `"source_revision": "abc123"`, `"profiles_source": "recorded"`} {
+	for _, want := range []string{`"managed_entries"`, `"tags"`, `"profiles"`, `"provenance"`, `"source_revision": "abc123"`, `"profiles_source": "recorded"`, `"selection_migration"`, `"ambiguity_reasons"`} {
 		if !strings.Contains(data, want) {
 			t.Fatalf("installed JSON missing %s\ndata:\n%s", want, data)
 		}
@@ -70,7 +70,7 @@ func TestInstalledTextExplainsPartialProfile(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit code = %d, want 0\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
 	}
-	for _, want := range []string{"Installed inventory", "Installed Selection: none recorded", "Historical inventory (non-authoritative)", "Managed Entries (1)", "Tags represented: core", "Profiles", "Notes", "inferred-from-manifest"} {
+	for _, want := range []string{"Installed inventory", "Installed Selection: none recorded", "Historical inventory (non-authoritative)", "Managed Entries (1)", "Tags represented: core", "Profiles", "Notes", "inferred-from-manifest", "Selection migration candidate (non-authoritative)", "Confidence:"} {
 		if !strings.Contains(out.String(), want) {
 			t.Fatalf("text output missing %q\noutput:\n%s", want, out.String())
 		}

--- a/internal/cli/output_golden_test.go
+++ b/internal/cli/output_golden_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/provision"
 	"github.com/yersonargotev/dots/internal/selection"
+	"github.com/yersonargotev/dots/internal/selectionmigration"
 	"github.com/yersonargotev/dots/internal/state"
 	"github.com/yersonargotev/dots/internal/status"
 	"github.com/yersonargotev/dots/internal/upgrade"
@@ -121,19 +122,19 @@ func TestEnvelopeGolden(t *testing.T) {
 				Status:        statusError,
 				Data: selectionMigrationErrorData{
 					Code: selectionMigrationRequiredCode,
-					Candidate: &selectionMigrationCandidate{
+					Candidate: &selectionmigration.Candidate{
 						Profiles:           []string{"core"},
 						ExtraTags:          []string{"adaptive-theme"},
 						EffectiveTags:      []string{"core", "adaptive-theme"},
-						Confidence:         "high",
-						AmbiguityReasons:   []string{},
+						Confidence:         selectionmigration.ConfidenceHigh,
+						AmbiguityReasons:   []selectionmigration.AmbiguityReason{},
 						RecommendedCommand: "dots install --profile core --tag adaptive-theme",
 					},
 					Remediation: selectionMigrationRemediation{
 						RecommendedCommand: "dots install --profile core --tag adaptive-theme",
 					},
 				},
-				Error: "selection-migration-required: Installation Metadata predates authoritative Installed Selection; choose an explicit selection",
+				Error: "selection-migration-required: Installation Metadata predates authoritative Installed Selection; run dots install --profile core --tag adaptive-theme",
 			},
 			golden: "envelope_selection_migration_required.golden",
 		},

--- a/internal/cli/output_golden_test.go
+++ b/internal/cli/output_golden_test.go
@@ -114,6 +114,30 @@ func TestEnvelopeGolden(t *testing.T) {
 			golden: "envelope_installed.golden",
 		},
 		{
+			name: "selection migration required",
+			env: envelope{
+				SchemaVersion: schemaVersion,
+				Command:       "status",
+				Status:        statusError,
+				Data: selectionMigrationErrorData{
+					Code: selectionMigrationRequiredCode,
+					Candidate: &selectionMigrationCandidate{
+						Profiles:           []string{"core"},
+						ExtraTags:          []string{"adaptive-theme"},
+						EffectiveTags:      []string{"core", "adaptive-theme"},
+						Confidence:         "high",
+						AmbiguityReasons:   []string{},
+						RecommendedCommand: "dots install --profile core --tag adaptive-theme",
+					},
+					Remediation: selectionMigrationRemediation{
+						RecommendedCommand: "dots install --profile core --tag adaptive-theme",
+					},
+				},
+				Error: "selection-migration-required: Installation Metadata predates authoritative Installed Selection; choose an explicit selection",
+			},
+			golden: "envelope_selection_migration_required.golden",
+		},
+		{
 			name: "plan",
 			env: envelope{
 				SchemaVersion: schemaVersion,

--- a/internal/cli/plan.go
+++ b/internal/cli/plan.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/yersonargotev/dots/internal/plan"
-	"github.com/yersonargotev/dots/internal/selection"
+	"github.com/yersonargotev/dots/internal/state"
 )
 
 func newPlanCommand() *cobra.Command {
@@ -41,7 +41,9 @@ func newPlanCommand() *cobra.Command {
 				return err
 			}
 
-			effective, err := selection.ResolveReadOnly(*m, profiles, extraTags, meta.InstalledSelection)
+			effective, err := resolveReadOnlySelection(*m, meta, profiles, extraTags, readOnlySelectionOptions{
+				Home: paths.Home, SourceRoot: paths.SourceRoot, StatePath: state.Path(paths.StateRoot),
+			})
 			if err != nil {
 				return err
 			}

--- a/internal/cli/selection_migration.go
+++ b/internal/cli/selection_migration.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"runtime"
+	"strings"
 
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/selection"
@@ -12,31 +13,29 @@ import (
 
 const selectionMigrationRequiredCode = "selection-migration-required"
 
-type selectionMigrationCandidate struct {
-	Profiles           []string `json:"profiles"`
-	ExtraTags          []string `json:"extra_tags"`
-	EffectiveTags      []string `json:"effective_tags"`
-	Confidence         string   `json:"confidence"`
-	AmbiguityReasons   []string `json:"ambiguity_reasons"`
-	RecommendedCommand string   `json:"recommended_command,omitempty"`
-}
-
 type selectionMigrationRemediation struct {
 	RecommendedCommand string `json:"recommended_command,omitempty"`
 }
 
 type selectionMigrationErrorData struct {
 	Code        string                        `json:"code"`
-	Candidate   *selectionMigrationCandidate  `json:"candidate"`
+	Candidate   *selectionmigration.Candidate `json:"candidate"`
 	Remediation selectionMigrationRemediation `json:"remediation"`
 }
 
 type selectionMigrationRequiredError struct {
-	candidate *selectionMigrationCandidate
+	candidate *selectionmigration.Candidate
 }
 
 func (e *selectionMigrationRequiredError) Error() string {
-	return fmt.Sprintf("%s: Installation Metadata predates authoritative Installed Selection; choose an explicit selection", selectionMigrationRequiredCode)
+	message := fmt.Sprintf("%s: Installation Metadata predates authoritative Installed Selection", selectionMigrationRequiredCode)
+	if e.candidate != nil && e.candidate.RecommendedCommand != "" {
+		return message + "; run " + e.candidate.RecommendedCommand
+	}
+	if e.candidate != nil && len(e.candidate.AmbiguityReasons) > 0 {
+		message += "; candidate ambiguity: " + strings.Join(e.candidate.AmbiguityReasonStrings(), ", ")
+	}
+	return message + "; inspect `dots installed`, then provide the complete selection with repeated --profile and --tag flags"
 }
 
 func (e *selectionMigrationRequiredError) JSONErrorData() any {
@@ -80,20 +79,6 @@ func resolveReadOnlySelection(m manifest.Manifest, meta state.Metadata, profiles
 		return selection.Effective{}, err
 	}
 	return selection.Effective{}, &selectionMigrationRequiredError{
-		candidate: migrationCandidate(analysis.Candidate),
-	}
-}
-
-func migrationCandidate(candidate *selectionmigration.Candidate) *selectionMigrationCandidate {
-	if candidate == nil {
-		return nil
-	}
-	return &selectionMigrationCandidate{
-		Profiles:           append([]string{}, candidate.Profiles...),
-		ExtraTags:          append([]string{}, candidate.ExtraTags...),
-		EffectiveTags:      append([]string{}, candidate.EffectiveTags...),
-		Confidence:         candidate.Confidence,
-		AmbiguityReasons:   append([]string{}, candidate.AmbiguityReasons...),
-		RecommendedCommand: candidate.RecommendedCommand,
+		candidate: analysis.Candidate,
 	}
 }

--- a/internal/cli/selection_migration.go
+++ b/internal/cli/selection_migration.go
@@ -1,0 +1,99 @@
+package cli
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/selection"
+	"github.com/yersonargotev/dots/internal/selectionmigration"
+	"github.com/yersonargotev/dots/internal/state"
+)
+
+const selectionMigrationRequiredCode = "selection-migration-required"
+
+type selectionMigrationCandidate struct {
+	Profiles           []string `json:"profiles"`
+	ExtraTags          []string `json:"extra_tags"`
+	EffectiveTags      []string `json:"effective_tags"`
+	Confidence         string   `json:"confidence"`
+	AmbiguityReasons   []string `json:"ambiguity_reasons"`
+	RecommendedCommand string   `json:"recommended_command,omitempty"`
+}
+
+type selectionMigrationRemediation struct {
+	RecommendedCommand string `json:"recommended_command,omitempty"`
+}
+
+type selectionMigrationErrorData struct {
+	Code        string                        `json:"code"`
+	Candidate   *selectionMigrationCandidate  `json:"candidate"`
+	Remediation selectionMigrationRemediation `json:"remediation"`
+}
+
+type selectionMigrationRequiredError struct {
+	candidate *selectionMigrationCandidate
+}
+
+func (e *selectionMigrationRequiredError) Error() string {
+	return fmt.Sprintf("%s: Installation Metadata predates authoritative Installed Selection; choose an explicit selection", selectionMigrationRequiredCode)
+}
+
+func (e *selectionMigrationRequiredError) JSONErrorData() any {
+	command := ""
+	if e.candidate != nil {
+		command = e.candidate.RecommendedCommand
+	}
+	return selectionMigrationErrorData{
+		Code:      selectionMigrationRequiredCode,
+		Candidate: e.candidate,
+		Remediation: selectionMigrationRemediation{
+			RecommendedCommand: command,
+		},
+	}
+}
+
+type readOnlySelectionOptions struct {
+	Home       string
+	SourceRoot string
+	StatePath  string
+}
+
+func resolveReadOnlySelection(m manifest.Manifest, meta state.Metadata, profiles, extraTags []string, opts readOnlySelectionOptions) (selection.Effective, error) {
+	// Explicit intent and an authoritative Installed Selection retain the
+	// existing resolution path. In particular, malformed explicit values must
+	// still be reported by selection.ResolveReadOnly.
+	if len(profiles) > 0 || len(extraTags) > 0 || meta.InstalledSelection != nil {
+		return selection.ResolveReadOnly(m, profiles, extraTags, meta.InstalledSelection)
+	}
+	if meta.Version != 1 && meta.Version != 2 {
+		return selection.ResolveReadOnly(m, profiles, extraTags, nil)
+	}
+
+	analysis, err := selectionmigration.Analyze(m, meta, selectionmigration.Options{
+		OS:         runtime.GOOS,
+		Home:       opts.Home,
+		SourceRoot: opts.SourceRoot,
+		StatePath:  opts.StatePath,
+	})
+	if err != nil {
+		return selection.Effective{}, err
+	}
+	return selection.Effective{}, &selectionMigrationRequiredError{
+		candidate: migrationCandidate(analysis.Candidate),
+	}
+}
+
+func migrationCandidate(candidate *selectionmigration.Candidate) *selectionMigrationCandidate {
+	if candidate == nil {
+		return nil
+	}
+	return &selectionMigrationCandidate{
+		Profiles:           append([]string{}, candidate.Profiles...),
+		ExtraTags:          append([]string{}, candidate.ExtraTags...),
+		EffectiveTags:      append([]string{}, candidate.EffectiveTags...),
+		Confidence:         candidate.Confidence,
+		AmbiguityReasons:   append([]string{}, candidate.AmbiguityReasons...),
+		RecommendedCommand: candidate.RecommendedCommand,
+	}
+}

--- a/internal/cli/selection_migration_golden_test.go
+++ b/internal/cli/selection_migration_golden_test.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/selectionmigration"
+)
+
+func TestSelectionMigrationTextGolden(t *testing.T) {
+	candidate := selectionmigration.Candidate{
+		Profiles:           []string{"core"},
+		ExtraTags:          []string{"adaptive-theme"},
+		EffectiveTags:      []string{"core", "adaptive-theme"},
+		Confidence:         selectionmigration.ConfidenceHigh,
+		AmbiguityReasons:   []selectionmigration.AmbiguityReason{},
+		RecommendedCommand: "dots install --profile core --tag adaptive-theme",
+	}
+	var out bytes.Buffer
+	renderMigrationCandidate(&out, candidate)
+
+	cmd := NewRootCommand()
+	cmd.SetIn(strings.NewReader("no\n"))
+	cmd.SetOut(&out)
+	confirmed, err := confirmSelectionMigration(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if confirmed {
+		t.Fatal("declined migration was confirmed")
+	}
+	fmt.Fprintln(&out)
+	fmt.Fprintln(&out, "Non-interactive error:")
+	fmt.Fprintln(&out, "Error:", (&selectionMigrationRequiredError{candidate: &candidate}).Error())
+
+	assertGolden(t, "selection_migration_text.golden", out.Bytes())
+}

--- a/internal/cli/selection_migration_test.go
+++ b/internal/cli/selection_migration_test.go
@@ -1,0 +1,73 @@
+package cli_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/cli"
+	"github.com/yersonargotev/dots/internal/state"
+)
+
+func TestLegacyMetadataBlocksReadOnlyCommandsWithMigrationCandidate(t *testing.T) {
+	home := t.TempDir()
+	manifestPath, sourceRoot := writeStatusManifest(t, home, "core")
+	stateRoot := filepath.Join(home, ".local", "state", "dots")
+	if err := state.Save(state.Path(stateRoot), state.Metadata{
+		Version: 1,
+		Entries: []state.Record{{
+			Target: filepath.Join(home, ".zshrc"), Source: "configs/zsh/zshrc",
+			Strategy: "symlink", Profiles: []string{"default"}, Tags: []string{"core"},
+		}},
+	}); err != nil {
+		t.Fatalf("save metadata: %v", err)
+	}
+
+	commands := []struct {
+		name string
+		args []string
+	}{
+		{"status", []string{"status", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot}},
+		{"doctor", []string{"doctor", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot}},
+		{"plan", []string{"plan", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot}},
+		{"deps check", []string{"deps", "check", "--file", manifestPath, "--home", home}},
+		{"deps plan", []string{"deps", "plan", "--file", manifestPath, "--home", home, "--tier", "generic"}},
+	}
+	for _, tt := range commands {
+		t.Run(tt.name, func(t *testing.T) {
+			args := append(append([]string{}, tt.args...), "--output", "json")
+			var stdout, stderr bytes.Buffer
+			if code := cli.Run(args, &stdout, &stderr); code != 1 {
+				t.Fatalf("exit code = %d, want 1\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+			}
+			env := decodeEnvelopeForCommand(t, stdout.String(), tt.name)
+			if env.Status != "error" || !strings.Contains(env.Error, "selection-migration-required") {
+				t.Fatalf("envelope = status %q error %q", env.Status, env.Error)
+			}
+			var data struct {
+				Code      string `json:"code"`
+				Candidate struct {
+					Profiles         []string `json:"profiles"`
+					ExtraTags        []string `json:"extra_tags"`
+					EffectiveTags    []string `json:"effective_tags"`
+					AmbiguityReasons []string `json:"ambiguity_reasons"`
+				} `json:"candidate"`
+				Remediation json.RawMessage `json:"remediation"`
+			}
+			if err := json.Unmarshal(env.Data, &data); err != nil {
+				t.Fatalf("decode migration data: %v\ndata:\n%s", err, env.Data)
+			}
+			if data.Code != "selection-migration-required" {
+				t.Fatalf("code = %q", data.Code)
+			}
+			if data.Candidate.Profiles == nil || data.Candidate.ExtraTags == nil || data.Candidate.EffectiveTags == nil || data.Candidate.AmbiguityReasons == nil {
+				t.Fatalf("candidate arrays must be stable empty arrays: %#v", data.Candidate)
+			}
+			if data.Remediation == nil {
+				t.Fatal("remediation missing")
+			}
+		})
+	}
+}

--- a/internal/cli/selection_migration_test.go
+++ b/internal/cli/selection_migration_test.go
@@ -3,7 +3,9 @@ package cli_test
 import (
 	"bytes"
 	"encoding/json"
+	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -70,4 +72,88 @@ func TestLegacyMetadataBlocksReadOnlyCommandsWithMigrationCandidate(t *testing.T
 			}
 		})
 	}
+}
+
+func TestLegacyMigrationAmbiguousAndNoEvidenceStayNonAuthoritative(t *testing.T) {
+	tests := []struct {
+		name       string
+		setup      func(*testing.T, string, string, string) state.Metadata
+		wantReason string
+	}{
+		{
+			name: "ambiguous profile coverage",
+			setup: func(t *testing.T, home, manifestPath, sourceRoot string) state.Metadata {
+				content, err := os.ReadFile(manifestPath)
+				if err != nil {
+					t.Fatal(err)
+				}
+				content = []byte(strings.Replace(string(content), "profiles:\n  default:", "profiles:\n  alternate:\n    tags: [core]\n  default:", 1))
+				if err := os.WriteFile(manifestPath, content, 0o600); err != nil {
+					t.Fatal(err)
+				}
+				target := filepath.Join(home, ".zshrc")
+				if err := os.Symlink(filepath.Join(sourceRoot, "configs/zsh/zshrc"), target); err != nil {
+					t.Fatal(err)
+				}
+				return state.Metadata{Version: 2, Entries: []state.Record{{
+					Target: target, Source: "configs/zsh/zshrc", Strategy: "symlink", Tags: []string{"core"},
+				}}}
+			},
+			wantReason: "multiple_complete_profiles",
+		},
+		{
+			name:       "no historical evidence",
+			setup:      func(*testing.T, string, string, string) state.Metadata { return state.Metadata{Version: 2} },
+			wantReason: "no_historical_evidence",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			manifestPath, sourceRoot := writeStatusManifest(t, home, "core")
+			stateRoot := filepath.Join(home, ".local", "state", "dots")
+			before := tt.setup(t, home, manifestPath, sourceRoot)
+			if err := state.Save(state.Path(stateRoot), before); err != nil {
+				t.Fatal(err)
+			}
+
+			var stdout, stderr bytes.Buffer
+			code := cli.Run([]string{
+				"status", "--output", "json", "--file", manifestPath,
+				"--home", home, "--source-root", sourceRoot, "--state-root", stateRoot,
+			}, &stdout, &stderr)
+			if code != cli.ExitError {
+				t.Fatalf("exit code = %d, want %d\nstdout:\n%s\nstderr:\n%s", code, cli.ExitError, stdout.String(), stderr.String())
+			}
+			env := decodeEnvelopeForCommand(t, stdout.String(), "status")
+			var data struct {
+				Candidate struct {
+					AmbiguityReasons []string `json:"ambiguity_reasons"`
+				} `json:"candidate"`
+			}
+			if err := json.Unmarshal(env.Data, &data); err != nil {
+				t.Fatalf("decode migration data: %v\n%s", err, env.Data)
+			}
+			if !containsString(data.Candidate.AmbiguityReasons, tt.wantReason) {
+				t.Fatalf("ambiguity reasons = %#v, want %q", data.Candidate.AmbiguityReasons, tt.wantReason)
+			}
+			after, err := state.Load(state.Path(stateRoot))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if after.Version != 2 || after.InstalledSelection != nil || !reflect.DeepEqual(after.Entries, before.Entries) {
+				t.Fatalf("read-only migration changed metadata: %#v", after)
+			}
+		})
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -6,7 +6,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/provision"
-	"github.com/yersonargotev/dots/internal/selection"
 	"github.com/yersonargotev/dots/internal/state"
 	"github.com/yersonargotev/dots/internal/status"
 )
@@ -53,7 +52,9 @@ func newStatusCommand() *cobra.Command {
 				return err
 			}
 
-			effective, err := selection.ResolveReadOnly(*m, profiles, extraTags, meta.InstalledSelection)
+			effective, err := resolveReadOnlySelection(*m, meta, profiles, extraTags, readOnlySelectionOptions{
+				Home: paths.Home, SourceRoot: paths.SourceRoot, StatePath: state.Path(paths.StateRoot),
+			})
 			if err != nil {
 				return err
 			}

--- a/internal/cli/testdata/envelope_selection_migration_required.golden
+++ b/internal/cli/testdata/envelope_selection_migration_required.golden
@@ -23,5 +23,5 @@
       "recommended_command": "dots install --profile core --tag adaptive-theme"
     }
   },
-  "error": "selection-migration-required: Installation Metadata predates authoritative Installed Selection; choose an explicit selection"
+  "error": "selection-migration-required: Installation Metadata predates authoritative Installed Selection; run dots install --profile core --tag adaptive-theme"
 }

--- a/internal/cli/testdata/envelope_selection_migration_required.golden
+++ b/internal/cli/testdata/envelope_selection_migration_required.golden
@@ -1,0 +1,27 @@
+{
+  "schema_version": "5",
+  "command": "status",
+  "status": "error",
+  "data": {
+    "code": "selection-migration-required",
+    "candidate": {
+      "profiles": [
+        "core"
+      ],
+      "extra_tags": [
+        "adaptive-theme"
+      ],
+      "effective_tags": [
+        "core",
+        "adaptive-theme"
+      ],
+      "confidence": "high",
+      "ambiguity_reasons": [],
+      "recommended_command": "dots install --profile core --tag adaptive-theme"
+    },
+    "remediation": {
+      "recommended_command": "dots install --profile core --tag adaptive-theme"
+    }
+  },
+  "error": "selection-migration-required: Installation Metadata predates authoritative Installed Selection; choose an explicit selection"
+}

--- a/internal/cli/testdata/selection_migration_text.golden
+++ b/internal/cli/testdata/selection_migration_text.golden
@@ -1,0 +1,6 @@
+Legacy Installation Metadata requires an authoritative Installed Selection.
+Migration candidate: profiles=core extra-tags=adaptive-theme effective-tags=core,adaptive-theme confidence=high
+Explicit alternative: dots install --profile core --tag adaptive-theme
+Confirm this migration candidate before update/upgrade? [y/N] 
+Non-interactive error:
+Error: selection-migration-required: Installation Metadata predates authoritative Installed Selection; run dots install --profile core --tag adaptive-theme

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -131,7 +131,7 @@ func renderUpdate(out io.Writer, upd gitrepo.Update, dryRun bool) {
 	fmt.Fprintln(out)
 }
 
-func resolveUpdateSelection(manifestPath string, paths resolvedPaths, opts updateOptions) (*manifest.Manifest, selection.Effective, error) {
+func resolveUpdateSelection(cmd *cobra.Command, manifestPath string, paths resolvedPaths, opts updateOptions) (*manifest.Manifest, selection.Effective, error) {
 	m, err := manifest.LoadFile(manifestPath)
 	if err != nil {
 		return nil, selection.Effective{}, err
@@ -143,6 +143,10 @@ func resolveUpdateSelection(manifestPath string, paths resolvedPaths, opts updat
 	meta, err := loadInstallationMetadata(paths, opts.stateRoot)
 	if err != nil {
 		return nil, selection.Effective{}, err
+	}
+	if len(opts.profiles) == 0 && len(opts.extraTags) == 0 && meta.InstalledSelection == nil && (meta.Version == 1 || meta.Version == 2) {
+		effective, err := resolveLegacyUpdateSelection(cmd, *m, meta, paths, opts)
+		return m, effective, err
 	}
 	effective, err := selection.ResolveEffective(*m, opts.profiles, opts.extraTags, meta.InstalledSelection)
 	return m, effective, err
@@ -160,7 +164,7 @@ func runUpdateWorkflow(cmd *cobra.Command, opts updateOptions, emit bool) (updat
 	if !cmd.Flags().Changed("file") {
 		manifestPath = filepath.Join(paths.SourceRoot, opts.file)
 	}
-	previousManifest, effective, err := resolveUpdateSelection(manifestPath, paths, opts)
+	previousManifest, effective, err := resolveUpdateSelection(cmd, manifestPath, paths, opts)
 	if err != nil {
 		return updateReport{}, err
 	}

--- a/internal/cli/update_migration.go
+++ b/internal/cli/update_migration.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/selection"
+	"github.com/yersonargotev/dots/internal/selectionmigration"
+	"github.com/yersonargotev/dots/internal/state"
+)
+
+func resolveLegacyUpdateSelection(cmd *cobra.Command, m manifest.Manifest, meta state.Metadata, paths resolvedPaths, opts updateOptions) (selection.Effective, error) {
+	analysis, err := selectionmigration.Analyze(m, meta, selectionmigration.Options{
+		OS:         runtime.GOOS,
+		Home:       paths.Home,
+		SourceRoot: paths.SourceRoot,
+		StatePath:  state.Path(paths.StateRoot),
+	})
+	if err != nil {
+		return selection.Effective{}, err
+	}
+	required := &selectionMigrationRequiredError{candidate: migrationCandidate(analysis.Candidate)}
+	if analysis.Candidate == nil || !analysis.Candidate.Unambiguous() || opts.yes || opts.dryRun || wantsJSON(cmd) {
+		return selection.Effective{}, required
+	}
+
+	renderMigrationCandidate(cmd.OutOrStdout(), *analysis.Candidate)
+	confirmed, err := confirmSelectionMigration(cmd)
+	if err != nil {
+		return selection.Effective{}, err
+	}
+	if !confirmed {
+		return selection.Effective{}, required
+	}
+	return selection.ResolveIntent(m, selection.Intent{
+		Source:    selection.SourceMigration,
+		Profiles:  analysis.Candidate.Profiles,
+		ExtraTags: analysis.Candidate.ExtraTags,
+	})
+}
+
+func renderMigrationCandidate(w interface{ Write([]byte) (int, error) }, candidate selectionmigration.Candidate) {
+	fmt.Fprintln(w, "Legacy Installation Metadata requires an authoritative Installed Selection.")
+	fmt.Fprintf(w, "Migration candidate: profiles=%s extra-tags=%s effective-tags=%s confidence=%s\n",
+		renderSelectionValues(candidate.Profiles), renderSelectionValues(candidate.ExtraTags),
+		renderSelectionValues(candidate.EffectiveTags), candidate.Confidence)
+	if candidate.RecommendedCommand != "" {
+		fmt.Fprintf(w, "Explicit alternative: %s\n", candidate.RecommendedCommand)
+	}
+}
+
+func confirmSelectionMigration(cmd *cobra.Command) (bool, error) {
+	fmt.Fprint(cmd.OutOrStdout(), "Confirm this migration candidate before update/upgrade? [y/N] ")
+	scanner := bufio.NewScanner(cmd.InOrStdin())
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+	switch strings.ToLower(strings.TrimSpace(scanner.Text())) {
+	case "y", "yes":
+		return true, nil
+	default:
+		return false, nil
+	}
+}

--- a/internal/cli/update_migration.go
+++ b/internal/cli/update_migration.go
@@ -24,7 +24,7 @@ func resolveLegacyUpdateSelection(cmd *cobra.Command, m manifest.Manifest, meta 
 	if err != nil {
 		return selection.Effective{}, err
 	}
-	required := &selectionMigrationRequiredError{candidate: migrationCandidate(analysis.Candidate)}
+	required := &selectionMigrationRequiredError{candidate: analysis.Candidate}
 	if analysis.Candidate == nil || !analysis.Candidate.Unambiguous() || opts.yes || opts.dryRun || wantsJSON(cmd) {
 		return selection.Effective{}, required
 	}

--- a/internal/cli/update_migration_test.go
+++ b/internal/cli/update_migration_test.go
@@ -1,0 +1,151 @@
+package cli_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/cli"
+	"github.com/yersonargotev/dots/internal/state"
+)
+
+func TestUpdateConfirmsUnambiguousLegacySelectionBeforeRecording(t *testing.T) {
+	requireGitCLI(t)
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	_, sourceRoot := newInstalledRepo(t, map[string]string{
+		"configs/core": "core\n",
+		"dots.yaml": `version: 1
+profiles:
+  core:
+    tags: [core]
+entries:
+  - source: configs/core
+    target: ~/.core
+    strategy: symlink
+    tags: [core]
+`,
+	})
+	target := filepath.Join(home, ".core")
+	if err := os.Symlink(filepath.Join(sourceRoot, "configs/core"), target); err != nil {
+		t.Fatalf("seed managed target: %v", err)
+	}
+	legacy := state.Metadata{
+		Version: 2,
+		Entries: []state.Record{{
+			Target: target, Source: "configs/core", Strategy: "symlink",
+			Profiles: []string{"core"}, Tags: []string{"core"},
+		}},
+	}
+	if err := state.Save(state.Path(stateRoot), legacy); err != nil {
+		t.Fatalf("save legacy metadata: %v", err)
+	}
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetIn(strings.NewReader("yes\n"))
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"update", "--file", filepath.Join(sourceRoot, "dots.yaml"),
+		"--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("update: %v\n%s", err, out.String())
+	}
+	for _, want := range []string{
+		"Migration candidate: profiles=core extra-tags=(none) effective-tags=core confidence=high",
+		"Confirm this migration candidate before update/upgrade? [y/N]",
+		"Selection: source=migration profiles=core",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output missing %q:\n%s", want, out.String())
+		}
+	}
+
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load migrated metadata: %v", err)
+	}
+	if meta.Version != state.CurrentVersion || meta.InstalledSelection == nil {
+		t.Fatalf("metadata was not migrated: %#v", meta)
+	}
+	if got, want := meta.InstalledSelection.Profiles, []string{"core"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Profiles = %#v, want %#v", got, want)
+	}
+	if len(meta.Entries) != 1 || meta.Entries[0].Target != target {
+		t.Fatalf("legacy inventory was not preserved: %#v", meta.Entries)
+	}
+}
+
+func TestUpdateNonInteractiveLegacySelectionReturnsStructuredMigrationError(t *testing.T) {
+	requireGitCLI(t)
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	origin, sourceRoot := newInstalledRepo(t, map[string]string{
+		"configs/core": "core\n",
+		"dots.yaml": `version: 1
+profiles:
+  core:
+    tags: [core]
+entries:
+  - source: configs/core
+    target: ~/.core
+    strategy: symlink
+    tags: [core]
+`,
+	})
+	target := filepath.Join(home, ".core")
+	if err := os.Symlink(filepath.Join(sourceRoot, "configs/core"), target); err != nil {
+		t.Fatalf("seed managed target: %v", err)
+	}
+	if err := state.Save(state.Path(stateRoot), state.Metadata{
+		Version: 2,
+		Entries: []state.Record{{
+			Target: target, Source: "configs/core", Strategy: "symlink",
+			Profiles: []string{"core"}, Tags: []string{"core"},
+		}},
+	}); err != nil {
+		t.Fatalf("save legacy metadata: %v", err)
+	}
+	oldHead := strings.TrimSpace(runGitOutput(t, sourceRoot, "rev-parse", "HEAD"))
+	advanceUpstream(t, origin, "incoming change", map[string]string{"incoming": "not applied\n"})
+
+	var out, errOut bytes.Buffer
+	code := cli.Run([]string{"update", "--yes", "--output", "json",
+		"--file", filepath.Join(sourceRoot, "dots.yaml"),
+		"--home", home, "--source-root", sourceRoot, "--state-root", stateRoot}, &out, &errOut)
+	if code != cli.ExitError {
+		t.Fatalf("exit code = %d, want %d\nstdout:\n%s\nstderr:\n%s", code, cli.ExitError, out.String(), errOut.String())
+	}
+	var envelope struct {
+		Status string `json:"status"`
+		Data   struct {
+			Code      string `json:"code"`
+			Candidate struct {
+				Profiles []string `json:"profiles"`
+			} `json:"candidate"`
+		} `json:"data"`
+	}
+	if jsonErr := json.Unmarshal(out.Bytes(), &envelope); jsonErr != nil {
+		t.Fatalf("decode JSON: %v\n%s", jsonErr, out.String())
+	}
+	if envelope.Status != "error" || envelope.Data.Code != "selection-migration-required" ||
+		!reflect.DeepEqual(envelope.Data.Candidate.Profiles, []string{"core"}) {
+		t.Fatalf("unexpected migration envelope: %#v", envelope)
+	}
+	if got := strings.TrimSpace(runGitOutput(t, sourceRoot, "rev-parse", "HEAD")); got != oldHead {
+		t.Fatalf("update mutated repository before explicit migration: HEAD=%s want=%s", got, oldHead)
+	}
+	meta, loadErr := state.Load(state.Path(stateRoot))
+	if loadErr != nil {
+		t.Fatalf("load metadata: %v", loadErr)
+	}
+	if meta.Version != 2 || meta.InstalledSelection != nil {
+		t.Fatalf("non-interactive migration mutated metadata: %#v", meta)
+	}
+}

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -170,7 +170,7 @@ func resolveUpgradeSelection(cmd *cobra.Command, opts updateOptions) (selection.
 	if !cmd.Flags().Changed("file") {
 		manifestPath = filepath.Join(paths.SourceRoot, opts.file)
 	}
-	_, effective, err := resolveUpdateSelection(manifestPath, paths, opts)
+	_, effective, err := resolveUpdateSelection(cmd, manifestPath, paths, opts)
 	return effective, err
 }
 

--- a/internal/cli/upgrade_continuation_test.go
+++ b/internal/cli/upgrade_continuation_test.go
@@ -147,6 +147,68 @@ func assertContinuationSelectionArgs(t *testing.T, args []string) {
 	}
 }
 
+func TestUpgradeRequiresExplicitLegacyMigrationBeforeBinaryMutation(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available on PATH")
+	}
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	_, sourceRoot := newContinuationRepo(t)
+	t.Setenv("HOME", t.TempDir())
+	target := filepath.Join(home, ".core")
+	if err := os.Symlink(filepath.Join(sourceRoot, "configs/core"), target); err != nil {
+		t.Fatalf("seed managed target: %v", err)
+	}
+	if err := state.Save(state.Path(stateRoot), state.Metadata{
+		Version: 2,
+		Entries: []state.Record{{
+			Target: target, Source: "configs/core", Strategy: "symlink",
+			Profiles: []string{"core"}, Tags: []string{"core"},
+		}},
+	}); err != nil {
+		t.Fatalf("save legacy metadata: %v", err)
+	}
+
+	originalExecutable := currentExecutable
+	originalPreview := previewUpgrade
+	originalExecute := executeUpgrade
+	t.Cleanup(func() {
+		currentExecutable = originalExecutable
+		previewUpgrade = originalPreview
+		executeUpgrade = originalExecute
+	})
+	currentExecutable = func() (string, error) { return "/tmp/fake-dots", nil }
+	plan := upgrade.Plan{Channel: upgrade.ChannelRelease, Action: upgrade.ActionReplaceBinary}
+	previewUpgrade = func(_ context.Context, _ upgrade.Options) (upgrade.Plan, error) { return plan, nil }
+	executed := false
+	executeUpgrade = func(_ context.Context, _ upgrade.Options) (upgrade.Plan, error) {
+		executed = true
+		return plan, nil
+	}
+
+	cmd := NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"upgrade", "--yes",
+		"--file", filepath.Join(sourceRoot, "dots.yaml"),
+		"--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), selectionMigrationRequiredCode) {
+		t.Fatalf("upgrade error = %v, want migration-required\n%s", err, out.String())
+	}
+	if executed {
+		t.Fatal("upgrade mutated the binary before explicit legacy migration")
+	}
+	meta, loadErr := state.Load(state.Path(stateRoot))
+	if loadErr != nil {
+		t.Fatalf("load metadata: %v", loadErr)
+	}
+	if meta.Version != 2 || meta.InstalledSelection != nil {
+		t.Fatalf("upgrade mutated legacy metadata: %#v", meta)
+	}
+}
+
 func newContinuationRepo(t *testing.T) (string, string) {
 	t.Helper()
 	origin := t.TempDir()

--- a/internal/cli/upgrade_internal_test.go
+++ b/internal/cli/upgrade_internal_test.go
@@ -26,3 +26,21 @@ func TestUpgradeContinuationArgsDoNotMarkDefaultFileChanged(t *testing.T) {
 		}
 	}
 }
+
+func TestUpgradeContinuationArgsPreserveConfirmedMigrationSource(t *testing.T) {
+	intent := selection.Intent{
+		Source:    selection.SourceMigration,
+		Profiles:  []string{"core"},
+		ExtraTags: []string{"adaptive-theme"},
+	}
+	got := upgradeContinuationArgs("dots.yaml", false, intent, "/src", "/home", "/state", false, false, false, upgrade.Plan{})
+	wantPrefix := []string{
+		"dots", "upgrade", "--continue",
+		"--selection-source", "migration",
+		"--selection-profile", "core",
+		"--selection-tag", "adaptive-theme",
+	}
+	if len(got) < len(wantPrefix) || !reflect.DeepEqual(got[:len(wantPrefix)], wantPrefix) {
+		t.Fatalf("args prefix = %#v, want %#v", got, wantPrefix)
+	}
+}

--- a/internal/selection/selection.go
+++ b/internal/selection/selection.go
@@ -14,8 +14,9 @@ import (
 type Source string
 
 const (
-	SourceExplicit Source = "explicit"
-	SourceRecorded Source = "recorded"
+	SourceExplicit  Source = "explicit"
+	SourceRecorded  Source = "recorded"
+	SourceMigration Source = "migration"
 )
 
 // ErrSelectionRequired means that neither invocation arguments nor Installation
@@ -113,9 +114,10 @@ func ResolveReadOnly(m manifest.Manifest, explicitProfiles, explicitTags []strin
 }
 
 // ResolveIntent re-resolves authoritative intent against the current Install
-// Manifest without changing whether its source was explicit or recorded.
+// Manifest without changing whether its source was explicit, recorded, or an
+// interactively confirmed migration candidate.
 func ResolveIntent(m manifest.Manifest, intent Intent) (Effective, error) {
-	if intent.Source != SourceExplicit && intent.Source != SourceRecorded {
+	if intent.Source != SourceExplicit && intent.Source != SourceRecorded && intent.Source != SourceMigration {
 		return Effective{}, fmt.Errorf("selection source %q is invalid", intent.Source)
 	}
 	if err := validateIntent(intent.Source, intent.Profiles, intent.ExtraTags); err != nil {

--- a/internal/selection/selection_test.go
+++ b/internal/selection/selection_test.go
@@ -361,6 +361,25 @@ func TestResolveReadOnlyClonesSlices(t *testing.T) {
 	}
 }
 
+func TestResolveIntentAcceptsConfirmedMigrationSource(t *testing.T) {
+	m := manifest.Manifest{
+		Profiles: map[string]manifest.Profile{
+			"core": {Tags: []string{"core"}},
+		},
+	}
+
+	effective, err := selection.ResolveIntent(m, selection.Intent{Source: selection.SourceMigration, Profiles: []string{"core"}, ExtraTags: []string{"extra"}})
+	if err != nil {
+		t.Fatalf("ResolveIntent: %v", err)
+	}
+	if got, want := effective.Report.Source, selection.SourceMigration; got != want {
+		t.Fatalf("Source = %q, want %q", got, want)
+	}
+	if got, want := effective.Report.EffectiveTags, []string{"core", "extra"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("EffectiveTags = %#v, want %#v", got, want)
+	}
+}
+
 func TestResolvePreservesExplicitSelectionIntent(t *testing.T) {
 	m := manifest.Manifest{Profiles: map[string]manifest.Profile{
 		"core":   {Tags: []string{"core", "shared"}},

--- a/internal/selectionmigration/migration.go
+++ b/internal/selectionmigration/migration.go
@@ -16,18 +16,38 @@ import (
 )
 
 const (
-	ConfidenceHigh   = "high"
-	ConfidenceMedium = "medium"
-	ConfidenceLow    = "low"
+	ConfidenceHigh   Confidence = "high"
+	ConfidenceMedium Confidence = "medium"
+	ConfidenceLow    Confidence = "low"
 )
 
+const (
+	ReasonConflictingRecordedProfiles AmbiguityReason = "conflicting_recorded_profiles"
+	ReasonConflictingRecordedTags     AmbiguityReason = "conflicting_recorded_tags"
+	ReasonMissingRecordedProfiles     AmbiguityReason = "missing_recorded_profiles"
+	ReasonMissingRecordedTags         AmbiguityReason = "missing_recorded_tags"
+	ReasonNoHistoricalEvidence        AmbiguityReason = "no_historical_evidence"
+	ReasonNoCompleteProfileCoverage   AmbiguityReason = "no_complete_profile_coverage"
+	ReasonMultipleCompleteProfiles    AmbiguityReason = "multiple_complete_profiles"
+	ReasonUnknownRecordedProfile      AmbiguityReason = "unknown_recorded_profile"
+	ReasonUnmatchedHistoricalRecord   AmbiguityReason = "unmatched_historical_record"
+	ReasonPartialProfileCoverage      AmbiguityReason = "partial_profile_coverage"
+	ReasonUnusableSelection           AmbiguityReason = "unusable_selection"
+	ReasonMissingTargetSourceEvidence AmbiguityReason = "missing_target_source_evidence"
+	ReasonTargetSourceMismatch        AmbiguityReason = "target_source_mismatch"
+)
+
+type Confidence string
+
+type AmbiguityReason string
+
 type Candidate struct {
-	Profiles           []string `json:"profiles"`
-	ExtraTags          []string `json:"extra_tags"`
-	EffectiveTags      []string `json:"effective_tags"`
-	Confidence         string   `json:"confidence"`
-	AmbiguityReasons   []string `json:"ambiguity_reasons"`
-	RecommendedCommand string   `json:"recommended_command,omitempty"`
+	Profiles           []string          `json:"profiles"`
+	ExtraTags          []string          `json:"extra_tags"`
+	EffectiveTags      []string          `json:"effective_tags"`
+	Confidence         Confidence        `json:"confidence"`
+	AmbiguityReasons   []AmbiguityReason `json:"ambiguity_reasons"`
+	RecommendedCommand string            `json:"recommended_command,omitempty"`
 }
 
 type Analysis struct {
@@ -44,6 +64,14 @@ type Options struct {
 
 func (c Candidate) Unambiguous() bool {
 	return len(c.AmbiguityReasons) == 0 && (len(c.Profiles) > 0 || len(c.ExtraTags) > 0)
+}
+
+func (c Candidate) AmbiguityReasonStrings() []string {
+	out := make([]string, len(c.AmbiguityReasons))
+	for i, reason := range c.AmbiguityReasons {
+		out[i] = string(reason)
+	}
+	return out
 }
 
 func (c Candidate) Effective(m manifest.Manifest) (manifest.Selection, error) {
@@ -69,7 +97,8 @@ func Analyze(m manifest.Manifest, meta state.Metadata, opts Options) (Analysis, 
 	represented := representedMatchedTags(report)
 	tagSets := recordedTagSets(meta)
 	candidateTags := represented
-	if len(tagSets) == 1 {
+	missingRecordedTags := len(tagSets) > 0 && hasMissingRecordedTags(meta)
+	if len(tagSets) == 1 && !missingRecordedTags {
 		candidateTags = newStringSet(tagSets[0])
 	}
 	addOverrideEvidence(m, meta, opts.OS, opts.Home, candidateTags)
@@ -81,11 +110,11 @@ func Analyze(m manifest.Manifest, meta state.Metadata, opts Options) (Analysis, 
 		profiles = append([]string(nil), profileSets[0]...)
 		confidence = ConfidenceHigh
 		if hasMissingRecordedProfiles(meta) {
-			reasons.add("missing_recorded_profiles")
+			reasons.add(ReasonMissingRecordedProfiles)
 		}
 	} else {
 		if len(profileSets) > 1 {
-			reasons.add("conflicting_recorded_profiles")
+			reasons.add(ReasonConflictingRecordedProfiles)
 		}
 		complete := completeProfiles(report)
 		switch len(complete) {
@@ -94,31 +123,34 @@ func Analyze(m manifest.Manifest, meta state.Metadata, opts Options) (Analysis, 
 			confidence = ConfidenceMedium
 		case 0:
 			if len(meta.Entries) == 0 && len(meta.Provisioners) == 0 {
-				reasons.add("no_historical_evidence")
+				reasons.add(ReasonNoHistoricalEvidence)
 			} else {
-				reasons.add("no_complete_profile_coverage")
+				reasons.add(ReasonNoCompleteProfileCoverage)
 			}
 		default:
-			reasons.add("multiple_complete_profiles")
+			reasons.add(ReasonMultipleCompleteProfiles)
 		}
 	}
 	if len(tagSets) > 1 {
-		reasons.add("conflicting_recorded_tags")
+		reasons.add(ReasonConflictingRecordedTags)
+	}
+	if missingRecordedTags {
+		reasons.add(ReasonMissingRecordedTags)
 	}
 
 	for _, p := range profiles {
 		if _, ok := m.Profiles[p]; !ok {
-			reasons.add("unknown_recorded_profile")
+			reasons.add(ReasonUnknownRecordedProfile)
 		}
 	}
 	for _, entry := range report.ManagedEntries {
 		if !entry.ManifestMatched {
-			reasons.add("unmatched_historical_record")
+			reasons.add(ReasonUnmatchedHistoricalRecord)
 		}
 	}
 	for _, prov := range report.Provisioners {
 		if !prov.ManifestMatched {
-			reasons.add("unmatched_historical_record")
+			reasons.add(ReasonUnmatchedHistoricalRecord)
 		}
 	}
 	for _, coverage := range report.Profiles {
@@ -126,7 +158,7 @@ func Analyze(m manifest.Manifest, meta state.Metadata, opts Options) (Analysis, 
 			continue
 		}
 		if len(profiles) == 0 || containsString(profiles, coverage.Name) {
-			reasons.add("partial_profile_coverage")
+			reasons.add(ReasonPartialProfileCoverage)
 		}
 	}
 
@@ -144,7 +176,7 @@ func Analyze(m manifest.Manifest, meta state.Metadata, opts Options) (Analysis, 
 	candidate := &Candidate{Profiles: profiles, ExtraTags: extra, Confidence: confidence}
 	selection, resolveErr := candidate.Effective(m)
 	if resolveErr != nil {
-		reasons.add("unusable_selection")
+		reasons.add(ReasonUnusableSelection)
 	} else {
 		candidate.EffectiveTags = append([]string{}, selection.Tags...)
 		statusReport, statusErr := status.Build(m, meta, status.Options{
@@ -152,7 +184,7 @@ func Analyze(m manifest.Manifest, meta state.Metadata, opts Options) (Analysis, 
 		})
 		if statusErr != nil {
 			if errors.Is(statusErr, os.ErrNotExist) {
-				reasons.add("missing_target_source_evidence")
+				reasons.add(ReasonMissingTargetSourceEvidence)
 			} else {
 				return Analysis{}, statusErr
 			}
@@ -164,13 +196,13 @@ func Analyze(m manifest.Manifest, meta state.Metadata, opts Options) (Analysis, 
 				}
 				evaluated++
 				if entry.State == status.StateMissing {
-					reasons.add("missing_target_source_evidence")
+					reasons.add(ReasonMissingTargetSourceEvidence)
 				} else if entry.State != status.StateOK {
-					reasons.add("target_source_mismatch")
+					reasons.add(ReasonTargetSourceMismatch)
 				}
 			}
 			if evaluated == 0 && (len(meta.Entries) > 0 || len(meta.Provisioners) > 0) {
-				reasons.add("missing_target_source_evidence")
+				reasons.add(ReasonMissingTargetSourceEvidence)
 			}
 		}
 	}
@@ -186,48 +218,37 @@ func Analyze(m manifest.Manifest, meta state.Metadata, opts Options) (Analysis, 
 }
 
 func recordedProfileSets(meta state.Metadata) [][]string {
-	unique := map[string][]string{}
-	add := func(values []string) {
-		set := newStringSet(values).values()
-		if len(set) == 0 {
-			return
-		}
-		unique[strings.Join(set, "\x00")] = set
-	}
+	values := make([][]string, 0, len(meta.Entries)+len(meta.Provisioners))
 	for _, rec := range meta.Entries {
-		add(rec.Profiles)
+		values = append(values, rec.Profiles)
 	}
 	for _, rec := range meta.Provisioners {
-		values := append([]string(nil), rec.Profiles...)
-		values = append(values, strings.Split(rec.Profile, ",")...)
-		add(values)
+		profiles := append([]string(nil), rec.Profiles...)
+		profiles = append(profiles, strings.Split(rec.Profile, ",")...)
+		values = append(values, profiles)
 	}
-	keys := make([]string, 0, len(unique))
-	for key := range unique {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	out := make([][]string, 0, len(keys))
-	for _, key := range keys {
-		out = append(out, unique[key])
-	}
-	return out
+	return distinctSets(values)
 }
 
 func recordedTagSets(meta state.Metadata) [][]string {
-	unique := map[string][]string{}
-	add := func(values []string) {
-		set := newStringSet(values).values()
-		if len(set) == 0 {
-			return
-		}
-		unique[strings.Join(set, "\x00")] = set
-	}
+	values := make([][]string, 0, len(meta.Entries)+len(meta.Provisioners))
 	for _, rec := range meta.Entries {
-		add(rec.Tags)
+		values = append(values, rec.Tags)
 	}
 	for _, rec := range meta.Provisioners {
-		add(rec.Tags)
+		values = append(values, rec.Tags)
+	}
+	return distinctSets(values)
+}
+
+func distinctSets(values [][]string) [][]string {
+	unique := map[string][]string{}
+	for _, values := range values {
+		set := newStringSet(values).values()
+		if len(set) == 0 {
+			continue
+		}
+		unique[strings.Join(set, "\x00")] = set
 	}
 	keys := make([]string, 0, len(unique))
 	for key := range unique {
@@ -251,6 +272,20 @@ func hasMissingRecordedProfiles(meta state.Metadata) bool {
 		values := append([]string(nil), rec.Profiles...)
 		values = append(values, strings.Split(rec.Profile, ",")...)
 		if len(newStringSet(values)) == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func hasMissingRecordedTags(meta state.Metadata) bool {
+	for _, rec := range meta.Entries {
+		if len(newStringSet(rec.Tags)) == 0 {
+			return true
+		}
+	}
+	for _, rec := range meta.Provisioners {
+		if len(newStringSet(rec.Tags)) == 0 {
 			return true
 		}
 	}
@@ -306,15 +341,15 @@ func addOverrideEvidence(m manifest.Manifest, meta state.Metadata, osName, home 
 	}
 }
 
-type reasonSet map[string]bool
+type reasonSet map[AmbiguityReason]bool
 
-func (s reasonSet) add(v string) { s[v] = true }
-func (s reasonSet) values() []string {
-	out := make([]string, 0, len(s))
+func (s reasonSet) add(v AmbiguityReason) { s[v] = true }
+func (s reasonSet) values() []AmbiguityReason {
+	out := make([]AmbiguityReason, 0, len(s))
 	for v := range s {
 		out = append(out, v)
 	}
-	sort.Strings(out)
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
 	return out
 }
 

--- a/internal/selectionmigration/migration.go
+++ b/internal/selectionmigration/migration.go
@@ -1,0 +1,366 @@
+// Package selectionmigration analyzes pre-v3 Installation Metadata and proposes
+// an explicit Installed Selection without mutating metadata or the filesystem.
+package selectionmigration
+
+import (
+	"errors"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/yersonargotev/dots/internal/installed"
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/plan"
+	"github.com/yersonargotev/dots/internal/state"
+	"github.com/yersonargotev/dots/internal/status"
+)
+
+const (
+	ConfidenceHigh   = "high"
+	ConfidenceMedium = "medium"
+	ConfidenceLow    = "low"
+)
+
+type Candidate struct {
+	Profiles           []string `json:"profiles"`
+	ExtraTags          []string `json:"extra_tags"`
+	EffectiveTags      []string `json:"effective_tags"`
+	Confidence         string   `json:"confidence"`
+	AmbiguityReasons   []string `json:"ambiguity_reasons"`
+	RecommendedCommand string   `json:"recommended_command,omitempty"`
+}
+
+type Analysis struct {
+	Required  bool       `json:"required"`
+	Candidate *Candidate `json:"candidate,omitempty"`
+}
+
+type Options struct {
+	OS         string
+	Home       string
+	SourceRoot string
+	StatePath  string
+}
+
+func (c Candidate) Unambiguous() bool {
+	return len(c.AmbiguityReasons) == 0 && (len(c.Profiles) > 0 || len(c.ExtraTags) > 0)
+}
+
+func (c Candidate) Effective(m manifest.Manifest) (manifest.Selection, error) {
+	return manifest.ResolveReadOnlySelection(m, c.Profiles, c.ExtraTags)
+}
+
+func Analyze(m manifest.Manifest, meta state.Metadata, opts Options) (Analysis, error) {
+	if meta.InstalledSelection != nil || (meta.Version != 1 && meta.Version != 2) {
+		return Analysis{Required: false}, nil
+	}
+
+	report, err := installed.Build(m, meta, installed.Options{
+		OS: opts.OS, Home: opts.Home, StatePath: opts.StatePath,
+	})
+	if err != nil {
+		return Analysis{}, err
+	}
+
+	reasons := reasonSet{}
+	// Only current-manifest matches may contribute represented Tags. The raw
+	// historical union in installed.Report intentionally remains diagnostic,
+	// not authoritative migration intent.
+	represented := representedMatchedTags(report)
+	tagSets := recordedTagSets(meta)
+	candidateTags := represented
+	if len(tagSets) == 1 {
+		candidateTags = newStringSet(tagSets[0])
+	}
+	addOverrideEvidence(m, meta, opts.OS, opts.Home, candidateTags)
+	profileSets := recordedProfileSets(meta)
+	profiles := []string(nil)
+	confidence := ConfidenceLow
+
+	if len(profileSets) == 1 {
+		profiles = append([]string(nil), profileSets[0]...)
+		confidence = ConfidenceHigh
+		if hasMissingRecordedProfiles(meta) {
+			reasons.add("missing_recorded_profiles")
+		}
+	} else {
+		if len(profileSets) > 1 {
+			reasons.add("conflicting_recorded_profiles")
+		}
+		complete := completeProfiles(report)
+		switch len(complete) {
+		case 1:
+			profiles = []string{complete[0]}
+			confidence = ConfidenceMedium
+		case 0:
+			if len(meta.Entries) == 0 && len(meta.Provisioners) == 0 {
+				reasons.add("no_historical_evidence")
+			} else {
+				reasons.add("no_complete_profile_coverage")
+			}
+		default:
+			reasons.add("multiple_complete_profiles")
+		}
+	}
+	if len(tagSets) > 1 {
+		reasons.add("conflicting_recorded_tags")
+	}
+
+	for _, p := range profiles {
+		if _, ok := m.Profiles[p]; !ok {
+			reasons.add("unknown_recorded_profile")
+		}
+	}
+	for _, entry := range report.ManagedEntries {
+		if !entry.ManifestMatched {
+			reasons.add("unmatched_historical_record")
+		}
+	}
+	for _, prov := range report.Provisioners {
+		if !prov.ManifestMatched {
+			reasons.add("unmatched_historical_record")
+		}
+	}
+	for _, coverage := range report.Profiles {
+		if coverage.State != installed.CoveragePartial {
+			continue
+		}
+		if len(profiles) == 0 || containsString(profiles, coverage.Name) {
+			reasons.add("partial_profile_coverage")
+		}
+	}
+
+	extra := candidateTags.values()
+	covered := map[string]bool{}
+	for _, p := range profiles {
+		if profile, ok := m.Profiles[p]; ok {
+			for _, tag := range profile.Tags {
+				covered[tag] = true
+			}
+		}
+	}
+	extra = filter(extra, func(tag string) bool { return !covered[tag] })
+
+	candidate := &Candidate{Profiles: profiles, ExtraTags: extra, Confidence: confidence}
+	selection, resolveErr := candidate.Effective(m)
+	if resolveErr != nil {
+		reasons.add("unusable_selection")
+	} else {
+		candidate.EffectiveTags = append([]string{}, selection.Tags...)
+		statusReport, statusErr := status.Build(m, meta, status.Options{
+			Selection: &selection, OS: opts.OS, Home: opts.Home, SourceRoot: opts.SourceRoot,
+		})
+		if statusErr != nil {
+			if errors.Is(statusErr, os.ErrNotExist) {
+				reasons.add("missing_target_source_evidence")
+			} else {
+				return Analysis{}, statusErr
+			}
+		} else {
+			evaluated := 0
+			for _, entry := range statusReport.Entries {
+				if entry.State == status.StateSkipped {
+					continue
+				}
+				evaluated++
+				if entry.State == status.StateMissing {
+					reasons.add("missing_target_source_evidence")
+				} else if entry.State != status.StateOK {
+					reasons.add("target_source_mismatch")
+				}
+			}
+			if evaluated == 0 && (len(meta.Entries) > 0 || len(meta.Provisioners) > 0) {
+				reasons.add("missing_target_source_evidence")
+			}
+		}
+	}
+
+	candidate.AmbiguityReasons = reasons.values()
+	if len(candidate.AmbiguityReasons) > 0 {
+		candidate.Confidence = ConfidenceLow
+	}
+	if candidate.Unambiguous() {
+		candidate.RecommendedCommand = command(candidate)
+	}
+	return Analysis{Required: true, Candidate: candidate}, nil
+}
+
+func recordedProfileSets(meta state.Metadata) [][]string {
+	unique := map[string][]string{}
+	add := func(values []string) {
+		set := newStringSet(values).values()
+		if len(set) == 0 {
+			return
+		}
+		unique[strings.Join(set, "\x00")] = set
+	}
+	for _, rec := range meta.Entries {
+		add(rec.Profiles)
+	}
+	for _, rec := range meta.Provisioners {
+		values := append([]string(nil), rec.Profiles...)
+		values = append(values, strings.Split(rec.Profile, ",")...)
+		add(values)
+	}
+	keys := make([]string, 0, len(unique))
+	for key := range unique {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	out := make([][]string, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, unique[key])
+	}
+	return out
+}
+
+func recordedTagSets(meta state.Metadata) [][]string {
+	unique := map[string][]string{}
+	add := func(values []string) {
+		set := newStringSet(values).values()
+		if len(set) == 0 {
+			return
+		}
+		unique[strings.Join(set, "\x00")] = set
+	}
+	for _, rec := range meta.Entries {
+		add(rec.Tags)
+	}
+	for _, rec := range meta.Provisioners {
+		add(rec.Tags)
+	}
+	keys := make([]string, 0, len(unique))
+	for key := range unique {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	out := make([][]string, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, unique[key])
+	}
+	return out
+}
+
+func hasMissingRecordedProfiles(meta state.Metadata) bool {
+	for _, rec := range meta.Entries {
+		if len(newStringSet(rec.Profiles)) == 0 {
+			return true
+		}
+	}
+	for _, rec := range meta.Provisioners {
+		values := append([]string(nil), rec.Profiles...)
+		values = append(values, strings.Split(rec.Profile, ",")...)
+		if len(newStringSet(values)) == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func completeProfiles(report installed.Report) []string {
+	var out []string
+	for _, coverage := range report.Profiles {
+		if coverage.State == installed.CoverageComplete {
+			out = append(out, coverage.Name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func representedMatchedTags(report installed.Report) stringSet {
+	out := stringSet{}
+	for _, entry := range report.ManagedEntries {
+		if entry.ManifestMatched {
+			for _, tag := range entry.Tags {
+				out[tag] = true
+			}
+		}
+	}
+	for _, prov := range report.Provisioners {
+		if prov.ManifestMatched {
+			for _, tag := range prov.Tags {
+				out[tag] = true
+			}
+		}
+	}
+	return out
+}
+
+func addOverrideEvidence(m manifest.Manifest, meta state.Metadata, osName, home string, represented map[string]bool) {
+	for _, rec := range meta.Entries {
+		for _, entry := range m.Entries {
+			if !manifest.MatchesOS(entry.OS, osName) || rec.Strategy != entry.Strategy {
+				continue
+			}
+			target, err := plan.ResolveTarget(entry.Target, home)
+			if err != nil || target != rec.Target {
+				continue
+			}
+			for tag, source := range entry.SourceOverrides {
+				if rec.Source == source {
+					represented[tag] = true
+				}
+			}
+		}
+	}
+}
+
+type reasonSet map[string]bool
+
+func (s reasonSet) add(v string) { s[v] = true }
+func (s reasonSet) values() []string {
+	out := make([]string, 0, len(s))
+	for v := range s {
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
+}
+
+type stringSet map[string]bool
+
+func newStringSet(values []string) stringSet {
+	out := stringSet{}
+	for _, v := range values {
+		if v = strings.TrimSpace(v); v != "" {
+			out[v] = true
+		}
+	}
+	return out
+}
+func (s stringSet) values() []string {
+	out := make([]string, 0, len(s))
+	for v := range s {
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
+}
+func filter(in []string, keep func(string) bool) []string {
+	out := []string{}
+	for _, v := range in {
+		if keep(v) {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+func containsString(values []string, value string) bool {
+	for _, candidate := range values {
+		if candidate == value {
+			return true
+		}
+	}
+	return false
+}
+func command(c *Candidate) string {
+	parts := []string{"dots", "install"}
+	for _, p := range c.Profiles {
+		parts = append(parts, "--profile", p)
+	}
+	for _, t := range c.ExtraTags {
+		parts = append(parts, "--tag", t)
+	}
+	return strings.Join(parts, " ")
+}

--- a/internal/selectionmigration/migration_test.go
+++ b/internal/selectionmigration/migration_test.go
@@ -1,0 +1,217 @@
+package selectionmigration
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/state"
+)
+
+func TestAnalyzeRecordedProfileHighConfidence(t *testing.T) {
+	m, meta, opts := fixture(t)
+	meta.Entries[0].Profiles = []string{"core"}
+
+	got, err := Analyze(m, meta, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := &Candidate{
+		Profiles:           []string{"core"},
+		ExtraTags:          []string{},
+		EffectiveTags:      []string{"core"},
+		Confidence:         ConfidenceHigh,
+		AmbiguityReasons:   []string{},
+		RecommendedCommand: "dots install --profile core",
+	}
+	if !got.Required || !reflect.DeepEqual(got.Candidate, want) {
+		t.Fatalf("Analyze() = %#v, want candidate %#v", got, want)
+	}
+}
+
+func TestAnalyzeInfersUniqueCompleteProfile(t *testing.T) {
+	m, meta, opts := fixture(t)
+	got, err := Analyze(m, meta, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Candidate.Confidence != ConfidenceMedium || !reflect.DeepEqual(got.Candidate.Profiles, []string{"core"}) || !got.Candidate.Unambiguous() {
+		t.Fatalf("candidate = %#v", got.Candidate)
+	}
+}
+
+func TestAnalyzeSourceOverrideBecomesExtraTag(t *testing.T) {
+	m, meta, opts := fixture(t)
+	override := filepath.Join(opts.SourceRoot, "configs", "work")
+	if err := os.WriteFile(override, []byte("work\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(meta.Entries[0].Target); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(override, meta.Entries[0].Target); err != nil {
+		t.Fatal(err)
+	}
+	m.Entries[0].SourceOverrides = map[string]string{"work": "configs/work"}
+	meta.Entries[0].Source = "configs/work"
+	meta.Entries[0].Profiles = []string{"core"}
+
+	got, err := Analyze(m, meta, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got.Candidate.ExtraTags, []string{"work"}) ||
+		!reflect.DeepEqual(got.Candidate.EffectiveTags, []string{"core", "work"}) ||
+		!got.Candidate.Unambiguous() {
+		t.Fatalf("candidate = %#v", got.Candidate)
+	}
+}
+
+func TestAnalyzeSourceOverrideEvidenceRequiresMatchingTarget(t *testing.T) {
+	m, meta, opts := fixture(t)
+	m.Entries = append(m.Entries, manifest.Entry{
+		Source:          "configs/other",
+		Target:          "~/.other",
+		Strategy:        "symlink",
+		Tags:            []string{"other"},
+		SourceOverrides: map[string]string{"unrelated": "configs/x"},
+	})
+	meta.Entries[0].Profiles = []string{"core"}
+
+	got, err := Analyze(m, meta, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if contains(got.Candidate.ExtraTags, "unrelated") {
+		t.Fatalf("unrelated source override leaked into candidate: %#v", got.Candidate)
+	}
+}
+
+func TestAnalyzeAmbiguities(t *testing.T) {
+	tests := []struct {
+		name   string
+		change func(*testing.T, *manifest.Manifest, *state.Metadata, Options)
+		reason string
+	}{
+		{"conflicting history", func(_ *testing.T, m *manifest.Manifest, meta *state.Metadata, _ Options) {
+			m.Profiles["work"] = manifest.Profile{Tags: []string{"core"}}
+			meta.Entries[0].Profiles = []string{"core"}
+			meta.Provisioners = []state.ProvisionerRecord{{Profiles: []string{"work"}, Tool: "missing"}}
+		}, "conflicting_recorded_profiles"},
+		{"conflicting recorded tags", func(_ *testing.T, _ *manifest.Manifest, meta *state.Metadata, _ Options) {
+			meta.Entries[0].Profiles = []string{"core"}
+			meta.Provisioners = []state.ProvisionerRecord{{Profiles: []string{"core"}, Tags: []string{"historical"}, Tool: "missing"}}
+		}, "conflicting_recorded_tags"},
+		{"multiple complete profiles", func(_ *testing.T, m *manifest.Manifest, _ *state.Metadata, _ Options) {
+			m.Profiles["also-core"] = manifest.Profile{Tags: []string{"core"}}
+		}, "multiple_complete_profiles"},
+		{"unmatched record", func(_ *testing.T, _ *manifest.Manifest, meta *state.Metadata, _ Options) {
+			meta.Entries[0].Source = "configs/removed"
+		}, "unmatched_historical_record"},
+		{"target mismatch", func(t *testing.T, _ *manifest.Manifest, meta *state.Metadata, _ Options) {
+			if err := os.Remove(meta.Entries[0].Target); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(meta.Entries[0].Target, []byte("different"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}, "target_source_mismatch"},
+		{"missing source", func(t *testing.T, _ *manifest.Manifest, _ *state.Metadata, opts Options) {
+			if err := os.Remove(filepath.Join(opts.SourceRoot, "configs", "x")); err != nil {
+				t.Fatal(err)
+			}
+		}, "missing_target_source_evidence"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, meta, opts := fixture(t)
+			tt.change(t, &m, &meta, opts)
+			got, err := Analyze(m, meta, opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !contains(got.Candidate.AmbiguityReasons, tt.reason) || got.Candidate.Confidence != ConfidenceLow || got.Candidate.RecommendedCommand != "" {
+				t.Fatalf("candidate = %#v, want reason %q", got.Candidate, tt.reason)
+			}
+		})
+	}
+}
+
+func TestAnalyzeNoEvidenceAndNonLegacy(t *testing.T) {
+	m, _, opts := fixture(t)
+	for _, meta := range []state.Metadata{{Version: 0}, {Version: 3}, {Version: 2, InstalledSelection: &state.InstalledSelection{}}} {
+		got, err := Analyze(m, meta, opts)
+		if err != nil || got.Required {
+			t.Fatalf("Analyze(%#v) = %#v, %v", meta, got, err)
+		}
+	}
+	got, err := Analyze(m, state.Metadata{Version: 2}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(got.Candidate.AmbiguityReasons, "no_historical_evidence") {
+		t.Fatalf("candidate = %#v", got.Candidate)
+	}
+}
+
+func TestAnalyzeOrderingIsDeterministic(t *testing.T) {
+	m, meta, opts := fixture(t)
+	m.Profiles["z"] = manifest.Profile{Tags: []string{"z", "a"}}
+	meta.Entries[0].Profiles = []string{"z", "core", "z"}
+	meta.Entries[0].Tags = []string{"z", "core", "a"}
+	first, err := Analyze(m, meta, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := Analyze(m, meta, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(first, second) ||
+		!reflect.DeepEqual(first.Candidate.Profiles, []string{"core", "z"}) ||
+		!reflect.DeepEqual(first.Candidate.ExtraTags, []string{}) {
+		t.Fatalf("results = %#v / %#v", first, second)
+	}
+}
+
+func fixture(t *testing.T) (manifest.Manifest, state.Metadata, Options) {
+	t.Helper()
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	sourceRoot := filepath.Join(root, "source")
+	if err := os.MkdirAll(filepath.Join(sourceRoot, "configs"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	source := filepath.Join(sourceRoot, "configs", "x")
+	target := filepath.Join(home, ".x")
+	if err := os.WriteFile(source, []byte("x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(home, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(source, target); err != nil {
+		t.Fatal(err)
+	}
+	m := manifest.Manifest{
+		Profiles: map[string]manifest.Profile{"core": {Tags: []string{"core"}}},
+		Entries: []manifest.Entry{{
+			Source: "configs/x", Target: "~/.x", Strategy: "symlink", Tags: []string{"core"},
+		}},
+	}
+	meta := state.Metadata{Version: 2, Entries: []state.Record{{
+		Source: "configs/x", Target: target, Strategy: "symlink", Tags: []string{"core"},
+	}}}
+	return m, meta, Options{OS: "linux", Home: home, SourceRoot: sourceRoot, StatePath: filepath.Join(root, "installed.json")}
+}
+
+func contains(values []string, value string) bool {
+	for _, candidate := range values {
+		if candidate == value {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/selectionmigration/migration_test.go
+++ b/internal/selectionmigration/migration_test.go
@@ -23,7 +23,7 @@ func TestAnalyzeRecordedProfileHighConfidence(t *testing.T) {
 		ExtraTags:          []string{},
 		EffectiveTags:      []string{"core"},
 		Confidence:         ConfidenceHigh,
-		AmbiguityReasons:   []string{},
+		AmbiguityReasons:   []AmbiguityReason{},
 		RecommendedCommand: "dots install --profile core",
 	}
 	if !got.Required || !reflect.DeepEqual(got.Candidate, want) {
@@ -89,11 +89,40 @@ func TestAnalyzeSourceOverrideEvidenceRequiresMatchingTarget(t *testing.T) {
 	}
 }
 
+func TestAnalyzeMixedMissingRecordedTagsIsAmbiguousAndRetainsInferredTag(t *testing.T) {
+	m, meta, opts := fixture(t)
+	workSource := filepath.Join(opts.SourceRoot, "configs", "work")
+	if err := os.WriteFile(workSource, []byte("work\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	workTarget := filepath.Join(opts.Home, ".work")
+	if err := os.Symlink(workSource, workTarget); err != nil {
+		t.Fatal(err)
+	}
+	m.Entries = append(m.Entries, manifest.Entry{
+		Source: "configs/work", Target: "~/.work", Strategy: "symlink", Tags: []string{"work"},
+	})
+	meta.Entries[0].Profiles = []string{"core"}
+	meta.Entries = append(meta.Entries, state.Record{
+		Source: "configs/work", Target: workTarget, Strategy: "symlink", Profiles: []string{"core"},
+	})
+
+	got, err := Analyze(m, meta, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(got.Candidate.AmbiguityReasons, ReasonMissingRecordedTags) ||
+		!contains(got.Candidate.ExtraTags, "work") ||
+		got.Candidate.Unambiguous() {
+		t.Fatalf("candidate = %#v", got.Candidate)
+	}
+}
+
 func TestAnalyzeAmbiguities(t *testing.T) {
 	tests := []struct {
 		name   string
 		change func(*testing.T, *manifest.Manifest, *state.Metadata, Options)
-		reason string
+		reason AmbiguityReason
 	}{
 		{"conflicting history", func(_ *testing.T, m *manifest.Manifest, meta *state.Metadata, _ Options) {
 			m.Profiles["work"] = manifest.Profile{Tags: []string{"core"}}
@@ -207,7 +236,7 @@ func fixture(t *testing.T) (manifest.Manifest, state.Metadata, Options) {
 	return m, meta, Options{OS: "linux", Home: home, SourceRoot: sourceRoot, StatePath: filepath.Join(root, "installed.json")}
 }
 
-func contains(values []string, value string) bool {
+func contains[T ~string](values []T, value T) bool {
 	for _, candidate := range values {
 		if candidate == value {
 			return true


### PR DESCRIPTION
Closes #345

## PR Type

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Derives conservative, non-authoritative migration candidates from v1/v2 Installation Metadata and current workstation evidence.
- Blocks ambiguous and non-interactive promotion with structured `selection-migration-required` remediation.
- Allows explicit interactive confirmation in update/upgrade and records intent only after terminal success.

## Changes

| File | Change |
|------|--------|
| `internal/selectionmigration/` | Analyze historical records, Profile coverage, source overrides, Provisioners, and target/source evidence with deterministic confidence and ambiguity. |
| `internal/cli/` | Gate selection-aware commands, expose candidates in `dots installed`, confirm safe update/upgrade migration, and preserve intent across upgrade continuation. |
| `internal/cli/testdata/` | Lock JSON and human migration output contracts. |
| `CONTEXT.md`, `README.md`, `docs/` | Document the migration policy, remediation, output contract, and terminal-success recording rule. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile core --source-root "$PWD" --home <tmp>`
- [x] `go build ./...`
- [x] Two-axis Standards and Spec review completed with no remaining findings.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #345`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
