### PR TITLE
docs(domain): define application-writable ownership

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -48,6 +48,14 @@ _Avoid_: dotfile item, config row, install target
 The part of a Managed Entry's target that dots claims when evaluating Dotfiles Status. The default ownership is the whole installed file, but an entry may declare a narrower ownership mode when a supported tool legitimately co-owns the target.
 _Avoid_: loose ownership, ignored drift, special case
 
+**Application-Writable Target**:
+A native configuration path that a supported application flow or configuration command can modify while the target exists. It excludes conditional creation when the target is absent, writes by external editors or arbitrary scripts, and output written only to an operator-selected destination.
+_Avoid_: mutable config, generated config, app-owned file
+
+**Seeded Runtime State**:
+Application-owned mutable state initialized from a reviewed Source of Truth baseline and allowed to evolve locally after materialization.
+_Avoid_: copied config, managed runtime file, drifted baseline
+
 **JSON Subset Ownership**:
 An Entry Ownership mode for co-owned JSON targets where the repository source is the dots-owned baseline and the workstation target may contain additional object keys or array elements added by another supported owner. All scalar values, object keys, and array elements present in the baseline must still be present and equal in the target; otherwise the target is Drift when Installation Metadata proves dots installed it, or a Conflict when it does not.
 _Avoid_: JSON merge, partial sync, tolerate anything

--- a/docs/adr/0017-keep-application-writable-targets-outside-the-installed-repository.md
+++ b/docs/adr/0017-keep-application-writable-targets-outside-the-installed-repository.md
@@ -1,0 +1,46 @@
+# Keep application-writable targets outside the Installed Repository
+
+Native configuration paths that a supported application flow or configuration
+command can modify while the target exists must never resolve inside the
+Installed Repository. Those Application-Writable Targets are materialized as
+regular files or application-owned state; symlinks remain available for
+exclusively dots-owned targets that are read under ordinary use or written only
+to an operator-selected output destination. This protects the Source of Truth
+from normal application writes without imposing reconciliation on every
+Managed Entry. The evidence behind the current classification is recorded in
+the [symlink ownership audit](../application-writable-target-research.md) and
+implements the architecture slice in [#384](https://github.com/yersonargotev/dots/issues/384)
+of the parent specification [#383](https://github.com/yersonargotev/dots/issues/383).
+
+Materialization and Entry Ownership are separate decisions. A regular target
+may remain wholly dots-owned, expose a structured subset or marked loader block,
+or become Seeded Runtime State according to its real lifecycle. Zsh and Git use
+marked loader blocks; Herdr and Atuin use TOML Subset Ownership; bat and Zellij
+configuration remain Whole-Target Ownership; Zed settings use JSONC Subset
+Ownership; Zed keybindings and the lazy.nvim lockfile use Seeded Runtime State;
+and Neovim uses a regular native loader for separately Managed Configuration.
+Whole-target application rewrites are Drift, while local evolution of Seeded
+Runtime State remains aligned.
+
+**Considered Options**: Universal symlinks were rejected because supported
+writers can dirty the Installed Repository. Universal regular targets or one
+universal ownership adapter were rejected because read-under-ordinary-use
+targets need no reconciliation and configuration formats have different
+composition, ordering, and lifecycle semantics. Explicit operator outputs do
+not alone make a target application-writable: selecting a destination such as
+Starship's preset output is treated as a deliberate Source of Truth edit.
+
+**Consequences**: A provenance-backed legacy writable symlink may migrate only
+after a Backup Set is created and its live content is reconciled without
+ambiguity. Manual, stale, ambiguous, or concurrently changed targets remain
+Conflicts and are never silently adopted. Uninstall removes only the proven
+dots-owned contribution, retains Seeded Runtime State and external content, and
+does not let force broaden partial ownership. Local state can enter the Source
+of Truth only through explicit review; no generic promotion command is added.
+The audit is dated evidence rather than a promise of immutability, so new
+first-party writer behavior requires reclassification and migration.
+
+**Non-goals**: This decision does not require a generic configuration adapter,
+automatic promotion or capture, purging application-owned state, migration of
+explicit-output-only targets, or replacement of symlinks without writer
+evidence.

--- a/docs/application-writable-target-research.md
+++ b/docs/application-writable-target-research.md
@@ -1,0 +1,162 @@
+# Application-writable target research
+
+Date: 2026-08-08
+
+## Question
+
+For every current `strategy: symlink` Managed Entry in `dots.yaml`, which
+target is an **Application-Writable Target** because ordinary application
+behaviour or a documented configuration command can write it; which is read
+under ordinary use; and which can change only through an explicitly selected
+operator output?
+
+## Operational criterion
+
+This note uses three deliberately narrow classifications:
+
+- **Application-Writable Target**: a first-party source documents either an
+  ordinary application/onboarding write to this exact target, or a supported
+  application configuration operation that persists to it. An interactive
+  configuration UI counts when the application saves its result to the target.
+- **Read under ordinary use**: first-party documentation or this repository
+  establishes that the program loads/reads the target, and this research found
+  no documented normal writer for that exact target. This is evidence about
+  ordinary use, *not* proof that no writer exists.
+- **Explicit operator output**: the documented writer is a save/export action
+  whose output name/location is chosen by the operator. It is not an automatic
+  normal-use write to the managed path.
+
+“No documented writer found” is stated explicitly where applicable; it is not
+treated as evidence of immutability. Sources below are first-party product
+documentation, official project documentation, or the repository under review.
+
+## Complete inventory
+
+| # | Source | Target | Classification | Evidence |
+|---:|---|---|---|---|
+| 1 | `configs/zsh/zshrc` | `~/.zshrc` | Application-Writable Target | The official Zsh `zsh-newuser-install` guided configuration supports `~/.zshrc`; after choices, it offers to save the file and backs up an existing one. [Zsh User Configuration Functions](https://zsh.sourceforge.io/Doc/Release/User-Contributions.html#User-Configuration-Functions) |
+| 2 | `configs/zsh/zimrc` | `~/.zimrc` | Read under ordinary use | Zimfw calls this its plugin-manager configuration and uses it to build files in `$ZIM_HOME`; its documented install/update commands write modules and `init.zsh` there, not `.zimrc`. No first-party normal writer to `.zimrc` was found. [Zimfw commands](https://zimfw.sh/docs/commands/) |
+| 3 | `configs/zsh/zshenv` | `~/.zshenv` | Read under ordinary use | Zsh documents `.zshenv` as a startup file it tests/loads. The documented new-user configurator handles only `.zshrc`; no normal writer to `.zshenv` was found. [Zsh modules](https://zsh.sourceforge.io/Doc/Release/Zsh-Modules.html), [new-user function](https://zsh.sourceforge.io/Doc/Release/User-Contributions.html#User-Configuration-Functions) |
+| 4 | `configs/git/gitconfig` | `~/.gitconfig` | Application-Writable Target | `git config --global` writes the global user configuration; Git’s own manual says the command adds values to `.gitconfig` in the home directory. [Git user manual](https://git-scm.com/docs/user-manual#telling-git-your-name) |
+| 5 | `configs/dots/theme.sh` | `~/.config/dots/theme.sh` | Read under ordinary use | This repository documents it as the helper read by the adaptive-theme setup; `tmux.conf` and statusline scripts source it. It has no external owning application or documented writer in scope. [Repository adaptive-theme audit](adaptive-theme-audit.md) |
+| 6 | `configs/dots/adaptive-theme` | `~/.config/dots/adaptive-theme` | Read under ordinary use | The repository documents it as an opt-in marker read by `theme.sh`; installing the tag creates it. No application writer in scope was found. [Repository adaptive-theme audit](adaptive-theme-audit.md) |
+| 7 | `configs/starship/starship.toml` | `~/.config/starship.toml` | Explicit operator output | Starship documents presets with an explicit output target, e.g. `starship preset no-runtime-versions -o ~/.config/starship.toml`. This can overwrite through the symlink only when the operator selects that path; it is not a normal prompt-runtime write. [Starship preset](https://starship.rs/presets/no-runtimes) |
+| 8 | `configs/tmux/tmux.conf` | `~/.tmux.conf` | Read under ordinary use | `tmux` uses the file as its user configuration. This audit found no documented tmux command that persists configuration changes to it during ordinary use. The negative result is not a claim that a script cannot edit it. [tmux manual](https://man.openbsd.org/tmux.1#FILES) |
+| 9 | `configs/herdr/config.toml` (or adaptive override) | `~/.config/herdr/config.toml` | Application-Writable Target | Herdr’s onboarding writes `onboarding = false` here. `herdr config reset-keys` backs up this file and removes key sections. Both are supported configuration flows. [Herdr configuration](https://herdr.dev/docs/configuration/) |
+| 10 | `configs/zellij/config.kdl` (or adaptive override) | `~/.config/zellij/config.kdl` | Application-Writable Target | Zellij’s documented Plugin API offers `reconfigure(..., save_configuration_file: true)` and `rebind_keys(..., write_config_to_disk: true)`, explicitly persisting configuration. [Zellij configuration commands](https://zellij.dev/documentation/plugin-api-commands) |
+| 11 | `configs/zellij/layouts/default.kdl` | `~/.config/zellij/layouts/default.kdl` | Explicit operator output | Zellij’s `save_layout(layout_name, layout_kdl, overwrite)` saves to the user layout directory; the caller supplies the layout name and overwrite choice. It can reach `default.kdl` only when that output is selected. [Zellij layout commands](https://zellij.dev/documentation/plugin-api-commands) |
+| 12 | `configs/ghostty/config.ghostty` | `~/.config/ghostty/config.ghostty` | Read under ordinary use (conditional initializer) | Ghostty creates a default only when no non-empty configuration exists. Its official source creates the file with exclusive creation and treats an existing path as already present; therefore this initialisation does not mutate an installed symlink. The `+edit-config` flow opens the chosen file in the operator’s `$EDITOR` rather than Ghostty rewriting it. [Ghostty 1.0.1 notes](https://ghostty.org/docs/install/release-notes/1-0-1), [Ghostty source](https://github.com/ghostty-org/ghostty/blob/main/src/config/edit.zig), [configuration paths](https://ghostty.org/docs/config) |
+| 13 | `configs/ghostty/adaptive/adaptive-theme.ghostty` | `~/.config/ghostty/adaptive-theme.ghostty` | Read under ordinary use | The repository makes this an optional `config-file = ?adaptive-theme.ghostty` include. Ghostty documents reading included config files; the automatic default-file behaviour concerns the main config, not this named fragment. No normal writer to this fragment was found. [Repository Ghostty config](../configs/ghostty/config.ghostty), [Ghostty configuration](https://ghostty.org/docs/config) |
+| 14 | `configs/atuin/config.toml` | `~/.config/atuin/config.toml` | Application-Writable Target | `atuin config set <key> <value>` changes values in `config.toml`, preserving formatting and comments; Atuin documents this exact default path. [Atuin config command](https://docs.atuin.sh/main/reference/config/), [Atuin configuration path](https://docs.atuin.sh/main/configuration/config/) |
+| 15 | `configs/atuin/themes/catppuccin-mocha.toml` | `~/.config/atuin/themes/catppuccin-mocha.toml` | Read under ordinary use | Atuin reads user theme TOML files from the themes directory, while its theme documentation instructs users to add or make themes. No Atuin theme-save/export command writing this target was found. [Atuin theming](https://docs.atuin.sh/18.18/guide/theming/) |
+| 16 | `configs/bat/config` | `~/.config/bat/config` | Application-Writable Target | `bat --generate-config-file` writes the default-path config. Its official source detects an existing regular file, prompts for overwrite, and then calls `fs::write`, so a confirmed operation can write through the existing symlink. [bat configuration](https://github.com/sharkdp/bat#configuration-file), [bat source](https://github.com/sharkdp/bat/blob/master/src/bin/bat/config.rs) |
+| 17 | `configs/nvim` | `~/.config/nvim` | Application-Writable Target (directory) | This repository contains `configs/nvim/lazy-lock.json`; lazy.nvim documents that after **every update** it updates local `lazy-lock.json`. With this directory symlink, that normal supported plugin-manager write traverses into the repository. Neovim’s documented auto-creation of its config directory is secondary evidence only, because an installed symlink already exists. [lazy.nvim lockfile](https://lazy.folke.io/usage/lockfile), [repository lockfile](../configs/nvim/lazy-lock.json), [Neovim standard paths](https://neovim.io/doc/user/starting/) |
+| 18 | `configs/zed/settings.json` | `~/.config/zed/settings.json` | Application-Writable Target | Zed’s theme selector saves the selected theme to the settings file, and its settings UI changes settings directly. The Zed FAQ identifies this exact path. [Zed themes](https://zed.dev/docs/themes), [Zed FAQ](https://zed.dev/faq) |
+| 19 | `configs/zed/keymap.json` | `~/.config/zed/keymap.json` | Application-Writable Target | Zed’s keymap editor says edits made there are reflected in `keymap.json`; the same page gives this exact macOS/Linux path. [Zed key bindings](https://zed.dev/docs/key-bindings) |
+| 20 | `configs/zed/themes/catppuccin-blue.json` | `~/.config/zed/themes/catppuccin-blue.json` | Explicit operator output | Zed’s Theme Builder lets the operator export JSON for local use; local theme files are then placed in the themes directory. The documentation does not identify an automatic writer to this filename, so this is an explicit export destination rather than normal-use mutation. [Zed themes](https://zed.dev/docs/themes), [Theme Builder announcement](https://zed.dev/blog/theme-builder) |
+
+## Special analysis
+
+### Git
+
+Git is unambiguous: `git config --global user.name ...` and `user.email ...`
+write the home `.gitconfig` according to Git’s own manual. This is a supported,
+ordinary configuration command, so the symlink would expose the repository
+source to a normal Git configuration operation.
+
+### Atuin
+
+Atuin is also unambiguous. Its current `atuin config set` command changes
+`config.toml` without requiring an editor and preserves comments/formatting.
+Atuin separately stores history, keys, sessions, and logs outside this target;
+those paths do not reduce the direct writer evidence for `config.toml`.
+
+### Starship
+
+Starship’s preset documentation gives an explicit output form:
+`starship preset no-runtime-versions -o ~/.config/starship.toml`. Thus it is
+not correct to call this target read-only. The write is nonetheless a selected
+operator output, rather than an automatic prompt-runtime mutation, and will
+traverse the symlink only if that exact path is chosen.
+
+### Herdr
+
+Herdr is an Application-Writable Target twice over: first-run onboarding writes
+`onboarding = false`, and `herdr config reset-keys` backs up and changes the
+same file. The prior premise that configuration is operator-created only by
+shell redirection is therefore false. This is the direct admission-blocking
+fact for issue #384.
+
+## Uncertainties and scope boundaries
+
+- This is a documentation/source audit as of the date above, not a proof that
+  every program, extension, shell hook, or third-party script is incapable of
+  writing a target.
+- The Zellij Plugin API is a first-party supported capability. Whether a
+  particular installed plugin exposes it is deployment-specific; that does not
+  remove the supported persistent writer.
+- Neovim’s documented auto-creation applies when its config directory is
+  absent. With a `dots` directory symlink already installed, that initial
+  creation path will normally not run. The lazy.nvim lockfile is the direct
+  writer evidence here: `:Lazy update` updates the existing file inside that
+  directory.
+- Ghostty’s documented automatic creation is for a main default configuration
+  when no non-empty configuration exists. Its source uses exclusive creation,
+  so an installed symlink prevents that creation path; it is not evidence of a
+  write-through candidate. It is also not evidence that Ghostty writes the
+  optional adaptive fragment.
+- Zed documents export of a local theme JSON but does not promise that an
+  export is named `catppuccin-blue.json`; hence the explicit-output category.
+
+## Consequences for the Agent Brief of #384
+
+The Agent Brief must be corrected before it is restored to `ready-for-agent`:
+
+1. It must include Herdr as an Application-Writable Target. Excluding it on
+   the claim that it lacks a normal writer contradicts current first-party
+   documentation.
+2. The brief’s evidence inventory should account for Git, Atuin, `bat`, Zellij
+   config, Zed settings/keymap, and the lazy.nvim lockfile inside the Neovim
+   directory. Each confirmed Application-Writable Target must migrate away from
+   `symlink` so it cannot resolve inside the Installed Repository. The audit
+   does not choose its regular-file ownership contract; that remains a separate
+   compatibility and lifecycle decision.
+3. Starship, Zellij layouts, and the Zed local theme must be described as
+   explicit-output cases, not automatic normal writers. Ghostty’s conditional
+   initial creation is not a write-through candidate once the target symlink
+   exists. Entries classified read-only retain an uncertainty statement rather
+   than a claim of impossibility.
+4. Application-writable classification governs materialization, not Entry
+   Ownership. A confirmed target must be regular, while its ownership may still
+   be whole-target, subset, marked-block, or seeded according to its lifecycle.
+5. Explicit-output and read-under-ordinary-use entries remain eligible for
+   symlinks. The dated inventory is revisable: new first-party writer evidence
+   requires reclassification and migration under the invariant.
+
+## Chosen ownership contracts
+
+The confirmed Application-Writable Targets use these regular-target contracts:
+
+| Target | Entry Ownership contract |
+|---|---|
+| Zsh `.zshrc` | Marked loader block |
+| Git `.gitconfig` | Marked loader block |
+| Herdr `config.toml` | TOML Subset Ownership |
+| Zellij `config.kdl` | Whole-Target Ownership |
+| Atuin `config.toml` | TOML Subset Ownership |
+| bat `config` | Whole-Target Ownership |
+| Neovim entrypoint | Whole-Target Ownership loader for separate Managed Configuration |
+| lazy.nvim `lazy-lock.json` | Seeded Runtime State |
+| Zed `settings.json` | JSONC Subset Ownership |
+| Zed `keymap.json` | Seeded Runtime State |
+
+Whole-Target Ownership for bat and Zellij deliberately reports supported
+application rewrites as Drift while keeping the Installed Repository clean.
+No KDL or line-oriented partial-ownership adapter is introduced without a
+concrete co-ownership requirement.
+
+## Coverage check
+
+The manifest inventory in `dots.yaml` has exactly 20 entries with
+`strategy: symlink`. Rows 1–20 above cover each source/target pair exactly
+once; no `copy` entry is included.


### PR DESCRIPTION
Closes #384

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [x] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Define Application-Writable Target and Seeded Runtime State in the domain glossary.
- Record the ownership invariant, alternatives, lifecycle, and non-goals in ADR 0017.
- Audit all 20 current symlink Managed Entries with primary-source evidence or explicit uncertainty.

## Changes

| File | Change |
|------|--------|
| `CONTEXT.md` | Add the two canonical domain terms and avoided synonyms. |
| `docs/adr/0017-keep-application-writable-targets-outside-the-installed-repository.md` | Record the application-writable ownership decision and contracts. |
| `docs/application-writable-target-research.md` | Classify every current symlink Managed Entry and retain its evidence. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [ ] `go run ./cmd/dots manifest validate --file dots.yaml` (not applicable: no manifest or behavior changes)
- [ ] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile core --source-root "$PWD" --home <tmp>` (not applicable: documentation only)
- [x] `go build ./...`
- [x] `git diff --check`
- [x] Documentation structure, relative links, external evidence URLs, and exact 20-entry audit coverage validated.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported. No such validation was needed for this documentation-only change.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #384`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

- Agent Brief: https://github.com/yersonargotev/dots/issues/384#issuecomment-5226644613; comment ID `5226644613`; SHA-256 `4da780ad441f8732b88424c7067b4192445c8c43981ba6d04880d233bced7aa2`
- Reviewed head: `ec3c8c807537257bc396d706acd91aaa819ce934`
- Acceptance coverage:
  - Glossary: both terms and avoided synonyms are defined in `CONTEXT.md`.
  - Decision: ADR 0017 records the invariant, rejected universal approaches, ownership contracts, lifecycle, and non-goals.
  - Audit: all 20 current symlink entries occur exactly once with evidence or explicit uncertainty; all named candidates and special cases are classified.
  - Validation: documentation checks and the full CI-equivalent suite pass.
- Automated validation: `git diff --check`; YAML/exact-coverage validation; glossary and ADR structure checks; relative-link checks; external evidence URL checks; `gofmt -l .`; `go vet ./...`; `go build ./...`; `go test ./...` — all passed.
- Manual verification: not applicable because the diff changes only architecture/domain documentation and does not change Go code, the Install Manifest, CLI behavior, or live configuration. Direct artifact review covered the documentation acceptance criteria.
- Independent Standards review: PASS; no documented-standard violations or required changes. One non-blocking vocabulary-drift judgement call was considered and left for implementation contracts rather than expanding this issue.
- Independent Spec review: PASS; no missing/partial requirements, scope creep, or incorrect implementation found.
- Delegation: implementation delegation skipped because the authorized change is one coherent three-document slice. The main agent inspected all hunks and ran focused documentation checks plus the complete CI-equivalent suite. Independent review was delegated to separate Standards and Spec reviewers.
<!-- delivery-issue:evidence:end -->
