### PR TITLE
fix(install): compose shared JSON subset targets

### DIFF
--- a/internal/cli/antigravity_config_test.go
+++ b/internal/cli/antigravity_config_test.go
@@ -81,6 +81,83 @@ func TestWorkstationAndMobileComposeAntigravitySettingsInSandbox(t *testing.T) {
 	}
 }
 
+func TestWorkstationAndMobileExpandLegacyAntigravityMetadataInSandbox(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	home := t.TempDir()
+	stateRoot := filepath.Join(home, ".local", "state", "dots")
+	t.Setenv("HOME", t.TempDir())
+	stubGentleAIProvisionerTools(t)
+
+	source := filepath.Join(repoRoot, "configs", "antigravity", "settings.json")
+	baseline, err := os.ReadFile(source)
+	if err != nil {
+		t.Fatalf("read baseline: %v", err)
+	}
+	var targetJSON map[string]any
+	if err := json.Unmarshal(baseline, &targetJSON); err != nil {
+		t.Fatalf("parse baseline: %v", err)
+	}
+	targetJSON["runtimeOnly"] = "keep"
+	targetData, err := json.Marshal(targetJSON)
+	if err != nil {
+		t.Fatalf("encode legacy target: %v", err)
+	}
+	target := filepath.Join(home, ".gemini", "antigravity-cli", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	if err := os.WriteFile(target, targetData, 0o600); err != nil {
+		t.Fatalf("write legacy target: %v", err)
+	}
+	hash, err := state.HashFile(source)
+	if err != nil {
+		t.Fatalf("hash baseline: %v", err)
+	}
+	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: 2, Entries: []state.Record{{
+		Target: target, Source: "configs/antigravity/settings.json", Strategy: "copy", Hash: hash,
+		Profiles: []string{"workstation"}, Tags: []string{"agents"},
+	}}}); err != nil {
+		t.Fatalf("save legacy metadata: %v", err)
+	}
+
+	install := cli.NewRootCommand()
+	var out bytes.Buffer
+	install.SetOut(&out)
+	install.SetErr(&out)
+	install.SetArgs([]string{
+		"install", "--file", filepath.Join(repoRoot, "dots.yaml"),
+		"--profile", "workstation", "--profile", "mobile", "--skip-deps",
+		"--source-root", repoRoot, "--home", home, "--state-root", stateRoot, "--yes",
+	})
+	if err := install.Execute(); err != nil {
+		t.Fatalf("legacy expansion install failed: %v\noutput:\n%s", err, out.String())
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read expanded target: %v", err)
+	}
+	for _, want := range []string{`"runtimeOnly": "keep"`, `"dart-mcp-server"`} {
+		if !strings.Contains(string(got), want) {
+			t.Fatalf("expanded target missing %s:\n%s", want, got)
+		}
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load migrated metadata: %v", err)
+	}
+	rec, ok := meta.FindByTarget(target)
+	if !ok || !rec.HasSource("configs/antigravity/mobile-mcp-settings.json") {
+		t.Fatalf("migrated target record = %+v, want mobile contributor", rec)
+	}
+	if meta.Version != state.CurrentVersion || meta.InstalledSelection == nil ||
+		!reflect.DeepEqual(meta.InstalledSelection.Profiles, []string{"workstation", "mobile"}) {
+		t.Fatalf("migrated metadata = %+v, want terminal v%d selection", meta, state.CurrentVersion)
+	}
+}
+
 // TestAntigravityAgentsProfileSeedsUserBaselineInSandbox proves that dots seeds the
 // user-owned Antigravity settings baseline with a copy strategy (regular files, not symlinks)
 // before the gentle-ai provisioner runs, that the settings contain the expected baseline keys,

--- a/internal/cli/antigravity_config_test.go
+++ b/internal/cli/antigravity_config_test.go
@@ -10,7 +10,76 @@ import (
 	"testing"
 
 	"github.com/yersonargotev/dots/internal/cli"
+	"github.com/yersonargotev/dots/internal/state"
 )
+
+func TestWorkstationAndMobileComposeAntigravitySettingsInSandbox(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	home := t.TempDir()
+	stateRoot := filepath.Join(home, ".local", "state", "dots")
+	t.Setenv("HOME", t.TempDir())
+	stubGentleAIProvisionerTools(t)
+
+	install := cli.NewRootCommand()
+	var out bytes.Buffer
+	install.SetOut(&out)
+	install.SetErr(&out)
+	install.SetArgs([]string{
+		"install", "--file", filepath.Join(repoRoot, "dots.yaml"),
+		"--profile", "workstation", "--profile", "mobile", "--skip-deps",
+		"--source-root", repoRoot, "--home", home, "--state-root", stateRoot, "--yes",
+	})
+	if err := install.Execute(); err != nil {
+		t.Fatalf("composed install failed: %v\noutput:\n%s", err, out.String())
+	}
+
+	target := filepath.Join(home, ".gemini", "antigravity-cli", "settings.json")
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read composed target: %v", err)
+	}
+	for _, want := range []string{`"toolPermission"`, `"allowNonWorkspaceAccess"`, `"dart-mcp-server"`} {
+		if !strings.Contains(string(data), want) {
+			t.Fatalf("composed target missing %s:\n%s", want, data)
+		}
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load metadata: %v", err)
+	}
+	rec, ok := meta.FindByTarget(target)
+	if !ok {
+		t.Fatal("metadata missing composed Antigravity target")
+	}
+	wantSources := []string{"configs/antigravity/settings.json", "configs/antigravity/mobile-mcp-settings.json"}
+	if !reflect.DeepEqual(rec.SourceList(), wantSources) {
+		t.Fatalf("metadata sources = %#v, want %#v", rec.SourceList(), wantSources)
+	}
+	if meta.InstalledSelection == nil || !reflect.DeepEqual(meta.InstalledSelection.Profiles, []string{"workstation", "mobile"}) {
+		t.Fatalf("installed selection = %+v, want workstation + mobile", meta.InstalledSelection)
+	}
+
+	statusCmd := cli.NewRootCommand()
+	var statusOut bytes.Buffer
+	statusCmd.SetOut(&statusOut)
+	statusCmd.SetErr(&statusOut)
+	statusCmd.SetArgs([]string{
+		"status", "--file", filepath.Join(repoRoot, "dots.yaml"),
+		"--profile", "workstation", "--profile", "mobile",
+		"--source-root", repoRoot, "--home", home, "--state-root", stateRoot,
+	})
+	if err := statusCmd.Execute(); err != nil {
+		t.Fatalf("status failed for composed install: %v\noutput:\n%s", err, statusOut.String())
+	}
+	for _, source := range wantSources {
+		if !strings.Contains(statusOut.String(), "ok") || !strings.Contains(statusOut.String(), source) {
+			t.Fatalf("status does not prove contributor %s aligned:\n%s", source, statusOut.String())
+		}
+	}
+}
 
 // TestAntigravityAgentsProfileSeedsUserBaselineInSandbox proves that dots seeds the
 // user-owned Antigravity settings baseline with a copy strategy (regular files, not symlinks)

--- a/internal/cli/output_golden_test.go
+++ b/internal/cli/output_golden_test.go
@@ -167,7 +167,7 @@ func TestEnvelopeGolden(t *testing.T) {
 					Source: selection.SourceExplicit, Profiles: []string{"default"}, ExtraTags: []string{"work"}, EffectiveTags: []string{"core", "work"},
 				}, Actions: []plan.Action{
 					{Source: "configs/zsh/zshrc", ResolvedSource: "/abs/machine/local/path/MUST/NOT/APPEAR", Target: "/home/user/.zshrc", Strategy: "symlink", Status: plan.StatusCreate},
-					{Source: "configs/git/config", ResolvedSource: "/abs/x", Target: "/home/user/.gitconfig", Strategy: "copy", Status: plan.StatusConflict, Reason: plan.ConflictReasonSourceOverrideNotSelected, MatchingTags: []string{"adaptive-theme"}},
+					{Source: "configs/git/config", Sources: []string{"configs/git/config", "configs/git/work.json"}, ResolvedSource: "/abs/x", ResolvedSources: []string{"/abs/x", "/abs/y"}, Content: []byte(`MUST NOT APPEAR`), Target: "/home/user/.gitconfig", Strategy: "copy", Status: plan.StatusConflict, Reason: plan.ConflictReasonSourceOverrideNotSelected, MatchingTags: []string{"adaptive-theme"}},
 				}},
 			},
 			golden: "envelope_plan.golden",

--- a/internal/cli/output_golden_test.go
+++ b/internal/cli/output_golden_test.go
@@ -173,6 +173,29 @@ func TestEnvelopeGolden(t *testing.T) {
 			golden: "envelope_plan.golden",
 		},
 		{
+			name: "uninstall",
+			env: envelope{
+				SchemaVersion: schemaVersion,
+				Command:       "uninstall",
+				Status:        statusOK,
+				Data: uninstallReport{
+					DryRun:    true,
+					StateRoot: "/home/user/.local/state/dots",
+					Plan: plan.UninstallPlan{Actions: []plan.UninstallAction{{
+						Source: "configs/antigravity/settings.json",
+						Sources: []string{
+							"configs/antigravity/settings.json",
+							"configs/antigravity/mobile-mcp-settings.json",
+						},
+						Target:   "/home/user/.gemini/antigravity-cli/settings.json",
+						Strategy: "copy",
+						Status:   plan.UninstallRemove,
+					}}},
+				},
+			},
+			golden: "envelope_uninstall.golden",
+		},
+		{
 			name: "doctor",
 			env: envelope{
 				SchemaVersion: schemaVersion,

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -20,6 +20,66 @@ type testEnvelope struct {
 	Error         string          `json:"error"`
 }
 
+func TestInstallJSONRejectsIncompatibleSharedSubsetDuringPlanningWithoutMutation(t *testing.T) {
+	sourceRoot := t.TempDir()
+	home := t.TempDir()
+	stateRoot := filepath.Join(home, ".local", "state", "dots")
+	for rel, content := range map[string]string{
+		"configs/base.json":   `{"editor":{"theme":"dark"}}`,
+		"configs/mobile.json": `{"editor":{"theme":"light"}}`,
+	} {
+		path := filepath.Join(sourceRoot, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir source: %v", err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write source: %v", err)
+		}
+	}
+	manifestPath := filepath.Join(sourceRoot, "dots.yaml")
+	if err := os.WriteFile(manifestPath, []byte(`version: 1
+profiles:
+  default:
+    tags: [base, mobile]
+entries:
+  - source: configs/base.json
+    target: ~/.config/shared.json
+    strategy: copy
+    ownership: json-subset
+    tags: [base]
+  - source: configs/mobile.json
+    target: ~/.config/shared.json
+    strategy: copy
+    ownership: json-subset
+    tags: [mobile]
+`), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	var out, errOut bytes.Buffer
+	code := cli.Run([]string{
+		"install", "--profile", "default", "--skip-deps", "--yes", "--no-tui",
+		"--output", "json", "--file", manifestPath, "--source-root", sourceRoot,
+		"--home", home, "--state-root", stateRoot,
+	}, &out, &errOut)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
+	}
+	env := decodeEnvelopeForCommand(t, out.String(), "install")
+	if env.Status != "error" || !strings.Contains(env.Error, "incompatible") {
+		t.Fatalf("envelope = %+v, want planning incompatibility", env)
+	}
+	if errOut.Len() != 0 {
+		t.Fatalf("Machine Output Mode wrote stderr:\n%s", errOut.String())
+	}
+	if _, err := os.Lstat(filepath.Join(home, ".config", "shared.json")); !os.IsNotExist(err) {
+		t.Fatalf("target mutated before planning failure; lstat err = %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(stateRoot, "installed.json")); !os.IsNotExist(err) {
+		t.Fatalf("metadata mutated before planning failure; lstat err = %v", err)
+	}
+}
+
 func decodeEnvelope(t *testing.T, out string) testEnvelope {
 	t.Helper()
 	var env testEnvelope

--- a/internal/cli/testdata/envelope_plan.golden
+++ b/internal/cli/testdata/envelope_plan.golden
@@ -26,6 +26,10 @@
       },
       {
         "source": "configs/git/config",
+        "sources": [
+          "configs/git/config",
+          "configs/git/work.json"
+        ],
         "target": "/home/user/.gitconfig",
         "strategy": "copy",
         "status": "conflict",

--- a/internal/cli/testdata/envelope_uninstall.golden
+++ b/internal/cli/testdata/envelope_uninstall.golden
@@ -1,0 +1,27 @@
+{
+  "schema_version": "5",
+  "command": "uninstall",
+  "status": "ok",
+  "data": {
+    "dry_run": true,
+    "state_root": "/home/user/.local/state/dots",
+    "plan": {
+      "actions": [
+        {
+          "target": "/home/user/.gemini/antigravity-cli/settings.json",
+          "source": "configs/antigravity/settings.json",
+          "sources": [
+            "configs/antigravity/settings.json",
+            "configs/antigravity/mobile-mcp-settings.json"
+          ],
+          "strategy": "copy",
+          "status": "remove"
+        }
+      ]
+    },
+    "result": {
+      "removed": null,
+      "restored_sets": null
+    }
+  }
+}

--- a/internal/configsubset/subset.go
+++ b/internal/configsubset/subset.go
@@ -36,6 +36,82 @@ type JSONFileRelation struct {
 	Mergeable bool
 }
 
+// ComposeJSONFiles reads source-owned JSON fragments and composes them in
+// manifest order. Compatible object and array values are merged using the same
+// subset semantics as MergeJSONFile. The returned JSON is deterministic and
+// suitable for a later plan or apply step; no source file is modified.
+func ComposeJSONFiles(sources []string) ([]byte, error) {
+	if len(sources) == 0 {
+		return nil, fmt.Errorf("compose JSON: no sources")
+	}
+
+	var composed any
+	for index, source := range sources {
+		data, err := os.ReadFile(source)
+		if err != nil {
+			return nil, fmt.Errorf("read source JSON %s: %w", source, err)
+		}
+		var sourceValue any
+		if err := decodeJSON(data, &sourceValue); err != nil {
+			return nil, fmt.Errorf("parse source JSON %s: %w", source, err)
+		}
+		if index == 0 {
+			composed = sourceValue
+			continue
+		}
+		result := mergeJSONValue(composed, sourceValue)
+		if !result.compatible {
+			return nil, fmt.Errorf("compose source JSON %s: incompatible overlap", source)
+		}
+		composed = result.value
+	}
+
+	data, err := json.MarshalIndent(composed, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("encode composed JSON: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
+// AnalyzeJSON compares target JSON content with a source-owned JSON subset.
+// Invalid target JSON is incompatible; invalid source JSON is returned as an
+// error because source content belongs to the repository-owned baseline.
+func AnalyzeJSON(targetData, sourceData []byte) (JSONFileRelation, error) {
+	var sourceValue, targetValue any
+	if err := decodeJSON(sourceData, &sourceValue); err != nil {
+		return JSONFileRelation{}, fmt.Errorf("parse source JSON: %w", err)
+	}
+	if err := decodeJSON(targetData, &targetValue); err != nil {
+		return JSONFileRelation{}, nil
+	}
+	result := mergeJSONValue(targetValue, sourceValue)
+	return JSONFileRelation{
+		Contains:  result.compatible && !result.changed,
+		Mergeable: result.compatible && result.changed,
+	}, nil
+}
+
+// MergeJSON adds source-owned values missing from target JSON content. It
+// returns deterministic indented JSON without mutating either input.
+func MergeJSON(targetData, sourceData []byte) ([]byte, error) {
+	var sourceValue, targetValue any
+	if err := decodeJSON(sourceData, &sourceValue); err != nil {
+		return nil, fmt.Errorf("parse source JSON: %w", err)
+	}
+	if err := decodeJSON(targetData, &targetValue); err != nil {
+		return nil, fmt.Errorf("parse target JSON: %w", err)
+	}
+	result := mergeJSONValue(targetValue, sourceValue)
+	if !result.compatible {
+		return nil, fmt.Errorf("source-owned JSON differences cannot be merged safely")
+	}
+	data, err := json.MarshalIndent(result.value, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("encode merged JSON: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
 // AnalyzeJSONFiles compares target with source in one read and parse pass.
 // Invalid target JSON is incompatible; invalid source JSON is an error because
 // source belongs to the repository-owned baseline.
@@ -52,18 +128,11 @@ func AnalyzeJSONFiles(target, source string) (JSONFileRelation, error) {
 		return JSONFileRelation{}, fmt.Errorf("read %s: %w", target, err)
 	}
 
-	var sourceValue, targetValue any
-	if err := decodeJSON(sourceData, &sourceValue); err != nil {
-		return JSONFileRelation{}, fmt.Errorf("parse source JSON %s: %w", source, err)
+	relation, err := AnalyzeJSON(targetData, sourceData)
+	if err != nil {
+		return JSONFileRelation{}, fmt.Errorf("analyze source JSON %s: %w", source, err)
 	}
-	if err := decodeJSON(targetData, &targetValue); err != nil {
-		return JSONFileRelation{}, nil
-	}
-	result := mergeJSONValue(targetValue, sourceValue)
-	return JSONFileRelation{
-		Contains:  result.compatible && !result.changed,
-		Mergeable: result.compatible && result.changed,
-	}, nil
+	return relation, nil
 }
 
 // JSONFileContains reports whether target contains every value present in
@@ -91,22 +160,10 @@ func MergeJSONFile(target, source string) error {
 		return fmt.Errorf("stat %s: %w", target, err)
 	}
 
-	var sourceValue, targetValue any
-	if err := decodeJSON(sourceData, &sourceValue); err != nil {
-		return fmt.Errorf("parse source JSON %s: %w", source, err)
-	}
-	if err := decodeJSON(targetData, &targetValue); err != nil {
-		return fmt.Errorf("parse target JSON %s: %w", target, err)
-	}
-	result := mergeJSONValue(targetValue, sourceValue)
-	if !result.compatible {
-		return fmt.Errorf("source-owned JSON differences cannot be merged safely")
-	}
-	data, err := json.MarshalIndent(result.value, "", "  ")
+	data, err := MergeJSON(targetData, sourceData)
 	if err != nil {
-		return fmt.Errorf("encode merged JSON: %w", err)
+		return fmt.Errorf("merge target JSON %s with source JSON %s: %w", target, source, err)
 	}
-	data = append(data, '\n')
 	if err := os.WriteFile(target, data, info.Mode().Perm()); err != nil {
 		return fmt.Errorf("write %s: %w", target, err)
 	}

--- a/internal/configsubset/subset_test.go
+++ b/internal/configsubset/subset_test.go
@@ -1,11 +1,128 @@
 package configsubset
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestComposeJSONFilesComposesSourcesInManifestOrder(t *testing.T) {
+	dir := t.TempDir()
+	first := filepath.Join(dir, "first.json")
+	second := filepath.Join(dir, "second.json")
+	third := filepath.Join(dir, "third.json")
+	for path, content := range map[string]string{
+		first:  `{"permissions":{"allow":["Read"],"mode":"default"},"runtimeCounter":9007199254740993}`,
+		second: `{"permissions":{"allow":["Bash(git *)"],"mode":"default"},"hooks":{"PostToolUse":[]}}`,
+		third:  `{"permissions":{"allow":["Read","Bash(go test *)"]}}`,
+	} {
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+
+	got, err := ComposeJSONFiles([]string{first, second, third})
+	if err != nil {
+		t.Fatalf("ComposeJSONFiles() error = %v", err)
+	}
+	want := `{
+  "hooks": {
+    "PostToolUse": []
+  },
+  "permissions": {
+    "allow": [
+      "Read",
+      "Bash(git *)",
+      "Bash(go test *)"
+    ],
+    "mode": "default"
+  },
+  "runtimeCounter": 9007199254740993
+}
+`
+	if string(got) != want {
+		t.Fatalf("ComposeJSONFiles() =\n%s\nwant:\n%s", got, want)
+	}
+
+	var decoded map[string]any
+	decoder := json.NewDecoder(strings.NewReader(string(got)))
+	decoder.UseNumber()
+	if err := decoder.Decode(&decoded); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if gotNumber := decoded["runtimeCounter"]; gotNumber != json.Number("9007199254740993") {
+		t.Fatalf("runtimeCounter = %#v, want preserved json.Number", gotNumber)
+	}
+}
+
+func TestComposeJSONFilesRejectsIncompatibleOverlap(t *testing.T) {
+	dir := t.TempDir()
+	first := filepath.Join(dir, "first.json")
+	second := filepath.Join(dir, "second.json")
+	if err := os.WriteFile(first, []byte(`{"permissions":{"mode":"default"}}`), 0o600); err != nil {
+		t.Fatalf("write first: %v", err)
+	}
+	if err := os.WriteFile(second, []byte(`{"permissions":{"mode":{"name":"default"}}}`), 0o600); err != nil {
+		t.Fatalf("write second: %v", err)
+	}
+
+	_, err := ComposeJSONFiles([]string{first, second})
+	if err == nil {
+		t.Fatal("ComposeJSONFiles() error = nil, want incompatible overlap")
+	}
+	if !strings.Contains(err.Error(), second) {
+		t.Fatalf("error %q does not contain conflicting source path %q", err, second)
+	}
+}
+
+func TestComposeJSONFilesReportsInvalidSourcePath(t *testing.T) {
+	dir := t.TempDir()
+	invalid := filepath.Join(dir, "invalid.json")
+	if err := os.WriteFile(invalid, []byte(`{"permissions":`), 0o600); err != nil {
+		t.Fatalf("write invalid source: %v", err)
+	}
+
+	_, err := ComposeJSONFiles([]string{invalid})
+	if err == nil {
+		t.Fatal("ComposeJSONFiles() error = nil, want parse error")
+	}
+	if !strings.Contains(err.Error(), invalid) {
+		t.Fatalf("error %q does not contain invalid source path %q", err, invalid)
+	}
+}
+
+func TestAnalyzeAndMergeJSONContent(t *testing.T) {
+	target := []byte(`{"permissions":{"allow":["Read"]},"runtimeCounter":9007199254740993}`)
+	source := []byte(`{"permissions":{"allow":["Read","Bash(git *)"]}}`)
+
+	relation, err := AnalyzeJSON(target, source)
+	if err != nil {
+		t.Fatalf("AnalyzeJSON() error = %v", err)
+	}
+	if !relation.Mergeable || relation.Contains {
+		t.Fatalf("AnalyzeJSON() = %#v, want mergeable only", relation)
+	}
+
+	got, err := MergeJSON(target, source)
+	if err != nil {
+		t.Fatalf("MergeJSON() error = %v", err)
+	}
+	want := `{
+  "permissions": {
+    "allow": [
+      "Read",
+      "Bash(git *)"
+    ]
+  },
+  "runtimeCounter": 9007199254740993
+}
+`
+	if string(got) != want {
+		t.Fatalf("MergeJSON() =\n%s\nwant:\n%s", got, want)
+	}
+}
 
 func TestMergeJSONFileAddsMissingValuesAndPreservesTargetState(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -164,6 +164,43 @@ func TestBuildDiagnosticSections(t *testing.T) {
 	}
 }
 
+func TestBuildReportsAllSharedJSONContributorsAligned(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	writeFile(t, sourceRoot, "configs/base.json", `{"base":true}`)
+	writeFile(t, sourceRoot, "configs/mobile.json", `{"mobile":true}`)
+	target := filepath.Join(home, ".config", "shared.json")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	if err := os.WriteFile(target, []byte(`{"base":true,"mobile":true,"runtime":"keep"}`), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"base", "mobile"}}},
+		Entries: []manifest.Entry{
+			{Source: "configs/base.json", Target: "~/.config/shared.json", Strategy: "copy", Ownership: "json-subset", Tags: []string{"base"}},
+			{Source: "configs/mobile.json", Target: "~/.config/shared.json", Strategy: "copy", Ownership: "json-subset", Tags: []string{"mobile"}},
+		},
+	}
+	meta := state.Metadata{Entries: []state.Record{{
+		Target: target, Source: "configs/base.json", Sources: []string{"configs/base.json", "configs/mobile.json"}, Strategy: "copy",
+	}}}
+
+	report, err := doctor.Build(m, meta, doctor.Options{
+		Profile: "default", OS: "linux", SourceRoot: sourceRoot, Home: home,
+	}, lookupSet(), fontLookupSet())
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if len(report.Configuration.Entries) != 2 ||
+		report.Configuration.Entries[0].State != "ok" ||
+		report.Configuration.Entries[1].State != "ok" {
+		t.Fatalf("configuration = %+v, want both shared-target contributors aligned", report.Configuration.Entries)
+	}
+}
+
 func TestBuildReportsProvisionerReadiness(t *testing.T) {
 	home := t.TempDir()
 	sourceRoot := t.TempDir()

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -92,8 +92,8 @@ func recordMetadata(p plan.Plan, resolvedSources [][]string, opts Options) error
 	if err != nil {
 		return err
 	}
-	if meta.Version < state.CurrentVersion {
-		meta.Version = state.CurrentVersion
+	if meta.Version < 2 {
+		meta.Version = 2
 	}
 	meta.Provenance = state.CaptureProvenance(opts.SourceRoot, version.Value)
 

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -1,6 +1,7 @@
 package install
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -44,15 +45,16 @@ func Apply(p plan.Plan, opts Options) error {
 	}
 
 	for i, action := range p.Actions {
+		source := resolvedSources[i][0]
 		switch action.Status {
 		case plan.StatusUnchanged:
 			continue
 		case plan.StatusCreate:
-			if err := applyCreate(action, resolvedSources[i]); err != nil {
+			if err := applyCreate(action, source); err != nil {
 				return err
 			}
 		case plan.StatusUpdate:
-			if err := applyUpdate(action, resolvedSources[i], opts); err != nil {
+			if err := applyUpdate(action, source, opts); err != nil {
 				return err
 			}
 		case plan.StatusConflict:
@@ -62,11 +64,11 @@ func Apply(p plan.Plan, opts Options) error {
 				// existing workstation target, but continue applying safe actions.
 				continue
 			case DecisionReplace:
-				if err := applyReplace(action, resolvedSources[i], opts); err != nil {
+				if err := applyReplace(action, source, opts); err != nil {
 					return err
 				}
 			case DecisionAdopt:
-				if err := applyAdopt(action, resolvedSources[i], opts); err != nil {
+				if err := applyAdopt(action, source, opts); err != nil {
 					return err
 				}
 			}
@@ -80,7 +82,7 @@ func Apply(p plan.Plan, opts Options) error {
 // installed or confirmed unchanged, so dots status has an authoritative record
 // of what dots owns. Copy-like records include a Source of Truth hash; symlink
 // records leave Hash empty because status compares the link destination.
-func recordMetadata(p plan.Plan, resolvedSources []string, opts Options) error {
+func recordMetadata(p plan.Plan, resolvedSources [][]string, opts Options) error {
 	if opts.StateRoot == "" {
 		return nil
 	}
@@ -90,8 +92,8 @@ func recordMetadata(p plan.Plan, resolvedSources []string, opts Options) error {
 	if err != nil {
 		return err
 	}
-	if meta.Version < 2 {
-		meta.Version = 2
+	if meta.Version < state.CurrentVersion {
+		meta.Version = state.CurrentVersion
 	}
 	meta.Provenance = state.CaptureProvenance(opts.SourceRoot, version.Value)
 
@@ -102,15 +104,20 @@ func recordMetadata(p plan.Plan, resolvedSources []string, opts Options) error {
 		}
 		hash := ""
 		if action.Strategy != "symlink" {
-			var err error
-			hash, err = state.HashFile(resolvedSources[i])
-			if err != nil {
-				return err
+			if len(action.Sources) > 0 {
+				hash = state.HashBytes(action.Content)
+			} else {
+				var err error
+				hash, err = state.HashFile(resolvedSources[i][0])
+				if err != nil {
+					return err
+				}
 			}
 		}
 		upsertRecord(&meta, state.Record{
 			Target:      action.Target,
 			Source:      action.Source,
+			Sources:     append([]string(nil), action.Sources...),
 			Strategy:    action.Strategy,
 			Hash:        hash,
 			InstalledAt: now,
@@ -132,7 +139,7 @@ func upsertRecord(meta *state.Metadata, rec state.Record) {
 	meta.Entries = append(meta.Entries, rec)
 }
 
-func validatePlan(p plan.Plan, opts Options) ([]string, error) {
+func validatePlan(p plan.Plan, opts Options) ([][]string, error) {
 	if opts.Home == "" {
 		return nil, fmt.Errorf("install home is required")
 	}
@@ -152,7 +159,7 @@ func validatePlan(p plan.Plan, opts Options) ([]string, error) {
 	}
 
 	seenTargets := map[string]struct{}{}
-	resolvedSources := make([]string, len(p.Actions))
+	resolvedSources := make([][]string, len(p.Actions))
 	for i, action := range p.Actions {
 		if err := plan.ValidateResolvedTarget(action.Target, home); err != nil {
 			return nil, err
@@ -165,14 +172,40 @@ func validatePlan(p plan.Plan, opts Options) ([]string, error) {
 			return nil, fmt.Errorf("install plan contains duplicate target %s", targetKey)
 		}
 		seenTargets[targetKey] = struct{}{}
-		source, err := plan.ResolveSource(action.Source, sourceRoot)
-		if err != nil {
-			return nil, err
+		sources := []string{action.Source}
+		declaredResolved := []string{action.ResolvedSource}
+		if len(action.Sources) > 0 {
+			sources = action.Sources
+			declaredResolved = action.ResolvedSources
+			if action.Strategy != "copy" || action.Ownership != "json-subset" || len(sources) < 2 {
+				return nil, fmt.Errorf("composed target %s requires at least two copy/json-subset sources", action.Target)
+			}
 		}
-		if action.ResolvedSource != "" && action.ResolvedSource != source {
-			return nil, fmt.Errorf("install plan source %q resolved to %q, want %q", action.Source, action.ResolvedSource, source)
+		for j, sourceName := range sources {
+			source, err := plan.ResolveSource(sourceName, sourceRoot)
+			if err != nil {
+				return nil, err
+			}
+			if j < len(declaredResolved) && declaredResolved[j] != "" && declaredResolved[j] != source {
+				return nil, fmt.Errorf("install plan source %q resolved to %q, want %q", sourceName, declaredResolved[j], source)
+			}
+			resolvedSources[i] = append(resolvedSources[i], source)
 		}
-		resolvedSources[i] = source
+		source := resolvedSources[i][0]
+		if len(action.Sources) > 0 {
+			for _, composedSource := range resolvedSources[i] {
+				if err := validateSource(action.Strategy, composedSource, sourceRoot); err != nil {
+					return nil, err
+				}
+			}
+			composed, err := configsubset.ComposeJSONFiles(resolvedSources[i])
+			if err != nil {
+				return nil, fmt.Errorf("validate composed target %s: %w", action.Target, err)
+			}
+			if !bytes.Equal(composed, action.Content) {
+				return nil, fmt.Errorf("install plan composed content is stale for %s", action.Target)
+			}
+		}
 
 		switch action.Status {
 		case plan.StatusCreate:
@@ -397,6 +430,12 @@ func applyCreate(action plan.Action, source string) error {
 		}
 		return nil
 	case "copy":
+		if len(action.Content) > 0 {
+			if err := writeNewFileFromSourceMode(source, action.Target, action.Content); err != nil {
+				return fmt.Errorf("write composed JSON to %s: %w", action.Target, err)
+			}
+			return nil
+		}
 		if err := copyRegularFile(source, action.Target); err != nil {
 			return fmt.Errorf("copy %s to %s: %w", source, action.Target, err)
 		}
@@ -425,6 +464,12 @@ func applyUpdate(action plan.Action, source string, opts Options) error {
 	}
 	switch action.Ownership {
 	case "json-subset":
+		if len(action.Content) > 0 {
+			if err := mergeJSONContentFile(action.Target, action.Content); err != nil {
+				return fmt.Errorf("merge composed JSON update for %s: %w", action.Target, err)
+			}
+			return nil
+		}
 		if err := configsubset.MergeJSONFile(action.Target, source); err != nil {
 			return fmt.Errorf("merge JSON update for %s: %w", action.Target, err)
 		}
@@ -555,4 +600,41 @@ func copyRegularFile(source, target string) error {
 		return err
 	}
 	return os.Chmod(target, info.Mode().Perm())
+}
+
+func writeNewFileFromSourceMode(source, target string, data []byte) error {
+	info, err := os.Stat(source)
+	if err != nil {
+		return err
+	}
+	file, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_EXCL, info.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		_ = os.Remove(target)
+		return err
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(target)
+		return err
+	}
+	return nil
+}
+
+func mergeJSONContentFile(target string, sourceData []byte) error {
+	targetData, err := os.ReadFile(target)
+	if err != nil {
+		return err
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		return err
+	}
+	merged, err := configsubset.MergeJSON(targetData, sourceData)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(target, merged, info.Mode().Perm())
 }

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -3,14 +3,123 @@ package install_test
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/yersonargotev/dots/internal/backups"
 	"github.com/yersonargotev/dots/internal/install"
+	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/state"
 )
+
+func TestApplyComposedJSONSubsetCreatesAndUpdatesOneSharedTarget(t *testing.T) {
+	sourceRoot := t.TempDir()
+	home := t.TempDir()
+	stateRoot := filepath.Join(home, ".local", "state", "dots")
+	for rel, content := range map[string]string{
+		"configs/base.json":   `{"editor":{"theme":"dark"},"servers":["one"]}`,
+		"configs/mobile.json": `{"mobile":true,"servers":["two"]}`,
+	} {
+		path := filepath.Join(sourceRoot, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir source: %v", err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write source: %v", err)
+		}
+	}
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"base", "mobile"}}},
+		Entries: []manifest.Entry{
+			{Source: "configs/base.json", Target: "~/.config/shared.json", Strategy: "copy", Ownership: "json-subset", Tags: []string{"base"}},
+			{Source: "configs/mobile.json", Target: "~/.config/shared.json", Strategy: "copy", Ownership: "json-subset", Tags: []string{"mobile"}},
+		},
+	}
+	opts := plan.Options{Profile: "default", OS: "darwin", SourceRoot: sourceRoot, Home: home}
+	p, err := plan.Build(m, opts)
+	if err != nil {
+		t.Fatalf("Build(create) error = %v", err)
+	}
+	if len(p.Actions) != 1 {
+		t.Fatalf("create actions = %d, want one", len(p.Actions))
+	}
+	if err := install.Apply(p, install.Options{SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot}); err != nil {
+		t.Fatalf("Apply(create) error = %v", err)
+	}
+
+	target := filepath.Join(home, ".config", "shared.json")
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load metadata: %v", err)
+	}
+	rec, ok := meta.FindByTarget(target)
+	if !ok {
+		t.Fatalf("metadata missing target %s", target)
+	}
+	wantSources := []string{"configs/base.json", "configs/mobile.json"}
+	if !reflect.DeepEqual(rec.SourceList(), wantSources) {
+		t.Fatalf("metadata sources = %#v, want %#v", rec.SourceList(), wantSources)
+	}
+	targetHash, err := state.HashFile(target)
+	if err != nil {
+		t.Fatalf("hash target: %v", err)
+	}
+	if rec.Hash != targetHash {
+		t.Fatalf("metadata hash = %q, want composed target hash %q", rec.Hash, targetHash)
+	}
+
+	if err := os.WriteFile(target, []byte(`{"editor":{"theme":"dark"},"servers":["one"],"userOnly":"keep"}`), 0o640); err != nil {
+		t.Fatalf("write trusted target: %v", err)
+	}
+	opts.Metadata = meta
+	p, err = plan.Build(m, opts)
+	if err != nil {
+		t.Fatalf("Build(update) error = %v", err)
+	}
+	if len(p.Actions) != 1 || p.Actions[0].Status != plan.StatusUpdate {
+		t.Fatalf("update actions = %+v, want one update", p.Actions)
+	}
+	if err := install.Apply(p, install.Options{SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot}); err != nil {
+		t.Fatalf("Apply(update) error = %v", err)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read updated target: %v", err)
+	}
+	for _, want := range []string{`"userOnly": "keep"`, `"mobile": true`, `"two"`} {
+		if !strings.Contains(string(got), want) {
+			t.Fatalf("updated target missing %s:\n%s", want, got)
+		}
+	}
+	backupMeta, err := backups.Load(backups.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load Backup Metadata: %v", err)
+	}
+	if len(backupMeta.Sets) != 1 {
+		t.Fatalf("backup sets = %d, want one shared-target backup", len(backupMeta.Sets))
+	}
+	meta, err = state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("reload metadata: %v", err)
+	}
+	uninstallPlan, err := plan.BuildUninstall(meta, plan.UninstallOptions{SourceRoot: sourceRoot, Home: home})
+	if err != nil {
+		t.Fatalf("BuildUninstall() error = %v", err)
+	}
+	var shared *plan.UninstallAction
+	for i := range uninstallPlan.Actions {
+		if uninstallPlan.Actions[i].Target == target {
+			shared = &uninstallPlan.Actions[i]
+			break
+		}
+	}
+	if shared == nil || shared.Status != plan.UninstallModified {
+		t.Fatalf("shared uninstall action = %+v, want modified so target-only state is preserved by default", shared)
+	}
+}
 
 func TestApplyCreatesSymlinkForCreateAction(t *testing.T) {
 	sourceRoot := t.TempDir()

--- a/internal/installed/installed.go
+++ b/internal/installed/installed.go
@@ -115,7 +115,7 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options) (Report, erro
 	legacyProfilesInferred := false
 	unmatchedEntries := false
 
-	for _, rec := range meta.Entries {
+	for _, rec := range expandedRecords(meta.Entries) {
 		entry, matched, err := matchEntry(m, rec, opts)
 		if err != nil {
 			return Report{}, err
@@ -226,6 +226,24 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options) (Report, erro
 		report.Notes = append(report.Notes, "metadata does not record Source of Truth provenance; run a future install/update to capture source revision and dots version")
 	}
 	return report, nil
+}
+
+func expandedRecords(records []state.Record) []state.Record {
+	expanded := make([]state.Record, 0, len(records))
+	for _, rec := range records {
+		sources := rec.SourceList()
+		if len(sources) == 0 {
+			expanded = append(expanded, rec)
+			continue
+		}
+		for _, source := range sources {
+			contributor := rec
+			contributor.Source = source
+			contributor.Sources = nil
+			expanded = append(expanded, contributor)
+		}
+	}
+	return expanded
 }
 
 func matchEntry(m manifest.Manifest, rec state.Record, opts Options) (manifest.Entry, bool, error) {

--- a/internal/installed/installed_test.go
+++ b/internal/installed/installed_test.go
@@ -2,6 +2,7 @@ package installed_test
 
 import (
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	inst "github.com/yersonargotev/dots/internal/installed"
@@ -9,6 +10,43 @@ import (
 	"github.com/yersonargotev/dots/internal/provision"
 	"github.com/yersonargotev/dots/internal/state"
 )
+
+func TestBuildExposesEverySharedTargetContributor(t *testing.T) {
+	home := t.TempDir()
+	target := filepath.Join(home, ".config", "shared.json")
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"base", "mobile"}}},
+		Entries: []manifest.Entry{
+			{Source: "configs/base.json", Target: "~/.config/shared.json", Strategy: "copy", Ownership: "json-subset", Tags: []string{"base"}},
+			{Source: "configs/mobile.json", Target: "~/.config/shared.json", Strategy: "copy", Ownership: "json-subset", Tags: []string{"mobile"}},
+		},
+	}
+	meta := state.Metadata{Version: state.CurrentVersion, Entries: []state.Record{{
+		Target: target, Source: "configs/base.json", Sources: []string{"configs/base.json", "configs/mobile.json"}, Strategy: "copy",
+		Profiles: []string{"default"}, Tags: []string{"base", "mobile"},
+	}}}
+
+	report, err := inst.Build(m, meta, inst.Options{StatePath: filepath.Join(home, "installed.json"), Home: home, OS: "linux"})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	gotSources := make([]string, 0, len(report.ManagedEntries))
+	for _, entry := range report.ManagedEntries {
+		gotSources = append(gotSources, entry.Source)
+		if !entry.ManifestMatched {
+			t.Fatalf("ManagedEntry = %+v, want manifest match", entry)
+		}
+	}
+	wantSources := []string{"configs/base.json", "configs/mobile.json"}
+	if !reflect.DeepEqual(gotSources, wantSources) {
+		t.Fatalf("managed sources = %#v, want %#v", gotSources, wantSources)
+	}
+	coverage := findProfile(t, report.Profiles, "default")
+	if coverage.TotalEntries != 2 || coverage.CoveredEntries != 2 || coverage.State != inst.CoverageComplete {
+		t.Fatalf("default coverage = %+v, want both contributors covered", coverage)
+	}
+}
 
 func TestBuildInfersLegacyMetadataAndPartialProfiles(t *testing.T) {
 	home := t.TempDir()

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -31,17 +31,24 @@ const ConflictReasonSourceOverrideNotSelected = "source-override-not-selected"
 // Action is a single planned filesystem change for a Managed Entry.
 type Action struct {
 	Source string `json:"source"`
+	// Sources lists every Source of Truth contribution when compatible
+	// json-subset Managed Entries compose into one physical target operation.
+	Sources []string `json:"sources,omitempty"`
 	// ResolvedSource is an absolute, machine-local path and is therefore kept out
 	// of the Agent Output Contract: it differs between machines and install
 	// locations, which would break idempotent envelope comparisons. Agents key on
 	// the portable, manifest-relative Source instead.
-	ResolvedSource string   `json:"-"`
-	Target         string   `json:"target"`
-	Strategy       string   `json:"strategy"`
-	Status         Status   `json:"status"`
-	Reason         string   `json:"reason,omitempty"`
-	MatchingTags   []string `json:"matching_tags,omitempty"`
-	Ownership      string   `json:"-"`
+	ResolvedSource  string   `json:"-"`
+	ResolvedSources []string `json:"-"`
+	// Content is the conservatively composed baseline for a shared json-subset
+	// target. Apply writes or merges it once instead of mutating per contributor.
+	Content      []byte   `json:"-"`
+	Target       string   `json:"target"`
+	Strategy     string   `json:"strategy"`
+	Status       Status   `json:"status"`
+	Reason       string   `json:"reason,omitempty"`
+	MatchingTags []string `json:"matching_tags,omitempty"`
+	Ownership    string   `json:"-"`
 }
 
 // Plan is the preview of changes the installer would apply for a Profile.
@@ -94,6 +101,7 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 	tags := resolved.Tags
 
 	plan := Plan{Profile: resolved.Profile, Profiles: resolved.Profiles, Tags: resolved.Tags}
+	actionByTarget := map[string]int{}
 	for _, entry := range m.Entries {
 		if !manifest.SharesTag(entry.Tags, tags) {
 			continue
@@ -128,7 +136,7 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 				reason = ConflictReasonSourceOverrideNotSelected
 			}
 		}
-		plan.Actions = append(plan.Actions, Action{
+		action := Action{
 			Source:         source,
 			ResolvedSource: sourceAbs,
 			Target:         target,
@@ -137,10 +145,77 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 			Reason:         reason,
 			MatchingTags:   matchingTags,
 			Ownership:      entry.Ownership,
-		})
+		}
+		targetKey := filepath.Clean(target)
+		if index, ok := actionByTarget[targetKey]; ok {
+			existing := &plan.Actions[index]
+			if existing.Strategy != "copy" || existing.Ownership != "json-subset" || action.Strategy != "copy" || action.Ownership != "json-subset" {
+				return Plan{}, fmt.Errorf("install plan contains duplicate target %s; only copy entries with json-subset ownership can compose", targetKey)
+			}
+			if len(existing.Sources) == 0 {
+				existing.Sources = []string{existing.Source}
+				existing.ResolvedSources = []string{existing.ResolvedSource}
+			}
+			existing.Sources = append(existing.Sources, action.Source)
+			existing.ResolvedSources = append(existing.ResolvedSources, action.ResolvedSource)
+			composed, err := configsubset.ComposeJSONFiles(existing.ResolvedSources)
+			if err != nil {
+				if strings.Contains(err.Error(), "incompatible") {
+					return Plan{}, fmt.Errorf("shared target %s has incompatible json-subset sources: %w", targetKey, err)
+				}
+				return Plan{}, fmt.Errorf("compose shared target %s: %w", targetKey, err)
+			}
+			existing.Content = composed
+			existing.Status, err = composedJSONStatus(*existing, opts.Metadata)
+			if err != nil {
+				return Plan{}, err
+			}
+			existing.Reason = ""
+			existing.MatchingTags = nil
+			continue
+		}
+		actionByTarget[targetKey] = len(plan.Actions)
+		plan.Actions = append(plan.Actions, action)
 	}
 
 	return plan, nil
+}
+
+func composedJSONStatus(action Action, meta state.Metadata) (Status, error) {
+	info, err := os.Lstat(action.Target)
+	if os.IsNotExist(err) {
+		return StatusCreate, nil
+	}
+	if err != nil || !info.Mode().IsRegular() {
+		return StatusConflict, nil
+	}
+	targetData, err := os.ReadFile(action.Target)
+	if err != nil {
+		return "", fmt.Errorf("read shared JSON target %s: %w", action.Target, err)
+	}
+	if bytes.Equal(targetData, action.Content) {
+		return StatusUnchanged, nil
+	}
+	rec, ok := meta.FindByTarget(action.Target)
+	trusted := ok && rec.Strategy == action.Strategy
+	for _, source := range action.Sources {
+		trusted = trusted && rec.HasSource(source)
+	}
+	if !trusted {
+		return StatusConflict, nil
+	}
+	relation, err := configsubset.AnalyzeJSON(targetData, action.Content)
+	if err != nil {
+		return "", fmt.Errorf("analyze shared JSON target %s: %w", action.Target, err)
+	}
+	switch {
+	case relation.Contains:
+		return StatusUnchanged, nil
+	case relation.Mergeable:
+		return StatusUpdate, nil
+	default:
+		return StatusConflict, nil
+	}
 }
 
 // MatchingUnselectedSourceOverrideTags returns the deterministic set of
@@ -447,7 +522,7 @@ func status(entry manifest.Entry, target, sourceAbs, sourceRoot string, meta sta
 
 func metadataMatchesEntry(meta state.Metadata, target, source, strategy string) bool {
 	rec, ok := meta.FindByTarget(target)
-	return ok && rec.Source == source && rec.Strategy == strategy
+	return ok && rec.HasSource(source) && rec.Strategy == strategy
 }
 
 func targetContainsCompatibleRecordedSource(entry manifest.Entry, target, sourceRoot string, meta state.Metadata, defaultSource string) bool {

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -197,9 +197,15 @@ func composedJSONStatus(action Action, meta state.Metadata) (Status, error) {
 		return StatusUnchanged, nil
 	}
 	rec, ok := meta.FindByTarget(action.Target)
-	trusted := ok && rec.Strategy == action.Strategy
+	recordedSources := rec.SourceList()
+	trusted := ok && rec.Strategy == action.Strategy && len(recordedSources) > 0
+	selectedSources := make(map[string]struct{}, len(action.Sources))
 	for _, source := range action.Sources {
-		trusted = trusted && rec.HasSource(source)
+		selectedSources[source] = struct{}{}
+	}
+	for _, source := range recordedSources {
+		_, selected := selectedSources[source]
+		trusted = trusted && selected
 	}
 	if !trusted {
 		return StatusConflict, nil
@@ -487,7 +493,7 @@ func status(entry manifest.Entry, target, sourceAbs, sourceRoot string, meta sta
 			return StatusConflict, nil
 		}
 		if same, err := sameContent(target, sourceAbs); err != nil || !same {
-			if isSubsetOwned(entry.Ownership) && metadataMatchesEntry(meta, target, entry.Source, entry.Strategy) {
+			if isSubsetOwned(entry.Ownership) && meta.MatchesEntry(target, entry.Source, entry.Strategy) {
 				if entry.Ownership == "json-subset" {
 					relation, relationErr := configsubset.AnalyzeJSONFiles(target, sourceAbs)
 					if relationErr != nil {
@@ -518,11 +524,6 @@ func status(entry manifest.Entry, target, sourceAbs, sourceRoot string, meta sta
 	default:
 		return StatusConflict, nil
 	}
-}
-
-func metadataMatchesEntry(meta state.Metadata, target, source, strategy string) bool {
-	rec, ok := meta.FindByTarget(target)
-	return ok && rec.HasSource(source) && rec.Strategy == strategy
 }
 
 func targetContainsCompatibleRecordedSource(entry manifest.Entry, target, sourceRoot string, meta state.Metadata, defaultSource string) bool {

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -133,6 +133,41 @@ func TestBuildRejectsIncompatibleSharedJSONSubsetBeforeApply(t *testing.T) {
 	}
 }
 
+func TestBuildExpandsTrustedSingleContributorIntoCompatibleSharedTarget(t *testing.T) {
+	sourceRoot := t.TempDir()
+	home := t.TempDir()
+	writeSource(t, sourceRoot, "configs/base.json", `{"editor":{"theme":"dark"}}`)
+	writeSource(t, sourceRoot, "configs/mobile.json", `{"mobile":true}`)
+	target := filepath.Join(home, ".config", "shared.json")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	if err := os.WriteFile(target, []byte(`{"editor":{"theme":"dark"},"userOnly":"keep"}`), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"base", "mobile"}}},
+		Entries: []manifest.Entry{
+			{Source: "configs/base.json", Target: "~/.config/shared.json", Strategy: "copy", Ownership: "json-subset", Tags: []string{"base"}},
+			{Source: "configs/mobile.json", Target: "~/.config/shared.json", Strategy: "copy", Ownership: "json-subset", Tags: []string{"mobile"}},
+		},
+	}
+	meta := state.Metadata{Version: 2, Entries: []state.Record{{
+		Target: target, Source: "configs/base.json", Strategy: "copy",
+	}}}
+
+	got, err := plan.Build(m, plan.Options{
+		Profile: "default", OS: "darwin", SourceRoot: sourceRoot, Home: home, Metadata: meta,
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if len(got.Actions) != 1 || got.Actions[0].Status != plan.StatusUpdate {
+		t.Fatalf("Actions = %+v, want one trusted expansion update", got.Actions)
+	}
+}
+
 func TestBuildRejectsUnsupportedDuplicateTargetDuringPlanning(t *testing.T) {
 	sourceRoot := t.TempDir()
 	home := t.TempDir()

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -3,6 +3,8 @@ package plan_test
 import (
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/yersonargotev/dots/internal/manifest"
@@ -69,6 +71,90 @@ func sources(p plan.Plan) []string {
 		out = append(out, a.Source)
 	}
 	return out
+}
+
+func TestBuildComposesCompatibleJSONSubsetEntriesForSharedTarget(t *testing.T) {
+	sourceRoot := t.TempDir()
+	home := t.TempDir()
+	writeSource(t, sourceRoot, "configs/base.json", `{"editor":{"theme":"dark"},"servers":["one"]}`)
+	writeSource(t, sourceRoot, "configs/mobile.json", `{"editor":{"theme":"dark","fontSize":14},"servers":["two"]}`)
+
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"base", "mobile"}}},
+		Entries: []manifest.Entry{
+			{Source: "configs/base.json", Target: "~/.config/shared.json", Strategy: "copy", Ownership: "json-subset", Tags: []string{"base"}},
+			{Source: "configs/mobile.json", Target: "~/.config/shared.json", Strategy: "copy", Ownership: "json-subset", Tags: []string{"mobile"}},
+		},
+	}
+
+	got, err := plan.Build(m, plan.Options{Profile: "default", OS: "darwin", SourceRoot: sourceRoot, Home: home})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if len(got.Actions) != 1 {
+		t.Fatalf("len(Actions) = %d, want one coherent target operation", len(got.Actions))
+	}
+	action := got.Actions[0]
+	if !reflect.DeepEqual(action.Sources, []string{"configs/base.json", "configs/mobile.json"}) {
+		t.Fatalf("Sources = %#v, want manifest-order contributors", action.Sources)
+	}
+	if action.Status != plan.StatusCreate {
+		t.Fatalf("Status = %q, want %q", action.Status, plan.StatusCreate)
+	}
+	for _, want := range []string{`"theme": "dark"`, `"fontSize": 14`, `"one"`, `"two"`} {
+		if !strings.Contains(string(action.Content), want) {
+			t.Fatalf("composed content missing %s:\n%s", want, action.Content)
+		}
+	}
+}
+
+func TestBuildRejectsIncompatibleSharedJSONSubsetBeforeApply(t *testing.T) {
+	sourceRoot := t.TempDir()
+	home := t.TempDir()
+	writeSource(t, sourceRoot, "configs/base.json", `{"editor":{"theme":"dark"}}`)
+	writeSource(t, sourceRoot, "configs/mobile.json", `{"editor":{"theme":"light"}}`)
+
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"base", "mobile"}}},
+		Entries: []manifest.Entry{
+			{Source: "configs/base.json", Target: "~/.config/shared.json", Strategy: "copy", Ownership: "json-subset", Tags: []string{"base"}},
+			{Source: "configs/mobile.json", Target: "~/.config/shared.json", Strategy: "copy", Ownership: "json-subset", Tags: []string{"mobile"}},
+		},
+	}
+
+	_, err := plan.Build(m, plan.Options{Profile: "default", OS: "darwin", SourceRoot: sourceRoot, Home: home})
+	if err == nil {
+		t.Fatal("Build() error = nil, want incompatible shared-target error")
+	}
+	if !strings.Contains(err.Error(), "shared target") || !strings.Contains(err.Error(), "incompatible") {
+		t.Fatalf("Build() error = %q, want clear shared-target incompatibility", err)
+	}
+}
+
+func TestBuildRejectsUnsupportedDuplicateTargetDuringPlanning(t *testing.T) {
+	sourceRoot := t.TempDir()
+	home := t.TempDir()
+	writeSource(t, sourceRoot, "configs/first", "first\n")
+	writeSource(t, sourceRoot, "configs/second", "second\n")
+
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}},
+		Entries: []manifest.Entry{
+			{Source: "configs/first", Target: "~/.shared", Strategy: "copy", Tags: []string{"core"}},
+			{Source: "configs/second", Target: "~/.shared", Strategy: "copy", Tags: []string{"core"}},
+		},
+	}
+
+	_, err := plan.Build(m, plan.Options{Profile: "default", OS: "darwin", SourceRoot: sourceRoot, Home: home})
+	if err == nil {
+		t.Fatal("Build() error = nil, want unsupported duplicate-target error")
+	}
+	if !strings.Contains(err.Error(), "duplicate target") {
+		t.Fatalf("Build() error = %q, want duplicate-target planning error", err)
+	}
 }
 
 func TestBuildSymlinkPointingToSourceIsUnchanged(t *testing.T) {

--- a/internal/plan/uninstall.go
+++ b/internal/plan/uninstall.go
@@ -34,6 +34,7 @@ const (
 type UninstallAction struct {
 	Target   string          `json:"target"`
 	Source   string          `json:"source"`
+	Sources  []string        `json:"sources,omitempty"`
 	Strategy string          `json:"strategy"`
 	Status   UninstallStatus `json:"status"`
 }
@@ -90,6 +91,9 @@ func BuildUninstall(meta state.Metadata, opts UninstallOptions) (UninstallPlan, 
 			Strategy: rec.Strategy,
 			Status:   status,
 		})
+		if len(rec.Sources) > 0 {
+			plan.Actions[len(plan.Actions)-1].Sources = rec.SourceList()
+		}
 	}
 	return plan, nil
 }

--- a/internal/plan/uninstall_test.go
+++ b/internal/plan/uninstall_test.go
@@ -3,11 +3,37 @@ package plan_test
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/state"
 )
+
+func TestBuildUninstallPlansOneRemovalForCompositeTarget(t *testing.T) {
+	f := newUninstallFixture(t)
+	target := f.target(".config/shared.json")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("{\"base\":true,\"mobile\":true}\n"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	hash, err := state.HashFile(target)
+	if err != nil {
+		t.Fatalf("hash target: %v", err)
+	}
+	sources := []string{"configs/base.json", "configs/mobile.json"}
+	p := f.build(t, state.Record{
+		Target: target, Source: sources[0], Sources: sources, Strategy: "copy", Hash: hash,
+	})
+	if len(p.Actions) != 1 {
+		t.Fatalf("actions = %d, want one physical removal", len(p.Actions))
+	}
+	if p.Actions[0].Status != plan.UninstallRemove || !reflect.DeepEqual(p.Actions[0].Sources, sources) {
+		t.Fatalf("action = %+v, want removable composite contributors", p.Actions[0])
+	}
+}
 
 func TestValidateBackupableTargetAcceptsFileDirAndSymlink(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -57,11 +57,35 @@ func (p Provenance) Empty() bool {
 type Record struct {
 	Target      string   `json:"target"`
 	Source      string   `json:"source"`
+	Sources     []string `json:"sources,omitempty"`
 	Strategy    string   `json:"strategy"`
 	Hash        string   `json:"hash"`
 	InstalledAt string   `json:"installedAt"`
 	Profiles    []string `json:"profiles,omitempty"`
 	Tags        []string `json:"tags,omitempty"`
+}
+
+// SourceList returns every Source of Truth contribution for the managed target.
+// Legacy metadata records only Source; composed subset targets additionally
+// record Sources in deterministic manifest order.
+func (r Record) SourceList() []string {
+	if len(r.Sources) > 0 {
+		return append([]string(nil), r.Sources...)
+	}
+	if r.Source == "" {
+		return nil
+	}
+	return []string{r.Source}
+}
+
+// HasSource reports whether source contributed to this managed target.
+func (r Record) HasSource(source string) bool {
+	for _, candidate := range r.SourceList() {
+		if candidate == source {
+			return true
+		}
+	}
+	return false
 }
 
 // ProvisionerRecord describes the last known result for one selected
@@ -253,4 +277,11 @@ func HashFile(path string) (string, error) {
 		return "", fmt.Errorf("hash source %s: %w", path, err)
 	}
 	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+// HashBytes returns the same content digest used by HashFile without requiring
+// a temporary file.
+func HashBytes(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -187,6 +187,13 @@ func (m Metadata) FindByTarget(target string) (Record, bool) {
 	return Record{}, false
 }
 
+// MatchesEntry reports whether Installation Metadata proves that source and
+// strategy contribute to the managed target.
+func (m Metadata) MatchesEntry(target, source, strategy string) bool {
+	rec, ok := m.FindByTarget(target)
+	return ok && rec.Strategy == strategy && rec.HasSource(source)
+}
+
 // FindProvisioner returns the last result for a selected Provisioner command.
 func (m Metadata) FindProvisioner(profile, tool, executable string, args []string) (ProvisionerRecord, bool) {
 	for _, r := range m.Provisioners {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -198,6 +198,15 @@ func TestRecordSourceListPreservesLegacyAndCompositeContributors(t *testing.T) {
 	if !composite.HasSource("configs/mobile.json") {
 		t.Fatal("composite HasSource() = false, want contributor match")
 	}
+	meta := state.Metadata{Entries: []state.Record{{
+		Target: "/home/user/.config/shared.json", Source: composite.Source, Sources: composite.Sources, Strategy: "copy",
+	}}}
+	if !meta.MatchesEntry("/home/user/.config/shared.json", "configs/mobile.json", "copy") {
+		t.Fatal("MatchesEntry() = false, want composite contributor ownership proof")
+	}
+	if meta.MatchesEntry("/home/user/.config/shared.json", "configs/mobile.json", "symlink") {
+		t.Fatal("MatchesEntry() = true for wrong strategy")
+	}
 }
 
 func TestHashFileIsStableAndContentSensitive(t *testing.T) {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -179,6 +179,27 @@ func TestFindByTargetReturnsRecordWhenPresent(t *testing.T) {
 	}
 }
 
+func TestRecordSourceListPreservesLegacyAndCompositeContributors(t *testing.T) {
+	legacy := state.Record{Source: "configs/base.json"}
+	if got := legacy.SourceList(); !reflect.DeepEqual(got, []string{"configs/base.json"}) {
+		t.Fatalf("legacy SourceList() = %#v, want singular source", got)
+	}
+	if !legacy.HasSource("configs/base.json") {
+		t.Fatal("legacy HasSource() = false, want singular source match")
+	}
+
+	composite := state.Record{
+		Source:  "configs/base.json",
+		Sources: []string{"configs/base.json", "configs/mobile.json"},
+	}
+	if got := composite.SourceList(); !reflect.DeepEqual(got, composite.Sources) {
+		t.Fatalf("composite SourceList() = %#v, want %#v", got, composite.Sources)
+	}
+	if !composite.HasSource("configs/mobile.json") {
+		t.Fatal("composite HasSource() = false, want contributor match")
+	}
+}
+
 func TestHashFileIsStableAndContentSensitive(t *testing.T) {
 	dir := t.TempDir()
 	a := filepath.Join(dir, "a")

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -174,7 +174,7 @@ func evaluate(entry manifest.Entry, target string, meta state.Metadata, sourceRo
 		return StateOK, nil
 	}
 
-	if isSubsetOwned(entry.Ownership) && metadataMatchesEntry(meta, target, entry.Source, entry.Strategy) {
+	if isSubsetOwned(entry.Ownership) && meta.MatchesEntry(target, entry.Source, entry.Strategy) {
 		subset, err := subsetContent(entry.Ownership, target, sourceAbs)
 		if err != nil {
 			return "", err
@@ -190,15 +190,10 @@ func evaluate(entry manifest.Entry, target string, meta state.Metadata, sourceRo
 	// The target diverges from the Source of Truth. Installation Metadata is the
 	// discriminator: if dots installed this target, the divergence is Drift; if
 	// not, it is a Conflict with a file dots never managed.
-	if metadataMatchesEntry(meta, target, entry.Source, entry.Strategy) {
+	if meta.MatchesEntry(target, entry.Source, entry.Strategy) {
 		return StateDrifted, nil
 	}
 	return StateConflict, nil
-}
-
-func metadataMatchesEntry(meta state.Metadata, target, source, strategy string) bool {
-	rec, ok := meta.FindByTarget(target)
-	return ok && rec.HasSource(source) && rec.Strategy == strategy
 }
 
 func targetContainsCompatibleRecordedSource(entry manifest.Entry, target, sourceRoot string, meta state.Metadata, defaultSource string) bool {

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -198,7 +198,7 @@ func evaluate(entry manifest.Entry, target string, meta state.Metadata, sourceRo
 
 func metadataMatchesEntry(meta state.Metadata, target, source, strategy string) bool {
 	rec, ok := meta.FindByTarget(target)
-	return ok && rec.Source == source && rec.Strategy == strategy
+	return ok && rec.HasSource(source) && rec.Strategy == strategy
 }
 
 func targetContainsCompatibleRecordedSource(entry manifest.Entry, target, sourceRoot string, meta state.Metadata, defaultSource string) bool {

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -287,6 +287,50 @@ func TestBuildReportsConflictForClaudeSettingsSubsetWithoutInstallMetadata(t *te
 	}
 }
 
+func TestBuildEvaluatesEveryContributorRecordedForSharedJSONTarget(t *testing.T) {
+	sourceRoot := t.TempDir()
+	home := t.TempDir()
+	writeSource(t, sourceRoot, "configs/base.json", `{"editor":{"theme":"dark"}}`)
+	writeSource(t, sourceRoot, "configs/mobile.json", `{"mobile":true}`)
+	target := filepath.Join(home, ".config", "shared.json")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	if err := os.WriteFile(target, []byte(`{"editor":{"theme":"dark"},"mobile":true,"userOnly":"keep"}`), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"base", "mobile"}}},
+		Entries: []manifest.Entry{
+			{Source: "configs/base.json", Target: "~/.config/shared.json", Strategy: "copy", Ownership: "json-subset", Tags: []string{"base"}},
+			{Source: "configs/mobile.json", Target: "~/.config/shared.json", Strategy: "copy", Ownership: "json-subset", Tags: []string{"mobile"}},
+		},
+	}
+	meta := state.Metadata{Entries: []state.Record{{
+		Target: target, Source: "configs/base.json", Sources: []string{"configs/base.json", "configs/mobile.json"}, Strategy: "copy",
+	}}}
+
+	report, err := status.Build(m, meta, status.Options{Profile: "default", OS: "linux", SourceRoot: sourceRoot, Home: home})
+	if err != nil {
+		t.Fatalf("Build(aligned) error = %v", err)
+	}
+	if len(report.Entries) != 2 || report.Entries[0].State != status.StateOK || report.Entries[1].State != status.StateOK {
+		t.Fatalf("aligned entries = %+v, want both contributors ok", report.Entries)
+	}
+
+	if err := os.WriteFile(target, []byte(`{"editor":{"theme":"dark"},"userOnly":"keep"}`), 0o600); err != nil {
+		t.Fatalf("write drifted target: %v", err)
+	}
+	report, err = status.Build(m, meta, status.Options{Profile: "default", OS: "linux", SourceRoot: sourceRoot, Home: home})
+	if err != nil {
+		t.Fatalf("Build(drifted) error = %v", err)
+	}
+	if report.Entries[0].State != status.StateOK || report.Entries[1].State != status.StateDrifted {
+		t.Fatalf("drifted entries = %+v, want only missing contributor drifted", report.Entries)
+	}
+}
+
 func TestBuildReportsOKForCodexConfigWithRuntimeAdditionsWhenInstalled(t *testing.T) {
 	f := newFixture(manifest.Entry{
 		Source:    "configs/codex/config.toml",


### PR DESCRIPTION
Closes #355

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Compose compatible `copy` + `json-subset` Managed Entries that resolve to one target into one Install Plan action.
- Preserve contributor ownership across Installation Metadata, status, doctor, installed inventory, and uninstall.
- Allow trusted v2/single-contributor metadata to expand conservatively while preserving target-only JSON and terminal Installed Selection migration.

## Changes

| File | Change |
|------|--------|
| `internal/configsubset/subset.go` | Adds pure deterministic multi-source JSON composition and content-level analyze/merge primitives. |
| `internal/plan/plan.go` | Groups compatible shared targets, rejects incompatible/unsupported duplicates during planning, and models contributors. |
| `internal/install/install.go` | Validates and applies composed content once, records contributor-aware baseline metadata, and creates one Backup Set. |
| `internal/state/state.go` | Adds backward-compatible contributor source lookup and shared ownership matching. |
| `internal/status`, `internal/doctor`, `internal/installed`, `internal/plan/uninstall.go` | Preserve contributor diagnostics, inventory, and uninstall behavior. |
| `internal/**/*_test.go`, `internal/cli/testdata/*.golden` | Adds focused, Temporary Home, migration, safety, and Agent Output Contract coverage. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go build ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan: `go run ./cmd/dots plan --file dots.yaml --profile workstation --profile mobile --source-root "$PWD" --home <tmp> --output json`
- [x] Sandboxed install with stubbed provisioners confirmed one composed Antigravity target, both contributor sources, and `workstation + mobile` Installed Selection.
- [x] Local Standards and Spec reviews: no remaining findings.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #355`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed, or confirmed no documentation change was needed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
