### PR TITLE
fix(deps): recognize installed macOS apps

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -77,7 +77,7 @@ A safety check that looks for known credential and private-key patterns in repos
 _Avoid_: security audit, secret validation, token check
 
 **Dependency**:
-An external tool, package, or font required for a managed configuration to work correctly, such as Neovim, Starship, ripgrep, tmux, or a Nerd Font. The Dotfiles CLI declares and checks Dependencies; their presence is detected either as an executable command on the search path or, for non-executable assets such as fonts, by the presence of their installed files.
+An external tool, application, package, or font required for a managed configuration to work correctly, such as Neovim, Ghostty, Starship, ripgrep, tmux, or a Nerd Font. The Dotfiles CLI declares and checks Dependencies; their presence is detected as an executable command on the search path, a declared macOS application bundle, or, for non-executable assets such as fonts, by the presence of their installed files.
 _Avoid_: package, app, required tool
 
 **Dependency Plan**:

--- a/configs/ghostty/README.md
+++ b/configs/ghostty/README.md
@@ -10,7 +10,9 @@ outside version control.
 
 ## Prerequisites
 
-- **`ghostty`** — declared as an advisory dependency for the desktop profile.
+- **`ghostty`** — declared for the desktop profile; macOS detection accepts
+  either the `ghostty` command or `Ghostty.app`, installed through the
+  `ghostty` Homebrew cask.
 - **Desktop Nerd Font** — declared on the `desktop` profile as shared desktop
   infrastructure. Ghostty consumes this shared requirement for the managed
   `font-family` baseline (`Cascadia Code NF`). The primary macOS package is the

--- a/docs/adr/0015-detect-macos-app-dependencies-by-bundle.md
+++ b/docs/adr/0015-detect-macos-app-dependencies-by-bundle.md
@@ -1,0 +1,29 @@
+# Detect macOS application Dependencies by bundle
+
+Some Homebrew casks install graphical applications under `/Applications`
+without placing their executable on `PATH`. A command-only Dependency probe can
+therefore remain missing after its cask installs successfully, causing the
+Dependency Plan and post-install gate to repeat an already completed action.
+Ghostty is the first observed case.
+
+Dependencies may declare an optional `darwin_app` bundle name, such as
+`Ghostty.app`. On macOS, the command probe and application-bundle probe are
+alternatives: either one satisfies the Dependency. Outside macOS,
+`darwin_app` is ignored and normal command detection remains authoritative.
+Application detection checks the selected user's `~/Applications` and the
+system `/Applications`. The manifest accepts only a single `.app` bundle name,
+not a path, so Install Manifest data cannot redirect the read-only probe outside
+those reviewed roots.
+
+The application lookup is an injected Dependency boundary, parallel to command
+and font lookups. Check, plan, integrated install, standalone dependency
+install, post-install verification, doctor, and Provisioner readiness reuse the
+same result. Tests provide a sandbox lookup or a temporary `--home`; they never
+depend on or mutate the operator's real Applications directories.
+
+**Consequences**: macOS cask installations can converge without PATH shims or
+ad hoc shell commands. The Install Manifest must explicitly opt each Dependency
+into application detection, so an unrelated app bundle cannot satisfy a
+command-only Dependency. App-bundle presence does not prove that the application
+launches correctly; deeper health probes remain separate, tool-specific
+diagnostics when a concrete need justifies them.

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -205,6 +205,7 @@ Tag-scoped Dependency Sets use:
 | `name` | Yes | Human-readable dependency name. Also used as the executable probe when `command` is omitted. |
 | `requirement` | No | `required` or `optional`. Omitted means `required`. Required Dependencies gate integrated install; optional Dependencies are reported but do not block Managed Configuration. |
 | `command` | No | Single executable name to probe on `PATH`. |
+| `darwin_app` | No | macOS `.app` bundle name that can satisfy the Dependency when its command is absent from `PATH`. Dots checks the selected user's `~/Applications` and the system `/Applications`; the value must be a bundle name such as `Ghostty.app`, not a path. Ignored outside macOS. |
 | `manual` | No | Dependency-specific remediation for manual-only tools. Use it when generic package-manager guidance would hide required user choices, privileges, or verification steps. |
 | `manual_debian` | No | Debian/Ubuntu-specific manual remediation. Prefer this over `manual` when instructions mention Debian/Ubuntu-only packages, commands, privileges, or verification. |
 | `commands` | No | Multiple executable names that must all be present. Use this for manager-owned toolchains where both the manager and runtime commands matter. |
@@ -254,7 +255,7 @@ Current dependency package coverage:
 | `fd` | `fd` | `fd` | Linuxbrew opt-in/manual | `fd-find` | `fd` |
 | `GitHub CLI` | `gh` | `gh` | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual |
 | `Playwright CLI` | `playwright-cli` | `playwright-cli` | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual | Linuxbrew opt-in/manual |
-| `ghostty` | `ghostty` | `ghostty` | Manual; Ubuntu guidance includes Ghostty upstream binary docs, the community `.deb` installer command, and notes `snap install ghostty --classic` requires sudo/password interactivity | Manual | Manual |
+| `ghostty` | `ghostty` or macOS `Ghostty.app` | `brew install --cask ghostty` | Manual; Ubuntu guidance includes Ghostty upstream binary docs, the community `.deb` installer command, and notes `snap install ghostty --classic` requires sudo/password interactivity | Manual | Manual |
 | `Warp` | `warp-terminal` | Manual | Manual | Manual | Manual |
 | `atuin` | `atuin` | `atuin` | User-local / Linuxbrew opt-in/manual | User-local / Linuxbrew opt-in/manual | User-local / Linuxbrew opt-in/manual |
 | `bat` | `bat` | `bat` | User-local / Linuxbrew opt-in/manual | `bat` | `bat` |

--- a/dots.yaml
+++ b/dots.yaml
@@ -327,6 +327,7 @@ entries:
     dependencies:
       - name: ghostty
         command: ghostty
+        darwin_app: Ghostty.app
         manual_debian: >-
           Install Ghostty from https://ghostty.org/docs/install/binary. On Ubuntu,
           use the community .deb installer from ghostty-ubuntu with /bin/bash -c
@@ -334,7 +335,7 @@ entries:
           or run snap install ghostty --classic; this requires sudo/password
           interactivity. After installation, verify ghostty --version and rerun
           dots deps check.
-        brew: ghostty
+        brew_cask: ghostty
   - source: configs/ghostty/adaptive/adaptive-theme.ghostty
     target: ~/.config/ghostty/adaptive-theme.ghostty
     strategy: symlink

--- a/internal/cli/deps.go
+++ b/internal/cli/deps.go
@@ -66,6 +66,7 @@ func newDepsCheckCommand(profiles *[]string, extraTags *[]string) *cobra.Command
 				ExtraTags: effective.ExtraTags,
 				Selection: &effective.Selection,
 				OS:        runtime.GOOS,
+				AppLookup: appInstalled(runtime.GOOS, resolvedHome),
 			}, lookupCommand, fontInstalled(runtime.GOOS, resolvedHome), commandOutput)
 			if err != nil {
 				return err
@@ -120,6 +121,7 @@ func newDepsPlanCommand(profiles *[]string, extraTags *[]string) *cobra.Command 
 				ExtraTags: effective.ExtraTags,
 				Selection: &effective.Selection,
 				OS:        runtime.GOOS,
+				AppLookup: appInstalled(runtime.GOOS, resolvedHome),
 			}, lookupCommand, fontInstalled(runtime.GOOS, resolvedHome), resolvedTier)
 			if err != nil {
 				return err
@@ -178,6 +180,7 @@ func newDepsInstallCommand(profiles *[]string, extraTags *[]string) *cobra.Comma
 				Arch:      runtime.GOARCH,
 				Home:      resolvedHome,
 				StateRoot: resolvedStateRoot,
+				AppLookup: appInstalled(runtime.GOOS, resolvedHome),
 			}
 
 			report, err := deps.InstallDryRun(*m, options, lookupCommand, fontInstalled(runtime.GOOS, resolvedHome), resolvedTier)
@@ -398,6 +401,28 @@ func fontInstalled(goos, home string) deps.FontLookup {
 	dirs := fontDirectories(goos, home)
 	return func(match string) bool {
 		return deps.ScanFonts(dirs, match)
+	}
+}
+
+// appInstalled is the production AppLookup. On macOS it checks the selected
+// user's Applications directory before the system Applications directory.
+// Other operating systems never satisfy a Darwin application probe.
+func appInstalled(goos, home string) deps.AppLookup {
+	var dirs []string
+	if goos == "darwin" {
+		if home != "" {
+			dirs = append(dirs, filepath.Join(home, "Applications"))
+		}
+		dirs = append(dirs, "/Applications")
+	}
+	return func(app string) bool {
+		for _, dir := range dirs {
+			info, err := os.Stat(filepath.Join(dir, app))
+			if err == nil && info.IsDir() {
+				return true
+			}
+		}
+		return false
 	}
 }
 

--- a/internal/cli/deps.go
+++ b/internal/cli/deps.go
@@ -408,6 +408,10 @@ func fontInstalled(goos, home string) deps.FontLookup {
 // user's Applications directory before the system Applications directory.
 // Other operating systems never satisfy a Darwin application probe.
 func appInstalled(goos, home string) deps.AppLookup {
+	return appInstalledIn(appDirectories(goos, home))
+}
+
+func appDirectories(goos, home string) []string {
 	var dirs []string
 	if goos == "darwin" {
 		if home != "" {
@@ -415,6 +419,10 @@ func appInstalled(goos, home string) deps.AppLookup {
 		}
 		dirs = append(dirs, "/Applications")
 	}
+	return dirs
+}
+
+func appInstalledIn(dirs []string) deps.AppLookup {
 	return func(app string) bool {
 		for _, dir := range dirs {
 			info, err := os.Stat(filepath.Join(dir, app))

--- a/internal/cli/deps_app_test.go
+++ b/internal/cli/deps_app_test.go
@@ -1,0 +1,34 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestAppDirectoriesUseSelectedHomeAndSystemApplicationsOnDarwin(t *testing.T) {
+	home := t.TempDir()
+	want := []string{filepath.Join(home, "Applications"), "/Applications"}
+	if got := appDirectories("darwin", home); !reflect.DeepEqual(got, want) {
+		t.Fatalf("appDirectories() = %#v, want %#v", got, want)
+	}
+	if got := appDirectories("linux", home); len(got) != 0 {
+		t.Fatalf("Linux appDirectories() = %#v, want none", got)
+	}
+}
+
+func TestAppInstalledInSandboxDirectories(t *testing.T) {
+	applications := filepath.Join(t.TempDir(), "Applications")
+	if err := os.MkdirAll(filepath.Join(applications, "Ghostty.app"), 0o755); err != nil {
+		t.Fatalf("create sandbox Ghostty app: %v", err)
+	}
+	lookup := appInstalledIn([]string{applications})
+
+	if !lookup("Ghostty.app") {
+		t.Fatal("Ghostty.app = missing, want present in sandbox Applications")
+	}
+	if lookup("Missing.app") {
+		t.Fatal("Missing.app = present, want missing in sandbox Applications")
+	}
+}

--- a/internal/cli/deps_home_test.go
+++ b/internal/cli/deps_home_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -27,6 +28,22 @@ entries:
     target: ~/.zshrc
     strategy: symlink
     tags: [core]
+`
+
+const darwinAppManifest = `version: 1
+profiles:
+  default:
+    tags: [desktop]
+    dependencies:
+      - name: Dots Sandbox App
+        command: dots-sandbox-app
+        darwin_app: DotsSandbox.app
+        brew_cask: dots-sandbox-app
+entries:
+  - source: configs/ghostty/config.ghostty
+    target: ~/.config/ghostty/config.ghostty
+    strategy: symlink
+    tags: [desktop]
 `
 
 // writeProbeFont drops a file matching the probe glob in every per-user font
@@ -73,6 +90,52 @@ func TestDepsCheckHomeFlagDetectsSandboxFont(t *testing.T) {
 	}
 	if !strings.Contains(got, "Summary: 1 present, 0 missing") {
 		t.Fatalf("unexpected summary\noutput:\n%s", got)
+	}
+}
+
+func TestDepsCheckHomeFlagDetectsSandboxDarwinApp(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("macOS application detection is Darwin-only")
+	}
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("PATH", t.TempDir())
+
+	sandbox := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(sandbox, "Applications", "DotsSandbox.app"), 0o755); err != nil {
+		t.Fatalf("create sandbox app bundle: %v", err)
+	}
+	manifestPath := writeCLIManifest(t, t.TempDir(), darwinAppManifest)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"deps", "check", "--profile", "default", "--file", manifestPath, "--home", sandbox})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+	if !strings.Contains(out.String(), "present  Dots Sandbox App") {
+		t.Fatalf("sandbox app not detected under --home\noutput:\n%s", out.String())
+	}
+}
+
+func TestDepsCheckHomeFlagReportsMissingSandboxDarwinApp(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("macOS application detection is Darwin-only")
+	}
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("PATH", t.TempDir())
+
+	sandbox := t.TempDir()
+	manifestPath := writeCLIManifest(t, t.TempDir(), darwinAppManifest)
+	var out, errOut bytes.Buffer
+	code := cli.Run([]string{"deps", "check", "--profile", "default", "--file", manifestPath, "--home", sandbox}, &out, &errOut)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2 (findings)\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
+	}
+	if !strings.Contains(out.String(), "missing  Dots Sandbox App") {
+		t.Fatalf("missing sandbox app not reported\noutput:\n%s", out.String())
 	}
 }
 
@@ -127,5 +190,32 @@ func TestDepsPlanHomeFlagDetectsSandboxFont(t *testing.T) {
 	got := out.String()
 	if !strings.Contains(got, "All declared dependencies are already installed.") {
 		t.Fatalf("plan did not honor --home for sandbox font detection\noutput:\n%s", got)
+	}
+}
+
+func TestDepsPlanHomeFlagDetectsSandboxDarwinApp(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("macOS application detection is Darwin-only")
+	}
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("PATH", t.TempDir())
+
+	sandbox := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(sandbox, "Applications", "DotsSandbox.app"), 0o755); err != nil {
+		t.Fatalf("create sandbox app bundle: %v", err)
+	}
+	manifestPath := writeCLIManifest(t, t.TempDir(), darwinAppManifest)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"deps", "plan", "--profile", "default", "--file", manifestPath, "--home", sandbox, "--tier", "homebrew"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+	if !strings.Contains(out.String(), "All declared dependencies are already installed.") {
+		t.Fatalf("plan did not honor --home for sandbox app detection\noutput:\n%s", out.String())
 	}
 }

--- a/internal/cli/deps_home_test.go
+++ b/internal/cli/deps_home_test.go
@@ -120,25 +120,6 @@ func TestDepsCheckHomeFlagDetectsSandboxDarwinApp(t *testing.T) {
 	}
 }
 
-func TestDepsCheckHomeFlagReportsMissingSandboxDarwinApp(t *testing.T) {
-	if runtime.GOOS != "darwin" {
-		t.Skip("macOS application detection is Darwin-only")
-	}
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("PATH", t.TempDir())
-
-	sandbox := t.TempDir()
-	manifestPath := writeCLIManifest(t, t.TempDir(), darwinAppManifest)
-	var out, errOut bytes.Buffer
-	code := cli.Run([]string{"deps", "check", "--profile", "default", "--file", manifestPath, "--home", sandbox}, &out, &errOut)
-	if code != 2 {
-		t.Fatalf("exit code = %d, want 2 (findings)\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
-	}
-	if !strings.Contains(out.String(), "missing  Dots Sandbox App") {
-		t.Fatalf("missing sandbox app not reported\noutput:\n%s", out.String())
-	}
-}
-
 func TestDepsCheckHomeFlagIgnoresRealHomeFont(t *testing.T) {
 	// The font lives only in the real home; --home points at an empty sandbox.
 	// A "missing" result proves --home overrides the real home rather than

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -66,6 +66,7 @@ func newDoctorCommand() *cobra.Command {
 				SourceRoot: paths.SourceRoot,
 				Home:       paths.Home,
 				ToolRunner: commandOutput,
+				AppLookup:  appInstalled(runtime.GOOS, paths.Home),
 			}, lookupCommand, fontInstalled(runtime.GOOS, paths.Home))
 			if err != nil {
 				return err

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -118,7 +118,7 @@ func newInstallCommand() *cobra.Command {
 
 			hostOS := installHostOS
 			hostArch := installHostArch
-			depOptions := deps.Options{Profiles: profiles, ExtraTags: extraTags, OS: hostOS, Arch: hostArch, Home: paths.Home, StateRoot: paths.StateRoot}
+			depOptions := deps.Options{Profiles: profiles, ExtraTags: extraTags, OS: hostOS, Arch: hostArch, Home: paths.Home, StateRoot: paths.StateRoot, AppLookup: appInstalled(hostOS, paths.Home)}
 			depTier, err := resolveInstallTier(hostOS)
 			if err != nil {
 				return err
@@ -466,6 +466,9 @@ func runProvisioners(cmd *cobra.Command, m manifest.Manifest, profiles []string,
 }
 
 func runProvisionersWithOptions(cmd *cobra.Command, m manifest.Manifest, provisionOpts provision.Options, home string, stateRoot string, sourceRoot string) (provision.Report, error) {
+	if provisionOpts.AppLookup == nil {
+		provisionOpts.AppLookup = appInstalled(provisionOpts.OS, home)
+	}
 	ctx := cmd.Context()
 	if ctx == nil {
 		ctx = context.Background()

--- a/internal/deps/deps.go
+++ b/internal/deps/deps.go
@@ -118,10 +118,10 @@ func checkResult(dep manifest.Dependency, opts Options, look Lookup, fontLook Fo
 		// by scanning the workstation font directories for any compatible file
 		// pattern, starting with the primary match.
 		matches := dep.FontMatches()
-		return Result{Name: dep.Name, Requirement: dep.RequirementValue(), Command: fontProbeLabel(matches), Present: fontPresent(matches, fontLook)}
+		return Result{Name: dep.Name, Requirement: dep.RequirementValue(), Command: fontProbeLabel(matches), Present: DependencyPresent(dep, opts, look, fontLook)}
 	}
 	probes := dep.Probes()
-	return Result{Name: dep.Name, Requirement: dep.RequirementValue(), Command: probeLabel(probes), Present: commandsPresent(probes, look) || darwinAppPresent(dep.DarwinApp, opts)}
+	return Result{Name: dep.Name, Requirement: dep.RequirementValue(), Command: probeLabel(probes), Present: DependencyPresent(dep, opts, look, fontLook)}
 }
 
 func darwinAppPresent(app string, opts Options) bool {

--- a/internal/deps/deps.go
+++ b/internal/deps/deps.go
@@ -21,6 +21,11 @@ type Lookup func(command string) bool
 // parallel to Lookup, so font dependency checks stay deterministic in tests.
 type FontLookup func(match string) bool
 
+// AppLookup reports whether a named macOS application bundle is installed.
+// It is injected so tests never need to inspect the operator's Applications
+// directories.
+type AppLookup func(app string) bool
+
 // CommandRunner executes a read-only tool probe and returns its combined output.
 type CommandRunner func(command string, args ...string) (string, error)
 
@@ -34,6 +39,7 @@ type Options struct {
 	Arch      string
 	Home      string
 	StateRoot string
+	AppLookup AppLookup
 }
 
 // Result is the presence finding for a single declared Dependency.
@@ -90,21 +96,21 @@ func CheckWithToolProbes(m manifest.Manifest, opts Options, look Lookup, fontLoo
 	selection, _ := resolveOptionsSelection(m, opts)
 	report := CheckReport{Profile: selection.Profile, Profiles: selection.Profiles, Tags: selection.Tags}
 	for _, dep := range selected {
-		result := checkResult(dep, look, fontLook)
+		result := checkResult(dep, opts, look, fontLook)
 		probeToolchain(&result, opts, run)
 		report.Results = append(report.Results, result)
 	}
 	return report, nil
 }
 
-func dependencyPresent(dep manifest.Dependency, look Lookup, fontLook FontLookup) bool {
+func dependencyPresent(dep manifest.Dependency, opts Options, look Lookup, fontLook FontLookup) bool {
 	if dep.IsFont() {
 		return fontPresent(dep.FontMatches(), fontLook)
 	}
-	return commandsPresent(dep.Probes(), look)
+	return commandsPresent(dep.Probes(), look) || darwinAppPresent(dep.DarwinApp, opts)
 }
 
-func checkResult(dep manifest.Dependency, look Lookup, fontLook FontLookup) Result {
+func checkResult(dep manifest.Dependency, opts Options, look Lookup, fontLook FontLookup) Result {
 	if dep.IsFont() {
 		// A font has no executable on PATH; detect it as an installed asset
 		// by scanning the workstation font directories for any compatible file
@@ -113,7 +119,12 @@ func checkResult(dep manifest.Dependency, look Lookup, fontLook FontLookup) Resu
 		return Result{Name: dep.Name, Requirement: dep.RequirementValue(), Command: fontProbeLabel(matches), Present: fontPresent(matches, fontLook)}
 	}
 	probes := dep.Probes()
-	return Result{Name: dep.Name, Requirement: dep.RequirementValue(), Command: probeLabel(probes), Present: commandsPresent(probes, look)}
+	return Result{Name: dep.Name, Requirement: dep.RequirementValue(), Command: probeLabel(probes), Present: commandsPresent(probes, look) || darwinAppPresent(dep.DarwinApp, opts)}
+}
+
+func darwinAppPresent(app string, opts Options) bool {
+	app = strings.TrimSpace(app)
+	return opts.OS == "darwin" && app != "" && opts.AppLookup != nil && opts.AppLookup(app)
 }
 
 const maxProbeDetailLen = 240

--- a/internal/deps/deps.go
+++ b/internal/deps/deps.go
@@ -103,7 +103,9 @@ func CheckWithToolProbes(m manifest.Manifest, opts Options, look Lookup, fontLoo
 	return report, nil
 }
 
-func dependencyPresent(dep manifest.Dependency, opts Options, look Lookup, fontLook FontLookup) bool {
+// DependencyPresent reports whether any declared detection mode satisfies a
+// Dependency in the selected environment.
+func DependencyPresent(dep manifest.Dependency, opts Options, look Lookup, fontLook FontLookup) bool {
 	if dep.IsFont() {
 		return fontPresent(dep.FontMatches(), fontLook)
 	}

--- a/internal/deps/deps_test.go
+++ b/internal/deps/deps_test.go
@@ -35,6 +35,37 @@ func fontLookupSet(present ...string) deps.FontLookup {
 	return func(match string) bool { return set[match] }
 }
 
+func appLookupSet(present ...string) deps.AppLookup {
+	set := make(map[string]bool, len(present))
+	for _, p := range present {
+		set[p] = true
+	}
+	return func(app string) bool { return set[app] }
+}
+
+func TestCheckDetectsDarwinAppWhenCommandIsMissing(t *testing.T) {
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"desktop"}}},
+		Entries: []manifest.Entry{{
+			Source: "configs/ghostty/config.ghostty", Target: "~/.config/ghostty/config.ghostty", Strategy: "symlink", Tags: []string{"desktop"},
+			Dependencies: []manifest.Dependency{{
+				Name: "ghostty", Command: "ghostty", DarwinApp: "Ghostty.app", BrewCask: "ghostty",
+			}},
+		}},
+	}
+
+	report, err := deps.Check(m, deps.Options{
+		Profile: "default", OS: "darwin", AppLookup: appLookupSet("Ghostty.app"),
+	}, lookupSet(), fontLookupSet())
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+	if len(report.Results) != 1 || !report.Results[0].Present {
+		t.Fatalf("Results = %#v, want Ghostty present via macOS app bundle", report.Results)
+	}
+}
+
 func TestCheckDetectsFontDependencyByScanNotPath(t *testing.T) {
 	m := manifest.Manifest{
 		Version:  1,

--- a/internal/deps/install.go
+++ b/internal/deps/install.go
@@ -216,7 +216,7 @@ func Install(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup
 			}
 			return report, fmt.Errorf("bootstrap %q: %w", action.Dependency, err)
 		}
-		if !actionPresent(action, look, fontLook) {
+		if !actionPresent(action, opts, look, fontLook) {
 			manual := unresolvedToolchainRemediation(action, look)
 			if action.Requirement == manifest.DependencyRequirementRequired {
 				requiredUnresolved = true
@@ -321,7 +321,7 @@ func runBootstrap(action InstallAction, runner Runner) error {
 	return nil
 }
 
-func actionPresent(action InstallAction, look Lookup, fontLook FontLookup) bool {
+func actionPresent(action InstallAction, opts Options, look Lookup, fontLook FontLookup) bool {
 	matches := action.FontMatches
 	if len(matches) == 0 && action.FontMatch != "" {
 		matches = []string{action.FontMatch}
@@ -333,7 +333,7 @@ func actionPresent(action InstallAction, look Lookup, fontLook FontLookup) bool 
 	if len(probes) == 0 && action.Probe != "" {
 		probes = []string{action.Probe}
 	}
-	return commandsPresent(probes, look)
+	return commandsPresent(probes, look) || darwinAppPresent(action.DarwinApp, opts)
 }
 
 func installArgsWithConfirmation(action InstallAction) []string {

--- a/internal/deps/install_test.go
+++ b/internal/deps/install_test.go
@@ -38,6 +38,36 @@ func TestInstallYesExecutesInstallableActionsThroughRunner(t *testing.T) {
 	}
 }
 
+func TestInstallYesAcceptsDarwinAppAfterCaskInstall(t *testing.T) {
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"desktop"}}},
+		Entries: []manifest.Entry{{
+			Source: "configs/ghostty/config.ghostty", Target: "~/.config/ghostty/config.ghostty", Strategy: "symlink", Tags: []string{"desktop"},
+			Dependencies: []manifest.Dependency{{
+				Name: "ghostty", Command: "ghostty", DarwinApp: "Ghostty.app", BrewCask: "ghostty",
+			}},
+		}},
+	}
+	appInstalled := false
+	runner := &recordingRunner{afterRun: func() { appInstalled = true }}
+	opts := deps.Options{
+		Profile: "default",
+		OS:      "darwin",
+		AppLookup: func(app string) bool {
+			return app == "Ghostty.app" && appInstalled
+		},
+	}
+
+	report, err := deps.Install(m, opts, lookupSet(), fontLookupSet(), deps.TierHomebrew, runner)
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if len(report.Items) != 1 || report.Items[0].Status != deps.InstallStatusInstalled {
+		t.Fatalf("report items = %#v, want Ghostty installed via app-bundle recheck", report.Items)
+	}
+}
+
 func TestInstallYesUsesPackageManagerConfirmationArgs(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/deps/install_test.go
+++ b/internal/deps/install_test.go
@@ -63,6 +63,9 @@ func TestInstallYesAcceptsDarwinAppAfterCaskInstall(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Install() error = %v", err)
 	}
+	if len(runner.calls) != 1 || !reflect.DeepEqual(runner.calls[0].args, []string{"install", "--cask", "ghostty"}) {
+		t.Fatalf("runner calls = %#v, want explicit Ghostty cask install", runner.calls)
+	}
 	if len(report.Items) != 1 || report.Items[0].Status != deps.InstallStatusInstalled {
 		t.Fatalf("report items = %#v, want Ghostty installed via app-bundle recheck", report.Items)
 	}

--- a/internal/deps/plan.go
+++ b/internal/deps/plan.go
@@ -49,6 +49,7 @@ type InstallAction struct {
 	Probes       []string            `json:"probes,omitempty"`
 	FontMatch    string              `json:"font_match,omitempty"`
 	FontMatches  []string            `json:"font_matches,omitempty"`
+	DarwinApp    string              `json:"-"`
 	Toolchain    string              `json:"toolchain,omitempty"`
 	Provider     Tier                `json:"provider,omitempty"`
 	Package      string              `json:"package,omitempty"`
@@ -107,7 +108,7 @@ func Plan(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup, t
 
 	report := PlanReport{Profile: selection.Profile, Profiles: selection.Profiles, Tags: selection.Tags, Tier: tier}
 	for _, dep := range selected {
-		if dependencyPresent(dep, look, fontLook) {
+		if dependencyPresent(dep, opts, look, fontLook) {
 			continue
 		}
 		action, err := actionFor(dep, opts, tier, look)
@@ -130,7 +131,7 @@ func actionFor(dep manifest.Dependency, opts Options, tier Tier, look Lookup) (I
 		fontMatch = fontMatches[0]
 	}
 	probes := dep.Probes()
-	action := InstallAction{Dependency: dep.Name, Requirement: dep.RequirementValue(), Status: InstallActionStatusManual, Probe: dep.Probe(), Probes: probes, FontMatch: fontMatch, FontMatches: fontMatches, Toolchain: strings.TrimSpace(dep.Toolchain), Bootstrap: bootstrapCommands(dep)}
+	action := InstallAction{Dependency: dep.Name, Requirement: dep.RequirementValue(), Status: InstallActionStatusManual, Probe: dep.Probe(), Probes: probes, FontMatch: fontMatch, FontMatches: fontMatches, DarwinApp: strings.TrimSpace(dep.DarwinApp), Toolchain: strings.TrimSpace(dep.Toolchain), Bootstrap: bootstrapCommands(dep)}
 
 	if officialRustupInstallerRunnable(action, opts, look) {
 		action.Status = InstallActionStatusInstallable

--- a/internal/deps/plan.go
+++ b/internal/deps/plan.go
@@ -108,7 +108,7 @@ func Plan(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup, t
 
 	report := PlanReport{Profile: selection.Profile, Profiles: selection.Profiles, Tags: selection.Tags, Tier: tier}
 	for _, dep := range selected {
-		if dependencyPresent(dep, opts, look, fontLook) {
+		if DependencyPresent(dep, opts, look, fontLook) {
 			continue
 		}
 		action, err := actionFor(dep, opts, tier, look)

--- a/internal/deps/plan_test.go
+++ b/internal/deps/plan_test.go
@@ -68,6 +68,43 @@ func TestPlanProducesStructuredInstallActionsForMappedPackages(t *testing.T) {
 	}
 }
 
+func TestPlanUsesDarwinAppAsAlternativeToCommandProbe(t *testing.T) {
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"desktop"}}},
+		Entries: []manifest.Entry{{
+			Source: "configs/ghostty/config.ghostty", Target: "~/.config/ghostty/config.ghostty", Strategy: "symlink", Tags: []string{"desktop"},
+			Dependencies: []manifest.Dependency{{
+				Name: "ghostty", Command: "ghostty", DarwinApp: "Ghostty.app", BrewCask: "ghostty",
+			}},
+		}},
+	}
+	tests := []struct {
+		name        string
+		os          string
+		apps        deps.AppLookup
+		wantActions int
+	}{
+		{name: "installed Darwin app", os: "darwin", apps: appLookupSet("Ghostty.app"), wantActions: 0},
+		{name: "missing Darwin app", os: "darwin", apps: appLookupSet(), wantActions: 1},
+		{name: "Linux ignores Darwin app", os: "linux", apps: appLookupSet("Ghostty.app"), wantActions: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report, err := deps.Plan(m, deps.Options{
+				Profile: "default", OS: tt.os, AppLookup: tt.apps,
+			}, lookupSet(), fontLookupSet(), deps.TierHomebrew)
+			if err != nil {
+				t.Fatalf("Plan() error = %v", err)
+			}
+			if len(report.Actions) != tt.wantActions {
+				t.Fatalf("Actions = %#v, want len %d", report.Actions, tt.wantActions)
+			}
+		})
+	}
+}
+
 func TestPlanUsesAtuinUserLocalProviderOnLinuxWhenDistroProviderUnavailable(t *testing.T) {
 	m := manifest.Manifest{
 		Version:  1,

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -31,6 +31,7 @@ type Options struct {
 	SourceRoot string
 	Home       string
 	ToolRunner deps.CommandRunner
+	AppLookup  deps.AppLookup
 }
 
 // Report is the consolidated doctor diagnostic output for a profile.
@@ -106,7 +107,7 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options, look deps.Loo
 		Platform: Platform{Supported: supportedOS(opts.OS), OS: opts.OS},
 	}
 
-	depReport, err := deps.CheckWithToolProbes(m, deps.Options{Profile: opts.Profile, Profiles: opts.Profiles, ExtraTags: opts.ExtraTags, Selection: resolved, OS: opts.OS}, look, fontLook, opts.ToolRunner)
+	depReport, err := deps.CheckWithToolProbes(m, deps.Options{Profile: opts.Profile, Profiles: opts.Profiles, ExtraTags: opts.ExtraTags, Selection: resolved, OS: opts.OS, AppLookup: opts.AppLookup}, look, fontLook, opts.ToolRunner)
 	if err != nil {
 		return Report{}, err
 	}
@@ -126,7 +127,7 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options, look deps.Loo
 	}
 	report.Configuration = statusReport
 
-	provReport, err := provision.Check(m, provision.Options{Profile: opts.Profile, Profiles: opts.Profiles, ExtraTags: opts.ExtraTags, Selection: resolved, OS: opts.OS}, look, fontLook)
+	provReport, err := provision.Check(m, provision.Options{Profile: opts.Profile, Profiles: opts.Profiles, ExtraTags: opts.ExtraTags, Selection: resolved, OS: opts.OS, AppLookup: opts.AppLookup}, look, fontLook)
 	if err != nil {
 		return Report{}, err
 	}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -124,6 +124,9 @@ type Dependency struct {
 	Name        string `yaml:"name"`
 	Requirement string `yaml:"requirement,omitempty"`
 	Command     string `yaml:"command,omitempty"`
+	// DarwinApp names a macOS application bundle that can satisfy the
+	// Dependency when its command is not available on PATH.
+	DarwinApp string `yaml:"darwin_app,omitempty"`
 	// Manual carries dependency-specific remediation for manual-only tools.
 	Manual string `yaml:"manual,omitempty"`
 	// ManualDebian carries Debian/Ubuntu-specific manual remediation.
@@ -469,6 +472,12 @@ func validateDependency(dep Dependency, path string) error {
 	}
 	if dep.Command != "" && strings.TrimSpace(dep.Command) == "" {
 		return fmt.Errorf("%s.command must not be empty", path)
+	}
+	if dep.DarwinApp != "" {
+		app := strings.TrimSpace(dep.DarwinApp)
+		if app == "" || strings.ContainsAny(app, `/\`) || !strings.HasSuffix(app, ".app") {
+			return fmt.Errorf("%s.darwin_app must be an .app bundle name without a path", path)
+		}
 	}
 	if dep.Manual != "" && strings.TrimSpace(dep.Manual) == "" {
 		return fmt.Errorf("%s.manual must not be empty", path)

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -760,13 +760,20 @@ func TestRepositoryManifestLinuxHomebrewReviewBoundary(t *testing.T) {
 		}
 	}
 	ghosttyManualFound := false
+	ghosttyDarwinAppFound := false
 	for _, dep := range dependencies["ghostty"] {
 		if strings.Contains(dep.ManualDebian, "snap install ghostty --classic") && strings.Contains(dep.ManualDebian, "requires sudo") {
 			ghosttyManualFound = true
 		}
+		if dep.DarwinApp == "Ghostty.app" {
+			ghosttyDarwinAppFound = true
+		}
 	}
 	if !ghosttyManualFound {
 		t.Fatalf("ghostty dependency missing explicit Ubuntu manual guidance with snap sudo/interactivity note: %#v", dependencies["ghostty"])
+	}
+	if !ghosttyDarwinAppFound {
+		t.Fatalf("ghostty dependency missing Darwin app-bundle detection: %#v", dependencies["ghostty"])
 	}
 
 	for _, name := range []string{"bat", "starship", "zellij", "atuin", "pnpm", "gentle-ai", "engram"} {
@@ -1757,6 +1764,23 @@ entries:
         command: "  "
 `,
 			want: `entries[0].dependencies[0].command must not be empty`,
+		},
+		{
+			name: "dependency with invalid Darwin app bundle name",
+			content: `version: 1
+profiles:
+  default:
+    tags: [desktop]
+entries:
+  - source: configs/ghostty/config.ghostty
+    target: ~/.config/ghostty/config.ghostty
+    strategy: symlink
+    tags: [desktop]
+    dependencies:
+      - name: ghostty
+        darwin_app: ../Ghostty.app
+`,
+			want: `entries[0].dependencies[0].darwin_app must be an .app bundle name without a path`,
 		},
 		{
 			name: "dependency with whitespace-only manual guidance",

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -765,7 +765,7 @@ func TestRepositoryManifestLinuxHomebrewReviewBoundary(t *testing.T) {
 		if strings.Contains(dep.ManualDebian, "snap install ghostty --classic") && strings.Contains(dep.ManualDebian, "requires sudo") {
 			ghosttyManualFound = true
 		}
-		if dep.DarwinApp == "Ghostty.app" {
+		if dep.DarwinApp == "Ghostty.app" && dep.BrewCask == "ghostty" && dep.Brew == "" {
 			ghosttyDarwinAppFound = true
 		}
 	}

--- a/internal/provision/apply.go
+++ b/internal/provision/apply.go
@@ -94,29 +94,17 @@ func Apply(m manifest.Manifest, opts Options, look deps.Lookup, fontLook deps.Fo
 func missingDependencies(prov manifest.Provisioner, opts Options, look deps.Lookup, fontLook deps.FontLookup) []string {
 	var missing []string
 	for _, dep := range prov.Dependencies {
-		if dep.IsFont() {
-			matches := dep.FontMatches()
-			if !fontDependencyPresent(matches, fontLook) {
-				missing = append(missing, fontDependencyLabel(matches))
-			}
+		if deps.DependencyPresent(dep, deps.Options{OS: opts.OS, AppLookup: opts.AppLookup}, look, fontLook) {
 			continue
 		}
-		probe := dep.Probe()
-		appPresent := opts.OS == "darwin" && dep.DarwinApp != "" && opts.AppLookup != nil && opts.AppLookup(dep.DarwinApp)
-		if !look(probe) && !appPresent {
-			missing = append(missing, probe)
+		if dep.IsFont() {
+			matches := dep.FontMatches()
+			missing = append(missing, fontDependencyLabel(matches))
+			continue
 		}
+		missing = append(missing, dep.Probe())
 	}
 	return missing
-}
-
-func fontDependencyPresent(matches []string, fontLook deps.FontLookup) bool {
-	for _, match := range matches {
-		if fontLook(match) {
-			return true
-		}
-	}
-	return false
 }
 
 func fontDependencyLabel(matches []string) string {

--- a/internal/provision/apply.go
+++ b/internal/provision/apply.go
@@ -58,7 +58,7 @@ func Apply(m manifest.Manifest, opts Options, look deps.Lookup, fontLook deps.Fo
 	for _, prov := range selected {
 		executable, args := RenderCommand(prov)
 
-		if missing := missingDependencies(prov, look, fontLook); len(missing) > 0 {
+		if missing := missingDependencies(prov, opts, look, fontLook); len(missing) > 0 {
 			report.Items = append(report.Items, RunItem{
 				Tool:       prov.Tool,
 				Executable: executable,
@@ -91,7 +91,7 @@ func Apply(m manifest.Manifest, opts Options, look deps.Lookup, fontLook deps.Fo
 
 // missingDependencies returns the probes of the Provisioner's declared
 // dependencies that are absent on the workstation, in declared order.
-func missingDependencies(prov manifest.Provisioner, look deps.Lookup, fontLook deps.FontLookup) []string {
+func missingDependencies(prov manifest.Provisioner, opts Options, look deps.Lookup, fontLook deps.FontLookup) []string {
 	var missing []string
 	for _, dep := range prov.Dependencies {
 		if dep.IsFont() {
@@ -102,7 +102,8 @@ func missingDependencies(prov manifest.Provisioner, look deps.Lookup, fontLook d
 			continue
 		}
 		probe := dep.Probe()
-		if !look(probe) {
+		appPresent := opts.OS == "darwin" && dep.DarwinApp != "" && opts.AppLookup != nil && opts.AppLookup(dep.DarwinApp)
+		if !look(probe) && !appPresent {
 			missing = append(missing, probe)
 		}
 	}

--- a/internal/provision/apply_test.go
+++ b/internal/provision/apply_test.go
@@ -42,6 +42,14 @@ func fontLookupWith(present ...string) deps.FontLookup {
 	return func(match string) bool { return set[match] }
 }
 
+func appLookupWith(present ...string) deps.AppLookup {
+	set := make(map[string]bool, len(present))
+	for _, p := range present {
+		set[p] = true
+	}
+	return func(app string) bool { return set[app] }
+}
+
 func gentleAIProvisioner(agent string) manifest.Provisioner {
 	return manifest.Provisioner{
 		Tool: "gentle-ai",

--- a/internal/provision/check.go
+++ b/internal/provision/check.go
@@ -54,7 +54,7 @@ func Check(m manifest.Manifest, opts Options, look deps.Lookup, fontLook deps.Fo
 			Tool:       prov.Tool,
 			Executable: executable,
 			Args:       args,
-			Missing:    missingDependencies(prov, look, fontLook),
+			Missing:    missingDependencies(prov, opts, look, fontLook),
 		})
 	}
 	return report, nil

--- a/internal/provision/check_test.go
+++ b/internal/provision/check_test.go
@@ -71,7 +71,7 @@ func TestCheckAcceptsProvisionerFontFallbackDependency(t *testing.T) {
 func TestCheckAcceptsProvisionerDarwinAppDependency(t *testing.T) {
 	prov := gentleAIProvisioner("codex")
 	prov.Dependencies = append(prov.Dependencies, manifest.Dependency{
-		Name: "ghostty", Command: "ghostty", DarwinApp: "Ghostty.app",
+		Name: "ghostty", Command: "ghostty", DarwinApp: " Ghostty.app ",
 	})
 	m := manifestWithProvisioners(prov)
 

--- a/internal/provision/check_test.go
+++ b/internal/provision/check_test.go
@@ -68,6 +68,24 @@ func TestCheckAcceptsProvisionerFontFallbackDependency(t *testing.T) {
 	}
 }
 
+func TestCheckAcceptsProvisionerDarwinAppDependency(t *testing.T) {
+	prov := gentleAIProvisioner("codex")
+	prov.Dependencies = append(prov.Dependencies, manifest.Dependency{
+		Name: "ghostty", Command: "ghostty", DarwinApp: "Ghostty.app",
+	})
+	m := manifestWithProvisioners(prov)
+
+	report, err := provision.Check(m, provision.Options{
+		Profile: "default", OS: "darwin", AppLookup: appLookupWith("Ghostty.app"),
+	}, lookupWith("gentle-ai", "engram"), fontLookupWith())
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+	if len(report.Items) != 1 || len(report.Items[0].Missing) != 0 {
+		t.Fatalf("readiness = %#v, want no missing deps when Darwin app is installed", report.Items)
+	}
+}
+
 func TestCheckUsesFontLookupForProvisionerFontDependencies(t *testing.T) {
 	prov := gentleAIProvisioner("codex")
 	prov.Dependencies = append(prov.Dependencies, manifest.Dependency{

--- a/internal/provision/plan.go
+++ b/internal/provision/plan.go
@@ -3,6 +3,7 @@ package provision
 import (
 	"strings"
 
+	"github.com/yersonargotev/dots/internal/deps"
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/profilesel"
 )
@@ -14,6 +15,7 @@ type Options struct {
 	ExtraTags []string
 	Selection *manifest.Selection
 	OS        string
+	AppLookup deps.AppLookup
 }
 
 // Step is a single planned Provisioner invocation: the exact resolved command


### PR DESCRIPTION
Closes #354

## PR Type

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Recognize a declared macOS application bundle as an alternative to a PATH command when checking Dependencies.
- Make Ghostty use `darwin_app: Ghostty.app` and the explicit Homebrew cask provider.
- Reuse the same presence decision for check, plan, install rechecks, doctor, and Provisioner readiness while leaving Linux command detection unchanged.

## Changes

| File | Change |
|------|--------|
| `internal/manifest/manifest.go` | Adds validated `darwin_app` Dependency policy. |
| `internal/deps/*` | Centralizes command/font/app presence and carries app detection through post-install verification. |
| `internal/cli/deps.go`, `internal/cli/install.go` | Scans selected-user and system Applications roots without touching real configuration in tests. |
| `internal/doctor/*`, `internal/provision/*` | Reuses the same app-aware Dependency result for diagnostics/readiness. |
| `dots.yaml` | Detects `Ghostty.app` and installs Ghostty through `brew install --cask ghostty`. |
| `CONTEXT.md`, `docs/manifest.md`, `docs/adr/0015-*.md` | Documents the domain and architecture decision. |
| Tests | Covers present/missing app bundles, plan suppression, explicit cask execution, post-install recheck, Linux behavior, validation, and normalized Provisioner detection. |

## Test Plan

- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Built-CLI sandbox: empty `PATH`, temporary `--home`, synthetic `~/Applications/DotsSandbox.app`; `deps check --output json` and `deps plan --output json` both returned `status: ok`.
- [x] Local Standards and Spec reviews against `origin/main`; final re-reviews found no actionable findings.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] CLI validation and Temporary Home Tests used isolated home/source/state roots.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #354`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs and architecture guidance for the behavior change.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

## Risk / rollback

- App-bundle presence is intentionally a read-only existence check, not a launch-health probe. The manifest validates a single `.app` bundle name and limits production scanning to the selected user's Applications directory plus `/Applications`.
- Reverting this PR restores PATH-only Ghostty detection and the prior implicit Homebrew package form.
