### PR TITLE
fix(deps): activate fnm-managed Node before reprobe

### DIFF
--- a/internal/cli/deps.go
+++ b/internal/cli/deps.go
@@ -2,7 +2,9 @@ package cli
 
 import (
 	"bufio"
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -269,14 +271,15 @@ func runDepsInstall(cmd *cobra.Command, m manifest.Manifest, options deps.Option
 	if wantsJSON(cmd) {
 		stdout = cmd.ErrOrStderr()
 	}
-	report, err := deps.Install(m, options, lookupCommand, fontInstalled(runtime.GOOS, home), tier, depsExecRunner{
+	runner := &depsExecRunner{
 		ctx:       cmd.Context(),
 		stdin:     cmd.InOrStdin(),
 		stdout:    stdout,
 		stderr:    cmd.ErrOrStderr(),
 		home:      home,
 		stateRoot: options.StateRoot,
-	})
+	}
+	report, err := deps.Install(m, options, lookupCommand, fontInstalled(runtime.GOOS, home), tier, runner)
 	if err != nil {
 		if !wantsJSON(cmd) && (report.Profile != "" || len(report.Items) > 0) {
 			renderDepsInstall(cmd.OutOrStdout(), report)
@@ -321,25 +324,143 @@ type depsExecRunner struct {
 	home      string
 	stateRoot string
 	brewPath  string
+	env       []string
 }
 
-func (r depsExecRunner) Run(executable string, args []string) error {
+func (r *depsExecRunner) Run(executable string, args []string) error {
 	if executable == "brew" && r.brewPath != "" {
 		executable = r.brewPath
+	} else if resolved, ok := lookPathInEnvironment(executable, r.environment()); ok {
+		executable = resolved
 	}
 	cmd := exec.CommandContext(r.ctx, executable, args...)
 	cmd.Stdin = r.stdin
 	cmd.Stdout = r.stdout
 	cmd.Stderr = r.stderr
+	cmd.Env = r.environment()
 	return cmd.Run()
 }
 
-func (r depsExecRunner) RunUserLocal(action deps.InstallAction) error {
+func (r *depsExecRunner) RunUserLocal(action deps.InstallAction) error {
 	return deps.InstallUserLocal(r.home, action)
 }
 
-func (r depsExecRunner) RecordUserLocal(action deps.InstallAction) error {
+func (r *depsExecRunner) RecordUserLocal(action deps.InstallAction) error {
 	return deps.RecordDependencyInstallation(r.stateRoot, r.home, action)
+}
+
+func (r *depsExecRunner) Lookup(command string) bool {
+	if command == "brew" && r.brewPath != "" {
+		return executableFile(r.brewPath)
+	}
+	if _, ok := lookPathInEnvironment(command, r.environment()); ok {
+		return true
+	}
+	if command != "fnm" {
+		return false
+	}
+	candidates := []string{filepath.Join(r.home, ".local", "share", "fnm", "fnm")}
+	if fnmDir := environmentValue(r.environment(), "FNM_DIR"); filepath.IsAbs(fnmDir) {
+		candidates = append([]string{filepath.Join(fnmDir, "fnm")}, candidates...)
+	}
+	for _, candidate := range candidates {
+		if !executableFile(candidate) {
+			continue
+		}
+		r.prependPath(filepath.Dir(candidate))
+		return true
+	}
+	return false
+}
+
+func (r *depsExecRunner) ActivateToolchain(toolchain string) error {
+	if toolchain != manifest.DependencyToolchainNodeLTSFNM {
+		return nil
+	}
+	fnmPath, ok := lookPathInEnvironment("fnm", r.environment())
+	if !ok {
+		return errors.New("fnm is not executable")
+	}
+	var stdout bytes.Buffer
+	cmd := exec.CommandContext(r.ctx, fnmPath, "exec", "--using=lts/latest", "node", "-p", "process.execPath")
+	cmd.Stdin = r.stdin
+	cmd.Stdout = &stdout
+	cmd.Stderr = r.stderr
+	cmd.Env = r.environment()
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	nodePath := strings.TrimSpace(stdout.String())
+	if !filepath.IsAbs(nodePath) || !executableFile(nodePath) {
+		return fmt.Errorf("fnm returned non-executable node path %q", nodePath)
+	}
+	r.prependPath(filepath.Dir(nodePath))
+	return nil
+}
+
+func (r *depsExecRunner) Environment() []string {
+	return append([]string(nil), r.environment()...)
+}
+
+func (r *depsExecRunner) environment() []string {
+	if r.env == nil {
+		r.env = replaceEnvironmentValue(os.Environ(), "HOME", r.home)
+	}
+	return r.env
+}
+
+func (r *depsExecRunner) prependPath(dir string) {
+	path := environmentValue(r.environment(), "PATH")
+	if path == "" {
+		r.env = replaceEnvironmentValue(r.env, "PATH", dir)
+		return
+	}
+	r.env = replaceEnvironmentValue(r.env, "PATH", dir+string(os.PathListSeparator)+path)
+}
+
+func lookPathInEnvironment(command string, env []string) (string, bool) {
+	if strings.ContainsRune(command, os.PathSeparator) {
+		return command, filepath.IsAbs(command) && executableFile(command)
+	}
+	for _, dir := range filepath.SplitList(environmentValue(env, "PATH")) {
+		if !filepath.IsAbs(dir) {
+			continue
+		}
+		candidate := filepath.Join(dir, command)
+		if executableFile(candidate) {
+			return candidate, true
+		}
+	}
+	return "", false
+}
+
+func executableFile(path string) bool {
+	if strings.TrimSpace(path) == "" {
+		return false
+	}
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir() && info.Mode().Perm()&0o111 != 0
+}
+
+func environmentValue(env []string, name string) string {
+	prefix := name + "="
+	for _, item := range env {
+		if strings.HasPrefix(item, prefix) {
+			return strings.TrimPrefix(item, prefix)
+		}
+	}
+	return ""
+}
+
+func replaceEnvironmentValue(env []string, name, value string) []string {
+	prefix := name + "="
+	out := make([]string, 0, len(env)+1)
+	for _, item := range env {
+		if !strings.HasPrefix(item, prefix) {
+			out = append(out, item)
+		}
+	}
+	return append(out, prefix+value)
 }
 
 // lookupCommand reports whether a command resolves on the current PATH. It is

--- a/internal/cli/deps_install_test.go
+++ b/internal/cli/deps_install_test.go
@@ -615,6 +615,70 @@ func TestDepsInstallYesDoesNotRunFNMBootstrapWhenFNMIsMissing(t *testing.T) {
 	}
 }
 
+func TestDepsInstallYesActivatesFNMManagedNodeBeforeReprobe(t *testing.T) {
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	binDir := t.TempDir()
+	nodeBinDir := filepath.Join(home, ".local", "share", "fnm", "node-versions", "v24.19.0", "installation", "bin")
+	fnmPath := filepath.Join(binDir, "fnm")
+	nodePath := filepath.Join(nodeBinDir, "node")
+	brewPath := filepath.Join(binDir, "brew")
+
+	if err := os.MkdirAll(nodeBinDir, 0o755); err != nil {
+		t.Fatalf("mkdir fnm node bin: %v", err)
+	}
+	writeExecStub(t, brewPath, "#!/bin/sh\n/bin/chmod +x \"$FNM_PATH\"\n")
+	if err := os.WriteFile(fnmPath, []byte("#!/bin/sh\nif [ \"$1\" = install ]; then /bin/chmod +x \"$NODE_PATH\"; exit 0; fi\nif [ \"$1\" = exec ]; then shift; [ \"$1\" = --using=lts/latest ] && shift; [ \"$1\" = node ] && shift; exec \"$NODE_PATH\" \"$@\"; fi\nexit 1\n"), 0o600); err != nil {
+		t.Fatalf("write fake fnm: %v", err)
+	}
+	if err := os.WriteFile(nodePath, []byte("#!/bin/sh\nif [ \"$1\" = -p ] && [ \"$2\" = process.execPath ]; then printf '%s\\n' \"$NODE_PATH\"; exit 0; fi\nexit 0\n"), 0o600); err != nil {
+		t.Fatalf("write fake node: %v", err)
+	}
+	t.Setenv("FNM_PATH", fnmPath)
+	t.Setenv("NODE_PATH", nodePath)
+	t.Setenv("PATH", binDir)
+	manifestPath := writeDepsInstallManifest(t, fnmBootstrapDepsManifest)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"deps", "install", "--yes", "--file", manifestPath, "--profile", "default", "--tier", "homebrew", "--home", home, "--state-root", stateRoot})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+	if !strings.Contains(out.String(), "Summary: 1 installed, 0 manual, 0 unresolved, 0 failed") {
+		t.Fatalf("deps install did not accept executable fnm-managed Node:\n%s", out.String())
+	}
+}
+
+func TestDepsInstallLeavesFNMNodeUnresolvedWhenSelectedNodeIsNotExecutable(t *testing.T) {
+	binDir := t.TempDir()
+	writeExecStub(t, filepath.Join(binDir, "fnm"), "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", binDir)
+	manifestPath := writeDepsInstallManifest(t, fnmBootstrapDepsManifest)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"deps", "install", "--yes", "--file", manifestPath, "--profile", "default", "--tier", "generic"})
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("Execute() error = nil, want unresolved Node dependency\noutput:\n%s", out.String())
+	}
+	for _, want := range []string{
+		"unresolved Node LTS (fnm)",
+		"node is not executable in fnm's selected environment",
+		"fnm exec --using=lts/latest node --version",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("fnm unresolved output missing %q\noutput:\n%s", want, out.String())
+		}
+	}
+}
+
 const fnmBootstrapDepsManifest = `version: 1
 profiles:
   default:

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -175,6 +175,7 @@ func newInstallCommand() *cobra.Command {
 			var p plan.Plan
 			var provPlan provision.Plan
 			installPlanReady := false
+			var dependencyEnvironment []string
 
 			if !skipDeps {
 				depsConfirmed := yes
@@ -226,7 +227,8 @@ func newInstallCommand() *cobra.Command {
 				p.Selection = &effective.Report
 				installPlanReady = true
 
-				depReport, depsApplied, err := runInstallDependencies(cmd, *m, depOptions, depTier, paths.Home, depPreview, depsConfirmed, depLookup, brewDetection.Path)
+				depReport, depsApplied, runEnvironment, err := runInstallDependencies(cmd, *m, depOptions, depTier, paths.Home, depPreview, depsConfirmed, depLookup, brewDetection.Path)
+				dependencyEnvironment = runEnvironment
 				dependenciesReport.Result = &depReport
 				if err != nil {
 					if wantsJSON(cmd) {
@@ -272,7 +274,7 @@ func newInstallCommand() *cobra.Command {
 				return nil
 			}
 
-			provResult, err := runProvisioners(cmd, *m, profiles, extraTags, paths.Home, paths.StateRoot, paths.SourceRoot)
+			provResult, err := runProvisionersWithEnvironment(cmd, *m, profiles, extraTags, paths.Home, paths.StateRoot, paths.SourceRoot, dependencyEnvironment)
 			if err != nil {
 				if wantsJSON(cmd) {
 					return installProvisionerError{err: err, report: installReport{DryRun: false, Selection: effective.Report, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan, BackupSets: createdBackups, ProvisionerResults: &provResult}}
@@ -413,23 +415,23 @@ func (e installProvisionerError) JSONErrorData() any { return e.report }
 // Managed Configuration is applied. Interactive runs reuse the deps confirmation
 // prompt for package-manager execution; manual or unresolved Dependencies abort
 // the install before filesystem targets are touched.
-func runInstallDependencies(cmd *cobra.Command, m manifest.Manifest, options deps.Options, tier deps.Tier, home string, preview deps.InstallDryRunReport, yes bool, look deps.Lookup, brewPath string) (deps.InstallReport, bool, error) {
+func runInstallDependencies(cmd *cobra.Command, m manifest.Manifest, options deps.Options, tier deps.Tier, home string, preview deps.InstallDryRunReport, yes bool, look deps.Lookup, brewPath string) (deps.InstallReport, bool, []string, error) {
 	if !yes {
 		if hasRequiredInstallablePreviewAction(preview) {
 			confirmed, err := confirmDepsInstall(cmd.InOrStdin(), cmd.OutOrStdout())
 			if err != nil {
-				return deps.InstallReport{}, false, err
+				return deps.InstallReport{}, false, nil, err
 			}
 			if !confirmed {
 				fmt.Fprintln(cmd.OutOrStdout(), "Dependency installation cancelled.")
-				return deps.InstallReport{}, false, nil
+				return deps.InstallReport{}, false, nil, nil
 			}
 		} else if hasInstallablePreviewAction(preview) {
 			report, err := unresolvedInstallReportFromPreview(preview)
 			if !wantsJSON(cmd) && (report.Profile != "" || len(report.Items) > 0) {
 				renderDepsInstall(cmd.OutOrStdout(), report)
 			}
-			return report, true, err
+			return report, true, nil, err
 		}
 	}
 
@@ -437,7 +439,7 @@ func runInstallDependencies(cmd *cobra.Command, m manifest.Manifest, options dep
 	if wantsJSON(cmd) {
 		stdout = cmd.ErrOrStderr()
 	}
-	report, err := deps.Install(m, options, look, fontInstalled(options.OS, home), tier, depsExecRunner{
+	runner := &depsExecRunner{
 		ctx:       cmd.Context(),
 		stdin:     cmd.InOrStdin(),
 		stdout:    stdout,
@@ -445,14 +447,16 @@ func runInstallDependencies(cmd *cobra.Command, m manifest.Manifest, options dep
 		home:      home,
 		stateRoot: options.StateRoot,
 		brewPath:  brewPath,
-	})
+	}
+	report, err := deps.Install(m, options, look, fontInstalled(options.OS, home), tier, runner)
+	runEnvironment := runner.Environment()
 	if !wantsJSON(cmd) && (report.Profile != "" || len(report.Items) > 0) {
 		renderDepsInstall(cmd.OutOrStdout(), report)
 	}
 	if err != nil {
-		return report, true, err
+		return report, true, runEnvironment, err
 	}
-	return report, true, nil
+	return report, true, runEnvironment, nil
 }
 
 // runProvisioners executes the selected provisioners after dependency installs
@@ -462,10 +466,18 @@ func runInstallDependencies(cmd *cobra.Command, m manifest.Manifest, options dep
 // error, which the caller surfaces; the tool's own stdout/stderr are streamed
 // through so its progress is visible.
 func runProvisioners(cmd *cobra.Command, m manifest.Manifest, profiles []string, extraTags []string, home string, stateRoot string, sourceRoot string) (provision.Report, error) {
-	return runProvisionersWithOptions(cmd, m, provision.Options{Profiles: profiles, ExtraTags: extraTags, OS: runtime.GOOS}, home, stateRoot, sourceRoot)
+	return runProvisionersWithEnvironment(cmd, m, profiles, extraTags, home, stateRoot, sourceRoot, nil)
+}
+
+func runProvisionersWithEnvironment(cmd *cobra.Command, m manifest.Manifest, profiles []string, extraTags []string, home string, stateRoot string, sourceRoot string, baseEnv []string) (provision.Report, error) {
+	return runProvisionersWithOptionsAndEnvironment(cmd, m, provision.Options{Profiles: profiles, ExtraTags: extraTags, OS: runtime.GOOS}, home, stateRoot, sourceRoot, baseEnv)
 }
 
 func runProvisionersWithOptions(cmd *cobra.Command, m manifest.Manifest, provisionOpts provision.Options, home string, stateRoot string, sourceRoot string) (provision.Report, error) {
+	return runProvisionersWithOptionsAndEnvironment(cmd, m, provisionOpts, home, stateRoot, sourceRoot, nil)
+}
+
+func runProvisionersWithOptionsAndEnvironment(cmd *cobra.Command, m manifest.Manifest, provisionOpts provision.Options, home string, stateRoot string, sourceRoot string, baseEnv []string) (provision.Report, error) {
 	if provisionOpts.AppLookup == nil {
 		provisionOpts.AppLookup = appInstalled(provisionOpts.OS, home)
 	}
@@ -478,17 +490,18 @@ func runProvisionersWithOptions(cmd *cobra.Command, m manifest.Manifest, provisi
 		stdout = cmd.ErrOrStderr()
 	}
 	runner := provisionExecRunner{
-		ctx:    ctx,
-		home:   home,
-		stdin:  cmd.InOrStdin(),
-		stdout: stdout,
-		stderr: cmd.ErrOrStderr(),
+		ctx:     ctx,
+		home:    home,
+		stdin:   cmd.InOrStdin(),
+		stdout:  stdout,
+		stderr:  cmd.ErrOrStderr(),
+		baseEnv: baseEnv,
 	}
 	selected, selectErr := provision.Select(m, provisionOpts)
 	if selectErr != nil {
 		return provision.Report{}, selectErr
 	}
-	report, err := provision.Apply(m, provisionOpts, lookupCommand, fontInstalled(runtime.GOOS, home), runner)
+	report, err := provision.Apply(m, provisionOpts, runner.Lookup, fontInstalled(runtime.GOOS, home), runner)
 	if !wantsJSON(cmd) {
 		renderProvisionReport(cmd.OutOrStdout(), report)
 	}

--- a/internal/cli/install_deps_test.go
+++ b/internal/cli/install_deps_test.go
@@ -163,6 +163,7 @@ dependencies:
       - name: Node LTS (fnm)
         commands: [fnm, node]
         brew: fnm
+        linux_homebrew: true
         toolchain: node-lts-fnm
 entries:
   - source: configs/zsh/zshrc

--- a/internal/cli/install_deps_test.go
+++ b/internal/cli/install_deps_test.go
@@ -122,6 +122,80 @@ func TestInstallRunsDependenciesBeforeManagedConfiguration(t *testing.T) {
 	}
 }
 
+func TestInstallThreadsFNMManagedNodeIntoLaterProvisioners(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	binDir := t.TempDir()
+	nodeBinDir := filepath.Join(home, ".local", "share", "fnm", "node-versions", "v24.19.0", "installation", "bin")
+	fnmPath := filepath.Join(binDir, "fnm")
+	nodePath := filepath.Join(nodeBinDir, "node")
+	npxPath := filepath.Join(nodeBinDir, "npx")
+	npxMarker := filepath.Join(stateRoot, "npx-ran")
+
+	if err := os.MkdirAll(nodeBinDir, 0o755); err != nil {
+		t.Fatalf("mkdir fnm node bin: %v", err)
+	}
+	writeExecStub(t, filepath.Join(binDir, "brew"), "#!/bin/sh\n/bin/chmod +x \"$FNM_PATH\"\n")
+	if err := os.WriteFile(fnmPath, []byte("#!/bin/sh\nif [ \"$1\" = install ]; then /bin/chmod +x \"$NODE_PATH\" \"$NPX_PATH\"; exit 0; fi\nif [ \"$1\" = exec ]; then shift; [ \"$1\" = --using=lts/latest ] && shift; [ \"$1\" = node ] && shift; exec \"$NODE_PATH\" \"$@\"; fi\nexit 1\n"), 0o600); err != nil {
+		t.Fatalf("write fake fnm: %v", err)
+	}
+	if err := os.WriteFile(nodePath, []byte("#!/bin/sh\nif [ \"$1\" = -p ] && [ \"$2\" = process.execPath ]; then printf '%s\\n' \"$NODE_PATH\"; exit 0; fi\nexit 0\n"), 0o600); err != nil {
+		t.Fatalf("write fake node: %v", err)
+	}
+	if err := os.WriteFile(npxPath, []byte("#!/bin/sh\nprintf 'ran\\n' > \"$NPX_MARKER\"\n"), 0o600); err != nil {
+		t.Fatalf("write fake npx: %v", err)
+	}
+	t.Setenv("FNM_PATH", fnmPath)
+	t.Setenv("NODE_PATH", nodePath)
+	t.Setenv("NPX_PATH", npxPath)
+	t.Setenv("NPX_MARKER", npxMarker)
+	t.Setenv("PATH", binDir)
+
+	writeCLISource(t, sourceRoot, "configs/zsh/zshrc", "managed\n")
+	manifestPath := writeCLIManifest(t, home, `version: 1
+profiles:
+  default:
+    tags: [core]
+dependencies:
+  - tags: [core]
+    dependencies:
+      - name: Node LTS (fnm)
+        commands: [fnm, node]
+        brew: fnm
+        toolchain: node-lts-fnm
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+provisioners:
+  - tool: skills
+    tags: [core]
+    spec:
+      package: example/skills
+      agents: [codex]
+      skills: [example]
+      global: true
+    dependencies:
+      - name: npx
+        command: npx
+`)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"install", "--yes", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+	if _, err := os.Stat(npxMarker); err != nil {
+		t.Fatalf("later npx provisioner did not receive fnm-managed Node PATH: %v\noutput:\n%s", err, out.String())
+	}
+}
+
 func TestInstallSkipDepsPreservesConfigOnlyBehavior(t *testing.T) {
 	home := t.TempDir()
 	sourceRoot := t.TempDir()

--- a/internal/cli/provision_runner.go
+++ b/internal/cli/provision_runner.go
@@ -25,17 +25,29 @@ type provisionExecRunner struct {
 }
 
 func (r provisionExecRunner) Run(executable string, args []string) error {
+	if resolved, ok := lookPathInEnvironment(executable, r.environment()); ok {
+		executable = resolved
+	}
 	cmd := exec.CommandContext(r.ctx, executable, args...)
 	cmd.Stdin = r.stdin
 	cmd.Stdout = r.stdout
 	cmd.Stderr = r.stderr
 
+	cmd.Env = r.environment()
+	return cmd.Run()
+}
+
+func (r provisionExecRunner) Lookup(command string) bool {
+	_, ok := lookPathInEnvironment(command, r.environment())
+	return ok
+}
+
+func (r provisionExecRunner) environment() []string {
 	base := r.baseEnv
 	if base == nil {
 		base = os.Environ()
 	}
-	cmd.Env = envForProvisioner(base, r.home)
-	return cmd.Run()
+	return envForProvisioner(base, r.home)
 }
 
 // envForProvisioner returns base with a sandboxed HOME, a user-local npm prefix,

--- a/internal/deps/install.go
+++ b/internal/deps/install.go
@@ -48,6 +48,14 @@ type Runner interface {
 	Run(executable string, args []string) error
 }
 
+// ToolchainEnvironment exposes an environment established by a constrained
+// toolchain bootstrap. Install uses it for reprobes and later child commands in
+// the same dependency run without mutating the parent process environment.
+type ToolchainEnvironment interface {
+	ActivateToolchain(toolchain string) error
+	Lookup(command string) bool
+}
+
 // InstallStatus describes the result of a real install action.
 type InstallStatus string
 
@@ -125,7 +133,19 @@ func Install(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup
 
 	report := InstallReport{Profile: plan.Profile, Profiles: plan.Profiles, Tags: plan.Tags, Tier: plan.Tier}
 	requiredUnresolved := false
+	executionLook := look
+	toolchainEnvironment, hasToolchainEnvironment := runner.(ToolchainEnvironment)
+	if hasToolchainEnvironment {
+		executionLook = toolchainEnvironment.Lookup
+	}
+	toolchainActivated := false
 	for _, action := range plan.Actions {
+		// Toolchain activation can satisfy a later action that was missing when
+		// the Install Plan was built (for example npx after fnm activates Node).
+		// Re-probe before honoring that stale plan status.
+		if toolchainActivated && actionPresent(action, opts, executionLook, fontLook) {
+			continue
+		}
 		if !actionExecutable(action) {
 			if action.Requirement == manifest.DependencyRequirementRequired {
 				requiredUnresolved = true
@@ -174,7 +194,7 @@ func Install(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup
 				return report, fmt.Errorf("install %q: %w", action.Dependency, err)
 			}
 		}
-		if len(action.Bootstrap) > 0 && !bootstrapRunnable(action.Bootstrap, look) {
+		if len(action.Bootstrap) > 0 && !bootstrapRunnable(action.Bootstrap, executionLook) {
 			if action.Requirement == manifest.DependencyRequirementRequired {
 				requiredUnresolved = true
 			}
@@ -187,7 +207,7 @@ func Install(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup
 				Executable:   action.Executable,
 				Args:         args,
 				Bootstrap:    append([]Command(nil), action.Bootstrap...),
-				Manual:       unresolvedToolchainRemediation(action, look),
+				Manual:       unresolvedToolchainRemediation(action, executionLook),
 				TrustCommand: action.TrustCommand,
 				Candidates:   action.Candidates,
 				UserLocal:    action.UserLocal,
@@ -216,8 +236,15 @@ func Install(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup
 			}
 			return report, fmt.Errorf("bootstrap %q: %w", action.Dependency, err)
 		}
-		if !actionPresent(action, opts, look, fontLook) {
-			manual := unresolvedToolchainRemediation(action, look)
+		if hasToolchainEnvironment && action.Toolchain != "" {
+			// Activation failure is represented as unresolved below: a successful
+			// bootstrap is not proof that the selected runtime is executable.
+			if err := toolchainEnvironment.ActivateToolchain(action.Toolchain); err == nil {
+				toolchainActivated = true
+			}
+		}
+		if !actionPresent(action, opts, executionLook, fontLook) {
+			manual := unresolvedToolchainRemediation(action, executionLook)
 			if action.Requirement == manifest.DependencyRequirementRequired {
 				requiredUnresolved = true
 			}
@@ -276,6 +303,9 @@ func unresolvedToolchainRemediation(action InstallAction, look Lookup) string {
 			return ""
 		}
 		return fmt.Sprintf("%s installed through the user-local provider, but %s is still not available on PATH; ensure ~/.local/bin is on PATH and rerun dots deps check", action.Dependency, strings.Join(missing, ", "))
+	}
+	if action.Toolchain == manifest.DependencyToolchainNodeLTSFNM {
+		return "Node LTS was installed through fnm, but node is not executable in fnm's selected environment; verify with `fnm exec --using=lts/latest node --version`, then rerun dots deps install"
 	}
 	if action.Toolchain != manifest.DependencyToolchainRustStableRustup {
 		return ""


### PR DESCRIPTION
Closes #362

## PR Type

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Activate the fnm-selected Node LTS in a scoped dependency-run environment after bootstrap.
- Reprobe later Dependencies against that environment and carry it into install-time provisioners.
- Keep Node unresolved with actionable guidance when fnm cannot expose an executable runtime.

## Changes

| File | Change |
|------|--------|
| `internal/deps/install.go` | Adds the constrained-toolchain environment boundary and reprobes Dependencies satisfied by activation. |
| `internal/cli/deps.go` | Discovers fnm, verifies Node through `fnm exec`, and maintains a scoped command environment. |
| `internal/cli/install.go` | Threads the dependency environment into later provisioners in the same install run. |
| `internal/cli/provision_runner.go` | Resolves and runs provisioner commands against the scoped environment. |
| `internal/cli/*_test.go` | Adds sandboxed fnm/Node regressions for success, unresolved verification, and later `npx` execution. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile core --source-root "$PWD" --home <tmp> --state-root <tmp>/state`
- [x] `go build ./...`
- [x] `go test ./internal/deps ./internal/cli`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #362`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed. (No documentation change required.)
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
