### PR TITLE
docs(agent): use native relationships for sliced plans

### DIFF
--- a/.agents/skills/dots-issue-creation/REFERENCE.md
+++ b/.agents/skills/dots-issue-creation/REFERENCE.md
@@ -72,9 +72,12 @@ CLI | Dotfiles configuration | Installation workflow | Documentation | CI / rele
 - Use temporary directories for home/config behavior.
 ```
 
-## Dependency notes for sliced issues
+## Optional relationship mirrors for sliced issues
 
-Add one of these sections when publishing multiple related issues:
+Native GitHub `parent`/`subIssues` and `blockedBy`/`blocking` relationships are
+the source of truth. Add these sections only as a readable mirror after native
+relationships are created, or as an explicitly reported fallback when the
+target tracker or installed CLI has no native relationship support.
 
 ```md
 ### Parent
@@ -91,3 +94,7 @@ Add one of these sections when publishing multiple related issues:
 ### Blocked by
 - #124
 ```
+
+Never leave placeholder issue numbers in a published body. A text-only section
+does not satisfy the sliced-work relationship contract when the supported
+native flags are available.

--- a/.agents/skills/dots-issue-creation/SKILL.md
+++ b/.agents/skills/dots-issue-creation/SKILL.md
@@ -18,8 +18,18 @@ Read these when context is stale or the workflow may have changed:
 
 ## Repository conventions
 
-- This repo uses `needs-triage` and `ready-for-agent`, not generic status labels.
+- Treat this repository's issue, relationship, Agent Brief, and readiness rules
+  as authoritative when composing with generic planning skills such as
+  `to-spec` or `to-tickets`. Those skills may shape or slice the plan, but they
+  must not choose repository labels or replace native GitHub relationships with
+  prose.
+- Use `needs-triage` for unreviewed work and `ready-for-agent` only for the
+  current unblocked delivery frontier. Do not use either label to represent a
+  native dependency state.
 - `gh issue create --template ... --body-file ...` does not work. Use a template-shaped body file plus explicit labels.
+- Inspect `gh issue create --help`, `gh issue edit --help`, and
+  `gh issue view --help` before sliced publication. When the installed CLI
+  exposes native hierarchy and dependency flags, using them is required.
 
 ## Delivery handoff
 
@@ -40,12 +50,22 @@ contract. Use the format in `../../../docs/agents/agent-brief.md`.
    - PRD / agent-ready work: implementation-ready outcome, requirements, and acceptance criteria.
    - Sliced plan: multiple PRD-style vertical slices.
 3. Draft a body using the headings in [REFERENCE.md](REFERENCE.md).
-4. Create with `--body-file` and explicit labels.
-5. Create new issues with `needs-triage`. For agent-ready work, post exactly one
-   complete Agent Brief, then replace `needs-triage` with `ready-for-agent`.
-   If the brief is incomplete, leave the issue in `needs-triage`.
-6. Return issue URL(s), labels, Agent Brief evidence, duplicate search result,
-   and dependency notes.
+4. For sliced work, map the hierarchy and every blocking edge before
+   publication. Create blockers before dependents, attach every child to its
+   tracking parent, and add every blocking edge with native GitHub
+   relationships when supported.
+5. Create with `--body-file` and explicit category/type labels. Start ordinary
+   unsliced issues in `needs-triage`; use the state transitions below for a
+   sliced plan.
+6. Create or update exactly one complete Agent Brief for every delivery issue.
+   Then apply the readiness state only after relationships and briefs verify.
+7. Verify each published issue's body, `parent`, `subIssues`, `blockedBy`,
+   `blocking`, labels, and Agent Brief count. Every delivery child requires
+   exactly one complete brief; a tracking parent must never have duplicate
+   briefs. Stop and repair missing edges, unresolved placeholders, incorrect
+   labels, or incorrect brief counts before reporting success.
+8. Return issue URL(s), native relationship evidence, labels, Agent Brief
+   evidence, and duplicate search results.
 
 ## CLI patterns
 
@@ -75,6 +95,65 @@ gh issue edit <N> --remove-label needs-triage --add-label ready-for-agent
 
 ## Slicing rules
 
-For multiple issues, publish blockers first and reference real issue numbers in dependent issues. Each issue should be independently reviewable, demoable, and small enough for one PR unless the body explicitly calls out slices.
+For multiple issues, publish blockers first. Each delivery issue should be
+independently reviewable, demonstrable, and small enough for one PR. Use native
+relationships whenever the installed CLI exposes them:
+
+```bash
+# Attach relationships during creation.
+gh issue create --title "feat(scope): child" --body-file /tmp/child.md \
+  --label enhancement --parent <parent-number> --blocked-by <blocker-number>
+
+# Or attach relationships after issue numbers exist (choose one hierarchy direction).
+gh issue edit <child-number> --parent <parent-number> \
+  --add-blocked-by <blocker-number>
+# Equivalent inverse when updating the parent instead of the child:
+gh issue edit <parent-number> --add-sub-issue <child-number>
+```
+
+`--parent` and `--add-sub-issue` express the same hierarchy from opposite
+directions; one verified native edge is sufficient. Likewise, use
+`--blocked-by`/`--add-blocked-by` (or the inverse
+`--blocking`/`--add-blocking`) for every dependency edge. Textual `Parent` or
+`Blocked by` sections may mirror native relationships for readers, but are not
+the source of truth. Use them as the only representation solely when the target
+tracker or installed CLI does not expose native relationships, and record that
+fallback explicitly.
+
+### Readiness states
+
+- **Unreviewed:** keep `needs-triage`; do not apply `ready-for-agent`.
+- **Fully specified and blocked:** create or update its one complete Agent
+  Brief, remove both `needs-triage` and `ready-for-agent`, and rely on the native
+  blocked state while any `blockedBy` issue remains open.
+- **Unblocked delivery frontier:** after verifying exactly one complete Agent
+  Brief and no open blockers, remove `needs-triage` and apply
+  `ready-for-agent`.
+- **Tracking parent:** after slicing a PRD, remove `ready-for-agent` and
+  `needs-triage`. The parent tracks the plan and is not a `delivery-issue` unit;
+  its children carry delivery readiness. Retain at most one existing Agent
+  Brief as historical context, but do not create another brief solely for the
+  tracking parent.
+
+When a blocker closes, re-read the dependent issue's native `blockedBy` state
+and Agent Brief. Promote each newly unblocked, fully specified child to
+`ready-for-agent`; leave descendants with open blockers label-free. There is no
+automatic label transition, so repeat this check whenever the frontier moves.
+
+### Publication verification
+
+Use machine-readable output rather than body prose:
+
+```bash
+gh issue view <issue-number> \
+  --json body,parent,subIssues,blockedBy,blocking,labels,comments \
+  --jq '{body, parent, subIssues, blockedBy, blocking, labels: [.labels[].name], agentBriefCount: ([.comments[].body | select(test("(?m)^## Agent Brief$"))] | length)}'
+```
+
+Check both ends of the graph where applicable: the parent lists the child under
+`subIssues`, the child reports `parent`, blockers and dependents agree through
+`blockedBy`/`blocking`, labels match the four states above, every delivery child
+has one Agent Brief, and a tracking parent has no duplicate briefs. Inspect
+`body` for unresolved placeholders such as `<issue-number>`, `<N>`, or `TBD`.
 
 See [REFERENCE.md](REFERENCE.md) for body templates and field guidance.

--- a/docs/agents/agent-brief.md
+++ b/docs/agents/agent-brief.md
@@ -19,7 +19,8 @@ fields. A field may explicitly state `None` or `Not applicable` when appropriate
 Completeness is semantic: the fields must be internally consistent, contain no
 open questions, cover relevant errors and edge cases, and provide independently
 verifiable acceptance criteria. Each criterion must map to automated evidence,
-manual evidence, or both. External dependencies and blocking issues must be
+manual evidence, or both. A complete brief may be prepared while its issue is
+natively blocked, but external dependencies and blocking issues must be
 resolved before the issue moves to `ready-for-agent`.
 
 ## Principles

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -11,6 +11,10 @@ This repository tracks work in GitHub Issues.
 ## Workflow
 
 - Product requirements and implementation-ready work should be published as GitHub Issues.
+- Sliced work uses GitHub's native parent/sub-issue and blocking relationships
+  whenever the supported CLI exposes them. Textual relationship sections are
+  only readable mirrors or an explicitly reported unsupported-platform
+  fallback, never the source of truth.
 - `dots-issue-creation` is the sole producer of `ready-for-agent` issues. It applies the label only after creating or updating exactly one complete Agent Brief.
 - `ready-for-agent` requires both the label and exactly one complete, internally consistent Agent Brief. See [`docs/agents/agent-brief.md`](agent-brief.md) for the repository-owned contract.
 - [`workflows/delivery-issue.md`](../../workflows/delivery-issue.md) is the single source of truth for taking one approved issue through squash merge and green post-merge CI on `main`. There is no separate delivery fast path.
@@ -18,6 +22,9 @@ This repository tracks work in GitHub Issues.
 - Public issue templates intentionally do not auto-apply labels; maintainers/admins apply triage labels after creation.
 - The `Maintainer governance` workflow removes issue/PR labels added by non-maintainers and reopens PRs closed without merge by non-maintainers.
 - Use the GitHub CLI (`gh`) when creating or updating issues from automation.
+- Generic planning skills such as `to-spec` and `to-tickets` may supply issue
+  content or slices, but must defer to `dots-issue-creation` for native
+  relationships, Agent Briefs, and readiness labels.
 - Authenticate before agent work that touches GitHub: run `gh auth login` for an interactive workstation, or export `GH_TOKEN`/`GITHUB_TOKEN` in non-interactive environments.
 
 ## Notes

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -15,4 +15,19 @@ This repository uses the default triage label vocabulary.
 `dots-issue-creation` is the sole readiness producer. It applies the
 `ready-for-agent` label only after creating or updating exactly one complete
 Agent Brief that satisfies the repository-owned contract in
-[`agent-brief.md`](agent-brief.md). Otherwise the issue remains `needs-triage`.
+[`agent-brief.md`](agent-brief.md).
+
+Use these four publication states for sliced work:
+
+| Work state | Triage/readiness labels | Delivery status |
+| --- | --- | --- |
+| Unreviewed or incompletely specified | `needs-triage` | Not ready |
+| Fully specified with one complete Agent Brief, but with an open native blocker | Neither `needs-triage` nor `ready-for-agent` | GitHub's native dependency state reports it as blocked |
+| Fully specified, unblocked delivery frontier with one complete Agent Brief | `ready-for-agent` | Ready for `delivery-issue` |
+| Sliced tracking parent | Neither `needs-triage` nor `ready-for-agent` | Tracking container, not a delivery unit |
+
+Do not use `needs-triage` as a blocked-work label. When a blocker closes,
+revalidate the dependent issue's native relationships and its single complete
+Agent Brief, then move each newly unblocked delivery issue to
+`ready-for-agent`. A PRD that becomes a sliced tracking parent must lose
+`ready-for-agent`; only its current unblocked child frontier may receive it.

--- a/internal/agentinstructions/trigger_rules_test.go
+++ b/internal/agentinstructions/trigger_rules_test.go
@@ -314,3 +314,32 @@ func TestReadinessProducerRequiresRepositoryAgentBrief(t *testing.T) {
 		}
 	}
 }
+
+func TestIssueCreationDocumentsNativeRelationshipsAndReadiness(t *testing.T) {
+	root := filepath.Join("..", "..")
+	cases := map[string][]string{
+		filepath.Join(root, ".agents", "skills", "dots-issue-creation", "SKILL.md"): {
+			"--parent <parent-number>",
+			"--add-sub-issue <child-number>",
+			"--add-blocked-by <blocker-number>",
+			"parent,subIssues,blockedBy,blocking,labels,comments",
+			"`to-spec` or `to-tickets`",
+		},
+		filepath.Join(root, "docs", "agents", "triage-labels.md"): {
+			"Fully specified with one complete Agent Brief, but with an open native blocker",
+			"Sliced tracking parent",
+			"Do not use `needs-triage` as a blocked-work label",
+		},
+	}
+	for path, wants := range cases {
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		for _, want := range wants {
+			if !strings.Contains(string(got), want) {
+				t.Fatalf("native relationship contract %s missing %q", path, want)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes #394

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [x] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Require native GitHub hierarchy and dependency relationships for sliced issue publication when supported by `gh`.
- Define unreviewed, blocked, frontier-ready, and tracking-parent label states, including readiness advancement.
- Add machine-readable publication verification and regression coverage for the repository-owned skill contract.

## Changes

| File | Change |
|------|--------|
| `.agents/skills/dots-issue-creation/SKILL.md` | Adds native relationship commands, readiness transitions, generic-skill precedence, and publication verification. |
| `.agents/skills/dots-issue-creation/REFERENCE.md` | Recasts textual dependency sections as mirrors or unsupported-platform fallbacks. |
| `docs/agents/*.md` | Documents the native relationship source of truth and four readiness states. |
| `internal/agentinstructions/trigger_rules_test.go` | Guards the native relationship and readiness contract. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go build ./...`
- [ ] `go run ./cmd/dots manifest validate --file dots.yaml` — not applicable; the Install Manifest is unchanged.
- [ ] Sandboxed plan — not applicable; dotfiles behavior is unchanged.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] No CLI validation targeted home/config paths; this change is limited to agent documentation and its contract test.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #394`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs and agent instructions for the workflow behavior change.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

- Agent Brief: [comment 5226889754](https://github.com/yersonargotev/dots/issues/394#issuecomment-5226889754), updated `2026-08-08T15:59:40Z`, SHA-256 `aae579bc774aa9b118b11ce4c740c1c5f9625159fe6f363057c2179411b1ccc2`.
- Reviewed head: `ddd35f3`.
- Acceptance coverage: native create/edit/view commands and graph fields; prose-only fallback boundary; four label states; frontier advancement; placeholder/edge/label/Brief verification; generic `to-spec`/`to-tickets` precedence; contract regression test.
- Automated validation: `gofmt -l .` produced no output; `go vet ./...`, `go build ./...`, and `go test ./...` passed.
- Manual verification: CLI behavior is not applicable because this is a skill/docs change. Direct artifact checks passed: `quick_validate.py` via `uv run --with pyyaml`; installed `gh issue create/edit/view --help` exposes every documented flag/field; #383–#385 verify the native parent/frontier/blocked model; tracked `.atl` JSON/Markdown and the Claude skill symlink remain valid and unchanged.
- Independent review: Spec — no findings; Standards — no findings, both for `origin/main...ddd35f3`.
- Delegation: implementation delegation skipped because the change is one cohesive skill/documentation surface. A read-only forward-test produced a parent → A → B sliced plan; its clarification about retaining at most one historical parent Brief was accepted. The main agent inspected the result, integrated the clarification, and reran focused and full validation.
<!-- delivery-issue:evidence:end -->
