### PR TITLE
fix(deps): expose Homebrew rustup proxies

### DIFF
--- a/configs/zsh/rc.d/post/30-path.zsh
+++ b/configs/zsh/rc.d/post/30-path.zsh
@@ -31,5 +31,18 @@ fi
 # `$(yarn global bin)`, which spawns a Node process on every shell startup.
 [[ -d "${HOME}/.yarn/bin" ]] && export PATH="${HOME}/.yarn/bin:${PATH}"
 
+# Homebrew's rustup formula keeps rustc and cargo proxies in its own prefix.
+# Resolve that prefix dynamically so both Apple Silicon and Intel layouts work.
+if (( ${+commands[brew]} )); then
+  _rustup_prefix="$(brew --prefix rustup 2>/dev/null)" || _rustup_prefix=""
+  if [[ -n "${_rustup_prefix}" && -d "${_rustup_prefix}/bin" ]]; then
+    case ":${PATH}:" in
+      *":${_rustup_prefix}/bin:"*) ;;
+      *) export PATH="${_rustup_prefix}/bin:${PATH}" ;;
+    esac
+  fi
+  unset _rustup_prefix
+fi
+
 # Generic local-bin env shim (rustup, uv, and similar installers write here).
 [[ -r "${HOME}/.local/bin/env" ]] && source "${HOME}/.local/bin/env"

--- a/internal/cli/deps.go
+++ b/internal/cli/deps.go
@@ -269,7 +269,7 @@ func runDepsInstall(cmd *cobra.Command, m manifest.Manifest, options deps.Option
 	if wantsJSON(cmd) {
 		stdout = cmd.ErrOrStderr()
 	}
-	report, err := deps.Install(m, options, lookupCommand, fontInstalled(runtime.GOOS, home), tier, depsExecRunner{
+	report, err := deps.Install(m, options, lookupCommand, fontInstalled(runtime.GOOS, home), tier, &depsExecRunner{
 		ctx:       cmd.Context(),
 		stdin:     cmd.InOrStdin(),
 		stdout:    stdout,
@@ -332,6 +332,37 @@ func (r depsExecRunner) Run(executable string, args []string) error {
 	cmd.Stdout = r.stdout
 	cmd.Stderr = r.stderr
 	return cmd.Run()
+}
+
+func (r depsExecRunner) AddHomebrewFormulaToPATH(formula string) error {
+	executable := "brew"
+	if r.brewPath != "" {
+		executable = r.brewPath
+	}
+	cmd := exec.CommandContext(r.ctx, executable, "--prefix", formula)
+	output, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("resolve Homebrew formula prefix for %q: %w", formula, err)
+	}
+	prefix := strings.TrimSpace(string(output))
+	if prefix == "" {
+		return fmt.Errorf("resolve Homebrew formula prefix for %q: empty output", formula)
+	}
+	bin := filepath.Join(prefix, "bin")
+	path := os.Getenv("PATH")
+	for _, entry := range filepath.SplitList(path) {
+		if entry == bin {
+			return nil
+		}
+	}
+	if path != "" {
+		bin += string(os.PathListSeparator) + path
+	}
+	return os.Setenv("PATH", bin)
+}
+
+func (r depsExecRunner) Lookup(command string) bool {
+	return lookupCommand(command)
 }
 
 func (r depsExecRunner) RunUserLocal(action deps.InstallAction) error {

--- a/internal/cli/deps_install_test.go
+++ b/internal/cli/deps_install_test.go
@@ -363,6 +363,131 @@ entries:
 	}
 }
 
+func TestDepsInstallUsesHomebrewRustupProxyPathForReprobesAndLaterCommands(t *testing.T) {
+	binDir := t.TempDir()
+	formulaPrefix := filepath.Join(t.TempDir(), "rustup")
+	proxyBin := filepath.Join(formulaPrefix, "bin")
+	if err := os.MkdirAll(proxyBin, 0o755); err != nil {
+		t.Fatalf("create fake rustup proxy bin: %v", err)
+	}
+	for _, command := range []string{"rustc", "cargo", "followup"} {
+		if err := os.WriteFile(filepath.Join(proxyBin, command), []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+			t.Fatalf("write fake %s proxy: %v", command, err)
+		}
+	}
+
+	runLog := filepath.Join(binDir, "calls")
+	brewScript := fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "--prefix" ] && [ "$2" = "rustup" ]; then
+  printf '%%s\n' %q
+  exit 0
+fi
+printf 'brew %%s %%s\n' "$1" "$2" >> %q
+if [ "$2" = "followup" ]; then
+  command -v rustc >/dev/null || exit 9
+fi
+`, formulaPrefix, runLog)
+	if err := os.WriteFile(filepath.Join(binDir, "brew"), []byte(brewScript), 0o700); err != nil {
+		t.Fatalf("write fake brew: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "rustup"), []byte(fmt.Sprintf("#!/bin/sh\nprintf 'rustup %%s %%s\\n' \"$1\" \"$2\" >> %q\n", runLog)), 0o700); err != nil {
+		t.Fatalf("write fake rustup: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+
+	manifestPath := writeDepsInstallManifest(t, `version: 1
+profiles:
+  default:
+    tags: [core]
+dependencies:
+  - tags: [core]
+    dependencies:
+      - name: Rust stable (rustup)
+        commands: [rustup, rustc, cargo]
+        brew: rustup
+        toolchain: rust-stable-rustup
+      - name: followup
+        command: followup
+        brew: followup
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+`)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"deps", "install", "--yes", "--file", manifestPath, "--tier", "homebrew"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+	gotCalls, err := os.ReadFile(runLog)
+	if err != nil {
+		t.Fatalf("read fake command calls: %v", err)
+	}
+	for _, want := range []string{"brew install rustup", "rustup default stable", "brew install followup"} {
+		if !strings.Contains(string(gotCalls), want) {
+			t.Fatalf("calls missing %q:\n%s", want, gotCalls)
+		}
+	}
+	if !strings.Contains(out.String(), "Summary: 2 installed, 0 manual, 0 unresolved, 0 failed") {
+		t.Fatalf("install did not converge:\n%s", out.String())
+	}
+}
+
+func TestDepsInstallHomebrewRustupPrefixFailureRemainsUnresolved(t *testing.T) {
+	binDir := t.TempDir()
+	brew := `#!/bin/sh
+if [ "$1" = "--prefix" ]; then exit 7; fi
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(binDir, "brew"), []byte(brew), 0o700); err != nil {
+		t.Fatalf("write fake brew: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "rustup"), []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+		t.Fatalf("write fake rustup: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+
+	manifestPath := writeDepsInstallManifest(t, `version: 1
+profiles:
+  default:
+    tags: [core]
+dependencies:
+  - tags: [core]
+    dependencies:
+      - name: Rust stable (rustup)
+        commands: [rustup, rustc, cargo]
+        brew: rustup
+        toolchain: rust-stable-rustup
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+`)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"deps", "install", "--yes", "--file", manifestPath, "--tier", "homebrew"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "unresolved required dependencies remain") {
+		t.Fatalf("Execute() error = %v, want unresolved dependency\noutput:\n%s", err, out.String())
+	}
+	for _, want := range []string{"unresolved Rust stable (rustup)", "brew --prefix rustup", "$(brew --prefix rustup)/bin"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("Homebrew prefix failure output missing %q:\n%s", want, out.String())
+		}
+	}
+}
+
 func TestDepsInstallDryRunRendersPreview(t *testing.T) {
 	binDir := t.TempDir()
 	brew := binDir + "/brew"

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -437,7 +437,7 @@ func runInstallDependencies(cmd *cobra.Command, m manifest.Manifest, options dep
 	if wantsJSON(cmd) {
 		stdout = cmd.ErrOrStderr()
 	}
-	report, err := deps.Install(m, options, look, fontInstalled(options.OS, home), tier, depsExecRunner{
+	report, err := deps.Install(m, options, look, fontInstalled(options.OS, home), tier, &depsExecRunner{
 		ctx:       cmd.Context(),
 		stdin:     cmd.InOrStdin(),
 		stdout:    stdout,

--- a/internal/cli/install_provision_test.go
+++ b/internal/cli/install_provision_test.go
@@ -275,6 +275,7 @@ dependencies:
       - name: Rust stable (rustup)
         commands: [rustup, rustc, cargo]
         brew: rustup
+        linux_homebrew: true
         toolchain: rust-stable-rustup
 entries:
   - source: configs/zsh/zshrc

--- a/internal/cli/install_provision_test.go
+++ b/internal/cli/install_provision_test.go
@@ -245,6 +245,68 @@ func TestInstallExecutesProvisionerAfterFilesWithHomeThreaded(t *testing.T) {
 	}
 }
 
+func TestInstallProvisionerInheritsHomebrewRustupProxyPath(t *testing.T) {
+	sandboxHome := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	stubDir := t.TempDir()
+	formulaPrefix := filepath.Join(t.TempDir(), "rustup")
+	proxyBin := filepath.Join(formulaPrefix, "bin")
+	if err := os.MkdirAll(proxyBin, 0o755); err != nil {
+		t.Fatalf("create fake rustup proxy bin: %v", err)
+	}
+	for _, command := range []string{"rustc", "cargo"} {
+		writeExecStub(t, filepath.Join(proxyBin, command), "#!/bin/sh\nexit 0\n")
+	}
+	writeExecStub(t, filepath.Join(stubDir, "brew"), "#!/bin/sh\nif [ \"$1\" = \"--prefix\" ]; then printf '%s\\n' "+strconv.Quote(formulaPrefix)+"; fi\n")
+	writeExecStub(t, filepath.Join(stubDir, "rustup"), "#!/bin/sh\nexit 0\n")
+	writeExecStub(t, filepath.Join(stubDir, "engram"), "#!/bin/sh\nexit 0\n")
+	writeExecStub(t, filepath.Join(stubDir, "gentle-ai"), "#!/bin/sh\ncommand -v rustc >/dev/null || exit 9\nprintf 'ok' > \"$HOME/provisioner-saw-rustc\"\n")
+	t.Setenv("PATH", stubDir)
+
+	writeCLISource(t, sourceRoot, "configs/zsh/zshrc", "managed\n")
+	manifestPath := writeCLIManifest(t, sandboxHome, `version: 1
+profiles:
+  default:
+    tags: [core]
+dependencies:
+  - tags: [core]
+    dependencies:
+      - name: Rust stable (rustup)
+        commands: [rustup, rustc, cargo]
+        brew: rustup
+        toolchain: rust-stable-rustup
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+provisioners:
+  - tool: gentle-ai
+    tags: [core]
+    spec:
+      scope: global
+      persona: neutral
+      agents: [codex]
+    dependencies:
+      - name: gentle-ai
+      - name: engram
+`)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"install", "--yes", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+	if _, err := os.Stat(filepath.Join(sandboxHome, "provisioner-saw-rustc")); err != nil {
+		t.Fatalf("provisioner did not inherit Homebrew rustup proxy PATH: %v\noutput:\n%s", err, out.String())
+	}
+}
+
 func TestInstallCoreZimFWProvisionerCreatesRuntimeInSandbox(t *testing.T) {
 	sandboxHome := t.TempDir()
 	sourceRoot := t.TempDir()

--- a/internal/cli/zsh_path_config_test.go
+++ b/internal/cli/zsh_path_config_test.go
@@ -1,0 +1,53 @@
+package cli_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestManagedZshPathExposesHomebrewRustupProxies(t *testing.T) {
+	zsh, err := exec.LookPath("zsh")
+	if err != nil {
+		t.Skip("zsh is not available")
+	}
+
+	fakeBin := t.TempDir()
+	formulaPrefix := filepath.Join(t.TempDir(), "rustup")
+	proxyBin := filepath.Join(formulaPrefix, "bin")
+	if err := os.MkdirAll(proxyBin, 0o755); err != nil {
+		t.Fatalf("create fake rustup proxy bin: %v", err)
+	}
+	for _, command := range []string{"rustc", "cargo"} {
+		if err := os.WriteFile(filepath.Join(proxyBin, command), []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+			t.Fatalf("write fake %s proxy: %v", command, err)
+		}
+	}
+	brew := "#!/bin/sh\nprintf '%s\\n' " + shellSingleQuote(formulaPrefix) + "\n"
+	if err := os.WriteFile(filepath.Join(fakeBin, "brew"), []byte(brew), 0o700); err != nil {
+		t.Fatalf("write fake brew: %v", err)
+	}
+
+	config := filepath.Join("..", "..", "configs", "zsh", "rc.d", "post", "30-path.zsh")
+	cmd := exec.Command(zsh, "-c", `source "$1"; command -v rustc; command -v cargo`, "zsh", config)
+	cmd.Env = []string{
+		"HOME=" + t.TempDir(),
+		"PATH=" + fakeBin + string(os.PathListSeparator) + "/usr/bin:/bin",
+	}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("source managed Zsh PATH config: %v\n%s", err, output)
+	}
+	for _, command := range []string{"rustc", "cargo"} {
+		want := filepath.Join(proxyBin, command)
+		if !strings.Contains(string(output), want) {
+			t.Fatalf("managed Zsh PATH did not expose %s proxy %q:\n%s", command, want, output)
+		}
+	}
+}
+
+func shellSingleQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+}

--- a/internal/deps/install.go
+++ b/internal/deps/install.go
@@ -48,6 +48,14 @@ type Runner interface {
 	Run(executable string, args []string) error
 }
 
+// HomebrewFormulaPATHRunner lets the Homebrew rustup provider expose its
+// formula-owned tool proxies to reprobes and later child commands in this run.
+type HomebrewFormulaPATHRunner interface {
+	Runner
+	AddHomebrewFormulaToPATH(formula string) error
+	Lookup(command string) bool
+}
+
 // InstallStatus describes the result of a real install action.
 type InstallStatus string
 
@@ -125,6 +133,7 @@ func Install(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup
 
 	report := InstallReport{Profile: plan.Profile, Profiles: plan.Profiles, Tags: plan.Tags, Tier: plan.Tier}
 	requiredUnresolved := false
+	effectiveLook := look
 	for _, action := range plan.Actions {
 		if !actionExecutable(action) {
 			if action.Requirement == manifest.DependencyRequirementRequired {
@@ -174,7 +183,14 @@ func Install(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup
 				return report, fmt.Errorf("install %q: %w", action.Dependency, err)
 			}
 		}
-		if len(action.Bootstrap) > 0 && !bootstrapRunnable(action.Bootstrap, look) {
+		if action.Provider == TierHomebrew && action.Toolchain == manifest.DependencyToolchainRustStableRustup {
+			if pathRunner, ok := runner.(HomebrewFormulaPATHRunner); ok {
+				if err := pathRunner.AddHomebrewFormulaToPATH(action.Package); err == nil {
+					effectiveLook = pathRunner.Lookup
+				}
+			}
+		}
+		if len(action.Bootstrap) > 0 && !bootstrapRunnable(action.Bootstrap, effectiveLook) {
 			if action.Requirement == manifest.DependencyRequirementRequired {
 				requiredUnresolved = true
 			}
@@ -187,7 +203,7 @@ func Install(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup
 				Executable:   action.Executable,
 				Args:         args,
 				Bootstrap:    append([]Command(nil), action.Bootstrap...),
-				Manual:       unresolvedToolchainRemediation(action, look),
+				Manual:       unresolvedToolchainRemediation(action, effectiveLook),
 				TrustCommand: action.TrustCommand,
 				Candidates:   action.Candidates,
 				UserLocal:    action.UserLocal,
@@ -216,8 +232,8 @@ func Install(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup
 			}
 			return report, fmt.Errorf("bootstrap %q: %w", action.Dependency, err)
 		}
-		if !actionPresent(action, opts, look, fontLook) {
-			manual := unresolvedToolchainRemediation(action, look)
+		if !actionPresent(action, opts, effectiveLook, fontLook) {
+			manual := unresolvedToolchainRemediation(action, effectiveLook)
 			if action.Requirement == manifest.DependencyRequirementRequired {
 				requiredUnresolved = true
 			}
@@ -288,7 +304,11 @@ func unresolvedToolchainRemediation(action InstallAction, look Lookup) string {
 	if len(missing) == 1 {
 		verb = "is"
 	}
-	return fmt.Sprintf("Rust stable is selected in rustup, but %s %s not available on PATH; ensure rustup exposes its proxies (usually by adding ~/.cargo/bin to PATH), then verify with `rustup which rustc` and `rustup which cargo`", strings.Join(missing, ", "), verb)
+	pathGuidance := "ensure rustup exposes its proxies (usually by adding ~/.cargo/bin to PATH)"
+	if action.Provider == TierHomebrew {
+		pathGuidance = "add the Homebrew rustup proxy directory from `brew --prefix rustup` (usually `$(brew --prefix rustup)/bin`) to PATH"
+	}
+	return fmt.Sprintf("Rust stable is selected in rustup, but %s %s not available on PATH; %s, then verify with `rustup which rustc` and `rustup which cargo`", strings.Join(missing, ", "), verb, pathGuidance)
 }
 
 func missingCommandProbes(probes []string, look Lookup) []string {

--- a/internal/deps/install_test.go
+++ b/internal/deps/install_test.go
@@ -318,11 +318,12 @@ type recordingRunner struct {
 	afterRun             func()
 	afterUserLocal       func(deps.InstallAction)
 	err                  error
+	failOnCall           int
 }
 
 func (r *recordingRunner) Run(executable string, args []string) error {
 	r.calls = append(r.calls, runnerCall{executable: executable, args: append([]string(nil), args...)})
-	if r.err != nil {
+	if r.err != nil && (r.failOnCall == 0 || r.failOnCall == len(r.calls)) {
 		return r.err
 	}
 	if r.afterRun != nil {
@@ -863,6 +864,79 @@ func TestInstallYesExplainsRustupToolchainWhenProbesRemainMissing(t *testing.T) 
 		if !strings.Contains(manual, want) {
 			t.Fatalf("Rust remediation missing %q: %q", want, manual)
 		}
+	}
+}
+
+func TestInstallYesExplainsHomebrewRustupPathWhenProxiesRemainMissing(t *testing.T) {
+	present := map[string]bool{"brew": true, "rustup": true}
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}},
+		Dependencies: []manifest.DependencySet{{
+			Tags: []string{"core"},
+			Dependencies: []manifest.Dependency{{
+				Name:      "Rust stable (rustup)",
+				Commands:  []string{"rustup", "rustc", "cargo"},
+				Brew:      "rustup",
+				Toolchain: manifest.DependencyToolchainRustStableRustup,
+			}},
+		}},
+		Entries: []manifest.Entry{{Source: "configs/x", Target: "~/.x", Strategy: "symlink", Tags: []string{"core"}}},
+	}
+
+	report, err := deps.Install(m, deps.Options{Profile: "default", OS: "darwin"}, func(command string) bool {
+		return present[command]
+	}, fontLookupSet(), deps.TierHomebrew, &recordingRunner{})
+	if err == nil {
+		t.Fatalf("Install() error = nil, want unresolved rust toolchain error")
+	}
+	if len(report.Items) != 1 || report.Items[0].Status != deps.InstallStatusUnresolved {
+		t.Fatalf("report items = %#v, want one unresolved Rust item", report.Items)
+	}
+	manual := report.Items[0].Manual
+	for _, want := range []string{"brew --prefix rustup", "$(brew --prefix rustup)/bin", "rustup which rustc", "rustup which cargo"} {
+		if !strings.Contains(manual, want) {
+			t.Fatalf("Homebrew Rust remediation missing %q: %q", want, manual)
+		}
+	}
+	if strings.Contains(manual, "~/.cargo/bin") {
+		t.Fatalf("Homebrew Rust remediation used standard installer path: %q", manual)
+	}
+}
+
+func TestInstallYesReportsFailedHomebrewRustupBootstrap(t *testing.T) {
+	present := map[string]bool{"brew": true, "rustup": true}
+	runner := &recordingRunner{err: errors.New("bootstrap failed"), failOnCall: 2}
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}},
+		Dependencies: []manifest.DependencySet{{
+			Tags: []string{"core"},
+			Dependencies: []manifest.Dependency{{
+				Name:      "Rust stable (rustup)",
+				Commands:  []string{"rustup", "rustc", "cargo"},
+				Brew:      "rustup",
+				Toolchain: manifest.DependencyToolchainRustStableRustup,
+			}},
+		}},
+		Entries: []manifest.Entry{{Source: "configs/x", Target: "~/.x", Strategy: "symlink", Tags: []string{"core"}}},
+	}
+
+	report, err := deps.Install(m, deps.Options{Profile: "default", OS: "darwin"}, func(command string) bool {
+		return present[command]
+	}, fontLookupSet(), deps.TierHomebrew, runner)
+	if err == nil || !strings.Contains(err.Error(), "bootstrap") {
+		t.Fatalf("Install() error = %v, want bootstrap failure", err)
+	}
+	if len(report.Items) != 1 || report.Items[0].Status != deps.InstallStatusFailed {
+		t.Fatalf("report items = %#v, want failed Rust bootstrap", report.Items)
+	}
+	wantCalls := []runnerCall{
+		{executable: "brew", args: []string{"install", "rustup"}},
+		{executable: "rustup", args: []string{"default", "stable"}},
+	}
+	if !reflect.DeepEqual(runner.calls, wantCalls) {
+		t.Fatalf("runner calls = %#v, want %#v", runner.calls, wantCalls)
 	}
 }
 


### PR DESCRIPTION
Closes #363

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Resolves the Homebrew rustup formula prefix dynamically after installation and exposes its proxy `bin` directory to dependency reprobes and later child commands in the same run.
- Persists the provider-specific proxy path through guarded repository-owned Zsh Managed Configuration without hardcoded Homebrew prefixes.
- Keeps unresolved behavior intact for failed bootstraps or unavailable proxies and renders provider-aware remediation.

## Changes

| File | Change |
|------|--------|
| `internal/deps/install.go` | Adds the narrow runner seam used to activate a Homebrew formula path before bootstrap and reprobes, plus provider-aware Rust remediation. |
| `internal/cli/deps.go` | Resolves `brew --prefix rustup`, prepends its `bin` directory to the current process PATH, and reuses the effective lookup for child commands. |
| `internal/cli/install.go` | Uses the environment-aware dependency runner in the integrated install flow. |
| `configs/zsh/rc.d/post/30-path.zsh` | Adds guarded dynamic Homebrew rustup PATH integration for future Zsh sessions. |
| `internal/deps/*_test.go`, `internal/cli/*_test.go` | Covers convergence, later Dependencies, Provisioner inheritance, missing prefixes/proxies, failed bootstrap, provider-aware repair, and new Zsh sessions with isolated fake executables. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan: `go run ./cmd/dots plan --file dots.yaml --profile core --source-root "$PWD" --home <tmp>`
- [x] Focused: `go test ./internal/deps ./internal/cli`
- [x] Zsh syntax: `zsh -n configs/zsh/rc.d/post/30-path.zsh`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] CLI validation targeting home/config paths used a temporary directory and explicit `--home` and `--source-root` flags.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #363`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated Managed Configuration because shell behavior changed; no workflow documentation changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

## Risk and rollback

The effective PATH change is process-local and limited to the dynamically reported Homebrew rustup formula `bin` directory. The Zsh block is guarded by both `brew` availability and the prefix directory's existence. Rollback is the single commit in this PR.
