### PR TITLE
feat(config): reconcile reversible owned subsets

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -57,7 +57,7 @@ Application-owned mutable state initialized from a reviewed Source of Truth base
 _Avoid_: copied config, managed runtime file, drifted baseline
 
 **JSON Subset Ownership**:
-An Entry Ownership mode for co-owned JSON targets where the repository source is the dots-owned baseline and the workstation target may contain additional object keys or array elements added by another supported owner. All scalar values, object keys, and array elements present in the baseline must still be present and equal in the target; otherwise the target is Drift when Installation Metadata proves dots installed it, or a Conflict when it does not.
+An Entry Ownership mode for co-owned strict-JSON targets where the repository source is the dots-owned baseline and the workstation target may contain additional object keys or array elements added by another supported owner. Installation Metadata records the last dots-owned contribution so a later install can add new values, remove unchanged retired values, and reject externally changed former values. Uninstall subtracts only that proven contribution and preserves the target while external content remains.
 _Avoid_: JSON merge, partial sync, tolerate anything
 
 **Backup Set**:
@@ -129,7 +129,7 @@ The current alignment between a workstation and the repository-owned Source of T
 _Avoid_: health, sync state, installed state
 
 **Installation Metadata**:
-The state file stored under `~/.local/state/dots/installed.json` that records what the Dotfiles CLI installed, including Managed Entries, Provisioners, strategies, hashes, timestamps, and an optional Installed Selection. It lets the CLI detect Drift for copied and templated targets while preserving machine-level selection intent separately from historical inventory.
+The state file stored under `~/.local/state/dots/installed.json` that records what the Dotfiles CLI installed, including Managed Entries, Provisioners, strategies, hashes, timestamps, optional structured-ownership evidence, and an optional Installed Selection. It lets the CLI detect Drift and reconcile or remove only proven contributions for copied subset-owned targets while preserving machine-level selection intent separately from historical inventory.
 _Avoid_: install log, state file, tracking file
 
 **Installed Selection**:

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -143,10 +143,13 @@ home directory.
 | `dependencies` | No | Entry-level Dependencies. |
 
 For a `json-subset` target already trusted by matching Installation Metadata,
-missing source-owned object keys and array elements are applied as a conservative
-update: target-only values are preserved, a Backup Set is created, and existing
-incompatible scalar or object/array values remain a Conflict. A compatible
-pre-existing target without matching metadata is still a Conflict.
+the recorded prior contribution enables a three-state update: new owned values
+are added, unchanged retired values are removed, and target-only values are
+preserved. A changed former contribution or incompatible scalar/object/array
+value remains a Conflict. Every applied update creates a Backup Set. Legacy
+metadata without prior-contribution evidence may establish a new baseline after
+a safe additive or unchanged install, but never authorizes removal retroactively;
+a compatible pre-existing target without matching metadata is still a Conflict.
 
 Current Managed Entries:
 

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -10,10 +10,10 @@ dots uninstall --yes       # remove owned targets without prompting
 
 ## What it does
 
-1. **Reads the Installation Metadata.** Each recorded target carries its source, install strategy, and — for copied files — a content hash. A run with no recorded targets reports that and stops.
+1. **Reads the Installation Metadata.** Each recorded target carries its source, install strategy, and — for copied files — a content hash. Strict-JSON subset records also carry the prior dots-owned contribution. A run with no recorded targets reports that and stops.
 2. **Builds the Uninstall Plan.** Every recorded target is classified against current disk state into one of four actions (see below).
 3. **Previews by default.** The plan is printed before anything is removed. Without `--yes`, the command then asks for confirmation; answering anything other than `y`/`yes` cancels with no changes.
-4. **Removes only owned targets.** Symlinks are deleted only when they still resolve to the recorded repository source; copies only when their content still matches the recorded hash.
+4. **Removes only owned content.** Symlinks are deleted only when they still resolve to the recorded repository source; whole-owned copies only when their content still matches the recorded hash. Strict-JSON subset targets lose only the recorded contribution and remain in place while external content survives.
 5. **Optionally restores backups.** With `--restore-backups`, each removed target's most recent Backup Set is restored, returning the workstation to its pre-install state.
 6. **Prunes the metadata.** Records for successfully removed targets are dropped, and the metadata file is deleted entirely once nothing remains.
 
@@ -21,8 +21,8 @@ dots uninstall --yes       # remove owned targets without prompting
 
 | Action | Meaning | Default behavior |
 |--------|---------|------------------|
-| `remove` | A symlink that resolves to the recorded source, or a copy whose content matches the recorded hash. `dots` still owns it. | Removed. |
-| `modified` | A copied target whose content drifted from the recorded hash — you edited it in place. | Skipped; pass `--force` to remove anyway. |
+| `remove` | A symlink or whole-owned copy is still proven owned, or a strict-JSON subset contribution can be subtracted safely. | Removes the target or only its proven contribution. |
+| `modified` | A whole-owned copy drifted, or a recorded partial contribution changed externally. | Whole-owned copies may be forced; partial targets are always preserved. |
 | `not-owned` | A symlink that is missing or now points elsewhere, or a target whose type changed. `dots` can no longer prove it owns it. | Skipped, always. |
 | `skip` | A copied target that is already absent. | Nothing to do. |
 
@@ -41,7 +41,8 @@ Summary: 1 to remove, 1 modified, 1 not-owned, 0 skipped
 Uninstall is conservative by design: it would rather leave a file in place than delete something it does not own.
 
 - **Symlinks** are verified by destination, not by name. A link is removed only if `readlink` still resolves to the source `dots` recorded (resolved against `--source-root`). A link the user repointed, or replaced with a real file, is `not-owned` and left untouched.
-- **Copies** are verified by content hash. A file whose hash still matches the recorded value is removed; a file you edited is `modified` and preserved unless you pass `--force`.
+- **Whole-owned copies** are verified by content hash. A file whose hash still matches the recorded value is removed; a file you edited is `modified` and preserved unless you pass `--force`.
+- **Strict-JSON subsets** are reconciled against their recorded contribution. Matching owned values are removed recursively, target-only keys and array items survive, and the physical file is deleted only when no external content remains. Changed owned values are `modified`; `--force` never broadens partial ownership or deletes the whole co-owned target. Legacy records without contribution evidence retain the older whole-copy safety behavior and gain no new removal authority.
 - **Re-verification at apply time.** The classification shown in the preview is recomputed against disk immediately before each removal, so a target that changed between preview and apply is never removed by surprise.
 - **No removal escapes HOME.** Every target is validated to stay inside the home sandbox, with the same no-symlink-escape guards install uses, before it is deleted.
 
@@ -61,7 +62,7 @@ A Backup Set is restored at most once even if it covers several removed targets,
 |------|---------|
 | `--dry-run` | Print the Uninstall Plan and stop without modifying files. |
 | `--yes` | Remove owned targets without the confirmation prompt. |
-| `--force` | Also remove copied targets whose content drifted from the recorded hash. |
+| `--force` | Also remove whole-owned copied targets whose content drifted from the recorded hash; never broadens partial ownership. |
 | `--restore-backups` | Restore each removed target's most recent Backup Set after removal. |
 | `--source-root` | Installed repository root used to verify symlink ownership (default `~/.local/share/dots`). |
 | `--home` | Target home directory to uninstall from (default: the current user's home). Use a sandbox path to avoid touching real config. |
@@ -71,6 +72,9 @@ A Backup Set is restored at most once even if it covers several removed targets,
 
 - Uninstall does **not** remove Dependencies — that stays in the `deps` domain.
 - It does **not** touch any path `dots` never recorded.
+- `--restore-backups` does not restore a whole-file Backup Set over a partially
+  owned target, because doing so could overwrite external content retained by
+  the partial uninstall.
 - It adds no rollback or version semantics beyond Backup Set restore.
 
 ## References

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -10,7 +10,7 @@ dots uninstall --yes       # remove owned targets without prompting
 
 ## What it does
 
-1. **Reads the Installation Metadata.** Each recorded target carries its source, install strategy, and — for copied files — a content hash. Strict-JSON subset records also carry the prior dots-owned contribution. A run with no recorded targets reports that and stops.
+1. **Reads the Installation Metadata.** Each newly recorded target carries its source, install strategy, explicit whole/partial ownership, and — for copied files — a content hash. Strict-JSON subset records also carry the prior dots-owned contribution. A run with no recorded targets reports that and stops.
 2. **Builds the Uninstall Plan.** Every recorded target is classified against current disk state into one of four actions (see below).
 3. **Previews by default.** The plan is printed before anything is removed. Without `--yes`, the command then asks for confirmation; answering anything other than `y`/`yes` cancels with no changes.
 4. **Removes only owned content.** Symlinks are deleted only when they still resolve to the recorded repository source; whole-owned copies only when their content still matches the recorded hash. Strict-JSON subset targets lose only the recorded contribution and remain in place while external content survives.
@@ -42,7 +42,7 @@ Uninstall is conservative by design: it would rather leave a file in place than 
 
 - **Symlinks** are verified by destination, not by name. A link is removed only if `readlink` still resolves to the source `dots` recorded (resolved against `--source-root`). A link the user repointed, or replaced with a real file, is `not-owned` and left untouched.
 - **Whole-owned copies** are verified by content hash. A file whose hash still matches the recorded value is removed; a file you edited is `modified` and preserved unless you pass `--force`.
-- **Strict-JSON subsets** are reconciled against their recorded contribution. Matching owned values are removed recursively, target-only keys and array items survive, and the physical file is deleted only when no external content remains. Changed owned values are `modified`; `--force` never broadens partial ownership or deletes the whole co-owned target. Legacy records without contribution evidence retain the older whole-copy safety behavior and gain no new removal authority.
+- **Strict-JSON subsets** are reconciled against their recorded contribution. Matching owned values are removed recursively, target-only keys and array items survive, and the physical file is deleted only when no external content remains. Changed owned values are `modified`; `--force` never broadens partial ownership or deletes the whole co-owned target. Legacy Installation Metadata without contribution evidence may remove an unchanged hash match, but cannot force-remove a modified copy; a safe install must first record current ownership evidence.
 - **Re-verification at apply time.** The classification shown in the preview is recomputed against disk immediately before each removal, so a target that changed between preview and apply is never removed by surprise.
 - **No removal escapes HOME.** Every target is validated to stay inside the home sandbox, with the same no-symlink-escape guards install uses, before it is deleted.
 

--- a/docs/update.md
+++ b/docs/update.md
@@ -42,12 +42,13 @@ Non-interactive runs (`--yes`) default every conflict to `skip`, so an unattende
 
 Some co-owned copied configuration can be updated without treating the target as
 a Conflict. When Installation Metadata proves dots installed the previous
-Source of Truth and the target still contains that dots-owned subset, the Install
-Plan may report an `update` action. Today this is used for TOML subset-owned
-Codex config migrations such as adding the CodeGraph `SessionStart` hook while
-preserving Codex- or user-owned settings. An `update` creates a Backup Set before
-mutating the target, and it is safe for Confirmed Install mode because unmanaged
-or incompatible targets still remain Conflicts.
+Source of Truth, the Install Plan may report an `update` action. Strict-JSON
+subset targets use the prior contribution recorded in Installation Metadata to
+add new values and remove unchanged retired values while preserving target-only
+content; an externally changed former value remains a Conflict. Legacy metadata
+without that evidence stays additive-only until a safe run records the current
+baseline. TOML subset updates remain additive. Every `update` creates a Backup
+Set before mutation, and unmanaged or incompatible targets remain Conflicts.
 
 ## Flags
 

--- a/internal/cli/issue385_subset_lifecycle_test.go
+++ b/internal/cli/issue385_subset_lifecycle_test.go
@@ -1,0 +1,99 @@
+package cli_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/cli"
+	"github.com/yersonargotev/dots/internal/state"
+)
+
+func TestJSONSubsetLifecycleReconcilesAndUninstallsOwnedContribution(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := filepath.Join(home, ".local", "state", "dots")
+	t.Setenv("HOME", t.TempDir())
+
+	source := filepath.Join(sourceRoot, "configs", "shared.json")
+	if err := os.MkdirAll(filepath.Dir(source), 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	fixture := func(name string) []byte {
+		t.Helper()
+		data, err := os.ReadFile(filepath.Join("testdata", "issue385", name))
+		if err != nil {
+			t.Fatalf("read fixture %s: %v", name, err)
+		}
+		return data
+	}
+	if err := os.WriteFile(source, fixture("previous.json"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	manifestPath := filepath.Join(sourceRoot, "dots.yaml")
+	if err := os.WriteFile(manifestPath, fixture("manifest.yaml"), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	run := func(want int, args ...string) string {
+		t.Helper()
+		var stdout, stderr bytes.Buffer
+		code := cli.Run(args, &stdout, &stderr)
+		if code != want {
+			t.Fatalf("cli.Run(%v) code = %d, want %d\nstdout:\n%s\nstderr:\n%s", args, code, want, stdout.String(), stderr.String())
+		}
+		return stdout.String()
+	}
+	common := []string{"--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot}
+	installArgs := append([]string{"install", "--yes", "--skip-deps"}, common...)
+	run(0, installArgs...)
+
+	target := filepath.Join(home, ".config", "shared.json")
+	if err := os.WriteFile(target, fixture("target-with-external.json"), 0o640); err != nil {
+		t.Fatalf("add target-only content: %v", err)
+	}
+	statusArgs := append([]string{"status", "--output", "json"}, common...)
+	run(0, statusArgs...)
+
+	if err := os.WriteFile(source, fixture("current.json"), 0o600); err != nil {
+		t.Fatalf("update source: %v", err)
+	}
+	run(2, statusArgs...)
+	run(0, installArgs...)
+	run(0, statusArgs...)
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read reconciled target: %v", err)
+	}
+	for _, want := range []string{`"added": "new"`, `"external": "preserve"`, `"targetOnly": true`, `"external"`} {
+		if !strings.Contains(string(got), want) {
+			t.Fatalf("reconciled target missing %s:\n%s", want, got)
+		}
+	}
+	if strings.Contains(string(got), `"retired"`) || strings.Contains(string(got), `"old"`) {
+		t.Fatalf("reconciled target retained retired contribution:\n%s", got)
+	}
+
+	uninstallOutput := run(0, "uninstall", "--yes", "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot)
+	if !strings.Contains(uninstallOutput, "Removed dots-owned content from 1 target.") {
+		t.Fatalf("uninstall output did not describe partial removal:\n%s", uninstallOutput)
+	}
+	got, err = os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target after partial uninstall: %v", err)
+	}
+	for _, want := range []string{`"external": "preserve"`, `"targetOnly": true`, `"external"`} {
+		if !strings.Contains(string(got), want) {
+			t.Fatalf("uninstall lost target-only content %s:\n%s", want, got)
+		}
+	}
+	if strings.Contains(string(got), `"added"`) || strings.Contains(string(got), `"new"`) || strings.Contains(string(got), `"keep"`) {
+		t.Fatalf("uninstall retained dots-owned contribution:\n%s", got)
+	}
+	if _, err := os.Stat(state.Path(stateRoot)); !os.IsNotExist(err) {
+		t.Fatalf("metadata should be pruned after partial uninstall, err = %v", err)
+	}
+}

--- a/internal/cli/output_golden_test.go
+++ b/internal/cli/output_golden_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/yersonargotev/dots/internal/selectionmigration"
 	"github.com/yersonargotev/dots/internal/state"
 	"github.com/yersonargotev/dots/internal/status"
+	"github.com/yersonargotev/dots/internal/uninstall"
 	"github.com/yersonargotev/dots/internal/upgrade"
 )
 
@@ -179,7 +180,7 @@ func TestEnvelopeGolden(t *testing.T) {
 				Command:       "uninstall",
 				Status:        statusOK,
 				Data: uninstallReport{
-					DryRun:    true,
+					DryRun:    false,
 					StateRoot: "/home/user/.local/state/dots",
 					Plan: plan.UninstallPlan{Actions: []plan.UninstallAction{{
 						Source: "configs/antigravity/settings.json",
@@ -187,10 +188,12 @@ func TestEnvelopeGolden(t *testing.T) {
 							"configs/antigravity/settings.json",
 							"configs/antigravity/mobile-mcp-settings.json",
 						},
-						Target:   "/home/user/.gemini/antigravity-cli/settings.json",
-						Strategy: "copy",
-						Status:   plan.UninstallRemove,
+						Target:    "/home/user/.gemini/antigravity-cli/settings.json",
+						Strategy:  "copy",
+						Ownership: "json-subset",
+						Status:    plan.UninstallRemove,
 					}}},
+					Result: uninstall.Result{Updated: []string{"/home/user/.gemini/antigravity-cli/settings.json"}},
 				},
 			},
 			golden: "envelope_uninstall.golden",

--- a/internal/cli/render_uninstall_golden_test.go
+++ b/internal/cli/render_uninstall_golden_test.go
@@ -19,7 +19,7 @@ func TestRenderUninstallPlanGolden(t *testing.T) {
 			name: "mixed actions",
 			plan: plan.UninstallPlan{Actions: []plan.UninstallAction{
 				{Target: "/home/user/.zshrc", Source: "shell/zshrc", Strategy: "symlink", Status: plan.UninstallRemove},
-				{Target: "/home/user/.gitconfig", Source: "git/gitconfig", Strategy: "copy", Status: plan.UninstallModified},
+				{Target: "/home/user/.gitconfig", Source: "git/gitconfig", Strategy: "copy", ForceRemovable: true, Status: plan.UninstallModified},
 				{Target: "/home/user/.tmux.conf", Source: "term/tmux.conf", Strategy: "symlink", Status: plan.UninstallNotOwned},
 				{Target: "/home/user/.vimrc", Source: "vim/vimrc", Strategy: "copy", Status: plan.UninstallSkip},
 			}},

--- a/internal/cli/testdata/envelope_uninstall.golden
+++ b/internal/cli/testdata/envelope_uninstall.golden
@@ -3,7 +3,7 @@
   "command": "uninstall",
   "status": "ok",
   "data": {
-    "dry_run": true,
+    "dry_run": false,
     "state_root": "/home/user/.local/state/dots",
     "plan": {
       "actions": [
@@ -15,12 +15,16 @@
             "configs/antigravity/mobile-mcp-settings.json"
           ],
           "strategy": "copy",
+          "ownership": "json-subset",
           "status": "remove"
         }
       ]
     },
     "result": {
       "removed": null,
+      "updated": [
+        "/home/user/.gemini/antigravity-cli/settings.json"
+      ],
       "restored_sets": null
     }
   }

--- a/internal/cli/testdata/issue385/current.json
+++ b/internal/cli/testdata/issue385/current.json
@@ -1,0 +1,1 @@
+{"owned":{"keep":true,"added":"new"},"items":["new"]}

--- a/internal/cli/testdata/issue385/manifest.yaml
+++ b/internal/cli/testdata/issue385/manifest.yaml
@@ -1,0 +1,11 @@
+version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/shared.json
+    target: ~/.config/shared.json
+    strategy: copy
+    ownership: json-subset
+    tags: [core]
+    os: [darwin, linux]

--- a/internal/cli/testdata/issue385/previous.json
+++ b/internal/cli/testdata/issue385/previous.json
@@ -1,0 +1,1 @@
+{"owned":{"keep":true,"retired":"old"},"items":["old"]}

--- a/internal/cli/testdata/issue385/target-with-external.json
+++ b/internal/cli/testdata/issue385/target-with-external.json
@@ -1,0 +1,1 @@
+{"owned":{"keep":true,"retired":"old","external":"preserve"},"items":["old","external"],"targetOnly":true}

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -131,7 +131,7 @@ func willRemove(p plan.UninstallPlan, force bool) bool {
 		case plan.UninstallRemove:
 			return true
 		case plan.UninstallModified:
-			if force && action.Ownership == "" {
+			if force && action.ForceRemovable {
 				return true
 			}
 		}
@@ -144,17 +144,17 @@ func willRemove(p plan.UninstallPlan, force bool) bool {
 // none so a clean plan reads without noise.
 func renderModifiedHint(w io.Writer, p plan.UninstallPlan, force bool) {
 	modified := 0
-	partial := 0
+	protected := 0
 	for _, action := range p.Actions {
 		if action.Status == plan.UninstallModified {
-			if action.Ownership == "" {
+			if action.ForceRemovable {
 				modified++
 			} else {
-				partial++
+				protected++
 			}
 		}
 	}
-	if modified == 0 && partial == 0 {
+	if modified == 0 && protected == 0 {
 		return
 	}
 	if modified > 0 && force {
@@ -162,8 +162,8 @@ func renderModifiedHint(w io.Writer, p plan.UninstallPlan, force bool) {
 	} else if modified > 0 {
 		fmt.Fprintf(w, "\nNote: %d modified target(s) will be skipped; re-run with --force to remove them.\n", modified)
 	}
-	if partial > 0 {
-		fmt.Fprintf(w, "\nNote: %d partially owned target(s) will be preserved because recorded owned content changed; --force never broadens partial ownership.\n", partial)
+	if protected > 0 {
+		fmt.Fprintf(w, "\nNote: %d target(s) will be preserved because partial or legacy ownership evidence is insufficient; --force never broadens ownership.\n", protected)
 	}
 }
 

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -99,7 +99,12 @@ func newUninstallCommand() *cobra.Command {
 			if wantsJSON(cmd) {
 				return emitOK(cmd, uninstallReport{DryRun: false, StateRoot: paths.StateRoot, Plan: p, Result: res})
 			}
-			fmt.Fprintf(out, "\nRemoved %s.\n", pluralizeTargets(len(res.Removed)))
+			if len(res.Removed) > 0 {
+				fmt.Fprintf(out, "\nRemoved %s.\n", pluralizeTargets(len(res.Removed)))
+			}
+			if len(res.Updated) > 0 {
+				fmt.Fprintf(out, "\nRemoved dots-owned content from %s.\n", pluralizeTargets(len(res.Updated)))
+			}
 			if restoreBackups && len(res.RestoredSets) > 0 {
 				fmt.Fprintf(out, "Restored %s from preserved Backup Sets.\n", pluralizeBackupSets(len(res.RestoredSets)))
 			}
@@ -126,7 +131,7 @@ func willRemove(p plan.UninstallPlan, force bool) bool {
 		case plan.UninstallRemove:
 			return true
 		case plan.UninstallModified:
-			if force {
+			if force && action.Ownership == "" {
 				return true
 			}
 		}
@@ -139,19 +144,27 @@ func willRemove(p plan.UninstallPlan, force bool) bool {
 // none so a clean plan reads without noise.
 func renderModifiedHint(w io.Writer, p plan.UninstallPlan, force bool) {
 	modified := 0
+	partial := 0
 	for _, action := range p.Actions {
 		if action.Status == plan.UninstallModified {
-			modified++
+			if action.Ownership == "" {
+				modified++
+			} else {
+				partial++
+			}
 		}
 	}
-	if modified == 0 {
+	if modified == 0 && partial == 0 {
 		return
 	}
-	if force {
+	if modified > 0 && force {
 		fmt.Fprintf(w, "\nNote: --force will remove %d modified target(s) whose content drifted from the recorded hash.\n", modified)
-		return
+	} else if modified > 0 {
+		fmt.Fprintf(w, "\nNote: %d modified target(s) will be skipped; re-run with --force to remove them.\n", modified)
 	}
-	fmt.Fprintf(w, "\nNote: %d modified target(s) will be skipped; re-run with --force to remove them.\n", modified)
+	if partial > 0 {
+		fmt.Fprintf(w, "\nNote: %d partially owned target(s) will be preserved because recorded owned content changed; --force never broadens partial ownership.\n", partial)
+	}
 }
 
 func confirmUninstall(r io.Reader, w io.Writer) (bool, error) {

--- a/internal/cli/uninstall_test.go
+++ b/internal/cli/uninstall_test.go
@@ -135,6 +135,56 @@ func TestUninstallYesRemovesOwnedTargetsAndPrunes(t *testing.T) {
 	}
 }
 
+func TestUninstallForcePreservesModifiedCopyFromLegacyMetadata(t *testing.T) {
+	e := newInstalledEnv(t)
+	// A global metadata upgrade must not retroactively mark an untouched legacy
+	// record as whole-owned; the per-record ownership field is the proof.
+	e.meta.Version = state.CurrentVersion
+	source := filepath.Join(e.sourceRoot, "configs", "shared.json")
+	if err := os.MkdirAll(filepath.Dir(source), 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	baseline := []byte(`{"owned":true}`)
+	if err := os.WriteFile(source, baseline, 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	hash := state.HashBytes(baseline)
+	target := filepath.Join(e.home, ".config", "shared.json")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	content := `{"owned":true,"external":"preserve"}`
+	if err := os.WriteFile(target, []byte(content), 0o640); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	e.meta.Entries = append(e.meta.Entries, state.Record{
+		Target: target, Source: "configs/shared.json", Strategy: "copy", Hash: hash,
+	})
+	e.save(t)
+
+	out, err := e.run(t, "", "--yes", "--force")
+	if err != nil {
+		t.Fatalf("uninstall legacy --force error = %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "legacy ownership evidence is insufficient") || !strings.Contains(out, "Nothing to remove") {
+		t.Fatalf("uninstall did not explain protected legacy target:\n%s", out)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read preserved target: %v", err)
+	}
+	if string(got) != content {
+		t.Fatalf("legacy --force changed target to %s", got)
+	}
+	meta, err := state.Load(state.Path(e.stateRoot))
+	if err != nil {
+		t.Fatalf("load metadata: %v", err)
+	}
+	if _, ok := meta.FindByTarget(target); !ok {
+		t.Fatal("legacy --force pruned ownership metadata")
+	}
+}
+
 func TestUninstallCancelLeavesTargetsUntouched(t *testing.T) {
 	e := newInstalledEnv(t)
 	target := e.installSymlink(t, "shell/zshrc", ".zshrc")

--- a/internal/configsubset/subset.go
+++ b/internal/configsubset/subset.go
@@ -36,6 +36,16 @@ type JSONFileRelation struct {
 	Mergeable bool
 }
 
+// JSONReconciliation describes a safe three-state update from a previously
+// recorded dots-owned contribution to the current Source of Truth. Compatible
+// is false when the live target changed a formerly owned value. Changed reports
+// whether applying Content would mutate the live target.
+type JSONReconciliation struct {
+	Content    []byte
+	Changed    bool
+	Compatible bool
+}
+
 // ComposeJSONFiles reads source-owned JSON fragments and composes them in
 // manifest order. Compatible object and array values are merged using the same
 // subset semantics as MergeJSONFile. The returned JSON is deterministic and
@@ -110,6 +120,64 @@ func MergeJSON(targetData, sourceData []byte) ([]byte, error) {
 		return nil, fmt.Errorf("encode merged JSON: %w", err)
 	}
 	return append(data, '\n'), nil
+}
+
+// ReconcileJSON compares the live target with the previously recorded and
+// current dots-owned JSON contributions. It adds new owned values, removes
+// retired values only while they remain unchanged, and preserves target-only
+// content. Invalid target JSON is incompatible; invalid owned content is an
+// error because both snapshots are dots-controlled evidence.
+func ReconcileJSON(targetData, previousData, currentData []byte) (JSONReconciliation, error) {
+	var targetValue, previousValue, currentValue any
+	if err := decodeJSON(previousData, &previousValue); err != nil {
+		return JSONReconciliation{}, fmt.Errorf("parse previous owned JSON: %w", err)
+	}
+	if err := decodeJSON(currentData, &currentValue); err != nil {
+		return JSONReconciliation{}, fmt.Errorf("parse current owned JSON: %w", err)
+	}
+	if err := decodeJSON(targetData, &targetValue); err != nil {
+		return JSONReconciliation{}, nil
+	}
+
+	result := reconcileJSONValue(targetValue, previousValue, currentValue)
+	if !result.compatible {
+		return JSONReconciliation{}, nil
+	}
+	data, err := json.MarshalIndent(result.value, "", "  ")
+	if err != nil {
+		return JSONReconciliation{}, fmt.Errorf("encode reconciled JSON: %w", err)
+	}
+	return JSONReconciliation{
+		Content:    append(data, '\n'),
+		Changed:    result.changed,
+		Compatible: true,
+	}, nil
+}
+
+// RemoveJSON subtracts a recorded dots-owned contribution from a live target.
+// It removes only values that still match the ownership evidence and preserves
+// target-only content. Empty reports whether no content remains in the root
+// container, allowing uninstall to remove the physical target safely.
+func RemoveJSON(targetData, ownedData []byte) (content []byte, changed, empty, compatible bool, err error) {
+	var targetValue, ownedValue any
+	if decodeErr := decodeJSON(ownedData, &ownedValue); decodeErr != nil {
+		err = fmt.Errorf("parse owned JSON: %w", decodeErr)
+		return
+	}
+	if decodeErr := decodeJSON(targetData, &targetValue); decodeErr != nil {
+		return nil, false, false, false, nil
+	}
+
+	result := subtractJSONValue(targetValue, ownedValue)
+	if !result.compatible {
+		return nil, false, false, false, nil
+	}
+	empty = jsonValueEmpty(result.value)
+	data, encodeErr := json.MarshalIndent(result.value, "", "  ")
+	if encodeErr != nil {
+		return nil, false, false, false, fmt.Errorf("encode JSON after removing owned content: %w", encodeErr)
+	}
+	return append(data, '\n'), result.changed, empty, true, nil
 }
 
 // AnalyzeJSONFiles compares target with source in one read and parse pass.
@@ -263,6 +331,199 @@ type jsonMergeResult struct {
 	value      any
 	changed    bool
 	compatible bool
+}
+
+func reconcileJSONValue(target, previous, current any) jsonMergeResult {
+	previousObject, previousIsObject := previous.(map[string]any)
+	currentObject, currentIsObject := current.(map[string]any)
+	if previousIsObject && currentIsObject {
+		targetObject, ok := target.(map[string]any)
+		if !ok {
+			return jsonMergeResult{value: target}
+		}
+		result := make(map[string]any, len(targetObject)+len(currentObject))
+		for key, value := range targetObject {
+			result[key] = value
+		}
+		changed := false
+		for key, previousChild := range previousObject {
+			targetChild, targetExists := targetObject[key]
+			currentChild, currentExists := currentObject[key]
+			if !currentExists {
+				if !targetExists {
+					continue
+				}
+				removed := subtractJSONValue(targetChild, previousChild)
+				if !removed.compatible {
+					return jsonMergeResult{value: target}
+				}
+				if jsonValueEmpty(removed.value) {
+					delete(result, key)
+					changed = true
+				} else {
+					result[key] = removed.value
+					changed = changed || removed.changed
+				}
+				continue
+			}
+			if !targetExists {
+				result[key] = currentChild
+				changed = true
+				continue
+			}
+			child := reconcileJSONValue(targetChild, previousChild, currentChild)
+			if !child.compatible {
+				return jsonMergeResult{value: target}
+			}
+			if child.changed {
+				result[key] = child.value
+				changed = true
+			}
+		}
+		for key, currentChild := range currentObject {
+			if _, existed := previousObject[key]; existed {
+				continue
+			}
+			targetChild, exists := targetObject[key]
+			if !exists {
+				result[key] = currentChild
+				changed = true
+				continue
+			}
+			merged := mergeJSONValue(targetChild, currentChild)
+			if !merged.compatible {
+				return jsonMergeResult{value: target}
+			}
+			if merged.changed {
+				result[key] = merged.value
+				changed = true
+			}
+		}
+		return jsonMergeResult{value: result, changed: changed, compatible: true}
+	}
+
+	previousArray, previousIsArray := previous.([]any)
+	currentArray, currentIsArray := current.([]any)
+	if previousIsArray && currentIsArray {
+		targetArray, ok := target.([]any)
+		if !ok {
+			return jsonMergeResult{value: target}
+		}
+		result := append([]any(nil), targetArray...)
+		changed := false
+		for _, previousItem := range multisetDifference(previousArray, currentArray) {
+			index := equalJSONIndex(result, previousItem)
+			if index < 0 {
+				return jsonMergeResult{value: target}
+			}
+			result = append(result[:index], result[index+1:]...)
+			changed = true
+		}
+		merged := mergeJSONValue(result, currentArray)
+		if !merged.compatible {
+			return jsonMergeResult{value: target}
+		}
+		return jsonMergeResult{value: merged.value, changed: changed || merged.changed, compatible: true}
+	}
+
+	if reflect.DeepEqual(previous, current) {
+		return jsonMergeResult{value: target, compatible: reflect.DeepEqual(target, current)}
+	}
+	if reflect.DeepEqual(target, current) {
+		return jsonMergeResult{value: target, compatible: true}
+	}
+	if reflect.DeepEqual(target, previous) {
+		return jsonMergeResult{value: current, changed: true, compatible: true}
+	}
+	return jsonMergeResult{value: target}
+}
+
+func subtractJSONValue(target, owned any) jsonMergeResult {
+	switch ownedTyped := owned.(type) {
+	case map[string]any:
+		targetTyped, ok := target.(map[string]any)
+		if !ok {
+			return jsonMergeResult{value: target}
+		}
+		result := make(map[string]any, len(targetTyped))
+		for key, value := range targetTyped {
+			result[key] = value
+		}
+		changed := false
+		for key, ownedChild := range ownedTyped {
+			targetChild, exists := targetTyped[key]
+			if !exists {
+				continue
+			}
+			removed := subtractJSONValue(targetChild, ownedChild)
+			if !removed.compatible {
+				return jsonMergeResult{value: target}
+			}
+			if jsonValueEmpty(removed.value) {
+				delete(result, key)
+				changed = true
+			} else {
+				result[key] = removed.value
+				changed = changed || removed.changed
+			}
+		}
+		return jsonMergeResult{value: result, changed: changed, compatible: true}
+	case []any:
+		targetTyped, ok := target.([]any)
+		if !ok {
+			return jsonMergeResult{value: target}
+		}
+		result := append([]any(nil), targetTyped...)
+		for _, ownedItem := range ownedTyped {
+			index := equalJSONIndex(result, ownedItem)
+			if index < 0 {
+				return jsonMergeResult{value: target}
+			}
+			result = append(result[:index], result[index+1:]...)
+		}
+		return jsonMergeResult{value: result, changed: len(ownedTyped) > 0, compatible: true}
+	default:
+		if !reflect.DeepEqual(target, owned) {
+			return jsonMergeResult{value: target}
+		}
+		return jsonMergeResult{changed: true, compatible: true}
+	}
+}
+
+func multisetDifference(left, right []any) []any {
+	remaining := append([]any(nil), right...)
+	var difference []any
+	for _, item := range left {
+		index := equalJSONIndex(remaining, item)
+		if index < 0 {
+			difference = append(difference, item)
+			continue
+		}
+		remaining = append(remaining[:index], remaining[index+1:]...)
+	}
+	return difference
+}
+
+func equalJSONIndex(values []any, want any) int {
+	for i, value := range values {
+		if reflect.DeepEqual(value, want) {
+			return i
+		}
+	}
+	return -1
+}
+
+func jsonValueEmpty(value any) bool {
+	switch typed := value.(type) {
+	case nil:
+		return true
+	case map[string]any:
+		return len(typed) == 0
+	case []any:
+		return len(typed) == 0
+	default:
+		return false
+	}
 }
 
 func mergeJSONValue(target, source any) jsonMergeResult {

--- a/internal/configsubset/subset.go
+++ b/internal/configsubset/subset.go
@@ -351,7 +351,7 @@ func reconcileJSONValue(target, previous, current any) jsonMergeResult {
 			currentChild, currentExists := currentObject[key]
 			if !currentExists {
 				if !targetExists {
-					continue
+					return jsonMergeResult{value: target}
 				}
 				removed := subtractJSONValue(targetChild, previousChild)
 				if !removed.compatible {
@@ -453,7 +453,7 @@ func subtractJSONValue(target, owned any) jsonMergeResult {
 		for key, ownedChild := range ownedTyped {
 			targetChild, exists := targetTyped[key]
 			if !exists {
-				continue
+				return jsonMergeResult{value: target}
 			}
 			removed := subtractJSONValue(targetChild, ownedChild)
 			if !removed.compatible {

--- a/internal/configsubset/subset_test.go
+++ b/internal/configsubset/subset_test.go
@@ -124,6 +124,101 @@ func TestAnalyzeAndMergeJSONContent(t *testing.T) {
 	}
 }
 
+func TestReconcileJSONAddsAndRemovesOwnedValuesWhilePreservingTargetOnlyContent(t *testing.T) {
+	target := []byte(`{"settings":{"keep":true,"retired":"old","external":"local"},"items":["old","external"]}`)
+	previous := []byte(`{"settings":{"keep":true,"retired":"old"},"items":["old"]}`)
+	current := []byte(`{"settings":{"keep":true,"added":"new"},"items":["new"]}`)
+
+	got, err := ReconcileJSON(target, previous, current)
+	if err != nil {
+		t.Fatalf("ReconcileJSON() error = %v", err)
+	}
+	if !got.Compatible || !got.Changed {
+		t.Fatalf("ReconcileJSON() = %#v, want compatible change", got)
+	}
+	want := `{
+  "items": [
+    "external",
+    "new"
+  ],
+  "settings": {
+    "added": "new",
+    "external": "local",
+    "keep": true
+  }
+}
+`
+	if string(got.Content) != want {
+		t.Fatalf("ReconcileJSON() content =\n%s\nwant:\n%s", got.Content, want)
+	}
+}
+
+func TestReconcileJSONRejectsChangedRetiredValue(t *testing.T) {
+	target := []byte(`{"settings":{"retired":"locally-changed","external":true}}`)
+	previous := []byte(`{"settings":{"retired":"old"}}`)
+	current := []byte(`{"settings":{}}`)
+
+	got, err := ReconcileJSON(target, previous, current)
+	if err != nil {
+		t.Fatalf("ReconcileJSON() error = %v", err)
+	}
+	if got.Compatible || got.Changed || got.Content != nil {
+		t.Fatalf("ReconcileJSON() = %#v, want incompatible without content", got)
+	}
+}
+
+func TestReconcileJSONRejectsMissingRetiredArrayItem(t *testing.T) {
+	target := []byte(`{"items":["locally-changed"]}`)
+	previous := []byte(`{"items":["old"]}`)
+	current := []byte(`{"items":[]}`)
+
+	got, err := ReconcileJSON(target, previous, current)
+	if err != nil {
+		t.Fatalf("ReconcileJSON() error = %v", err)
+	}
+	if got.Compatible {
+		t.Fatalf("ReconcileJSON() = %#v, want conservative array conflict", got)
+	}
+}
+
+func TestRemoveJSONSubtractsOnlyOwnedContribution(t *testing.T) {
+	target := []byte(`{"settings":{"owned":true,"external":"keep"},"items":["owned","external"]}`)
+	owned := []byte(`{"settings":{"owned":true},"items":["owned"]}`)
+
+	content, changed, empty, compatible, err := RemoveJSON(target, owned)
+	if err != nil {
+		t.Fatalf("RemoveJSON() error = %v", err)
+	}
+	if !compatible || !changed || empty {
+		t.Fatalf("RemoveJSON() = changed %t, empty %t, compatible %t", changed, empty, compatible)
+	}
+	want := `{
+  "items": [
+    "external"
+  ],
+  "settings": {
+    "external": "keep"
+  }
+}
+`
+	if string(content) != want {
+		t.Fatalf("RemoveJSON() content =\n%s\nwant:\n%s", content, want)
+	}
+}
+
+func TestRemoveJSONRejectsChangedOwnedValue(t *testing.T) {
+	target := []byte(`{"owned":"changed","external":true}`)
+	owned := []byte(`{"owned":"recorded"}`)
+
+	content, changed, empty, compatible, err := RemoveJSON(target, owned)
+	if err != nil {
+		t.Fatalf("RemoveJSON() error = %v", err)
+	}
+	if compatible || changed || empty || content != nil {
+		t.Fatalf("RemoveJSON() = content %s, changed %t, empty %t, compatible %t", content, changed, empty, compatible)
+	}
+}
+
 func TestMergeJSONFileAddsMissingValuesAndPreservesTargetState(t *testing.T) {
 	dir := t.TempDir()
 	source := filepath.Join(dir, "source.json")

--- a/internal/configsubset/subset_test.go
+++ b/internal/configsubset/subset_test.go
@@ -167,6 +167,20 @@ func TestReconcileJSONRejectsChangedRetiredValue(t *testing.T) {
 	}
 }
 
+func TestReconcileJSONRejectsMissingRetiredObjectKey(t *testing.T) {
+	target := []byte(`{"settings":{"external":true}}`)
+	previous := []byte(`{"settings":{"retired":"old"}}`)
+	current := []byte(`{"settings":{}}`)
+
+	got, err := ReconcileJSON(target, previous, current)
+	if err != nil {
+		t.Fatalf("ReconcileJSON() error = %v", err)
+	}
+	if got.Compatible || got.Changed || got.Content != nil {
+		t.Fatalf("ReconcileJSON() = %#v, want missing retired key to be incompatible", got)
+	}
+}
+
 func TestReconcileJSONRejectsMissingRetiredArrayItem(t *testing.T) {
 	target := []byte(`{"items":["locally-changed"]}`)
 	previous := []byte(`{"items":["old"]}`)
@@ -208,6 +222,19 @@ func TestRemoveJSONSubtractsOnlyOwnedContribution(t *testing.T) {
 
 func TestRemoveJSONRejectsChangedOwnedValue(t *testing.T) {
 	target := []byte(`{"owned":"changed","external":true}`)
+	owned := []byte(`{"owned":"recorded"}`)
+
+	content, changed, empty, compatible, err := RemoveJSON(target, owned)
+	if err != nil {
+		t.Fatalf("RemoveJSON() error = %v", err)
+	}
+	if compatible || changed || empty || content != nil {
+		t.Fatalf("RemoveJSON() = content %s, changed %t, empty %t, compatible %t", content, changed, empty, compatible)
+	}
+}
+
+func TestRemoveJSONRejectsMissingOwnedObjectKey(t *testing.T) {
+	target := []byte(`{"external":true}`)
 	owned := []byte(`{"owned":"recorded"}`)
 
 	content, changed, empty, compatible, err := RemoveJSON(target, owned)

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -92,9 +92,7 @@ func recordMetadata(p plan.Plan, resolvedSources [][]string, opts Options) error
 	if err != nil {
 		return err
 	}
-	if meta.Version < 2 {
-		meta.Version = 2
-	}
+	meta.Version = state.CurrentVersion
 	meta.Provenance = state.CaptureProvenance(opts.SourceRoot, version.Value)
 
 	now := time.Now().UTC().Format(time.RFC3339)
@@ -103,26 +101,38 @@ func recordMetadata(p plan.Plan, resolvedSources [][]string, opts Options) error
 			continue
 		}
 		hash := ""
+		var ownedContent []byte
 		if action.Strategy != "symlink" {
 			if len(action.Sources) > 0 {
 				hash = state.HashBytes(action.Content)
+				if action.Ownership == "json-subset" {
+					ownedContent = append([]byte(nil), action.Content...)
+				}
 			} else {
 				var err error
 				hash, err = state.HashFile(resolvedSources[i][0])
 				if err != nil {
 					return err
 				}
+				if action.Ownership == "json-subset" {
+					ownedContent, err = os.ReadFile(resolvedSources[i][0])
+					if err != nil {
+						return fmt.Errorf("read owned JSON contribution %s: %w", resolvedSources[i][0], err)
+					}
+				}
 			}
 		}
 		upsertRecord(&meta, state.Record{
-			Target:      action.Target,
-			Source:      action.Source,
-			Sources:     append([]string(nil), action.Sources...),
-			Strategy:    action.Strategy,
-			Hash:        hash,
-			InstalledAt: now,
-			Profiles:    append([]string(nil), p.Profiles...),
-			Tags:        append([]string(nil), p.Tags...),
+			Target:       action.Target,
+			Source:       action.Source,
+			Sources:      append([]string(nil), action.Sources...),
+			Strategy:     action.Strategy,
+			Ownership:    action.Ownership,
+			OwnedContent: ownedContent,
+			Hash:         hash,
+			InstalledAt:  now,
+			Profiles:     append([]string(nil), p.Profiles...),
+			Tags:         append([]string(nil), p.Tags...),
 		})
 	}
 
@@ -464,6 +474,20 @@ func applyUpdate(action plan.Action, source string, opts Options) error {
 	}
 	switch action.Ownership {
 	case "json-subset":
+		if len(action.PreviousContent) > 0 {
+			current := action.Content
+			if len(current) == 0 {
+				var err error
+				current, err = os.ReadFile(source)
+				if err != nil {
+					return fmt.Errorf("read current owned JSON %s: %w", source, err)
+				}
+			}
+			if err := reconcileJSONContentFile(action.Target, action.PreviousContent, current); err != nil {
+				return fmt.Errorf("reconcile JSON update for %s: %w", action.Target, err)
+			}
+			return nil
+		}
 		if len(action.Content) > 0 {
 			if err := mergeJSONContentFile(action.Target, action.Content); err != nil {
 				return fmt.Errorf("merge composed JSON update for %s: %w", action.Target, err)
@@ -637,4 +661,26 @@ func mergeJSONContentFile(target string, sourceData []byte) error {
 		return err
 	}
 	return os.WriteFile(target, merged, info.Mode().Perm())
+}
+
+func reconcileJSONContentFile(target string, previousData, currentData []byte) error {
+	targetData, err := os.ReadFile(target)
+	if err != nil {
+		return err
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		return err
+	}
+	reconciliation, err := configsubset.ReconcileJSON(targetData, previousData, currentData)
+	if err != nil {
+		return err
+	}
+	if !reconciliation.Compatible {
+		return fmt.Errorf("live target changed a previously owned JSON value")
+	}
+	if !reconciliation.Changed {
+		return nil
+	}
+	return os.WriteFile(target, reconciliation.Content, info.Mode().Perm())
 }

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -102,6 +102,10 @@ func recordMetadata(p plan.Plan, resolvedSources [][]string, opts Options) error
 		}
 		hash := ""
 		var ownedContent []byte
+		recordedOwnership := action.Ownership
+		if recordedOwnership == "" {
+			recordedOwnership = "whole"
+		}
 		if action.Strategy != "symlink" {
 			if len(action.Sources) > 0 {
 				hash = state.HashBytes(action.Content)
@@ -127,7 +131,7 @@ func recordMetadata(p plan.Plan, resolvedSources [][]string, opts Options) error
 			Source:       action.Source,
 			Sources:      append([]string(nil), action.Sources...),
 			Strategy:     action.Strategy,
-			Ownership:    action.Ownership,
+			Ownership:    recordedOwnership,
 			OwnedContent: ownedContent,
 			Hash:         hash,
 			InstalledAt:  now,

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -1,6 +1,7 @@
 package install_test
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -116,8 +117,8 @@ func TestApplyComposedJSONSubsetCreatesAndUpdatesOneSharedTarget(t *testing.T) {
 			break
 		}
 	}
-	if shared == nil || shared.Status != plan.UninstallModified {
-		t.Fatalf("shared uninstall action = %+v, want modified so target-only state is preserved by default", shared)
+	if shared == nil || shared.Status != plan.UninstallRemove || shared.Ownership != "json-subset" {
+		t.Fatalf("shared uninstall action = %+v, want partial removal that preserves target-only state", shared)
 	}
 }
 
@@ -631,6 +632,79 @@ func TestApplyStatusUpdateMergesJSONSubsetAndRecordsMetadata(t *testing.T) {
 	}
 	if len(backupMeta.Sets) != 1 {
 		t.Fatalf("backup sets = %d, want 1", len(backupMeta.Sets))
+	}
+}
+
+func TestApplyReconcilesRecordedJSONContributionAndPreservesExternalContent(t *testing.T) {
+	sourceRoot := t.TempDir()
+	home := t.TempDir()
+	stateRoot := filepath.Join(home, ".local", "state", "dots")
+	source := filepath.Join(sourceRoot, "configs", "shared.json")
+	if err := os.MkdirAll(filepath.Dir(source), 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	previous := []byte(`{"owned":{"keep":true,"retired":"old"},"items":["old"]}`)
+	current := []byte(`{"owned":{"keep":true,"added":"new"},"items":["new"]}`)
+	if err := os.WriteFile(source, current, 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	target := filepath.Join(home, ".config", "shared.json")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	if err := os.WriteFile(target, []byte(`{"owned":{"keep":true,"retired":"old","external":"preserve"},"items":["old","external"],"targetOnly":true}`), 0o640); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, Entries: []state.Record{{
+		Target: target, Source: "configs/shared.json", Strategy: "copy", Ownership: "json-subset", OwnedContent: previous,
+	}}}); err != nil {
+		t.Fatalf("save metadata: %v", err)
+	}
+	m := manifest.Manifest{
+		Version: 1, Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}},
+		Entries: []manifest.Entry{{Source: "configs/shared.json", Target: "~/.config/shared.json", Strategy: "copy", Ownership: "json-subset", Tags: []string{"core"}}},
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load metadata: %v", err)
+	}
+	p, err := plan.Build(m, plan.Options{Profile: "default", OS: "linux", SourceRoot: sourceRoot, Home: home, Metadata: meta})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if len(p.Actions) != 1 || p.Actions[0].Status != plan.StatusUpdate {
+		t.Fatalf("actions = %+v, want reversible update", p.Actions)
+	}
+	if err := install.Apply(p, install.Options{SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot}); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	for _, want := range []string{`"added": "new"`, `"external": "preserve"`, `"targetOnly": true`, `"external"`} {
+		if !strings.Contains(string(got), want) {
+			t.Fatalf("reconciled target missing %s:\n%s", want, got)
+		}
+	}
+	if strings.Contains(string(got), `"retired"`) || strings.Contains(string(got), `"old"`) {
+		t.Fatalf("reconciled target retained retired contribution:\n%s", got)
+	}
+	meta, err = state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("reload metadata: %v", err)
+	}
+	rec, ok := meta.FindByTarget(target)
+	if !ok || rec.Ownership != "json-subset" || !json.Valid(rec.OwnedContent) {
+		t.Fatalf("metadata record = %+v, want valid owned JSON evidence", rec)
+	}
+	if meta.Version != state.CurrentVersion {
+		t.Fatalf("metadata version = %d, want %d", meta.Version, state.CurrentVersion)
+	}
+	backupMeta, err := backups.Load(backups.Path(stateRoot))
+	if err != nil || len(backupMeta.Sets) != 1 {
+		t.Fatalf("Backup Sets = %+v, err = %v; want one", backupMeta.Sets, err)
 	}
 }
 

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -42,13 +42,16 @@ type Action struct {
 	ResolvedSources []string `json:"-"`
 	// Content is the conservatively composed baseline for a shared json-subset
 	// target. Apply writes or merges it once instead of mutating per contributor.
-	Content      []byte   `json:"-"`
-	Target       string   `json:"target"`
-	Strategy     string   `json:"strategy"`
-	Status       Status   `json:"status"`
-	Reason       string   `json:"reason,omitempty"`
-	MatchingTags []string `json:"matching_tags,omitempty"`
-	Ownership    string   `json:"-"`
+	Content []byte `json:"-"`
+	// PreviousContent is the last recorded dots-owned JSON contribution. It is
+	// used only to revalidate a reversible update at apply time.
+	PreviousContent []byte   `json:"-"`
+	Target          string   `json:"target"`
+	Strategy        string   `json:"strategy"`
+	Status          Status   `json:"status"`
+	Reason          string   `json:"reason,omitempty"`
+	MatchingTags    []string `json:"matching_tags,omitempty"`
+	Ownership       string   `json:"-"`
 }
 
 // Plan is the preview of changes the installer would apply for a Profile.
@@ -159,6 +162,9 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 			MatchingTags:   matchingTags,
 			Ownership:      entry.Ownership,
 		}
+		if rec, ok := opts.Metadata.FindByTarget(target); ok && rec.Ownership == "json-subset" && len(rec.OwnedContent) > 0 {
+			action.PreviousContent = append([]byte(nil), rec.OwnedContent...)
+		}
 		targetKey := filepath.Clean(target)
 		if index, ok := actionByTarget[targetKey]; ok {
 			existing := &plan.Actions[index]
@@ -180,6 +186,9 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 				return Plan{}, fmt.Errorf("compose shared target %s: %w", targetKey, err)
 			}
 			existing.Content = composed
+			if rec, ok := opts.Metadata.FindByTarget(existing.Target); ok && rec.Ownership == "json-subset" && len(rec.OwnedContent) > 0 {
+				existing.PreviousContent = append([]byte(nil), rec.OwnedContent...)
+			}
 			existing.Status, err = composedJSONStatus(*existing, opts.Metadata)
 			if err != nil {
 				return Plan{}, err
@@ -224,6 +233,19 @@ func composedJSONStatus(action Action, meta state.Metadata) (Status, error) {
 	}
 	if !trusted {
 		return StatusConflict, nil
+	}
+	if rec.Ownership == "json-subset" && len(rec.OwnedContent) > 0 {
+		reconciliation, err := configsubset.ReconcileJSON(targetData, rec.OwnedContent, action.Content)
+		if err != nil {
+			return "", fmt.Errorf("reconcile shared JSON target %s: %w", action.Target, err)
+		}
+		if !reconciliation.Compatible {
+			return StatusConflict, nil
+		}
+		if reconciliation.Changed {
+			return StatusUpdate, nil
+		}
+		return StatusUnchanged, nil
 	}
 	relation, err := configsubset.AnalyzeJSON(targetData, action.Content)
 	if err != nil {
@@ -518,6 +540,27 @@ func status(entry manifest.Entry, target, sourceAbs, sourceRoot, canonicalSource
 		if same, err := sameContent(target, sourceAbs); err != nil || !same {
 			if isSubsetOwned(entry.Ownership) && meta.MatchesEntry(target, entry.Source, entry.Strategy) {
 				if entry.Ownership == "json-subset" {
+					if rec, ok := meta.FindByTarget(target); ok && rec.Ownership == "json-subset" && len(rec.OwnedContent) > 0 {
+						targetData, readErr := os.ReadFile(target)
+						if readErr != nil {
+							return "", fmt.Errorf("read JSON target %s: %w", target, readErr)
+						}
+						currentData, readErr := os.ReadFile(sourceAbs)
+						if readErr != nil {
+							return "", fmt.Errorf("read source JSON %s: %w", sourceAbs, readErr)
+						}
+						reconciliation, reconcileErr := configsubset.ReconcileJSON(targetData, rec.OwnedContent, currentData)
+						if reconcileErr != nil {
+							return "", fmt.Errorf("reconcile JSON target %s: %w", target, reconcileErr)
+						}
+						if reconciliation.Compatible {
+							if reconciliation.Changed {
+								return StatusUpdate, nil
+							}
+							return StatusUnchanged, nil
+						}
+						return StatusConflict, nil
+					}
 					relation, relationErr := configsubset.AnalyzeJSONFiles(target, sourceAbs)
 					if relationErr != nil {
 						return "", relationErr

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -488,6 +488,16 @@ func TestBuildJSONSubsetUsesRecordedContributionForReversibleRemoval(t *testing.
 	if action.Status != plan.StatusConflict {
 		t.Fatalf("Status = %q, want conflict for changed retired value", action.Status)
 	}
+
+	if err := os.WriteFile(target, []byte(`{"owned":{"keep":true},"external":"preserve"}`), 0o600); err != nil {
+		t.Fatalf("rewrite target without retired key: %v", err)
+	}
+	action = buildOneWithMetadata(t, sourceRoot, home, manifest.Entry{
+		Source: "configs/shared.json", Target: "~/.config/shared.json", Strategy: "copy", Ownership: "json-subset", Tags: []string{"core"},
+	}, meta)
+	if action.Status != plan.StatusConflict {
+		t.Fatalf("Status = %q, want conflict for missing retired key", action.Status)
+	}
 }
 
 func TestBuildJSONSubsetLegacyMetadataDoesNotAuthorizeRemoval(t *testing.T) {

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -453,6 +453,64 @@ func TestBuildCopyJSONSubsetOwnership(t *testing.T) {
 	}
 }
 
+func TestBuildJSONSubsetUsesRecordedContributionForReversibleRemoval(t *testing.T) {
+	sourceRoot := t.TempDir()
+	home := t.TempDir()
+	writeSource(t, sourceRoot, "configs/shared.json", `{"owned":{"keep":true,"added":"new"}}`)
+	target := filepath.Join(home, ".config", "shared.json")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	if err := os.WriteFile(target, []byte(`{"owned":{"keep":true,"retired":"old"},"external":"preserve"}`), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	previous := []byte(`{"owned":{"keep":true,"retired":"old"}}`)
+	meta := state.Metadata{Entries: []state.Record{{
+		Target: target, Source: "configs/shared.json", Strategy: "copy", Ownership: "json-subset", OwnedContent: previous,
+	}}}
+
+	action := buildOneWithMetadata(t, sourceRoot, home, manifest.Entry{
+		Source: "configs/shared.json", Target: "~/.config/shared.json", Strategy: "copy", Ownership: "json-subset", Tags: []string{"core"},
+	}, meta)
+	if action.Status != plan.StatusUpdate {
+		t.Fatalf("Status = %q, want update", action.Status)
+	}
+	if !reflect.DeepEqual(action.PreviousContent, previous) {
+		t.Fatalf("PreviousContent = %s, want %s", action.PreviousContent, previous)
+	}
+
+	if err := os.WriteFile(target, []byte(`{"owned":{"keep":true,"retired":"locally-changed"},"external":"preserve"}`), 0o600); err != nil {
+		t.Fatalf("rewrite target: %v", err)
+	}
+	action = buildOneWithMetadata(t, sourceRoot, home, manifest.Entry{
+		Source: "configs/shared.json", Target: "~/.config/shared.json", Strategy: "copy", Ownership: "json-subset", Tags: []string{"core"},
+	}, meta)
+	if action.Status != plan.StatusConflict {
+		t.Fatalf("Status = %q, want conflict for changed retired value", action.Status)
+	}
+}
+
+func TestBuildJSONSubsetLegacyMetadataDoesNotAuthorizeRemoval(t *testing.T) {
+	sourceRoot := t.TempDir()
+	home := t.TempDir()
+	writeSource(t, sourceRoot, "configs/shared.json", `{"owned":{"keep":true}}`)
+	target := filepath.Join(home, ".config", "shared.json")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	if err := os.WriteFile(target, []byte(`{"owned":{"keep":true,"retired":"old"},"external":"preserve"}`), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	meta := state.Metadata{Version: 3, Entries: []state.Record{{Target: target, Source: "configs/shared.json", Strategy: "copy"}}}
+
+	action := buildOneWithMetadata(t, sourceRoot, home, manifest.Entry{
+		Source: "configs/shared.json", Target: "~/.config/shared.json", Strategy: "copy", Ownership: "json-subset", Tags: []string{"core"},
+	}, meta)
+	if action.Status != plan.StatusUnchanged || len(action.PreviousContent) != 0 {
+		t.Fatalf("action = %+v, want unchanged without removal evidence", action)
+	}
+}
+
 func TestBuildCopyTOMLSubsetOwnership(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/plan/uninstall.go
+++ b/internal/plan/uninstall.go
@@ -22,8 +22,8 @@ const (
 	// UninstallSkip means there is nothing to remove: a copied target that is
 	// already absent.
 	UninstallSkip UninstallStatus = "skip"
-	// UninstallModified means a copied target's content drifted from the recorded
-	// hash, so it is preserved unless the caller forces removal.
+	// UninstallModified means recorded content drifted. Only explicitly
+	// whole-owned targets may become removable when the caller forces removal.
 	UninstallModified UninstallStatus = "modified"
 	// UninstallNotOwned means the target no longer matches what dots recorded (a
 	// symlink that is missing or points elsewhere, or a path whose type changed),
@@ -51,7 +51,7 @@ type UninstallPlan struct {
 // would delete: an owned target, or a drifted copy that --force would remove.
 func (p UninstallPlan) Removable() bool {
 	for _, a := range p.Actions {
-		if a.Status == UninstallRemove || a.Status == UninstallModified {
+		if a.Status == UninstallRemove || (a.Status == UninstallModified && a.ForceRemovable) {
 			return true
 		}
 	}

--- a/internal/plan/uninstall.go
+++ b/internal/plan/uninstall.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/yersonargotev/dots/internal/configsubset"
 	"github.com/yersonargotev/dots/internal/state"
 )
 
@@ -32,11 +33,12 @@ const (
 
 // UninstallAction is a single planned removal for a recorded Managed Entry.
 type UninstallAction struct {
-	Target   string          `json:"target"`
-	Source   string          `json:"source"`
-	Sources  []string        `json:"sources,omitempty"`
-	Strategy string          `json:"strategy"`
-	Status   UninstallStatus `json:"status"`
+	Target    string          `json:"target"`
+	Source    string          `json:"source"`
+	Sources   []string        `json:"sources,omitempty"`
+	Strategy  string          `json:"strategy"`
+	Ownership string          `json:"ownership,omitempty"`
+	Status    UninstallStatus `json:"status"`
 }
 
 // UninstallPlan is the preview of removals an uninstall would apply.
@@ -86,10 +88,11 @@ func BuildUninstall(meta state.Metadata, opts UninstallOptions) (UninstallPlan, 
 			return UninstallPlan{}, err
 		}
 		plan.Actions = append(plan.Actions, UninstallAction{
-			Target:   rec.Target,
-			Source:   rec.Source,
-			Strategy: rec.Strategy,
-			Status:   status,
+			Target:    rec.Target,
+			Source:    rec.Source,
+			Strategy:  rec.Strategy,
+			Ownership: rec.Ownership,
+			Status:    status,
 		})
 		if len(rec.Sources) > 0 {
 			plan.Actions[len(plan.Actions)-1].Sources = rec.SourceList()
@@ -144,6 +147,20 @@ func uninstallStatus(rec state.Record, sourceRoot, home string) (UninstallStatus
 	case "copy":
 		if !info.Mode().IsRegular() {
 			return UninstallNotOwned, nil
+		}
+		if rec.Ownership == "json-subset" && len(rec.OwnedContent) > 0 {
+			targetData, err := os.ReadFile(rec.Target)
+			if err != nil {
+				return "", fmt.Errorf("read uninstall target %s: %w", rec.Target, err)
+			}
+			_, _, _, compatible, err := configsubset.RemoveJSON(targetData, rec.OwnedContent)
+			if err != nil {
+				return "", fmt.Errorf("analyze owned JSON for %s: %w", rec.Target, err)
+			}
+			if compatible {
+				return UninstallRemove, nil
+			}
+			return UninstallModified, nil
 		}
 		hash, err := state.HashFile(rec.Target)
 		if err != nil {

--- a/internal/plan/uninstall.go
+++ b/internal/plan/uninstall.go
@@ -33,12 +33,13 @@ const (
 
 // UninstallAction is a single planned removal for a recorded Managed Entry.
 type UninstallAction struct {
-	Target    string          `json:"target"`
-	Source    string          `json:"source"`
-	Sources   []string        `json:"sources,omitempty"`
-	Strategy  string          `json:"strategy"`
-	Ownership string          `json:"ownership,omitempty"`
-	Status    UninstallStatus `json:"status"`
+	Target         string          `json:"target"`
+	Source         string          `json:"source"`
+	Sources        []string        `json:"sources,omitempty"`
+	Strategy       string          `json:"strategy"`
+	Ownership      string          `json:"ownership,omitempty"`
+	ForceRemovable bool            `json:"-"`
+	Status         UninstallStatus `json:"status"`
 }
 
 // UninstallPlan is the preview of removals an uninstall would apply.
@@ -94,6 +95,7 @@ func BuildUninstall(meta state.Metadata, opts UninstallOptions) (UninstallPlan, 
 			Ownership: rec.Ownership,
 			Status:    status,
 		})
+		plan.Actions[len(plan.Actions)-1].ForceRemovable = rec.Ownership == "whole"
 		if len(rec.Sources) > 0 {
 			plan.Actions[len(plan.Actions)-1].Sources = rec.SourceList()
 		}

--- a/internal/plan/uninstall_test.go
+++ b/internal/plan/uninstall_test.go
@@ -67,6 +67,29 @@ func TestBuildUninstallClassifiesChangedPartialJSONAsModified(t *testing.T) {
 	if len(p.Actions) != 1 || p.Actions[0].Status != plan.UninstallModified {
 		t.Fatalf("action = %+v, want modified partial ownership", p.Actions)
 	}
+	if p.Removable() {
+		t.Fatal("Removable() = true, want false for modified partial ownership")
+	}
+}
+
+func TestUninstallPlanRemovableRequiresExplicitWholeOwnershipForModifiedTarget(t *testing.T) {
+	tests := []struct {
+		name string
+		plan plan.UninstallPlan
+		want bool
+	}{
+		{name: "owned remove", plan: plan.UninstallPlan{Actions: []plan.UninstallAction{{Status: plan.UninstallRemove}}}, want: true},
+		{name: "whole modified", plan: plan.UninstallPlan{Actions: []plan.UninstallAction{{Status: plan.UninstallModified, ForceRemovable: true}}}, want: true},
+		{name: "legacy modified", plan: plan.UninstallPlan{Actions: []plan.UninstallAction{{Status: plan.UninstallModified}}}, want: false},
+		{name: "partial modified", plan: plan.UninstallPlan{Actions: []plan.UninstallAction{{Status: plan.UninstallModified, Ownership: "json-subset"}}}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.plan.Removable(); got != tt.want {
+				t.Fatalf("Removable() = %t, want %t", got, tt.want)
+			}
+		})
+	}
 }
 
 func TestValidateBackupableTargetAcceptsFileDirAndSymlink(t *testing.T) {

--- a/internal/plan/uninstall_test.go
+++ b/internal/plan/uninstall_test.go
@@ -35,6 +35,40 @@ func TestBuildUninstallPlansOneRemovalForCompositeTarget(t *testing.T) {
 	}
 }
 
+func TestBuildUninstallPlansPartialJSONRemovalFromRecordedContribution(t *testing.T) {
+	f := newUninstallFixture(t)
+	target := f.target(".config/shared.json")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	if err := os.WriteFile(target, []byte(`{"owned":true,"external":"keep"}`), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	p := f.build(t, state.Record{
+		Target: target, Source: "configs/shared.json", Strategy: "copy", Ownership: "json-subset", OwnedContent: []byte(`{"owned":true}`),
+	})
+	if len(p.Actions) != 1 || p.Actions[0].Status != plan.UninstallRemove || p.Actions[0].Ownership != "json-subset" {
+		t.Fatalf("action = %+v, want safe partial remove", p.Actions)
+	}
+}
+
+func TestBuildUninstallClassifiesChangedPartialJSONAsModified(t *testing.T) {
+	f := newUninstallFixture(t)
+	target := f.target(".config/shared.json")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	if err := os.WriteFile(target, []byte(`{"owned":"locally-changed","external":true}`), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	p := f.build(t, state.Record{
+		Target: target, Source: "configs/shared.json", Strategy: "copy", Ownership: "json-subset", OwnedContent: []byte(`{"owned":"recorded"}`),
+	})
+	if len(p.Actions) != 1 || p.Actions[0].Status != plan.UninstallModified {
+		t.Fatalf("action = %+v, want modified partial ownership", p.Actions)
+	}
+}
+
 func TestValidateBackupableTargetAcceptsFileDirAndSymlink(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -51,9 +51,11 @@ func (p Provenance) Empty() bool {
 	return p.SourceRoot == "" && p.SourceRevision == "" && p.DotsVersion == "" && p.RecordedAt == ""
 }
 
-// Record describes a single managed target the CLI installed. Copy-like
-// strategies may record a source content hash; symlink records leave Hash empty
-// because drift is detected from the link destination.
+// Record describes a single managed target the CLI installed. Version 4 records
+// explicit whole or partial Ownership; an empty value is legacy and grants no
+// force-removal authority. Copy-like strategies may record a source content
+// hash; symlink records leave Hash empty because drift is detected from the link
+// destination.
 type Record struct {
 	Target       string          `json:"target"`
 	Source       string          `json:"source"`

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -18,7 +18,7 @@ import (
 )
 
 // CurrentVersion is the current Installation Metadata schema version.
-const CurrentVersion = 3
+const CurrentVersion = 4
 
 // Metadata is the machine-readable record of installed managed targets.
 type Metadata struct {
@@ -55,14 +55,16 @@ func (p Provenance) Empty() bool {
 // strategies may record a source content hash; symlink records leave Hash empty
 // because drift is detected from the link destination.
 type Record struct {
-	Target      string   `json:"target"`
-	Source      string   `json:"source"`
-	Sources     []string `json:"sources,omitempty"`
-	Strategy    string   `json:"strategy"`
-	Hash        string   `json:"hash"`
-	InstalledAt string   `json:"installedAt"`
-	Profiles    []string `json:"profiles,omitempty"`
-	Tags        []string `json:"tags,omitempty"`
+	Target       string          `json:"target"`
+	Source       string          `json:"source"`
+	Sources      []string        `json:"sources,omitempty"`
+	Strategy     string          `json:"strategy"`
+	Ownership    string          `json:"ownership,omitempty"`
+	OwnedContent json.RawMessage `json:"owned_content,omitempty"`
+	Hash         string          `json:"hash"`
+	InstalledAt  string          `json:"installedAt"`
+	Profiles     []string        `json:"profiles,omitempty"`
+	Tags         []string        `json:"tags,omitempty"`
 }
 
 // SourceList returns every Source of Truth contribution for the managed target.

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,6 +1,7 @@
 package state_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -94,6 +95,56 @@ func TestSaveThenLoadRoundTripsInstalledSelectionV3(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("Load() metadata = %+v, want %+v", got, want)
+	}
+}
+
+func TestSaveThenLoadRoundTripsOwnedJSONContributionV4(t *testing.T) {
+	path := state.Path(t.TempDir())
+	want := state.Metadata{
+		Version: state.CurrentVersion,
+		Entries: []state.Record{{
+			Target:       "/home/user/.config/shared.json",
+			Source:       "configs/shared.json",
+			Strategy:     "copy",
+			Ownership:    "json-subset",
+			OwnedContent: []byte(`{"owned":true}`),
+		}},
+	}
+
+	if err := state.Save(path, want); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	got, err := state.Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if got.Version != want.Version || len(got.Entries) != 1 || got.Entries[0].Ownership != "json-subset" {
+		t.Fatalf("Load() metadata = %+v, want v4 owned JSON record", got)
+	}
+	var gotOwned, wantOwned any
+	if err := json.Unmarshal(got.Entries[0].OwnedContent, &gotOwned); err != nil {
+		t.Fatalf("decode loaded owned content: %v", err)
+	}
+	if err := json.Unmarshal(want.Entries[0].OwnedContent, &wantOwned); err != nil {
+		t.Fatalf("decode wanted owned content: %v", err)
+	}
+	if !reflect.DeepEqual(gotOwned, wantOwned) {
+		t.Fatalf("owned content = %v, want %v", gotOwned, wantOwned)
+	}
+}
+
+func TestLoadLegacyRecordDoesNotGainPartialOwnershipEvidence(t *testing.T) {
+	path := state.Path(t.TempDir())
+	data := `{"version":3,"entries":[{"target":"/home/user/.config/shared.json","source":"configs/shared.json","strategy":"copy","hash":"abc","installedAt":"now"}]}`
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatalf("write legacy metadata: %v", err)
+	}
+	got, err := state.Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(got.Entries) != 1 || got.Entries[0].Ownership != "" || len(got.Entries[0].OwnedContent) != 0 {
+		t.Fatalf("Load() legacy record = %+v, want no partial ownership evidence", got.Entries)
 	}
 }
 

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -159,6 +159,12 @@ func selectedJSONContributions(m manifest.Manifest, tags []string, opts Options)
 		if err != nil {
 			return nil, nil, err
 		}
+		if err := plan.ValidateResolvedTarget(target, opts.Home); err != nil {
+			return nil, nil, err
+		}
+		if err := plan.ValidateTargetParentInsideHome(target, opts.Home); err != nil {
+			return nil, nil, err
+		}
 		if _, err := os.Lstat(target); os.IsNotExist(err) {
 			continue
 		}

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -96,6 +96,10 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options) (Report, erro
 		resolved = &selection
 	}
 	tags := resolved.Tags
+	jsonContentByTarget, jsonSourcesByTarget, err := selectedJSONContributions(m, tags, opts)
+	if err != nil {
+		return Report{}, err
+	}
 
 	report := Report{Profile: resolved.Profile, Profiles: resolved.Profiles, Tags: resolved.Tags}
 	for _, entry := range m.Entries {
@@ -122,7 +126,7 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options) (Report, erro
 		}
 
 		entry.Source = source
-		st, err := evaluate(entry, target, meta, opts.SourceRoot, defaultSource)
+		st, err := evaluate(entry, target, meta, opts.SourceRoot, defaultSource, jsonContentByTarget[target], jsonSourcesByTarget[target])
 		if err != nil {
 			return Report{}, err
 		}
@@ -143,7 +147,44 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options) (Report, erro
 	return report, nil
 }
 
-func evaluate(entry manifest.Entry, target string, meta state.Metadata, sourceRoot string, defaultSource string) (State, error) {
+func selectedJSONContributions(m manifest.Manifest, tags []string, opts Options) (map[string][]byte, map[string][]string, error) {
+	pathsByTarget := map[string][]string{}
+	sourcesByTarget := map[string][]string{}
+	for _, entry := range m.Entries {
+		if entry.Strategy != "copy" || entry.Ownership != "json-subset" || !manifest.SharesTag(entry.Tags, tags) || !manifest.MatchesOS(entry.OS, opts.OS) {
+			continue
+		}
+		source := manifest.EntrySource(entry, tags)
+		target, err := plan.ResolveTarget(entry.Target, opts.Home)
+		if err != nil {
+			return nil, nil, err
+		}
+		if _, err := os.Lstat(target); os.IsNotExist(err) {
+			continue
+		}
+		sourcePath, err := plan.ResolveSource(source, opts.SourceRoot)
+		if err != nil {
+			return nil, nil, err
+		}
+		if err := plan.ValidateResolvedSource(sourcePath, opts.SourceRoot); err != nil {
+			return nil, nil, err
+		}
+		pathsByTarget[target] = append(pathsByTarget[target], sourcePath)
+		sourcesByTarget[target] = append(sourcesByTarget[target], source)
+	}
+
+	contentByTarget := make(map[string][]byte, len(pathsByTarget))
+	for target, paths := range pathsByTarget {
+		content, err := configsubset.ComposeJSONFiles(paths)
+		if err != nil {
+			return nil, nil, fmt.Errorf("compose JSON ownership for %s: %w", target, err)
+		}
+		contentByTarget[target] = content
+	}
+	return contentByTarget, sourcesByTarget, nil
+}
+
+func evaluate(entry manifest.Entry, target string, meta state.Metadata, sourceRoot string, defaultSource string, currentJSON []byte, currentSources []string) (State, error) {
 	if _, err := os.Lstat(target); err != nil {
 		if os.IsNotExist(err) {
 			return StateMissing, nil
@@ -165,13 +206,80 @@ func evaluate(entry manifest.Entry, target string, meta state.Metadata, sourceRo
 	if err := plan.ValidateResolvedSource(sourceAbs, sourceRoot); err != nil {
 		return "", err
 	}
-
 	aligned, err := matchesSource(entry.Strategy, target, sourceAbs)
 	if err != nil {
 		return "", err
 	}
 	if aligned {
 		return StateOK, nil
+	}
+	if entry.Ownership == "json-subset" && len(currentJSON) > 0 {
+		info, err := os.Lstat(target)
+		if err != nil {
+			return "", fmt.Errorf("stat target %s: %w", target, err)
+		}
+		if !info.Mode().IsRegular() {
+			if trustedJSONRecord(meta, target, entry.Strategy, currentSources) {
+				return StateDrifted, nil
+			}
+			return StateConflict, nil
+		}
+		targetData, err := os.ReadFile(target)
+		if err != nil {
+			return "", fmt.Errorf("read JSON target %s: %w", target, err)
+		}
+		if bytes.Equal(targetData, currentJSON) {
+			return StateOK, nil
+		}
+		rec, recorded := meta.FindByTarget(target)
+		if trustedJSONRecord(meta, target, entry.Strategy, currentSources) {
+			if rec.Ownership == "json-subset" && len(rec.OwnedContent) > 0 {
+				reconciliation, err := configsubset.ReconcileJSON(targetData, rec.OwnedContent, currentJSON)
+				if err != nil {
+					return "", fmt.Errorf("reconcile JSON target %s: %w", target, err)
+				}
+				if reconciliation.Compatible && !reconciliation.Changed {
+					return StateOK, nil
+				}
+				overall, err := configsubset.AnalyzeJSON(targetData, currentJSON)
+				if err != nil {
+					return "", fmt.Errorf("analyze current JSON ownership for %s: %w", target, err)
+				}
+				if overall.Contains {
+					if len(currentSources) > 0 && entry.Source != currentSources[0] {
+						return StateOK, nil
+					}
+					return StateDrifted, nil
+				}
+				entryRelation, err := configsubset.AnalyzeJSONFiles(target, sourceAbs)
+				if err != nil {
+					return "", err
+				}
+				if entryRelation.Contains {
+					return StateOK, nil
+				}
+				return StateDrifted, nil
+			}
+			relation, err := configsubset.AnalyzeJSON(targetData, currentJSON)
+			if err != nil {
+				return "", fmt.Errorf("analyze JSON target %s: %w", target, err)
+			}
+			if relation.Contains {
+				return StateOK, nil
+			}
+			entryRelation, err := configsubset.AnalyzeJSONFiles(target, sourceAbs)
+			if err != nil {
+				return "", err
+			}
+			if entryRelation.Contains {
+				return StateOK, nil
+			}
+			return StateDrifted, nil
+		}
+		if recorded && rec.Strategy == entry.Strategy {
+			return StateDrifted, nil
+		}
+		return StateConflict, nil
 	}
 
 	if isSubsetOwned(entry.Ownership) && meta.MatchesEntry(target, entry.Source, entry.Strategy) {
@@ -194,6 +302,23 @@ func evaluate(entry manifest.Entry, target string, meta state.Metadata, sourceRo
 		return StateDrifted, nil
 	}
 	return StateConflict, nil
+}
+
+func trustedJSONRecord(meta state.Metadata, target, strategy string, currentSources []string) bool {
+	rec, ok := meta.FindByTarget(target)
+	if !ok || rec.Strategy != strategy || len(rec.SourceList()) == 0 {
+		return false
+	}
+	selected := make(map[string]struct{}, len(currentSources))
+	for _, source := range currentSources {
+		selected[source] = struct{}{}
+	}
+	for _, source := range rec.SourceList() {
+		if _, ok := selected[source]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func targetContainsCompatibleRecordedSource(entry manifest.Entry, target, sourceRoot string, meta state.Metadata, defaultSource string) bool {

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -565,6 +565,27 @@ func TestBuildRejectsTargetParentSymlinkEscapeBeforeReadingTarget(t *testing.T) 
 	}
 }
 
+func TestBuildRejectsJSONSubsetParentSymlinkEscapeBeforeCollectingContributions(t *testing.T) {
+	f := newFixture(manifest.Entry{Source: "configs/shared.json", Target: "~/.config/shared.json", Strategy: "copy", Ownership: "json-subset", Tags: []string{"core"}})
+	f.sourceRoot = t.TempDir()
+	f.home = t.TempDir()
+	outsideHome := t.TempDir()
+	writeSource(t, f.sourceRoot, "configs/shared.json", `{"owned":true}`)
+	if err := os.Symlink(outsideHome, filepath.Join(f.home, ".config")); err != nil {
+		t.Fatalf("symlink escaped target parent: %v", err)
+	}
+
+	_, err := status.Build(f.manifest, state.Metadata{}, status.Options{
+		Profile:    "default",
+		OS:         "linux",
+		SourceRoot: f.sourceRoot,
+		Home:       f.home,
+	})
+	if err == nil {
+		t.Fatal("Build() error = nil, want JSON contribution target parent symlink escape error")
+	}
+}
+
 func TestBuildRejectsSourceSymlinkEscape(t *testing.T) {
 	f := newFixture(manifest.Entry{Source: "configs/secret", Target: "~/.secret", Strategy: "copy", Tags: []string{"core"}})
 	f.sourceRoot = t.TempDir()

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -263,6 +263,29 @@ func TestBuildReportsDriftedForChangedDotsOwnedClaudeSettingsValues(t *testing.T
 	}
 }
 
+func TestBuildReportsDriftedWhenRecordedJSONContributionNeedsRetirement(t *testing.T) {
+	f := newFixture(manifest.Entry{
+		Source: "configs/shared.json", Target: "~/.config/shared.json", Strategy: "copy", Ownership: "json-subset", Tags: []string{"core"},
+	})
+	f.sourceRoot = t.TempDir()
+	f.home = t.TempDir()
+	writeSource(t, f.sourceRoot, "configs/shared.json", `{"owned":{"keep":true}}`)
+	target := filepath.Join(f.home, ".config", "shared.json")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	if err := os.WriteFile(target, []byte(`{"owned":{"keep":true,"retired":"old"},"external":true}`), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	meta := state.Metadata{Entries: []state.Record{{
+		Target: target, Source: "configs/shared.json", Strategy: "copy", Ownership: "json-subset", OwnedContent: []byte(`{"owned":{"keep":true,"retired":"old"}}`),
+	}}}
+
+	if got := onlyEntry(t, f.build(t, meta)).State; got != status.StateDrifted {
+		t.Fatalf("state = %q, want drifted until retired owned value is reconciled", got)
+	}
+}
+
 func TestBuildReportsConflictForClaudeSettingsSubsetWithoutInstallMetadata(t *testing.T) {
 	f := newFixture(manifest.Entry{
 		Source:    "configs/claude/settings.json",

--- a/internal/uninstall/uninstall.go
+++ b/internal/uninstall/uninstall.go
@@ -189,7 +189,7 @@ func stillRemovable(rec state.Record, sourceRoot, home string, force bool) (bool
 	case plan.UninstallRemove:
 		return true, nil
 	case plan.UninstallModified:
-		if rec.Ownership != "" {
+		if rec.Ownership != "whole" {
 			return false, nil
 		}
 		return force, nil

--- a/internal/uninstall/uninstall.go
+++ b/internal/uninstall/uninstall.go
@@ -139,7 +139,7 @@ func removeOwnedJSON(rec state.Record, home string) (applied, deleted bool, err 
 	}
 	leaf, err := os.Lstat(rec.Target)
 	if os.IsNotExist(err) {
-		return true, true, nil
+		return false, false, nil
 	}
 	if err != nil {
 		return false, false, fmt.Errorf("stat owned JSON target %s: %w", rec.Target, err)

--- a/internal/uninstall/uninstall.go
+++ b/internal/uninstall/uninstall.go
@@ -128,6 +128,15 @@ func Apply(p plan.UninstallPlan, opts Options) (Result, error) {
 // time. It preserves the physical target when external content remains and
 // reports false without mutation when any formerly owned value changed.
 func removeOwnedJSON(rec state.Record, home string) (applied, deleted bool, err error) {
+	if err := plan.ValidateResolvedTarget(rec.Target, home); err != nil {
+		return false, false, err
+	}
+	if err := plan.ValidateTargetParentInsideHome(rec.Target, home); err != nil {
+		return false, false, err
+	}
+	if err := plan.ValidateFilePathInsideHomeNoSymlinkEscape(rec.Target, home, "owned JSON target"); err != nil {
+		return false, false, err
+	}
 	leaf, err := os.Lstat(rec.Target)
 	if os.IsNotExist(err) {
 		return true, true, nil
@@ -137,12 +146,6 @@ func removeOwnedJSON(rec state.Record, home string) (applied, deleted bool, err 
 	}
 	if !leaf.Mode().IsRegular() {
 		return false, false, nil
-	}
-	if err := validateRemovableTarget(rec.Target, home); err != nil {
-		return false, false, err
-	}
-	if err := plan.ValidateFilePathInsideHomeNoSymlinkEscape(rec.Target, home, "owned JSON target"); err != nil {
-		return false, false, err
 	}
 	targetData, err := os.ReadFile(rec.Target)
 	if err != nil {

--- a/internal/uninstall/uninstall.go
+++ b/internal/uninstall/uninstall.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 
 	"github.com/yersonargotev/dots/internal/backups"
+	"github.com/yersonargotev/dots/internal/configsubset"
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/state"
 )
@@ -34,6 +35,9 @@ type Options struct {
 type Result struct {
 	// Removed lists the targets successfully deleted, in plan order.
 	Removed []string `json:"removed"`
+	// Updated lists co-owned targets that remained after dots removed or pruned
+	// its recorded contribution.
+	Updated []string `json:"updated,omitempty"`
 	// RestoredSets lists the IDs of Backup Sets restored when RestoreBackups is
 	// set, each restored at most once even if it covers several removed targets.
 	RestoredSets []string `json:"restored_sets"`
@@ -46,6 +50,7 @@ type Result struct {
 // was removed, and the metadata file is deleted once empty.
 func Apply(p plan.UninstallPlan, opts Options) (Result, error) {
 	var result Result
+	var restorableRemoved []string
 
 	home, err := cleanAbs(opts.Home)
 	if err != nil {
@@ -72,6 +77,21 @@ func Apply(p plan.UninstallPlan, opts Options) (Result, error) {
 			// The plan references a target dots no longer records; never act on it.
 			continue
 		}
+		if rec.Ownership == "json-subset" && len(rec.OwnedContent) > 0 {
+			if action.Status != plan.UninstallRemove {
+				continue
+			}
+			applied, deleted, err := removeOwnedJSON(rec, home)
+			if err != nil {
+				return result, err
+			}
+			if applied && deleted {
+				result.Removed = append(result.Removed, action.Target)
+			} else if applied {
+				result.Updated = append(result.Updated, action.Target)
+			}
+			continue
+		}
 		remove, err := stillRemovable(rec, opts.SourceRoot, home, opts.Force)
 		if err != nil {
 			return result, err
@@ -87,19 +107,71 @@ func Apply(p plan.UninstallPlan, opts Options) (Result, error) {
 			return result, fmt.Errorf("remove %s: %w", action.Target, err)
 		}
 		result.Removed = append(result.Removed, action.Target)
+		restorableRemoved = append(restorableRemoved, action.Target)
 	}
 
 	if opts.RestoreBackups {
-		if err := restoreBackups(&result, opts, home); err != nil {
+		if err := restoreBackups(&result, restorableRemoved, opts, home); err != nil {
 			return result, err
 		}
 	}
 
-	if err := pruneMetadata(opts.StateRoot, meta, result.Removed); err != nil {
+	prunedTargets := append(append([]string(nil), result.Removed...), result.Updated...)
+	if err := pruneMetadata(opts.StateRoot, meta, prunedTargets); err != nil {
 		return result, err
 	}
 
 	return result, nil
+}
+
+// removeOwnedJSON revalidates and subtracts a partial contribution at apply
+// time. It preserves the physical target when external content remains and
+// reports false without mutation when any formerly owned value changed.
+func removeOwnedJSON(rec state.Record, home string) (applied, deleted bool, err error) {
+	leaf, err := os.Lstat(rec.Target)
+	if os.IsNotExist(err) {
+		return true, true, nil
+	}
+	if err != nil {
+		return false, false, fmt.Errorf("stat owned JSON target %s: %w", rec.Target, err)
+	}
+	if !leaf.Mode().IsRegular() {
+		return false, false, nil
+	}
+	if err := validateRemovableTarget(rec.Target, home); err != nil {
+		return false, false, err
+	}
+	if err := plan.ValidateFilePathInsideHomeNoSymlinkEscape(rec.Target, home, "owned JSON target"); err != nil {
+		return false, false, err
+	}
+	targetData, err := os.ReadFile(rec.Target)
+	if err != nil {
+		return false, false, fmt.Errorf("read owned JSON target %s: %w", rec.Target, err)
+	}
+	info, err := os.Stat(rec.Target)
+	if err != nil {
+		return false, false, fmt.Errorf("stat owned JSON target %s: %w", rec.Target, err)
+	}
+	content, changed, empty, compatible, err := configsubset.RemoveJSON(targetData, rec.OwnedContent)
+	if err != nil {
+		return false, false, fmt.Errorf("remove owned JSON from %s: %w", rec.Target, err)
+	}
+	if !compatible {
+		return false, false, nil
+	}
+	if empty {
+		if err := removeTarget(rec.Target); err != nil {
+			return false, false, fmt.Errorf("remove emptied JSON target %s: %w", rec.Target, err)
+		}
+		return true, true, nil
+	}
+	if !changed {
+		return true, false, nil
+	}
+	if err := os.WriteFile(rec.Target, content, info.Mode().Perm()); err != nil {
+		return false, false, fmt.Errorf("write JSON target %s after removing owned content: %w", rec.Target, err)
+	}
+	return true, false, nil
 }
 
 // stillRemovable re-derives the record's status from current disk state using the
@@ -117,6 +189,9 @@ func stillRemovable(rec state.Record, sourceRoot, home string, force bool) (bool
 	case plan.UninstallRemove:
 		return true, nil
 	case plan.UninstallModified:
+		if rec.Ownership != "" {
+			return false, nil
+		}
 		return force, nil
 	default:
 		return false, nil
@@ -147,14 +222,14 @@ func removeTarget(target string) error {
 // target. Install records single-target pre-install Backup Sets, so this returns
 // each target to the file that existed before dots managed it. A set is restored
 // at most once even when it covers several removed targets.
-func restoreBackups(result *Result, opts Options, home string) error {
+func restoreBackups(result *Result, targets []string, opts Options, home string) error {
 	meta, err := backups.Load(backups.Path(opts.StateRoot))
 	if err != nil {
 		return err
 	}
 
 	restored := map[string]struct{}{}
-	for _, target := range result.Removed {
+	for _, target := range targets {
 		set, ok := latestSetContaining(meta, target)
 		if !ok {
 			continue

--- a/internal/uninstall/uninstall_test.go
+++ b/internal/uninstall/uninstall_test.go
@@ -3,6 +3,7 @@ package uninstall_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/yersonargotev/dots/internal/backups"
@@ -70,6 +71,22 @@ func (e *env) installCopy(t *testing.T, rel, name string) string {
 		t.Fatalf("write target: %v", err)
 	}
 	e.meta.Entries = append(e.meta.Entries, state.Record{Target: target, Source: rel, Strategy: "copy", Hash: hash})
+	return target
+}
+
+func (e *env) installOwnedJSON(t *testing.T, rel, name, owned, targetContent string) string {
+	t.Helper()
+	e.writeSource(t, rel, owned)
+	target := filepath.Join(e.home, name)
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	if err := os.WriteFile(target, []byte(targetContent), 0o640); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	e.meta.Entries = append(e.meta.Entries, state.Record{
+		Target: target, Source: rel, Strategy: "copy", Ownership: "json-subset", OwnedContent: []byte(owned),
+	})
 	return target
 }
 
@@ -217,6 +234,93 @@ func TestApplyRemovesModifiedCopyWithForce(t *testing.T) {
 	}
 	if _, err := os.Lstat(target); !os.IsNotExist(err) {
 		t.Fatalf("modified copy should be removed with force, err = %v", err)
+	}
+}
+
+func TestApplyJSONSubsetUninstallPreservesExternalContentAndPrunesMetadata(t *testing.T) {
+	e := newEnv(t)
+	target := e.installOwnedJSON(t, "configs/shared.json", ".config/shared.json",
+		`{"owned":{"remove":true},"items":["owned"]}`,
+		`{"owned":{"remove":true,"external":"keep"},"items":["owned","external"],"targetOnly":true}`,
+	)
+	e.saveMeta(t)
+
+	res := e.apply(t, uninstall.Options{Force: true})
+	if len(res.Removed) != 0 || len(res.Updated) != 1 || res.Updated[0] != target {
+		t.Fatalf("result = %+v, want preserved target with recorded contribution removed", res)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read preserved target: %v", err)
+	}
+	for _, want := range []string{`"external": "keep"`, `"external"`, `"targetOnly": true`} {
+		if !strings.Contains(string(got), want) {
+			t.Fatalf("target missing external content %s:\n%s", want, got)
+		}
+	}
+	if strings.Contains(string(got), `"remove"`) {
+		t.Fatalf("target retained dots-owned content:\n%s", got)
+	}
+	if _, ok := loadMeta(t, e.stateRoot).FindByTarget(target); ok {
+		t.Fatal("metadata record not pruned after partial uninstall")
+	}
+}
+
+func TestApplyJSONSubsetForcePreservesChangedOwnedContentAndMetadata(t *testing.T) {
+	e := newEnv(t)
+	target := e.installOwnedJSON(t, "configs/shared.json", ".config/shared.json",
+		`{"owned":"recorded"}`,
+		`{"owned":"locally-changed","external":true}`,
+	)
+	e.saveMeta(t)
+
+	res := e.apply(t, uninstall.Options{Force: true})
+	if len(res.Removed) != 0 {
+		t.Fatalf("Removed = %v, want none for changed partial ownership", res.Removed)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read preserved target: %v", err)
+	}
+	if string(got) != `{"owned":"locally-changed","external":true}` {
+		t.Fatalf("force changed partial target to %s", got)
+	}
+	if _, ok := loadMeta(t, e.stateRoot).FindByTarget(target); !ok {
+		t.Fatal("metadata record pruned despite changed owned content")
+	}
+}
+
+func TestApplyJSONSubsetRevalidatesStaleRemovalBeforeMutation(t *testing.T) {
+	e := newEnv(t)
+	target := e.installOwnedJSON(t, "configs/shared.json", ".config/shared.json",
+		`{"owned":"recorded"}`,
+		`{"owned":"recorded","external":true}`,
+	)
+	e.saveMeta(t)
+	stalePlan := e.buildPlan(t)
+	changed := `{"owned":"changed-after-preview","external":true}`
+	if err := os.WriteFile(target, []byte(changed), 0o640); err != nil {
+		t.Fatalf("change target after preview: %v", err)
+	}
+
+	res, err := uninstall.Apply(stalePlan, uninstall.Options{
+		SourceRoot: e.sourceRoot, Home: e.home, StateRoot: e.stateRoot, Force: true,
+	})
+	if err != nil {
+		t.Fatalf("Apply(stale plan) error = %v", err)
+	}
+	if len(res.Removed) != 0 || len(res.Updated) != 0 {
+		t.Fatalf("result = %+v, want no stale-plan mutation", res)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(got) != changed {
+		t.Fatalf("stale plan changed target to %s", got)
+	}
+	if _, ok := loadMeta(t, e.stateRoot).FindByTarget(target); !ok {
+		t.Fatal("stale plan pruned metadata")
 	}
 }
 

--- a/internal/uninstall/uninstall_test.go
+++ b/internal/uninstall/uninstall_test.go
@@ -427,3 +427,36 @@ func TestApplyIgnoresForgedRemovableActionOutsideHome(t *testing.T) {
 		t.Fatalf("forged action modified out-of-home target: %q", got)
 	}
 }
+
+func TestApplyDoesNotPruneMissingJSONTargetBehindEscapedParent(t *testing.T) {
+	e := newEnv(t)
+	outside := t.TempDir()
+	parent := filepath.Join(e.home, ".config")
+	if err := os.Symlink(outside, parent); err != nil {
+		t.Fatalf("symlink escaped target parent: %v", err)
+	}
+	target := filepath.Join(parent, "shared.json")
+	e.meta.Entries = append(e.meta.Entries, state.Record{
+		Target:       target,
+		Source:       "configs/shared.json",
+		Strategy:     "copy",
+		Ownership:    "json-subset",
+		OwnedContent: []byte(`{"owned":true}`),
+	})
+	e.saveMeta(t)
+
+	forged := plan.UninstallPlan{Actions: []plan.UninstallAction{{
+		Target: target, Source: "configs/shared.json", Strategy: "copy", Ownership: "json-subset", Status: plan.UninstallRemove,
+	}}}
+	_, err := uninstall.Apply(forged, uninstall.Options{
+		SourceRoot: e.sourceRoot,
+		Home:       e.home,
+		StateRoot:  e.stateRoot,
+	})
+	if err == nil {
+		t.Fatal("Apply() error = nil, want escaped JSON target parent error")
+	}
+	if _, ok := loadMeta(t, e.stateRoot).FindByTarget(target); !ok {
+		t.Fatal("escaped missing JSON target record should be kept, not pruned")
+	}
+}

--- a/internal/uninstall/uninstall_test.go
+++ b/internal/uninstall/uninstall_test.go
@@ -290,6 +290,30 @@ func TestApplyJSONSubsetForcePreservesChangedOwnedContentAndMetadata(t *testing.
 	}
 }
 
+func TestApplyJSONSubsetPreservesMissingOwnedKeyAndMetadata(t *testing.T) {
+	e := newEnv(t)
+	target := e.installOwnedJSON(t, "configs/shared.json", ".config/shared.json",
+		`{"owned":"recorded"}`,
+		`{"external":true}`,
+	)
+	e.saveMeta(t)
+
+	res := e.apply(t, uninstall.Options{Force: true})
+	if len(res.Removed) != 0 || len(res.Updated) != 0 {
+		t.Fatalf("result = %+v, want no mutation for missing owned key", res)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read preserved target: %v", err)
+	}
+	if string(got) != `{"external":true}` {
+		t.Fatalf("missing-owned-key target changed to %s", got)
+	}
+	if _, ok := loadMeta(t, e.stateRoot).FindByTarget(target); !ok {
+		t.Fatal("metadata record pruned despite missing owned key")
+	}
+}
+
 func TestApplyJSONSubsetRevalidatesStaleRemovalBeforeMutation(t *testing.T) {
 	e := newEnv(t)
 	target := e.installOwnedJSON(t, "configs/shared.json", ".config/shared.json",
@@ -458,5 +482,39 @@ func TestApplyDoesNotPruneMissingJSONTargetBehindEscapedParent(t *testing.T) {
 	}
 	if _, ok := loadMeta(t, e.stateRoot).FindByTarget(target); !ok {
 		t.Fatal("escaped missing JSON target record should be kept, not pruned")
+	}
+}
+
+func TestApplyDoesNotPruneJSONTargetMissingSincePreview(t *testing.T) {
+	e := newEnv(t)
+	target := filepath.Join(e.home, ".config", "shared.json")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target parent: %v", err)
+	}
+	e.meta.Entries = append(e.meta.Entries, state.Record{
+		Target:       target,
+		Source:       "configs/shared.json",
+		Strategy:     "copy",
+		Ownership:    "json-subset",
+		OwnedContent: []byte(`{"owned":true}`),
+	})
+	e.saveMeta(t)
+
+	stale := plan.UninstallPlan{Actions: []plan.UninstallAction{{
+		Target: target, Source: "configs/shared.json", Strategy: "copy", Ownership: "json-subset", Status: plan.UninstallRemove,
+	}}}
+	res, err := uninstall.Apply(stale, uninstall.Options{
+		SourceRoot: e.sourceRoot,
+		Home:       e.home,
+		StateRoot:  e.stateRoot,
+	})
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if len(res.Removed) != 0 || len(res.Updated) != 0 {
+		t.Fatalf("result = %+v, want no mutation for target missing since preview", res)
+	}
+	if _, ok := loadMeta(t, e.stateRoot).FindByTarget(target); !ok {
+		t.Fatal("missing JSON target record should be kept, not pruned")
 	}
 }

--- a/internal/uninstall/uninstall_test.go
+++ b/internal/uninstall/uninstall_test.go
@@ -27,7 +27,7 @@ func newEnv(t *testing.T) *env {
 		sourceRoot: t.TempDir(),
 		home:       t.TempDir(),
 		stateRoot:  t.TempDir(),
-		meta:       state.Metadata{Version: 1},
+		meta:       state.Metadata{Version: state.CurrentVersion},
 	}
 }
 
@@ -70,7 +70,7 @@ func (e *env) installCopy(t *testing.T, rel, name string) string {
 	if err := os.WriteFile(target, []byte(content), 0o600); err != nil {
 		t.Fatalf("write target: %v", err)
 	}
-	e.meta.Entries = append(e.meta.Entries, state.Record{Target: target, Source: rel, Strategy: "copy", Hash: hash})
+	e.meta.Entries = append(e.meta.Entries, state.Record{Target: target, Source: rel, Strategy: "copy", Ownership: "whole", Hash: hash})
 	return target
 }
 


### PR DESCRIPTION
Closes #385

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Record prior strict-JSON owned contributions and reconcile them as a conservative three-way update.
- Remove only proven dots-owned JSON content during uninstall while preserving external keys, values, arrays, and the shared container.
- Keep legacy, changed, missing, and escaped ownership evidence fail-closed; `--force` never broadens partial ownership.

## Changes

| File | Change |
|------|--------|
| `internal/configsubset/` | Add deterministic strict-JSON composition, reconciliation, and subtraction. |
| `internal/{state,plan,install,status,uninstall}/` | Persist ownership evidence and use it consistently across lifecycle planning and apply. |
| `internal/cli/` | Report partial updates accurately and cover the full issue lifecycle plus JSON golden output. |
| `CONTEXT.md`, `docs/` | Document reversible subset ownership, legacy behavior, update, and uninstall contracts. |

## Test Plan

- [x] `go test -count=1 ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile core --source-root "$PWD" --home <tmp>`
- [x] `go build ./...`
- [x] Real compiled binary lifecycle in a temporary home: install prior contribution, verify a missing retired key conflicts without byte changes, update compatible owned content, verify status, uninstall, and assert external content remains.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #385`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

- Agent Brief: https://github.com/yersonargotev/dots/issues/385#issuecomment-5226645197; database ID `5226645197`; updated `2026-08-08T14:56:26Z`; SHA-256 `9da414d8e2c2d8148cfe3fd19b2b494fc019139547c71f080d9a554d33d7452c`.
- Reviewed head: `02716d0998c020aaed767b23237f051855e43c0f` against `origin/main` `2631aaafc88875ddd446f981234aefee3b25ea69`.
- Acceptance coverage: compatible strict-JSON add/remove lifecycle; target-only preservation; changed or missing retired values conflict without mutation; legacy metadata gains no force-removal authority; partial uninstall preserves the co-owned target; confinement revalidated before inspection.
- Automated validation: `gofmt -l .` produced no output; `go vet ./...`, `go build ./...`, and `go test -count=1 ./...` passed; manifest validation and sandboxed repository plan passed.
- Manual validation: compiled `./cmd/dots` to `/var/folders/4b/hlh_7n9n4wbfcqx7ppdrbqn80000gn/T/tmp.YTeTVRAHky`; all install/status/uninstall commands used explicit temporary `--home`, `--source-root`, and `--state-root`; missing-retired conflict preserved the exact file digest; pre-update status exited `2`; final target was `{"items":["external"],"owned":{"external":"preserve"},"targetOnly":true}`.
- Independent reviews: Spec — no findings; Standards/security/error handling/output contracts — no findings.
- Delegation: a read-only exploration slice mapped the issue's affected lifecycle and tests; implementation remained direct because the state-model and lifecycle changes form one cohesive cross-module unit. The main agent verified all delegated findings and all final evidence.
<!-- delivery-issue:evidence:end -->
