### PR TITLE
feat(selection): guard explicit Installed Selection changes

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -124,6 +124,10 @@ _Avoid_: install log, state file, tracking file
 The authoritative machine-level installation intent recorded only after terminal success of an explicit install, update, or upgrade, including an operator-confirmed Selection Migration Candidate. It preserves the ordered Profiles and explicit extra Tags selected by the operator, the ordered resolved Tag snapshot, Source of Truth provenance, and recording time. Profiles and explicit extra Tags are intent; resolved Tags are an audit snapshot. Per-Managed-Entry and per-Provisioner Profiles and Tags remain historical inventory and ownership evidence, not a substitute for an Installed Selection.
 _Avoid_: inferred selection, installed profile, tag inventory
 
+**Installed Selection Change**:
+A complete explicit Profile/Tag request on a mutating command that differs from the authoritative Installed Selection. Its delta reports added and removed Profiles, explicit extra Tags, effective Tags, Managed Entries, Dependencies, and Provisioners before mutation. Removing a recorded Profile or explicit extra Tag is a reduction that requires distinct interactive confirmation or, in Confirmed Install mode, `--acknowledge-selection-change` in addition to `--yes`.
+_Avoid_: implicit selection update, selection merge, automatic retirement
+
 **Selection Migration Candidate**:
 A non-authoritative selection proposed for Installation Metadata v1 or v2 from historical Managed Entry and Provisioner records plus current Install Manifest, target, and Source of Truth evidence. It reports ordered Profiles, explicit extra Tags, effective Tags, confidence, and ambiguity reasons. Only an unambiguous candidate can become an Installed Selection, and only after interactive operator confirmation and terminal success; ambiguous or absent evidence requires an explicit selection.
 _Avoid_: inferred selection, migrated selection, implicit default
@@ -186,7 +190,7 @@ The normal installation mode used when a terminal is available. It shows an Inst
 _Avoid_: normal install, guided install, TUI install
 
 **Confirmed Install**:
-A non-interactive installation mode requested with `--yes`. It applies safe changes without prompting and resolves conflicts with conservative defaults such as `skip`.
+A non-interactive installation mode requested with `--yes`. It applies safe changes without prompting and resolves conflicts with conservative defaults such as `skip`. It does not authorize an Installed Selection reduction; removing a recorded Profile or explicit extra Tag also requires `--acknowledge-selection-change`.
 _Avoid_: auto install, force install, unattended install
 
 **Text Prompt Mode**:

--- a/README.md
+++ b/README.md
@@ -90,8 +90,12 @@ After a successful explicit install, `status`, `doctor`, `plan`, `deps check`,
 `deps plan`, `update`, and `upgrade` reuse the recorded Installed Selection when
 no `--profile` or `--tag` is supplied. Supplying either flag makes that
 invocation's complete explicit selection win. Read-only commands never change
-Installation Metadata; successful update/upgrade refreshes the selection only
-after Managed Entries and Provisioners finish. A machine with no recorded
+Installation Metadata. Mutating commands show an Installed Selection Change
+before applying a differing explicit selection. Removing a recorded Profile or
+explicit extra Tag requires a distinct interactive confirmation; unattended
+runs require both `--yes` and `--acknowledge-selection-change`. Successful
+install/update/upgrade records the requested selection only after Managed
+Entries and Provisioners finish. A machine with no recorded
 selection must pass an explicit `--profile` or `--tag`; selection-aware commands
 never invent an implicit Profile.
 
@@ -165,6 +169,10 @@ Non-interactive installs stay conservative: `dots install --profile workstation 
 ```bash
 dots install --profile workstation --yes --backup-and-replace
 ```
+
+When replacing an existing Installed Selection and removing a recorded Profile
+or explicit extra Tag, add `--acknowledge-selection-change` after reviewing the
+reported delta. This acknowledgement is separate from Conflict Resolution.
 
 That mode creates Backup Sets before replacement, reports them in JSON as `data.backup_sets`, and still runs selected Provisioners after Managed Configuration is applied.
 

--- a/README.md
+++ b/README.md
@@ -92,8 +92,9 @@ no `--profile` or `--tag` is supplied. Supplying either flag makes that
 invocation's complete explicit selection win. Read-only commands never change
 Installation Metadata. Mutating commands show an Installed Selection Change
 before applying a differing explicit selection. Removing a recorded Profile or
-explicit extra Tag requires a distinct interactive confirmation; unattended
-runs require both `--yes` and `--acknowledge-selection-change`. Successful
+explicit extra Tag requires a distinct interactive confirmation; Confirmed
+Install mode requires both `--yes` and
+`--acknowledge-selection-change`. Successful
 install/update/upgrade records the requested selection only after Managed
 Entries and Provisioners finish. A machine with no recorded
 selection must pass an explicit `--profile` or `--tag`; selection-aware commands

--- a/docs/adr/0014-record-authoritative-installed-selection.md
+++ b/docs/adr/0014-record-authoritative-installed-selection.md
@@ -135,3 +135,32 @@ Installed Selection, the non-authoritative Selection Migration Candidate, and
 historical inventory. Read-only selection-aware commands likewise do not
 silently consume a migration candidate; until migration succeeds, callers must
 provide an explicit selection.
+
+## Explicit selection replacement amendment
+
+Issue #346 defines any complete explicit Profile/Tag request on `install`,
+`update`, or `upgrade` that differs from Installed Selection as an Installed
+Selection Change. It is not merged with recorded intent. Before applying the
+requested selection to Dependencies, Managed Configuration, or Provisioners,
+dots reports deterministic added and removed Profiles, explicit extra Tags,
+effective Tags, Managed Entries, Dependencies, and Provisioners. Update does so
+before Installed Repository mutation, and upgrade before binary mutation. The
+existing selection-evolution delta remains separate because it compares one
+intent across Install Manifest revisions rather than two intents in one
+manifest.
+
+Removing a recorded Profile or explicit extra Tag is a reduction. Interactive
+operation requires a confirmation distinct from Conflict Resolution.
+Non-interactive operation requires both `--yes` and
+`--acknowledge-selection-change`; `--yes` alone returns the structured
+`selection-change-acknowledgement-required` error before mutation. Consequential
+surface removals are reported but do not authorize deletion or uninstall and do
+not independently require acknowledgement.
+
+Dry runs report whether acknowledgement would be required without accepting or
+persisting the change. Decline, missing acknowledgement, cancellation, or any
+Dependency, Managed Entry, Provisioner, upgrade-continuation, convergence, or
+metadata-write failure preserves the previous Installed Selection. Only
+terminal success records the requested intent. Read-only explicit selection
+remains invocation-scoped and never produces a persistent Installed Selection
+Change.

--- a/docs/agents/output-contract.md
+++ b/docs/agents/output-contract.md
@@ -155,6 +155,22 @@ prose the text surface prints:
   empty, and `remediation.recommended_command` is included when the evidence
   supports an explicit command. `--yes` and JSON output never confirm a
   candidate.
+- Mutating `install`, `update`, and `upgrade` reports may add
+  `data.selection.change` when a complete explicit request differs from the
+  authoritative Installed Selection. `change.delta` contains stable
+  `previous`/`current` intent snapshots and `added`/`removed` arrays for
+  `profiles`, `extra_tags`, `effective_tags`, `managed_entries`,
+  `dependencies`, and `provisioners`. The sibling booleans
+  `acknowledgement_required` and `acknowledgement_accepted` let automation
+  distinguish a preview, an accepted change, and a blocked reduction.
+  `install` exposes the same portable `data.selection` object as update and
+  upgrade.
+- A non-interactive explicit request that removes a recorded Profile or extra
+  Tag requires both `--yes` and `--acknowledge-selection-change`. Without both,
+  the command exits `1` before mutation with
+  `selection-change-acknowledgement-required`; error `data` contains `code` and
+  the complete `selection_change`. This acknowledgement is independent from
+  Conflict Resolution and `--backup-and-replace`.
 - `plan`'s `resolved_source` (a per-machine absolute path) and `deps`'s
   `probe_detail`/`hint` (unstable human prose) are excluded. Agents key on the
   portable, structured fields (`source`, `present`, `warning`, and the

--- a/docs/update.md
+++ b/docs/update.md
@@ -61,6 +61,7 @@ or incompatible targets still remain Conflicts.
 | `--home` | Target home directory; use a sandbox path to avoid touching real config. |
 | `--state-root` | State directory for Installation Metadata and Backup Sets. |
 | `--yes` | Apply safe actions without prompting; conflicts default to `skip`. |
+| `--acknowledge-selection-change` | With `--yes`, acknowledge removal of recorded Profiles or explicit extra Tags after reviewing the Installed Selection Change. |
 | `--no-tui` | Use text prompts instead of the interactive TUI for conflict resolution. |
 
 ## Dry run
@@ -94,8 +95,15 @@ mutation, with a recommended explicit command when one can be constructed.
 There is no implicit default.
 
 Any supplied `--profile` or `--tag` makes the complete explicit selection win
-for that invocation; dots never merges it with recorded intent. The selection
-is validated before the Installed Repository changes and resolved again against
+for that invocation; dots never merges it with recorded intent. Before the
+Installed Repository changes, update reports the requested selection delta from
+the Installed Selection, including added and removed Profiles, explicit extra
+Tags, effective Tags, Managed Entries, Dependencies, and Provisioners. Removing
+a recorded Profile or explicit extra Tag requires a distinct interactive
+confirmation. Non-interactive execution requires both `--yes` and
+`--acknowledge-selection-change`; `--yes` alone returns
+`selection-change-acknowledgement-required` before mutation. The selection is
+then validated and resolved again against
 the refreshed manifest before Managed Configuration is applied. Update reports
 the resulting effective Tag and selected Managed Entry, Dependency, and
 Provisioner additions and removals before application. A missing saved Profile
@@ -104,7 +112,7 @@ stops application with remediation and structured delta data instead of
 choosing an implicit default or silently rewriting intent. Removed surfaces are
 informational and are never automatically deleted or uninstalled. Only terminal
 success records or refreshes the Installed Selection, so dry runs, declined
-migration confirmation, cancellations, and
+selection-change or migration confirmation, cancellations, and
 failed Managed Entry or Provisioner work preserve the previous intent.
 
 ## Profiles and provisioners

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -56,7 +56,8 @@ dots upgrade --profile workstation --yes --output json
 ```
 
 A real non-dry-run JSON upgrade requires `--yes` so Machine Output Mode never
-prompts on stdout.
+prompts on stdout. If the complete explicit selection removes a recorded
+Profile or extra Tag, it also requires `--acknowledge-selection-change`.
 
 After a successful explicit install, an unattended workstation upgrade can
 reuse the Installed Selection:
@@ -75,7 +76,14 @@ non-interactive runs fail before binary or repository mutation with the stable
 `selection-migration-required` error and a recommended explicit command when
 possible. Upgrade never chooses an implicit default.
 
-Selection is validated before binary replacement and re-resolved against the
+An explicit selection that differs from Installed Selection is reported before
+binary replacement. The delta contains added and removed Profiles, explicit
+extra Tags, effective Tags, Managed Entries, Dependencies, and Provisioners.
+Removing a recorded Profile or explicit extra Tag requires a distinct
+interactive confirmation; non-interactive execution requires both `--yes` and
+`--acknowledge-selection-change`, otherwise upgrade returns
+`selection-change-acknowledgement-required` before binary or repository
+mutation. Selection is then validated before binary replacement and re-resolved against the
 refreshed manifest before Managed Configuration is applied. Upgrade reports
 effective Tag and selected Managed Entry, Dependency, and Provisioner additions
 and removals before application. Missing Profiles and explicit extra Tags no
@@ -99,6 +107,7 @@ dots upgrade \
   --home "$HOME" \
   --state-root ~/.local/state/dots \
   --yes \
+  --acknowledge-selection-change \
   --no-tui
 ```
 

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -105,7 +105,9 @@ func newInstallCommand() *cobra.Command {
 				return err
 			}
 			effective = selection.CompareInstalled(*m, effective, meta.InstalledSelection, installHostOS)
-			proceed, _, err := guardSelectionChange(cmd, &effective, dryRun, yes, ackSelection, false)
+			proceed, _, err := guardSelectionChange(cmd, &effective, selectionChangePolicy{
+				DryRun: dryRun, Confirmed: yes, Acknowledge: ackSelection,
+			})
 			if err != nil {
 				return err
 			}

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -50,6 +50,7 @@ func newInstallCommand() *cobra.Command {
 		noTUI            bool
 		skipDeps         bool
 		backupAndReplace bool
+		ackSelection     bool
 	)
 
 	cmd := &cobra.Command{
@@ -86,7 +87,15 @@ func newInstallCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			installedSelection, err := selection.Resolve(*m, profiles, extraTags)
+			requestedSelection, err := selection.Resolve(*m, profiles, extraTags)
+			if err != nil {
+				return err
+			}
+			effective, err := selection.ResolveIntent(*m, selection.Intent{
+				Source:    selection.SourceExplicit,
+				Profiles:  requestedSelection.Profiles,
+				ExtraTags: requestedSelection.ExtraTags,
+			})
 			if err != nil {
 				return err
 			}
@@ -95,6 +104,15 @@ func newInstallCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			effective = selection.CompareInstalled(*m, effective, meta.InstalledSelection, installHostOS)
+			proceed, _, err := guardSelectionChange(cmd, &effective, dryRun, yes, ackSelection, false)
+			if err != nil {
+				return err
+			}
+			if !proceed {
+				return nil
+			}
+			installedSelection := effective.InstalledSelection(state.Provenance{})
 
 			hostOS := installHostOS
 			hostArch := installHostArch
@@ -142,8 +160,9 @@ func newInstallCommand() *cobra.Command {
 				if err != nil {
 					return err
 				}
+				p.Selection = &effective.Report
 				if wantsJSON(cmd) {
-					return emitOK(cmd, installReport{DryRun: true, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan})
+					return emitOK(cmd, installReport{DryRun: true, Selection: effective.Report, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan})
 				}
 				if err := renderInstallPlanAndProvisioners(cmd, *m, p, provPlan, profiles); err != nil {
 					return err
@@ -162,7 +181,7 @@ func newInstallCommand() *cobra.Command {
 						packageManagerSetup.Status = pkgmgr.StatusUnavailable
 						err := fmt.Errorf("Homebrew Package Manager Setup requires interactive confirmation; rerun without --yes or install Homebrew manually with %s", packageManagerSetup.Command.Display)
 						if wantsJSON(cmd) {
-							return installDependencyGateError{err: err, report: installReport{DryRun: false, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport}}
+							return installDependencyGateError{err: err, report: installReport{DryRun: false, Selection: effective.Report, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport}}
 						}
 						return err
 					}
@@ -202,13 +221,14 @@ func newInstallCommand() *cobra.Command {
 				if err != nil {
 					return err
 				}
+				p.Selection = &effective.Report
 				installPlanReady = true
 
 				depReport, depsApplied, err := runInstallDependencies(cmd, *m, depOptions, depTier, paths.Home, depPreview, depsConfirmed, depLookup, brewDetection.Path)
 				dependenciesReport.Result = &depReport
 				if err != nil {
 					if wantsJSON(cmd) {
-						return installDependencyGateError{err: err, report: installReport{DryRun: false, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan}}
+						return installDependencyGateError{err: err, report: installReport{DryRun: false, Selection: effective.Report, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan}}
 					}
 					return err
 				}
@@ -222,6 +242,7 @@ func newInstallCommand() *cobra.Command {
 				if err != nil {
 					return err
 				}
+				p.Selection = &effective.Report
 			}
 
 			if !wantsJSON(cmd) {
@@ -244,7 +265,7 @@ func newInstallCommand() *cobra.Command {
 			}
 			if !applied {
 				if wantsJSON(cmd) {
-					return emitOK(cmd, installReport{DryRun: false, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan})
+					return emitOK(cmd, installReport{DryRun: false, Selection: effective.Report, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan})
 				}
 				return nil
 			}
@@ -252,7 +273,7 @@ func newInstallCommand() *cobra.Command {
 			provResult, err := runProvisioners(cmd, *m, profiles, extraTags, paths.Home, paths.StateRoot, paths.SourceRoot)
 			if err != nil {
 				if wantsJSON(cmd) {
-					return installProvisionerError{err: err, report: installReport{DryRun: false, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan, BackupSets: createdBackups, ProvisionerResults: &provResult}}
+					return installProvisionerError{err: err, report: installReport{DryRun: false, Selection: effective.Report, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan, BackupSets: createdBackups, ProvisionerResults: &provResult}}
 				}
 				return err
 			}
@@ -261,7 +282,7 @@ func newInstallCommand() *cobra.Command {
 				return err
 			}
 			if wantsJSON(cmd) {
-				return emitOK(cmd, installReport{DryRun: false, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan, BackupSets: createdBackups})
+				return emitOK(cmd, installReport{DryRun: false, Selection: effective.Report, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan, BackupSets: createdBackups})
 			}
 			return nil
 		},
@@ -278,6 +299,7 @@ func newInstallCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&noTUI, "no-tui", false, "use text prompts instead of the interactive TUI for conflict resolution")
 	cmd.Flags().BoolVar(&skipDeps, "skip-deps", false, "skip dependency provisioning before applying managed configuration")
 	cmd.Flags().BoolVar(&backupAndReplace, "backup-and-replace", false, "with --yes, replace every conflict after creating Backup Sets")
+	cmd.Flags().BoolVar(&ackSelection, "acknowledge-selection-change", false, "with --yes, acknowledge removal of previously selected Profiles or extra Tags")
 	return cmd
 }
 

--- a/internal/cli/install_provision_test.go
+++ b/internal/cli/install_provision_test.go
@@ -1003,8 +1003,8 @@ func TestInstallTUICancelDoesNotRunProvisioners(t *testing.T) {
 	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	previousSelection := state.InstalledSelection{
-		Profiles:     []string{"old"},
-		ResolvedTags: []string{"old"},
+		Profiles:     []string{"default"},
+		ResolvedTags: []string{"core"},
 		Provenance:   state.Provenance{RecordedAt: "2026-01-02T03:04:05Z"},
 	}
 	if err := state.Save(state.Path(stateRoot), state.Metadata{

--- a/internal/cli/install_selection_internal_test.go
+++ b/internal/cli/install_selection_internal_test.go
@@ -62,7 +62,7 @@ entries:
 	cmd.SetOut(&output)
 	cmd.SetErr(&output)
 	cmd.SetArgs([]string{
-		"--yes", "--skip-deps", "--profile", "core",
+		"--yes", "--acknowledge-selection-change", "--skip-deps", "--profile", "core",
 		"--file", manifestPath,
 		"--home", home,
 		"--source-root", sourceRoot,

--- a/internal/cli/install_selection_test.go
+++ b/internal/cli/install_selection_test.go
@@ -133,7 +133,7 @@ provisioners:
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
 	cmd.SetArgs([]string{
-		"install", "--yes", "--skip-deps", "--profile", "new",
+		"install", "--yes", "--acknowledge-selection-change", "--skip-deps", "--profile", "new",
 		"--file", manifestPath,
 		"--home", home,
 		"--source-root", sourceRoot,
@@ -158,6 +158,58 @@ provisioners:
 	}
 	if len(meta.Provisioners) != 1 || meta.Provisioners[0].Status != "failed" {
 		t.Fatalf("Provisioners = %#v, want failed inventory retained", meta.Provisioners)
+	}
+}
+
+func TestInstallYesSelectionReductionRequiresDedicatedAcknowledgement(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	previous := state.InstalledSelection{
+		Profiles:     []string{"old"},
+		ExtraTags:    []string{"old-extra"},
+		ResolvedTags: []string{"old", "old-extra"},
+	}
+	if err := state.Save(state.Path(stateRoot), state.Metadata{
+		Version:            state.CurrentVersion,
+		InstalledSelection: &previous,
+	}); err != nil {
+		t.Fatalf("seed metadata: %v", err)
+	}
+	writeCLISource(t, sourceRoot, "configs/new", "new\n")
+	manifestPath := writeCLIManifest(t, home, `version: 1
+profiles:
+  new:
+    tags: [new]
+entries:
+  - source: configs/new
+    target: ~/.new
+    strategy: symlink
+    tags: [new]
+`)
+
+	var out, errOut bytes.Buffer
+	code := cli.Run([]string{
+		"install", "--yes", "--skip-deps", "--output", "json", "--profile", "new",
+		"--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot,
+	}, &out, &errOut)
+	if code != cli.ExitError {
+		t.Fatalf("exit code = %d, want %d\nstdout:\n%s\nstderr:\n%s", code, cli.ExitError, out.String(), errOut.String())
+	}
+	if !strings.Contains(out.String(), "selection-change-acknowledgement-required") {
+		t.Fatalf("JSON error missing acknowledgement code:\n%s", out.String())
+	}
+	if _, err := os.Lstat(filepath.Join(home, ".new")); !os.IsNotExist(err) {
+		t.Fatalf("selection rejection applied Managed Configuration: %v", err)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load metadata: %v", err)
+	}
+	if meta.InstalledSelection == nil || !reflect.DeepEqual(*meta.InstalledSelection, previous) {
+		t.Fatalf("InstalledSelection = %#v, want previous %#v", meta.InstalledSelection, previous)
 	}
 }
 
@@ -208,7 +260,7 @@ provisioners:
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
 	cmd.SetArgs([]string{
-		"install", "--yes", "--skip-deps", "--profile", "new",
+		"install", "--yes", "--acknowledge-selection-change", "--skip-deps", "--profile", "new",
 		"--file", manifestPath,
 		"--home", home,
 		"--source-root", sourceRoot,

--- a/internal/cli/json_reports.go
+++ b/internal/cli/json_reports.go
@@ -40,6 +40,7 @@ type manifestValidateReport struct {
 
 type installReport struct {
 	DryRun              bool                       `json:"dry_run"`
+	Selection           selection.Report           `json:"selection"`
 	PackageManagerSetup *pkgmgr.Report             `json:"package_manager_setup,omitempty"`
 	Dependencies        *installDependenciesReport `json:"dependencies,omitempty"`
 	Plan                plan.Plan                  `json:"plan"`

--- a/internal/cli/output_golden_test.go
+++ b/internal/cli/output_golden_test.go
@@ -35,10 +35,10 @@ func TestEnvelopeGolden(t *testing.T) {
 		Previous: selection.Snapshot{Profiles: []string{"core"}, ExtraTags: []string{"work"}, EffectiveTags: []string{"core", "work"}},
 		Current:  selection.Snapshot{Profiles: []string{"core"}, ExtraTags: []string{"work"}, EffectiveTags: []string{"core", "desktop", "work"}},
 		Added: selection.Changes{
-			EffectiveTags: []string{"desktop"}, ManagedEntries: []string{"~/.config/ghostty/config"}, Dependencies: []string{}, Provisioners: []string{},
+			Profiles: []string{}, ExtraTags: []string{}, EffectiveTags: []string{"desktop"}, ManagedEntries: []string{"~/.config/ghostty/config"}, Dependencies: []string{}, Provisioners: []string{},
 		},
 		Removed: selection.Changes{
-			EffectiveTags: []string{}, ManagedEntries: []string{}, Dependencies: []string{}, Provisioners: []string{},
+			Profiles: []string{}, ExtraTags: []string{}, EffectiveTags: []string{}, ManagedEntries: []string{}, Dependencies: []string{}, Provisioners: []string{},
 		},
 		MissingProfiles: []string{},
 		StaleExtraTags:  []string{},
@@ -47,14 +47,33 @@ func TestEnvelopeGolden(t *testing.T) {
 		Source: selection.SourceRecorded, Profiles: []string{"core"}, ExtraTags: []string{"work"},
 		EffectiveTags: []string{"core", "desktop", "work"}, Delta: &selectionDelta,
 	}
+	installSelection := selection.Report{
+		Source: selection.SourceExplicit, Profiles: []string{"default"}, ExtraTags: []string{}, EffectiveTags: []string{"default"},
+		Change: &selection.Change{
+			Delta: selection.Delta{
+				Previous: selection.Snapshot{Profiles: []string{"core", "work"}, ExtraTags: []string{"adaptive-theme"}, EffectiveTags: []string{"core", "work", "adaptive-theme"}},
+				Current:  selection.Snapshot{Profiles: []string{"default"}, ExtraTags: []string{}, EffectiveTags: []string{"default"}},
+				Added: selection.Changes{
+					Profiles: []string{"default"}, ExtraTags: []string{}, EffectiveTags: []string{"default"}, ManagedEntries: []string{"~/.zshrc"}, Dependencies: []string{}, Provisioners: []string{},
+				},
+				Removed: selection.Changes{
+					Profiles: []string{"core", "work"}, ExtraTags: []string{"adaptive-theme"}, EffectiveTags: []string{"core", "work", "adaptive-theme"}, ManagedEntries: []string{"~/.work"}, Dependencies: []string{}, Provisioners: []string{"gentle-ai"},
+				},
+				MissingProfiles: []string{},
+				StaleExtraTags:  []string{},
+			},
+			AcknowledgementRequired: true,
+			AcknowledgementAccepted: true,
+		},
+	}
 	blockingDelta := selection.Delta{
 		Previous: selection.Snapshot{Profiles: []string{"core"}, ExtraTags: []string{"retired"}, EffectiveTags: []string{"core", "retired"}},
 		Current:  selection.Snapshot{Profiles: []string{"core"}, ExtraTags: []string{"retired"}, EffectiveTags: []string{"core", "retired"}},
 		Added: selection.Changes{
-			EffectiveTags: []string{}, ManagedEntries: []string{}, Dependencies: []string{}, Provisioners: []string{},
+			Profiles: []string{}, ExtraTags: []string{}, EffectiveTags: []string{}, ManagedEntries: []string{}, Dependencies: []string{}, Provisioners: []string{},
 		},
 		Removed: selection.Changes{
-			EffectiveTags: []string{}, ManagedEntries: []string{"~/.retired"}, Dependencies: []string{}, Provisioners: []string{},
+			Profiles: []string{}, ExtraTags: []string{}, EffectiveTags: []string{}, ManagedEntries: []string{"~/.retired"}, Dependencies: []string{}, Provisioners: []string{},
 		},
 		MissingProfiles: []string{},
 		StaleExtraTags:  []string{"retired"},
@@ -227,7 +246,8 @@ func TestEnvelopeGolden(t *testing.T) {
 				Command:       "install",
 				Status:        statusOK,
 				Data: installReport{
-					DryRun: false,
+					DryRun:    false,
+					Selection: installSelection,
 					PackageManagerSetup: &pkgmgr.Report{
 						Manager: "homebrew",
 						Status:  pkgmgr.StatusInstalled,
@@ -245,7 +265,7 @@ func TestEnvelopeGolden(t *testing.T) {
 						Preview: &installPreview,
 						Result:  &installResult,
 					},
-					Plan: plan.Plan{Profile: "default", Actions: []plan.Action{
+					Plan: plan.Plan{Profile: "default", Selection: &installSelection, Actions: []plan.Action{
 						{Source: "configs/zsh/zshrc", Target: "/home/user/.zshrc", Strategy: "symlink", Status: plan.StatusCreate},
 					}},
 					Provisioners: provision.Plan{Profile: "default", Steps: []provision.Step{

--- a/internal/cli/render_golden_test.go
+++ b/internal/cli/render_golden_test.go
@@ -115,3 +115,26 @@ func TestRenderSelectionEvolutionGolden(t *testing.T) {
 		})
 	}
 }
+
+func TestRenderSelectionChangeGolden(t *testing.T) {
+	change := selection.Change{
+		Delta: selection.Delta{
+			Previous: selection.Snapshot{Profiles: []string{"core", "work"}, ExtraTags: []string{"adaptive-theme"}, EffectiveTags: []string{"core", "work", "adaptive-theme"}},
+			Current:  selection.Snapshot{Profiles: []string{"core"}, ExtraTags: []string{}, EffectiveTags: []string{"core"}},
+			Added: selection.Changes{
+				Profiles: []string{}, ExtraTags: []string{}, EffectiveTags: []string{}, ManagedEntries: []string{}, Dependencies: []string{}, Provisioners: []string{},
+			},
+			Removed: selection.Changes{
+				Profiles: []string{"work"}, ExtraTags: []string{"adaptive-theme"}, EffectiveTags: []string{"work", "adaptive-theme"},
+				ManagedEntries: []string{"~/.work"}, Dependencies: []string{"work-tool"}, Provisioners: []string{"gentle-ai"},
+			},
+			MissingProfiles: []string{},
+			StaleExtraTags:  []string{},
+		},
+		AcknowledgementRequired: true,
+		AcknowledgementAccepted: true,
+	}
+	var out bytes.Buffer
+	renderSelectionChange(&out, change)
+	assertGolden(t, "selection_change.golden", out.Bytes())
+}

--- a/internal/cli/selection_change.go
+++ b/internal/cli/selection_change.go
@@ -21,6 +21,13 @@ type selectionChangeAcknowledgementError struct {
 	change selection.Change
 }
 
+type selectionChangePolicy struct {
+	DryRun          bool
+	Confirmed       bool
+	Acknowledge     bool
+	AlreadyAccepted bool
+}
+
 func (e *selectionChangeAcknowledgementError) Error() string {
 	return selectionChangeAcknowledgementRequiredCode +
 		": removing previously selected Profiles or extra Tags requires --yes and --acknowledge-selection-change"
@@ -33,33 +40,33 @@ func (e *selectionChangeAcknowledgementError) JSONErrorData() any {
 	}
 }
 
-func guardSelectionChange(cmd *cobra.Command, effective *selection.Effective, dryRun, yes, acknowledge, alreadyAccepted bool) (bool, bool, error) {
+func guardSelectionChange(cmd *cobra.Command, effective *selection.Effective, policy selectionChangePolicy) (bool, bool, error) {
 	if effective.Report.Change == nil {
-		return true, alreadyAccepted, nil
+		return true, policy.AlreadyAccepted, nil
 	}
 	change := effective.Report.Change
-	if alreadyAccepted {
+	if policy.AlreadyAccepted {
 		change.AcknowledgementAccepted = true
 		return true, true, nil
 	}
 
 	if !change.AcknowledgementRequired {
-		change.AcknowledgementAccepted = !dryRun
+		change.AcknowledgementAccepted = !policy.DryRun
 		if !wantsJSON(cmd) {
 			renderSelectionChange(cmd.OutOrStdout(), *change)
 		}
 		return true, change.AcknowledgementAccepted, nil
 	}
 
-	if dryRun {
+	if policy.DryRun {
 		if !wantsJSON(cmd) {
 			renderSelectionChange(cmd.OutOrStdout(), *change)
 		}
 		return true, false, nil
 	}
 
-	if yes || wantsJSON(cmd) {
-		change.AcknowledgementAccepted = yes && acknowledge
+	if policy.Confirmed || wantsJSON(cmd) {
+		change.AcknowledgementAccepted = policy.Confirmed && policy.Acknowledge
 		if !wantsJSON(cmd) {
 			renderSelectionChange(cmd.OutOrStdout(), *change)
 		}

--- a/internal/cli/selection_change.go
+++ b/internal/cli/selection_change.go
@@ -1,0 +1,127 @@
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/yersonargotev/dots/internal/selection"
+)
+
+const selectionChangeAcknowledgementRequiredCode = "selection-change-acknowledgement-required"
+
+type selectionChangeErrorData struct {
+	Code   string           `json:"code"`
+	Change selection.Change `json:"selection_change"`
+}
+
+type selectionChangeAcknowledgementError struct {
+	change selection.Change
+}
+
+func (e *selectionChangeAcknowledgementError) Error() string {
+	return selectionChangeAcknowledgementRequiredCode +
+		": removing previously selected Profiles or extra Tags requires --yes and --acknowledge-selection-change"
+}
+
+func (e *selectionChangeAcknowledgementError) JSONErrorData() any {
+	return selectionChangeErrorData{
+		Code:   selectionChangeAcknowledgementRequiredCode,
+		Change: e.change,
+	}
+}
+
+func guardSelectionChange(cmd *cobra.Command, effective *selection.Effective, dryRun, yes, acknowledge, alreadyAccepted bool) (bool, bool, error) {
+	if effective.Report.Change == nil {
+		return true, alreadyAccepted, nil
+	}
+	change := effective.Report.Change
+	if alreadyAccepted {
+		change.AcknowledgementAccepted = true
+		return true, true, nil
+	}
+
+	if !change.AcknowledgementRequired {
+		change.AcknowledgementAccepted = !dryRun
+		if !wantsJSON(cmd) {
+			renderSelectionChange(cmd.OutOrStdout(), *change)
+		}
+		return true, change.AcknowledgementAccepted, nil
+	}
+
+	if dryRun {
+		if !wantsJSON(cmd) {
+			renderSelectionChange(cmd.OutOrStdout(), *change)
+		}
+		return true, false, nil
+	}
+
+	if yes || wantsJSON(cmd) {
+		change.AcknowledgementAccepted = yes && acknowledge
+		if !wantsJSON(cmd) {
+			renderSelectionChange(cmd.OutOrStdout(), *change)
+		}
+		if !change.AcknowledgementAccepted {
+			return false, false, &selectionChangeAcknowledgementError{change: *change}
+		}
+		return true, true, nil
+	}
+
+	if !wantsJSON(cmd) {
+		renderSelectionChange(cmd.OutOrStdout(), *change)
+	}
+	confirmed, err := confirmSelectionChange(cmd.InOrStdin(), cmd.OutOrStdout())
+	if err != nil {
+		return false, false, err
+	}
+	if !confirmed {
+		fmt.Fprintln(cmd.OutOrStdout(), "Installed Selection change declined; operation canceled before mutation.")
+		return false, false, nil
+	}
+	change.AcknowledgementAccepted = true
+	fmt.Fprintln(cmd.OutOrStdout(), "Installed Selection change acknowledgement accepted.")
+	return true, true, nil
+}
+
+func renderSelectionChange(w io.Writer, change selection.Change) {
+	fmt.Fprintln(w, "Installed Selection change:")
+	renderSelectionDelta(w, change.Delta)
+	fmt.Fprintf(w, "  Acknowledgement: required=%t accepted=%t\n\n",
+		change.AcknowledgementRequired, change.AcknowledgementAccepted)
+}
+
+func renderSelectionDelta(w io.Writer, delta selection.Delta) {
+	fmt.Fprintf(w, "  Previous: profiles=%s extra-tags=%s effective-tags=%s\n",
+		renderSelectionValues(delta.Previous.Profiles), renderSelectionValues(delta.Previous.ExtraTags), renderSelectionValues(delta.Previous.EffectiveTags))
+	fmt.Fprintf(w, "  Requested: profiles=%s extra-tags=%s effective-tags=%s\n",
+		renderSelectionValues(delta.Current.Profiles), renderSelectionValues(delta.Current.ExtraTags), renderSelectionValues(delta.Current.EffectiveTags))
+	fmt.Fprintf(w, "  Added: profiles=%s extra-tags=%s effective-tags=%s managed-entries=%s dependencies=%s provisioners=%s\n",
+		renderSelectionValues(delta.Added.Profiles), renderSelectionValues(delta.Added.ExtraTags),
+		renderSelectionValues(delta.Added.EffectiveTags), renderSelectionValues(delta.Added.ManagedEntries),
+		renderSelectionValues(delta.Added.Dependencies), renderSelectionValues(delta.Added.Provisioners))
+	fmt.Fprintf(w, "  Removed: profiles=%s extra-tags=%s effective-tags=%s managed-entries=%s dependencies=%s provisioners=%s\n",
+		renderSelectionValues(delta.Removed.Profiles), renderSelectionValues(delta.Removed.ExtraTags),
+		renderSelectionValues(delta.Removed.EffectiveTags), renderSelectionValues(delta.Removed.ManagedEntries),
+		renderSelectionValues(delta.Removed.Dependencies), renderSelectionValues(delta.Removed.Provisioners))
+}
+
+func confirmSelectionChange(r io.Reader, w io.Writer) (bool, error) {
+	fmt.Fprint(w, "Apply this Installed Selection reduction? This is separate from Conflict Resolution. [y/N] ")
+	scanner := bufio.NewScanner(r)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return false, fmt.Errorf("read Installed Selection change confirmation: %w", err)
+		}
+		return false, nil
+	}
+	switch strings.ToLower(strings.TrimSpace(scanner.Text())) {
+	case "y", "yes":
+		return true, nil
+	case "", "n", "no":
+		return false, nil
+	default:
+		return false, nil
+	}
+}

--- a/internal/cli/testdata/envelope_install.golden
+++ b/internal/cli/testdata/envelope_install.golden
@@ -4,6 +4,82 @@
   "status": "ok",
   "data": {
     "dry_run": false,
+    "selection": {
+      "source": "explicit",
+      "profiles": [
+        "default"
+      ],
+      "extra_tags": [],
+      "effective_tags": [
+        "default"
+      ],
+      "change": {
+        "delta": {
+          "previous": {
+            "profiles": [
+              "core",
+              "work"
+            ],
+            "extra_tags": [
+              "adaptive-theme"
+            ],
+            "effective_tags": [
+              "core",
+              "work",
+              "adaptive-theme"
+            ]
+          },
+          "current": {
+            "profiles": [
+              "default"
+            ],
+            "extra_tags": [],
+            "effective_tags": [
+              "default"
+            ]
+          },
+          "added": {
+            "profiles": [
+              "default"
+            ],
+            "extra_tags": [],
+            "effective_tags": [
+              "default"
+            ],
+            "managed_entries": [
+              "~/.zshrc"
+            ],
+            "dependencies": [],
+            "provisioners": []
+          },
+          "removed": {
+            "profiles": [
+              "core",
+              "work"
+            ],
+            "extra_tags": [
+              "adaptive-theme"
+            ],
+            "effective_tags": [
+              "core",
+              "work",
+              "adaptive-theme"
+            ],
+            "managed_entries": [
+              "~/.work"
+            ],
+            "dependencies": [],
+            "provisioners": [
+              "gentle-ai"
+            ]
+          },
+          "missing_profiles": [],
+          "stale_extra_tags": []
+        },
+        "acknowledgement_required": true,
+        "acknowledgement_accepted": true
+      }
+    },
     "package_manager_setup": {
       "manager": "homebrew",
       "status": "installed",
@@ -64,6 +140,82 @@
     },
     "plan": {
       "profile": "default",
+      "selection": {
+        "source": "explicit",
+        "profiles": [
+          "default"
+        ],
+        "extra_tags": [],
+        "effective_tags": [
+          "default"
+        ],
+        "change": {
+          "delta": {
+            "previous": {
+              "profiles": [
+                "core",
+                "work"
+              ],
+              "extra_tags": [
+                "adaptive-theme"
+              ],
+              "effective_tags": [
+                "core",
+                "work",
+                "adaptive-theme"
+              ]
+            },
+            "current": {
+              "profiles": [
+                "default"
+              ],
+              "extra_tags": [],
+              "effective_tags": [
+                "default"
+              ]
+            },
+            "added": {
+              "profiles": [
+                "default"
+              ],
+              "extra_tags": [],
+              "effective_tags": [
+                "default"
+              ],
+              "managed_entries": [
+                "~/.zshrc"
+              ],
+              "dependencies": [],
+              "provisioners": []
+            },
+            "removed": {
+              "profiles": [
+                "core",
+                "work"
+              ],
+              "extra_tags": [
+                "adaptive-theme"
+              ],
+              "effective_tags": [
+                "core",
+                "work",
+                "adaptive-theme"
+              ],
+              "managed_entries": [
+                "~/.work"
+              ],
+              "dependencies": [],
+              "provisioners": [
+                "gentle-ai"
+              ]
+            },
+            "missing_profiles": [],
+            "stale_extra_tags": []
+          },
+          "acknowledgement_required": true,
+          "acknowledgement_accepted": true
+        }
+      },
       "actions": [
         {
           "source": "configs/zsh/zshrc",

--- a/internal/cli/testdata/envelope_update.golden
+++ b/internal/cli/testdata/envelope_update.golden
@@ -44,6 +44,8 @@
           ]
         },
         "added": {
+          "profiles": [],
+          "extra_tags": [],
           "effective_tags": [
             "desktop"
           ],
@@ -54,6 +56,8 @@
           "provisioners": []
         },
         "removed": {
+          "profiles": [],
+          "extra_tags": [],
           "effective_tags": [],
           "managed_entries": [],
           "dependencies": [],
@@ -120,6 +124,8 @@
             ]
           },
           "added": {
+            "profiles": [],
+            "extra_tags": [],
             "effective_tags": [
               "desktop"
             ],
@@ -130,6 +136,8 @@
             "provisioners": []
           },
           "removed": {
+            "profiles": [],
+            "extra_tags": [],
             "effective_tags": [],
             "managed_entries": [],
             "dependencies": [],

--- a/internal/cli/testdata/envelope_update_selection_error.golden
+++ b/internal/cli/testdata/envelope_update_selection_error.golden
@@ -29,12 +29,16 @@
         ]
       },
       "added": {
+        "profiles": [],
+        "extra_tags": [],
         "effective_tags": [],
         "managed_entries": [],
         "dependencies": [],
         "provisioners": []
       },
       "removed": {
+        "profiles": [],
+        "extra_tags": [],
         "effective_tags": [],
         "managed_entries": [
           "~/.retired"

--- a/internal/cli/testdata/envelope_upgrade.golden
+++ b/internal/cli/testdata/envelope_upgrade.golden
@@ -44,6 +44,8 @@
           ]
         },
         "added": {
+          "profiles": [],
+          "extra_tags": [],
           "effective_tags": [
             "desktop"
           ],
@@ -54,6 +56,8 @@
           "provisioners": []
         },
         "removed": {
+          "profiles": [],
+          "extra_tags": [],
           "effective_tags": [],
           "managed_entries": [],
           "dependencies": [],
@@ -127,6 +131,8 @@
             ]
           },
           "added": {
+            "profiles": [],
+            "extra_tags": [],
             "effective_tags": [
               "desktop"
             ],
@@ -137,6 +143,8 @@
             "provisioners": []
           },
           "removed": {
+            "profiles": [],
+            "extra_tags": [],
             "effective_tags": [],
             "managed_entries": [],
             "dependencies": [],

--- a/internal/cli/testdata/selection_change.golden
+++ b/internal/cli/testdata/selection_change.golden
@@ -1,0 +1,7 @@
+Installed Selection change:
+  Previous: profiles=core,work extra-tags=adaptive-theme effective-tags=core,work,adaptive-theme
+  Requested: profiles=core extra-tags=(none) effective-tags=core
+  Added: profiles=(none) extra-tags=(none) effective-tags=(none) managed-entries=(none) dependencies=(none) provisioners=(none)
+  Removed: profiles=work extra-tags=adaptive-theme effective-tags=work,adaptive-theme managed-entries=~/.work dependencies=work-tool provisioners=gentle-ai
+  Acknowledgement: required=true accepted=true
+

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -27,20 +27,23 @@ type updateOptions struct {
 	dryRun          bool
 	yes             bool
 	noTUI           bool
+	ackSelection    bool
+	changeAccepted  bool
 	selectionIntent *selection.Intent
 }
 
 func newUpdateCommand() *cobra.Command {
 	var (
-		file       string
-		profiles   []string
-		extraTags  []string
-		sourceRoot string
-		home       string
-		stateRoot  string
-		dryRun     bool
-		yes        bool
-		noTUI      bool
+		file         string
+		profiles     []string
+		extraTags    []string
+		sourceRoot   string
+		home         string
+		stateRoot    string
+		dryRun       bool
+		yes          bool
+		noTUI        bool
+		ackSelection bool
 	)
 
 	cmd := &cobra.Command{
@@ -57,7 +60,7 @@ func newUpdateCommand() *cobra.Command {
 		// conditions, not command misuse, so do not dump the usage block.
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			_, err := runUpdateWorkflow(cmd, updateOptions{file: file, profiles: profiles, extraTags: extraTags, sourceRoot: sourceRoot, home: home, stateRoot: stateRoot, dryRun: dryRun, yes: yes, noTUI: noTUI}, true)
+			_, err := runUpdateWorkflow(cmd, updateOptions{file: file, profiles: profiles, extraTags: extraTags, sourceRoot: sourceRoot, home: home, stateRoot: stateRoot, dryRun: dryRun, yes: yes, noTUI: noTUI, ackSelection: ackSelection}, true)
 			return err
 		},
 	}
@@ -71,6 +74,7 @@ func newUpdateCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "fetch and report the available update and Install Plan without fast-forwarding the working tree or installing files")
 	cmd.Flags().BoolVar(&yes, "yes", false, "apply safe install actions without prompting; conflicts default to skip")
 	cmd.Flags().BoolVar(&noTUI, "no-tui", false, "use text prompts instead of the interactive TUI for conflict resolution")
+	cmd.Flags().BoolVar(&ackSelection, "acknowledge-selection-change", false, "with --yes, acknowledge removal of previously selected Profiles or extra Tags")
 	return cmd
 }
 
@@ -136,19 +140,28 @@ func resolveUpdateSelection(cmd *cobra.Command, manifestPath string, paths resol
 	if err != nil {
 		return nil, selection.Effective{}, err
 	}
-	if opts.selectionIntent != nil {
-		effective, err := selection.ResolveIntent(*m, *opts.selectionIntent)
-		return m, effective, err
-	}
 	meta, err := loadInstallationMetadata(paths, opts.stateRoot)
 	if err != nil {
 		return nil, selection.Effective{}, err
+	}
+	if opts.selectionIntent != nil {
+		effective, err := selection.ResolveIntent(*m, *opts.selectionIntent)
+		if err != nil {
+			return nil, selection.Effective{}, err
+		}
+		if opts.selectionIntent.Source == selection.SourceExplicit {
+			effective = selection.CompareInstalled(*m, effective, meta.InstalledSelection, runtime.GOOS)
+		}
+		return m, effective, nil
 	}
 	if len(opts.profiles) == 0 && len(opts.extraTags) == 0 && meta.InstalledSelection == nil && (meta.Version == 1 || meta.Version == 2) {
 		effective, err := resolveLegacyUpdateSelection(cmd, *m, meta, paths, opts)
 		return m, effective, err
 	}
 	effective, err := selection.ResolveEffective(*m, opts.profiles, opts.extraTags, meta.InstalledSelection)
+	if err == nil && effective.Report.Source == selection.SourceExplicit {
+		effective = selection.CompareInstalled(*m, effective, meta.InstalledSelection, runtime.GOOS)
+	}
 	return m, effective, err
 }
 
@@ -168,6 +181,14 @@ func runUpdateWorkflow(cmd *cobra.Command, opts updateOptions, emit bool) (updat
 	if err != nil {
 		return updateReport{}, err
 	}
+	proceed, accepted, err := guardSelectionChange(cmd, &effective, opts.dryRun, opts.yes, opts.ackSelection, opts.changeAccepted)
+	if err != nil {
+		return updateReport{}, err
+	}
+	if !proceed {
+		return updateReport{DryRun: opts.dryRun, Selection: effective.Report}, nil
+	}
+	opts.changeAccepted = accepted
 
 	out := cmd.OutOrStdout()
 	var update gitrepo.Update

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -181,7 +181,9 @@ func runUpdateWorkflow(cmd *cobra.Command, opts updateOptions, emit bool) (updat
 	if err != nil {
 		return updateReport{}, err
 	}
-	proceed, accepted, err := guardSelectionChange(cmd, &effective, opts.dryRun, opts.yes, opts.ackSelection, opts.changeAccepted)
+	proceed, accepted, err := guardSelectionChange(cmd, &effective, selectionChangePolicy{
+		DryRun: opts.dryRun, Confirmed: opts.yes, Acknowledge: opts.ackSelection, AlreadyAccepted: opts.changeAccepted,
+	})
 	if err != nil {
 		return updateReport{}, err
 	}

--- a/internal/cli/update_selection_test.go
+++ b/internal/cli/update_selection_test.go
@@ -215,6 +215,56 @@ entries:
 	}
 }
 
+func TestUpdateAdditiveSelectionChangeAppliesWithoutDedicatedAcknowledgement(t *testing.T) {
+	requireGitCLI(t)
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	_, sourceRoot := newInstalledRepo(t, map[string]string{
+		"configs/core":  "core\n",
+		"configs/extra": "extra\n",
+		"dots.yaml": `version: 1
+profiles:
+  core:
+    tags: [core]
+entries:
+  - source: configs/core
+    target: ~/.core
+    strategy: symlink
+    tags: [core]
+  - source: configs/extra
+    target: ~/.extra
+    strategy: symlink
+    tags: [extra]
+`,
+	})
+	saveInstalledSelection(t, stateRoot, "core")
+
+	out := runUpdate(t,
+		"--yes", "--profile", "core", "--tag", "extra",
+		"--file", filepath.Join(sourceRoot, "dots.yaml"),
+		"--home", home, "--source-root", sourceRoot, "--state-root", stateRoot,
+	)
+	for _, want := range []string{
+		"Added: profiles=(none) extra-tags=extra effective-tags=extra",
+		"Acknowledgement: required=false accepted=true",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing additive change %q:\n%s", want, out)
+		}
+	}
+	if _, err := os.Readlink(filepath.Join(home, ".extra")); err != nil {
+		t.Fatalf("additive selection did not apply extra Managed Entry: %v", err)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load metadata: %v", err)
+	}
+	if got, want := meta.InstalledSelection.ExtraTags, []string{"extra"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Installed Selection extra Tags = %#v, want %#v", got, want)
+	}
+}
+
 func TestUpdateInteractiveSelectionReductionCanBeDeclinedBeforeMutation(t *testing.T) {
 	requireGitCLI(t)
 	home := t.TempDir()

--- a/internal/cli/update_selection_test.go
+++ b/internal/cli/update_selection_test.go
@@ -119,12 +119,15 @@ entries:
 	})
 	saveInstalledSelection(t, stateRoot, "core")
 
-	out := runUpdate(t, "--yes", "--profile", "work", "--tag", "extra",
+	out := runUpdate(t, "--yes", "--acknowledge-selection-change", "--profile", "work", "--tag", "extra",
 		"--file", filepath.Join(sourceRoot, "dots.yaml"),
 		"--home", home, "--source-root", sourceRoot, "--state-root", stateRoot)
 
 	if want := "Selection: source=explicit profiles=work extra-tags=extra effective-tags=work,extra"; !strings.Contains(out, want) {
 		t.Fatalf("output missing selection report %q:\n%s", want, out)
+	}
+	if want := "Acknowledgement: required=true accepted=true"; !strings.Contains(out, want) {
+		t.Fatalf("output missing accepted selection change %q:\n%s", want, out)
 	}
 	if _, err := os.Lstat(filepath.Join(home, ".core")); !os.IsNotExist(err) {
 		t.Fatalf("recorded core selection leaked into explicit update: %v", err)
@@ -143,6 +146,120 @@ entries:
 	}
 	if got, want := meta.InstalledSelection.ExtraTags, []string{"extra"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("ExtraTags = %#v, want %#v", got, want)
+	}
+}
+
+func TestUpdateYesSelectionReductionRequiresDedicatedAcknowledgement(t *testing.T) {
+	requireGitCLI(t)
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	_, sourceRoot := newInstalledRepo(t, map[string]string{
+		"configs/core": "core\n",
+		"configs/work": "work\n",
+		"dots.yaml": `version: 1
+profiles:
+  core:
+    tags: [core]
+  work:
+    tags: [work]
+entries:
+  - source: configs/core
+    target: ~/.core
+    strategy: symlink
+    tags: [core]
+  - source: configs/work
+    target: ~/.work
+    strategy: symlink
+    tags: [work]
+`,
+	})
+	saveInstalledSelection(t, stateRoot, "core")
+
+	var out, errOut bytes.Buffer
+	code := cli.Run([]string{
+		"update", "--yes", "--output", "json", "--profile", "work",
+		"--file", filepath.Join(sourceRoot, "dots.yaml"),
+		"--home", home, "--source-root", sourceRoot, "--state-root", stateRoot,
+	}, &out, &errOut)
+	if code != cli.ExitError {
+		t.Fatalf("exit code = %d, want %d\nstdout:\n%s\nstderr:\n%s", code, cli.ExitError, out.String(), errOut.String())
+	}
+	var env struct {
+		Data struct {
+			Code   string           `json:"code"`
+			Change selection.Change `json:"selection_change"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal JSON: %v\n%s", err, out.String())
+	}
+	if env.Data.Code != "selection-change-acknowledgement-required" ||
+		!env.Data.Change.AcknowledgementRequired ||
+		env.Data.Change.AcknowledgementAccepted {
+		t.Fatalf("selection change error data = %#v", env.Data)
+	}
+	if got, want := env.Data.Change.Delta.Removed.Profiles, []string{"core"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("removed Profiles = %#v, want %#v", got, want)
+	}
+	if _, err := os.Lstat(filepath.Join(home, ".work")); !os.IsNotExist(err) {
+		t.Fatalf("selection rejection applied Managed Configuration: %v", err)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load metadata: %v", err)
+	}
+	if got, want := meta.InstalledSelection.Profiles, []string{"core"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Installed Selection Profiles = %#v, want %#v", got, want)
+	}
+}
+
+func TestUpdateInteractiveSelectionReductionCanBeDeclinedBeforeMutation(t *testing.T) {
+	requireGitCLI(t)
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	_, sourceRoot := newInstalledRepo(t, map[string]string{
+		"configs/core": "core\n",
+		"configs/work": "work\n",
+		"dots.yaml": `version: 1
+profiles:
+  core:
+    tags: [core]
+  work:
+    tags: [work]
+entries:
+  - source: configs/core
+    target: ~/.core
+    strategy: symlink
+    tags: [core]
+  - source: configs/work
+    target: ~/.work
+    strategy: symlink
+    tags: [work]
+`,
+	})
+	saveInstalledSelection(t, stateRoot, "core")
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetIn(strings.NewReader("n\n"))
+	cmd.SetArgs([]string{
+		"update", "--profile", "work", "--no-tui",
+		"--file", filepath.Join(sourceRoot, "dots.yaml"),
+		"--home", home, "--source-root", sourceRoot, "--state-root", stateRoot,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\n%s", err, out.String())
+	}
+	if !strings.Contains(out.String(), "Installed Selection change declined; operation canceled before mutation.") {
+		t.Fatalf("output missing decline confirmation:\n%s", out.String())
+	}
+	if _, err := os.Lstat(filepath.Join(home, ".work")); !os.IsNotExist(err) {
+		t.Fatalf("declined selection change applied Managed Configuration: %v", err)
 	}
 }
 

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -21,27 +21,29 @@ var (
 
 func newUpgradeCommand() *cobra.Command {
 	var (
-		file       string
-		profiles   []string
-		extraTags  []string
-		sourceRoot string
-		home       string
-		stateRoot  string
-		dryRun     bool
-		yes        bool
-		noTUI      bool
-		continue_  bool
+		file         string
+		profiles     []string
+		extraTags    []string
+		sourceRoot   string
+		home         string
+		stateRoot    string
+		dryRun       bool
+		yes          bool
+		noTUI        bool
+		ackSelection bool
+		continue_    bool
 
-		binaryChannel        string
-		binaryCurrentVersion string
-		binaryLatestVersion  string
-		binaryAction         string
-		binaryExecutable     string
-		binaryArtifact       string
-		binaryChecksum       string
-		selectionSource      string
-		selectionProfiles    []string
-		selectionTags        []string
+		binaryChannel           string
+		binaryCurrentVersion    string
+		binaryLatestVersion     string
+		binaryAction            string
+		binaryExecutable        string
+		binaryArtifact          string
+		binaryChecksum          string
+		selectionSource         string
+		selectionProfiles       []string
+		selectionTags           []string
+		selectionChangeAccepted bool
 	)
 
 	cmd := &cobra.Command{
@@ -51,7 +53,7 @@ func newUpgradeCommand() *cobra.Command {
 			"Managed Entries, and Provisioners. It never performs a broad system package upgrade.",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts := updateOptions{file: file, profiles: profiles, extraTags: extraTags, sourceRoot: sourceRoot, home: home, stateRoot: stateRoot, dryRun: dryRun, yes: yes, noTUI: noTUI}
+			opts := updateOptions{file: file, profiles: profiles, extraTags: extraTags, sourceRoot: sourceRoot, home: home, stateRoot: stateRoot, dryRun: dryRun, yes: yes, noTUI: noTUI, ackSelection: ackSelection, changeAccepted: selectionChangeAccepted}
 			if continue_ {
 				if selectionSource != "" {
 					intent := selection.Intent{Source: selection.Source(selectionSource), Profiles: selectionProfiles, ExtraTags: selectionTags}
@@ -105,8 +107,16 @@ func newUpgradeCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			proceed, accepted, err := guardSelectionChange(cmd, &effective, false, yes, ackSelection, false)
+			if err != nil {
+				return err
+			}
+			if !proceed {
+				return nil
+			}
 			intent := effective.Intent()
 			opts.selectionIntent = &intent
+			opts.changeAccepted = accepted
 			binPlan, err := executeUpgrade(cmd.Context(), binOpts)
 			if err != nil {
 				return err
@@ -115,7 +125,7 @@ func newUpgradeCommand() *cobra.Command {
 				renderUpgradeBinary(cmd.OutOrStdout(), binPlan, false)
 			}
 			if binPlan.Action == upgrade.ActionHomebrewUpgrade || binPlan.Action == upgrade.ActionReplaceBinary {
-				return execBinary(exe, upgradeContinuationArgs(file, cmd.Flags().Changed("file"), intent, sourceRoot, home, stateRoot, yes, noTUI, wantsJSON(cmd), binPlan), os.Environ())
+				return execBinary(exe, upgradeContinuationArgs(file, cmd.Flags().Changed("file"), intent, sourceRoot, home, stateRoot, yes, noTUI, ackSelection, accepted, wantsJSON(cmd), binPlan), os.Environ())
 			}
 			updateReport, err := runUpdateWorkflow(cmd, opts, false)
 			if err != nil {
@@ -136,6 +146,7 @@ func newUpgradeCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview the binary upgrade and Source of Truth update without modifying either phase")
 	cmd.Flags().BoolVar(&yes, "yes", false, "apply safe install actions without prompting; conflicts default to skip")
 	cmd.Flags().BoolVar(&noTUI, "no-tui", false, "use text prompts instead of the interactive TUI for conflict resolution")
+	cmd.Flags().BoolVar(&ackSelection, "acknowledge-selection-change", false, "with --yes, acknowledge removal of previously selected Profiles or extra Tags")
 	cmd.Flags().BoolVar(&continue_, "continue", false, "continue Source of Truth upgrade after binary replacement")
 	cmd.Flags().StringVar(&binaryChannel, "binary-channel", "", "binary phase channel preserved across upgrade continuation")
 	cmd.Flags().StringVar(&binaryCurrentVersion, "binary-current-version", "", "binary phase current version preserved across upgrade continuation")
@@ -147,6 +158,7 @@ func newUpgradeCommand() *cobra.Command {
 	cmd.Flags().StringVar(&selectionSource, "selection-source", "", "selection source preserved across upgrade continuation")
 	cmd.Flags().StringArrayVar(&selectionProfiles, "selection-profile", nil, "selection Profile preserved across upgrade continuation")
 	cmd.Flags().StringArrayVar(&selectionTags, "selection-tag", nil, "selection extra Tag preserved across upgrade continuation")
+	cmd.Flags().BoolVar(&selectionChangeAccepted, "selection-change-accepted", false, "selection change acknowledgement preserved across upgrade continuation")
 	_ = cmd.Flags().MarkHidden("continue")
 	_ = cmd.Flags().MarkHidden("binary-channel")
 	_ = cmd.Flags().MarkHidden("binary-current-version")
@@ -158,6 +170,7 @@ func newUpgradeCommand() *cobra.Command {
 	_ = cmd.Flags().MarkHidden("selection-source")
 	_ = cmd.Flags().MarkHidden("selection-profile")
 	_ = cmd.Flags().MarkHidden("selection-tag")
+	_ = cmd.Flags().MarkHidden("selection-change-accepted")
 	return cmd
 }
 
@@ -174,7 +187,7 @@ func resolveUpgradeSelection(cmd *cobra.Command, opts updateOptions) (selection.
 	return effective, err
 }
 
-func upgradeContinuationArgs(file string, fileChanged bool, intent selection.Intent, sourceRoot, home, stateRoot string, yes, noTUI, json bool, binPlan upgrade.Plan) []string {
+func upgradeContinuationArgs(file string, fileChanged bool, intent selection.Intent, sourceRoot, home, stateRoot string, yes, noTUI, acknowledgeSelectionChange, selectionChangeAccepted, json bool, binPlan upgrade.Plan) []string {
 	args := []string{"dots", "upgrade", "--continue"}
 	if fileChanged {
 		args = append(args, "--file", file)
@@ -200,6 +213,12 @@ func upgradeContinuationArgs(file string, fileChanged bool, intent selection.Int
 	}
 	if noTUI {
 		args = append(args, "--no-tui")
+	}
+	if acknowledgeSelectionChange {
+		args = append(args, "--acknowledge-selection-change")
+	}
+	if selectionChangeAccepted {
+		args = append(args, "--selection-change-accepted")
 	}
 	if json {
 		args = append(args, "--output", "json")

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -33,17 +33,16 @@ func newUpgradeCommand() *cobra.Command {
 		ackSelection bool
 		continue_    bool
 
-		binaryChannel           string
-		binaryCurrentVersion    string
-		binaryLatestVersion     string
-		binaryAction            string
-		binaryExecutable        string
-		binaryArtifact          string
-		binaryChecksum          string
-		selectionSource         string
-		selectionProfiles       []string
-		selectionTags           []string
-		selectionChangeAccepted bool
+		binaryChannel        string
+		binaryCurrentVersion string
+		binaryLatestVersion  string
+		binaryAction         string
+		binaryExecutable     string
+		binaryArtifact       string
+		binaryChecksum       string
+		selectionSource      string
+		selectionProfiles    []string
+		selectionTags        []string
 	)
 
 	cmd := &cobra.Command{
@@ -53,7 +52,7 @@ func newUpgradeCommand() *cobra.Command {
 			"Managed Entries, and Provisioners. It never performs a broad system package upgrade.",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts := updateOptions{file: file, profiles: profiles, extraTags: extraTags, sourceRoot: sourceRoot, home: home, stateRoot: stateRoot, dryRun: dryRun, yes: yes, noTUI: noTUI, ackSelection: ackSelection, changeAccepted: selectionChangeAccepted}
+			opts := updateOptions{file: file, profiles: profiles, extraTags: extraTags, sourceRoot: sourceRoot, home: home, stateRoot: stateRoot, dryRun: dryRun, yes: yes, noTUI: noTUI, ackSelection: ackSelection}
 			if continue_ {
 				if selectionSource != "" {
 					intent := selection.Intent{Source: selection.Source(selectionSource), Profiles: selectionProfiles, ExtraTags: selectionTags}
@@ -107,7 +106,9 @@ func newUpgradeCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			proceed, accepted, err := guardSelectionChange(cmd, &effective, false, yes, ackSelection, false)
+			proceed, accepted, err := guardSelectionChange(cmd, &effective, selectionChangePolicy{
+				Confirmed: yes, Acknowledge: ackSelection,
+			})
 			if err != nil {
 				return err
 			}
@@ -125,7 +126,7 @@ func newUpgradeCommand() *cobra.Command {
 				renderUpgradeBinary(cmd.OutOrStdout(), binPlan, false)
 			}
 			if binPlan.Action == upgrade.ActionHomebrewUpgrade || binPlan.Action == upgrade.ActionReplaceBinary {
-				return execBinary(exe, upgradeContinuationArgs(file, cmd.Flags().Changed("file"), intent, sourceRoot, home, stateRoot, yes, noTUI, ackSelection, accepted, wantsJSON(cmd), binPlan), os.Environ())
+				return execBinary(exe, upgradeContinuationArgs(opts, cmd.Flags().Changed("file"), intent, wantsJSON(cmd), binPlan), os.Environ())
 			}
 			updateReport, err := runUpdateWorkflow(cmd, opts, false)
 			if err != nil {
@@ -158,7 +159,6 @@ func newUpgradeCommand() *cobra.Command {
 	cmd.Flags().StringVar(&selectionSource, "selection-source", "", "selection source preserved across upgrade continuation")
 	cmd.Flags().StringArrayVar(&selectionProfiles, "selection-profile", nil, "selection Profile preserved across upgrade continuation")
 	cmd.Flags().StringArrayVar(&selectionTags, "selection-tag", nil, "selection extra Tag preserved across upgrade continuation")
-	cmd.Flags().BoolVar(&selectionChangeAccepted, "selection-change-accepted", false, "selection change acknowledgement preserved across upgrade continuation")
 	_ = cmd.Flags().MarkHidden("continue")
 	_ = cmd.Flags().MarkHidden("binary-channel")
 	_ = cmd.Flags().MarkHidden("binary-current-version")
@@ -170,7 +170,6 @@ func newUpgradeCommand() *cobra.Command {
 	_ = cmd.Flags().MarkHidden("selection-source")
 	_ = cmd.Flags().MarkHidden("selection-profile")
 	_ = cmd.Flags().MarkHidden("selection-tag")
-	_ = cmd.Flags().MarkHidden("selection-change-accepted")
 	return cmd
 }
 
@@ -187,10 +186,10 @@ func resolveUpgradeSelection(cmd *cobra.Command, opts updateOptions) (selection.
 	return effective, err
 }
 
-func upgradeContinuationArgs(file string, fileChanged bool, intent selection.Intent, sourceRoot, home, stateRoot string, yes, noTUI, acknowledgeSelectionChange, selectionChangeAccepted, json bool, binPlan upgrade.Plan) []string {
+func upgradeContinuationArgs(opts updateOptions, fileChanged bool, intent selection.Intent, json bool, binPlan upgrade.Plan) []string {
 	args := []string{"dots", "upgrade", "--continue"}
 	if fileChanged {
-		args = append(args, "--file", file)
+		args = append(args, "--file", opts.file)
 	}
 	args = append(args, "--selection-source", string(intent.Source))
 	for _, profile := range intent.Profiles {
@@ -199,26 +198,23 @@ func upgradeContinuationArgs(file string, fileChanged bool, intent selection.Int
 	for _, tag := range intent.ExtraTags {
 		args = append(args, "--selection-tag", tag)
 	}
-	if sourceRoot != "" {
-		args = append(args, "--source-root", sourceRoot)
+	if opts.sourceRoot != "" {
+		args = append(args, "--source-root", opts.sourceRoot)
 	}
-	if home != "" {
-		args = append(args, "--home", home)
+	if opts.home != "" {
+		args = append(args, "--home", opts.home)
 	}
-	if stateRoot != "" {
-		args = append(args, "--state-root", stateRoot)
+	if opts.stateRoot != "" {
+		args = append(args, "--state-root", opts.stateRoot)
 	}
-	if yes {
+	if opts.yes {
 		args = append(args, "--yes")
 	}
-	if noTUI {
+	if opts.noTUI {
 		args = append(args, "--no-tui")
 	}
-	if acknowledgeSelectionChange {
+	if opts.ackSelection {
 		args = append(args, "--acknowledge-selection-change")
-	}
-	if selectionChangeAccepted {
-		args = append(args, "--selection-change-accepted")
 	}
 	if json {
 		args = append(args, "--output", "json")

--- a/internal/cli/upgrade_internal_test.go
+++ b/internal/cli/upgrade_internal_test.go
@@ -11,15 +11,15 @@ import (
 func TestUpgradeContinuationArgsPreserveUpdateFlags(t *testing.T) {
 	binPlan := upgrade.Plan{Channel: "homebrew", CurrentVersion: "v0.18.0", LatestVersion: "v0.19.0", Action: "homebrew-upgrade", Executable: "/bin/dots", Artifact: "dots_v0.19.0_darwin_arm64", Checksum: "abc123"}
 	intent := selection.Intent{Source: selection.SourceRecorded, Profiles: []string{"core", "work"}, ExtraTags: []string{"core", "desktop"}}
-	got := upgradeContinuationArgs("custom.yaml", true, intent, "/src", "/home", "/state", true, true, true, binPlan)
-	want := []string{"dots", "upgrade", "--continue", "--file", "custom.yaml", "--selection-source", "recorded", "--selection-profile", "core", "--selection-profile", "work", "--selection-tag", "core", "--selection-tag", "desktop", "--source-root", "/src", "--home", "/home", "--state-root", "/state", "--yes", "--no-tui", "--output", "json", "--binary-channel", "homebrew", "--binary-current-version", "v0.18.0", "--binary-latest-version", "v0.19.0", "--binary-action", "homebrew-upgrade", "--binary-executable", "/bin/dots", "--binary-artifact", "dots_v0.19.0_darwin_arm64", "--binary-checksum", "abc123"}
+	got := upgradeContinuationArgs("custom.yaml", true, intent, "/src", "/home", "/state", true, true, true, true, true, binPlan)
+	want := []string{"dots", "upgrade", "--continue", "--file", "custom.yaml", "--selection-source", "recorded", "--selection-profile", "core", "--selection-profile", "work", "--selection-tag", "core", "--selection-tag", "desktop", "--source-root", "/src", "--home", "/home", "--state-root", "/state", "--yes", "--no-tui", "--acknowledge-selection-change", "--selection-change-accepted", "--output", "json", "--binary-channel", "homebrew", "--binary-current-version", "v0.18.0", "--binary-latest-version", "v0.19.0", "--binary-action", "homebrew-upgrade", "--binary-executable", "/bin/dots", "--binary-artifact", "dots_v0.19.0_darwin_arm64", "--binary-checksum", "abc123"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("args = %#v, want %#v", got, want)
 	}
 }
 
 func TestUpgradeContinuationArgsDoNotMarkDefaultFileChanged(t *testing.T) {
-	got := upgradeContinuationArgs("dots.yaml", false, selection.Intent{Source: selection.SourceExplicit, Profiles: []string{"default"}}, "/src", "/home", "", true, false, false, upgrade.Plan{})
+	got := upgradeContinuationArgs("dots.yaml", false, selection.Intent{Source: selection.SourceExplicit, Profiles: []string{"default"}}, "/src", "/home", "", true, false, false, false, false, upgrade.Plan{})
 	for i, arg := range got {
 		if arg == "--file" || arg == "-f" {
 			t.Fatalf("args[%d] = %q; default manifest must not be forwarded as an explicit --file: %#v", i, arg, got)
@@ -33,7 +33,7 @@ func TestUpgradeContinuationArgsPreserveConfirmedMigrationSource(t *testing.T) {
 		Profiles:  []string{"core"},
 		ExtraTags: []string{"adaptive-theme"},
 	}
-	got := upgradeContinuationArgs("dots.yaml", false, intent, "/src", "/home", "/state", false, false, false, upgrade.Plan{})
+	got := upgradeContinuationArgs("dots.yaml", false, intent, "/src", "/home", "/state", false, false, false, false, false, upgrade.Plan{})
 	wantPrefix := []string{
 		"dots", "upgrade", "--continue",
 		"--selection-source", "migration",

--- a/internal/cli/upgrade_internal_test.go
+++ b/internal/cli/upgrade_internal_test.go
@@ -11,15 +11,16 @@ import (
 func TestUpgradeContinuationArgsPreserveUpdateFlags(t *testing.T) {
 	binPlan := upgrade.Plan{Channel: "homebrew", CurrentVersion: "v0.18.0", LatestVersion: "v0.19.0", Action: "homebrew-upgrade", Executable: "/bin/dots", Artifact: "dots_v0.19.0_darwin_arm64", Checksum: "abc123"}
 	intent := selection.Intent{Source: selection.SourceRecorded, Profiles: []string{"core", "work"}, ExtraTags: []string{"core", "desktop"}}
-	got := upgradeContinuationArgs("custom.yaml", true, intent, "/src", "/home", "/state", true, true, true, true, true, binPlan)
-	want := []string{"dots", "upgrade", "--continue", "--file", "custom.yaml", "--selection-source", "recorded", "--selection-profile", "core", "--selection-profile", "work", "--selection-tag", "core", "--selection-tag", "desktop", "--source-root", "/src", "--home", "/home", "--state-root", "/state", "--yes", "--no-tui", "--acknowledge-selection-change", "--selection-change-accepted", "--output", "json", "--binary-channel", "homebrew", "--binary-current-version", "v0.18.0", "--binary-latest-version", "v0.19.0", "--binary-action", "homebrew-upgrade", "--binary-executable", "/bin/dots", "--binary-artifact", "dots_v0.19.0_darwin_arm64", "--binary-checksum", "abc123"}
+	opts := updateOptions{file: "custom.yaml", sourceRoot: "/src", home: "/home", stateRoot: "/state", yes: true, noTUI: true, ackSelection: true}
+	got := upgradeContinuationArgs(opts, true, intent, true, binPlan)
+	want := []string{"dots", "upgrade", "--continue", "--file", "custom.yaml", "--selection-source", "recorded", "--selection-profile", "core", "--selection-profile", "work", "--selection-tag", "core", "--selection-tag", "desktop", "--source-root", "/src", "--home", "/home", "--state-root", "/state", "--yes", "--no-tui", "--acknowledge-selection-change", "--output", "json", "--binary-channel", "homebrew", "--binary-current-version", "v0.18.0", "--binary-latest-version", "v0.19.0", "--binary-action", "homebrew-upgrade", "--binary-executable", "/bin/dots", "--binary-artifact", "dots_v0.19.0_darwin_arm64", "--binary-checksum", "abc123"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("args = %#v, want %#v", got, want)
 	}
 }
 
 func TestUpgradeContinuationArgsDoNotMarkDefaultFileChanged(t *testing.T) {
-	got := upgradeContinuationArgs("dots.yaml", false, selection.Intent{Source: selection.SourceExplicit, Profiles: []string{"default"}}, "/src", "/home", "", true, false, false, false, false, upgrade.Plan{})
+	got := upgradeContinuationArgs(updateOptions{file: "dots.yaml", sourceRoot: "/src", home: "/home", yes: true}, false, selection.Intent{Source: selection.SourceExplicit, Profiles: []string{"default"}}, false, upgrade.Plan{})
 	for i, arg := range got {
 		if arg == "--file" || arg == "-f" {
 			t.Fatalf("args[%d] = %q; default manifest must not be forwarded as an explicit --file: %#v", i, arg, got)
@@ -33,7 +34,7 @@ func TestUpgradeContinuationArgsPreserveConfirmedMigrationSource(t *testing.T) {
 		Profiles:  []string{"core"},
 		ExtraTags: []string{"adaptive-theme"},
 	}
-	got := upgradeContinuationArgs("dots.yaml", false, intent, "/src", "/home", "/state", false, false, false, false, false, upgrade.Plan{})
+	got := upgradeContinuationArgs(updateOptions{file: "dots.yaml", sourceRoot: "/src", home: "/home", stateRoot: "/state"}, false, intent, false, upgrade.Plan{})
 	wantPrefix := []string{
 		"dots", "upgrade", "--continue",
 		"--selection-source", "migration",

--- a/internal/selection/selection.go
+++ b/internal/selection/selection.go
@@ -32,6 +32,7 @@ type Report struct {
 	ExtraTags     []string `json:"extra_tags"`
 	EffectiveTags []string `json:"effective_tags"`
 	Delta         *Delta   `json:"delta,omitempty"`
+	Change        *Change  `json:"change,omitempty"`
 }
 
 // Snapshot is the portable selection state on one side of an evolution.
@@ -43,6 +44,8 @@ type Snapshot struct {
 
 // Changes describes an ordered change to the selected manifest surface.
 type Changes struct {
+	Profiles       []string `json:"profiles"`
+	ExtraTags      []string `json:"extra_tags"`
 	EffectiveTags  []string `json:"effective_tags"`
 	ManagedEntries []string `json:"managed_entries"`
 	Dependencies   []string `json:"dependencies"`
@@ -58,6 +61,15 @@ type Delta struct {
 	Removed         Changes  `json:"removed"`
 	MissingProfiles []string `json:"missing_profiles"`
 	StaleExtraTags  []string `json:"stale_extra_tags"`
+}
+
+// Change describes an explicit replacement of the authoritative Installed
+// Selection. Acknowledgement state is intentionally separate from manifest
+// evolution semantics.
+type Change struct {
+	Delta                   Delta `json:"delta"`
+	AcknowledgementRequired bool  `json:"acknowledgement_required"`
+	AcknowledgementAccepted bool  `json:"acknowledgement_accepted"`
 }
 
 // EvolutionError is an actionable, machine-readable blocking validation error.
@@ -182,6 +194,7 @@ func CompareEvolution(previousManifest, currentManifest manifest.Manifest, previ
 		delta.Removed = surfaceDifference(previousSurface, currentSurface)
 		if len(delta.StaleExtraTags) == 0 {
 			current.Report.Delta = &delta
+			current.Report.Change = previous.Report.Change
 			return current, nil
 		}
 	}
@@ -199,6 +212,42 @@ func CompareEvolution(previousManifest, currentManifest manifest.Manifest, previ
 	}
 }
 
+// CompareInstalled compares an explicit effective request with the
+// authoritative Installed Selection recorded for the same Install Manifest.
+// The recorded resolved Tags are retained as the previous audit snapshot
+// rather than being re-resolved.
+func CompareInstalled(m manifest.Manifest, requested Effective, recorded *state.InstalledSelection, osName string) Effective {
+	requested.Report.Change = nil
+	if recorded == nil {
+		return requested
+	}
+
+	previousSelection := manifest.Selection{
+		Profiles: cloneStrings(recorded.Profiles),
+		Tags:     cloneStrings(recorded.ResolvedTags),
+	}
+	previousSurface := selectedSurface(m, previousSelection, osName)
+	currentSurface := selectedSurface(m, requested.Selection, osName)
+	previous := surfaceSnapshot(recorded.Profiles, recorded.ExtraTags, previousSurface)
+	current := surfaceSnapshot(requested.Profiles, requested.ExtraTags, currentSurface)
+	delta := emptyDelta(previous, current)
+	delta.Added = surfaceDifference(currentSurface, previousSurface)
+	delta.Added.Profiles = difference(current.Profiles, previous.Profiles)
+	delta.Added.ExtraTags = difference(current.ExtraTags, previous.ExtraTags)
+	delta.Removed = surfaceDifference(previousSurface, currentSurface)
+	delta.Removed.Profiles = difference(previous.Profiles, current.Profiles)
+	delta.Removed.ExtraTags = difference(previous.ExtraTags, current.ExtraTags)
+	if deltaIsEmpty(delta) {
+		return requested
+	}
+	requested.Report.Change = &Change{
+		Delta: delta,
+		AcknowledgementRequired: len(delta.Removed.Profiles) > 0 ||
+			len(delta.Removed.ExtraTags) > 0,
+	}
+	return requested
+}
+
 func snapshot(e Effective) Snapshot {
 	return Snapshot{
 		Profiles:      cloneStrings(e.Profiles),
@@ -207,17 +256,29 @@ func snapshot(e Effective) Snapshot {
 	}
 }
 
+func surfaceSnapshot(profiles, extraTags []string, surface Changes) Snapshot {
+	return Snapshot{
+		Profiles:      cloneStrings(profiles),
+		ExtraTags:     cloneStrings(extraTags),
+		EffectiveTags: cloneStrings(surface.EffectiveTags),
+	}
+}
+
 func emptyDelta(previous, current Snapshot) Delta {
 	return Delta{
 		Previous: previous,
 		Current:  current,
 		Added: Changes{
+			Profiles:       make([]string, 0),
+			ExtraTags:      make([]string, 0),
 			EffectiveTags:  make([]string, 0),
 			ManagedEntries: make([]string, 0),
 			Dependencies:   make([]string, 0),
 			Provisioners:   make([]string, 0),
 		},
 		Removed: Changes{
+			Profiles:       make([]string, 0),
+			ExtraTags:      make([]string, 0),
 			EffectiveTags:  make([]string, 0),
 			ManagedEntries: make([]string, 0),
 			Dependencies:   make([]string, 0),
@@ -276,6 +337,8 @@ func supportedSelectionModifier(tag string) bool {
 
 func selectedSurface(m manifest.Manifest, selected manifest.Selection, osName string) Changes {
 	result := Changes{
+		Profiles:       make([]string, 0),
+		ExtraTags:      make([]string, 0),
 		EffectiveTags:  cloneStrings(selected.Tags),
 		ManagedEntries: make([]string, 0),
 		Dependencies:   make([]string, 0),
@@ -323,11 +386,28 @@ func selectedSurface(m manifest.Manifest, selected manifest.Selection, osName st
 
 func surfaceDifference(left, right Changes) Changes {
 	return Changes{
+		Profiles:       make([]string, 0),
+		ExtraTags:      make([]string, 0),
 		EffectiveTags:  difference(left.EffectiveTags, right.EffectiveTags),
 		ManagedEntries: difference(left.ManagedEntries, right.ManagedEntries),
 		Dependencies:   difference(left.Dependencies, right.Dependencies),
 		Provisioners:   difference(left.Provisioners, right.Provisioners),
 	}
+}
+
+func deltaIsEmpty(delta Delta) bool {
+	return len(delta.Added.Profiles) == 0 &&
+		len(delta.Added.ExtraTags) == 0 &&
+		len(delta.Added.EffectiveTags) == 0 &&
+		len(delta.Added.ManagedEntries) == 0 &&
+		len(delta.Added.Dependencies) == 0 &&
+		len(delta.Added.Provisioners) == 0 &&
+		len(delta.Removed.Profiles) == 0 &&
+		len(delta.Removed.ExtraTags) == 0 &&
+		len(delta.Removed.EffectiveTags) == 0 &&
+		len(delta.Removed.ManagedEntries) == 0 &&
+		len(delta.Removed.Dependencies) == 0 &&
+		len(delta.Removed.Provisioners) == 0
 }
 
 func difference(left, right []string) []string {

--- a/internal/selection/selection.go
+++ b/internal/selection/selection.go
@@ -221,6 +221,10 @@ func CompareInstalled(m manifest.Manifest, requested Effective, recorded *state.
 	if recorded == nil {
 		return requested
 	}
+	if equalStrings(recorded.Profiles, requested.Profiles) &&
+		equalStrings(recorded.ExtraTags, requested.ExtraTags) {
+		return requested
+	}
 
 	previousSelection := manifest.Selection{
 		Profiles: cloneStrings(recorded.Profiles),
@@ -422,6 +426,18 @@ func difference(left, right []string) []string {
 		}
 	}
 	return result
+}
+
+func equalStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func validateIntent(source Source, profiles, extraTags []string) error {

--- a/internal/selection/selection_test.go
+++ b/internal/selection/selection_test.go
@@ -100,6 +100,10 @@ func TestCompareInstalledNoRecordedSelectionOrEqualSelectionHasNoChange(t *testi
 	if got := selection.CompareInstalled(m, requested, recorded, "linux"); got.Report.Change != nil {
 		t.Fatalf("equal Change = %#v, want nil", got.Report.Change)
 	}
+	recorded.ResolvedTags = []string{"core"}
+	if got := selection.CompareInstalled(m, requested, recorded, "linux"); got.Report.Change != nil {
+		t.Fatalf("equal intent with stale audit snapshot Change = %#v, want nil", got.Report.Change)
+	}
 }
 
 func TestCompareInstalledAdditiveChangeDoesNotRequireAcknowledgement(t *testing.T) {

--- a/internal/selection/selection_test.go
+++ b/internal/selection/selection_test.go
@@ -82,6 +82,166 @@ func TestCompareEvolutionReportsSelectedSurfaceChangesInManifestOrder(t *testing
 	}
 }
 
+func TestCompareInstalledNoRecordedSelectionOrEqualSelectionHasNoChange(t *testing.T) {
+	m := replacementManifest()
+	requested, err := selection.ResolveIntent(m, selection.Intent{
+		Source: selection.SourceExplicit, Profiles: []string{"core"}, ExtraTags: []string{"extra"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := selection.CompareInstalled(m, requested, nil, "linux"); got.Report.Change != nil {
+		t.Fatalf("nil recorded Change = %#v, want nil", got.Report.Change)
+	}
+	recorded := &state.InstalledSelection{
+		Profiles: []string{"core"}, ExtraTags: []string{"extra"},
+		ResolvedTags: []string{"core", "extra"},
+	}
+	if got := selection.CompareInstalled(m, requested, recorded, "linux"); got.Report.Change != nil {
+		t.Fatalf("equal Change = %#v, want nil", got.Report.Change)
+	}
+}
+
+func TestCompareInstalledAdditiveChangeDoesNotRequireAcknowledgement(t *testing.T) {
+	m := replacementManifest()
+	requested, err := selection.ResolveIntent(m, selection.Intent{
+		Source: selection.SourceExplicit, Profiles: []string{"core", "work"}, ExtraTags: []string{"extra"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := selection.CompareInstalled(m, requested, &state.InstalledSelection{
+		Profiles: []string{"core"}, ResolvedTags: []string{"core"},
+	}, "linux")
+	change := got.Report.Change
+	if change == nil {
+		t.Fatal("Change = nil")
+	}
+	if change.AcknowledgementRequired || change.AcknowledgementAccepted {
+		t.Fatalf("acknowledgement = required:%t accepted:%t, want false/false",
+			change.AcknowledgementRequired, change.AcknowledgementAccepted)
+	}
+	if want := []string{"work"}; !reflect.DeepEqual(change.Delta.Added.Profiles, want) {
+		t.Fatalf("added Profiles = %#v, want %#v", change.Delta.Added.Profiles, want)
+	}
+	if want := []string{"extra"}; !reflect.DeepEqual(change.Delta.Added.ExtraTags, want) {
+		t.Fatalf("added extra Tags = %#v, want %#v", change.Delta.Added.ExtraTags, want)
+	}
+}
+
+func TestCompareInstalledIntentReductionRequiresAcknowledgement(t *testing.T) {
+	m := replacementManifest()
+	requested, err := selection.ResolveIntent(m, selection.Intent{
+		Source: selection.SourceExplicit, Profiles: []string{"core"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := selection.CompareInstalled(m, requested, &state.InstalledSelection{
+		Profiles: []string{"core", "work"}, ExtraTags: []string{"extra"},
+		ResolvedTags: []string{"core", "work", "extra"},
+	}, "linux")
+	change := got.Report.Change
+	if change == nil || !change.AcknowledgementRequired || change.AcknowledgementAccepted {
+		t.Fatalf("Change = %#v, want required and unaccepted", change)
+	}
+	if want := []string{"work"}; !reflect.DeepEqual(change.Delta.Removed.Profiles, want) {
+		t.Fatalf("removed Profiles = %#v, want %#v", change.Delta.Removed.Profiles, want)
+	}
+	if want := []string{"extra"}; !reflect.DeepEqual(change.Delta.Removed.ExtraTags, want) {
+		t.Fatalf("removed extra Tags = %#v, want %#v", change.Delta.Removed.ExtraTags, want)
+	}
+}
+
+func TestCompareInstalledReportsRecordedAuditSurfaceDifferences(t *testing.T) {
+	m := replacementManifest()
+	requested, err := selection.ResolveIntent(m, selection.Intent{
+		Source: selection.SourceExplicit, Profiles: []string{"work"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := selection.CompareInstalled(m, requested, &state.InstalledSelection{
+		Profiles: []string{"core"}, ResolvedTags: []string{"core", "retired"},
+	}, "linux")
+	delta := got.Report.Change.Delta
+	if want := []string{"work"}; !reflect.DeepEqual(delta.Current.Profiles, want) {
+		t.Fatalf("current Profiles = %#v, want %#v", delta.Current.Profiles, want)
+	}
+	if want := []string{"core", "retired"}; !reflect.DeepEqual(delta.Previous.EffectiveTags, want) {
+		t.Fatalf("previous effective Tags = %#v, want recorded audit snapshot %#v", delta.Previous.EffectiveTags, want)
+	}
+	if want := []string{".work"}; !reflect.DeepEqual(delta.Added.ManagedEntries, want) {
+		t.Fatalf("added Managed Entries = %#v, want %#v", delta.Added.ManagedEntries, want)
+	}
+	if want := []string{".core", ".retired"}; !reflect.DeepEqual(delta.Removed.ManagedEntries, want) {
+		t.Fatalf("removed Managed Entries = %#v, want %#v", delta.Removed.ManagedEntries, want)
+	}
+	if want := []string{"work-dep"}; !reflect.DeepEqual(delta.Added.Dependencies, want) {
+		t.Fatalf("added Dependencies = %#v, want %#v", delta.Added.Dependencies, want)
+	}
+	if want := []string{"core-dep", "retired-dep"}; !reflect.DeepEqual(delta.Removed.Dependencies, want) {
+		t.Fatalf("removed Dependencies = %#v, want %#v", delta.Removed.Dependencies, want)
+	}
+	if want := []string{"work-tool"}; !reflect.DeepEqual(delta.Added.Provisioners, want) {
+		t.Fatalf("added Provisioners = %#v, want %#v", delta.Added.Provisioners, want)
+	}
+	if want := []string{"retired-tool"}; !reflect.DeepEqual(delta.Removed.Provisioners, want) {
+		t.Fatalf("removed Provisioners = %#v, want %#v", delta.Removed.Provisioners, want)
+	}
+}
+
+func TestCompareInstalledChangeJSONHasDeterministicArraysAndEvolutionPreservesChange(t *testing.T) {
+	m := replacementManifest()
+	requested, err := selection.ResolveIntent(m, selection.Intent{
+		Source: selection.SourceExplicit, Profiles: []string{"work"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	compared := selection.CompareInstalled(m, requested, &state.InstalledSelection{
+		Profiles: []string{"core"}, ResolvedTags: []string{"core"},
+	}, "linux")
+	data, err := json.Marshal(compared.Report.Change)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		`"extra_tags":[]`, `"provisioners":[]`,
+		`"missing_profiles":[]`, `"stale_extra_tags":[]`,
+	} {
+		if !strings.Contains(string(data), want) {
+			t.Fatalf("JSON = %s, want %s", data, want)
+		}
+	}
+	evolved, err := selection.CompareEvolution(m, m, compared, "linux")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evolved.Report.Delta == nil || !reflect.DeepEqual(evolved.Report.Change, compared.Report.Change) {
+		t.Fatalf("evolved Report = %#v, want evolution Delta and preserved Change", evolved.Report)
+	}
+}
+
+func replacementManifest() manifest.Manifest {
+	return manifest.Manifest{
+		Profiles: map[string]manifest.Profile{
+			"core": {Tags: []string{"core"}},
+			"work": {Tags: []string{"work"}},
+		},
+		Entries: []manifest.Entry{
+			{Target: ".core", Tags: []string{"core"}, Dependencies: []manifest.Dependency{{Name: "core-dep"}}},
+			{Target: ".retired", Tags: []string{"retired"}, Dependencies: []manifest.Dependency{{Name: "retired-dep"}}},
+			{Target: ".work", Tags: []string{"work"}, Dependencies: []manifest.Dependency{{Name: "work-dep"}}},
+			{Target: ".extra", Tags: []string{"extra"}},
+		},
+		Provisioners: []manifest.Provisioner{
+			{Tool: "retired-tool", Tags: []string{"retired"}},
+			{Tool: "work-tool", Tags: []string{"work"}},
+		},
+	}
+}
+
 func TestCompareEvolutionRejectsMissingProfileWithStructuredDelta(t *testing.T) {
 	oldManifest := manifest.Manifest{Profiles: map[string]manifest.Profile{"core": {Tags: []string{"core"}}}}
 	previous, err := selection.ResolveIntent(oldManifest, selection.Intent{


### PR DESCRIPTION
Closes #346

## PR Type

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Report explicit Installed Selection replacements separately from manifest evolution, including full intent and selected-surface deltas.
- Require distinct interactive confirmation for reductions and both `--yes` plus `--acknowledge-selection-change` in Confirmed Install mode.
- Preserve the previous Installed Selection until terminal success across install, update, upgrade, and binary continuation.

## Changes

| File | Change |
|------|--------|
| `internal/selection/selection.go` | Adds portable Installed Selection Change comparison and acknowledgement state. |
| `internal/cli/selection_change.go` | Adds deterministic text/JSON rendering, confirmation, and structured rejection. |
| `internal/cli/install.go`, `internal/cli/update.go`, `internal/cli/upgrade.go` | Guards explicit reductions before selected mutation and threads the public acknowledgement through upgrade continuation. |
| `internal/cli/*selection*_test.go`, `internal/cli/testdata/*` | Covers additive changes, reductions, cancellation, Confirmed Install rejection/acceptance, rollback, and output contracts in temporary homes. |
| `CONTEXT.md`, `README.md`, `docs/` | Documents the domain term, ADR amendment, command flags, safety rules, and agent output contract. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go build ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan: `go run ./cmd/dots plan --file dots.yaml --profile core --source-root "$PWD" --home <tmp>/home --state-root <tmp>/state --output json`
- [x] Local Standards and Spec reviews against `origin/main`; final re-review found no actionable findings.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] CLI validation and Temporary Home Tests used isolated home/source/state roots.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #346`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs and output-contract guidance for the behavior change.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

## Risk / rollback

- Reductions now intentionally fail earlier in Confirmed Install mode unless the new acknowledgement flag is present. Rolling back the PR restores the prior behavior; Installation Metadata remains backward compatible and is only rewritten after terminal success.
