### PR TITLE
feat(install): migrate legacy writable targets

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -153,7 +153,7 @@ A workstation state where a managed target no longer matches the repository-owne
 _Avoid_: local change, mismatch, dirty config
 
 **Dotfiles Update**:
-The `dots update` workflow that fast-forwards the Installed Repository to its upstream and re-runs the safe install flow so managed configuration stays aligned with the Source of Truth. It refuses to touch a repository with local changes and only ever applies a clean fast-forward, never a merge or rebase. Shipped in v1.1.
+The `dots update` workflow that preserves local Installed Repository changes in a reported stash, fast-forwards the repository to its upstream, and re-runs the safe install flow so Managed Configuration stays aligned with the Source of Truth. It shares repository preservation with default-path install, captures provenance-backed legacy writable targets before checkout, and never merges, rebases, or automatically restores a stash. Shipped in v1.1.
 _Avoid_: sync, pull, upgrade
 
 **Repository Layout**:

--- a/docs/agents/output-contract.md
+++ b/docs/agents/output-contract.md
@@ -38,7 +38,7 @@ state.
 
 ```json
 {
-  "schema_version": "5",
+  "schema_version": "6",
   "command": "doctor",
   "status": "ok",
   "data": { "...": "command-specific report" }
@@ -59,7 +59,7 @@ Schema version `3` introduced this partial-error report allowance:
 
 ```json
 {
-  "schema_version": "5",
+  "schema_version": "6",
   "command": "doctor",
   "status": "error",
   "error": "read manifest: open dots.yaml: no such file or directory"
@@ -176,10 +176,14 @@ prose the text surface prints:
   portable, structured fields (`source`, `present`, `warning`, and the
   `deps plan` install action).
 - `plan` action `status` values are portable intent, not prose. `create`,
-  `update`, and `unchanged` are non-findings; `conflict` and `missing-source`
+  `update`, `migrate`, and `unchanged` are non-findings; `conflict` and `missing-source`
   are findings. `update` means dots has enough Installation Metadata and
   Entry Ownership proof to safely mutate a previously managed target, creating a
-  Backup Set before writing, while preserving the conservative conflict model
+  Backup Set before writing. `migrate` means a repository refresh proved a
+  legacy symlink through Installation Metadata provenance, captured its content
+  before checkout, and can safely materialize the new regular target after
+  last-moment type and content revalidation. Schema version `6` adds this
+  semantic status while preserving the conservative conflict model
   for unmanaged or incompatible targets.
 - Plan actions and Status Managed Entry items may add the optional reason
   `source-override-not-selected` and a deterministic `matching_tags` array when
@@ -224,6 +228,9 @@ prose the text surface prints:
   `install --yes --backup-and-replace --output json` replaces Conflicts,
   `data.backup_sets` lists the Backup Sets created by that run, including each
   set ID, target list, and state-root path.
+- Confirmed `update` reports the same optional `data.backup_sets` evidence for
+  any safe `update` or `migrate` action that created Backup Sets after repository
+  refresh.
 
 Profile-aware reports retain the compatibility `profile`, `profiles`, and
 `tags` fields. For selection-aware commands, agents should prefer the

--- a/docs/update.md
+++ b/docs/update.md
@@ -1,6 +1,6 @@
 # `dots update`
 
-`dots update` refreshes the [Installed Repository](../CONTEXT.md#installed-repository) (default `~/.local/share/dots`) and re-runs the safe install flow so managed configuration stays aligned with the [Source of Truth](../CONTEXT.md). It reuses the existing Install Plan, Conflict Resolution, and Backup Set machinery rather than reimplementing filesystem logic — the only behavior unique to `update` is advancing the repository's Git state.
+`dots update` refreshes the [Installed Repository](../CONTEXT.md#installed-repository) (default `~/.local/share/dots`) and re-runs the safe install flow so managed configuration stays aligned with the [Source of Truth](../CONTEXT.md). It shares repository preservation with default-path `dots install` and reuses the existing Install Plan, Conflict Resolution, and Backup Set machinery rather than reimplementing filesystem logic — the only behavior unique to `update` is its upstream fast-forward target.
 
 ## What it does
 
@@ -50,6 +50,18 @@ without that evidence stays additive-only until a safe run records the current
 baseline. TOML subset updates remain additive. Every `update` creates a Backup
 Set before mutation, and unmanaged or incompatible targets remain Conflicts.
 
+When an incoming manifest changes a previously installed symlink into a regular
+copy target, the plan may instead report `migrate`. This status requires matching
+Installation Metadata provenance, an exact legacy manifest entry and symlink
+destination, and an unambiguous content reconciliation. Dots captures the live
+legacy content before stashing and refreshing the repository. Apply then
+revalidates the symlink type, destination, and post-refresh content, creates a
+Backup Set containing the captured regular-file content, and only then
+materializes the new target. Manual or stale symlinks, incompatible content,
+ambiguous metadata, and targets changed after planning remain Conflicts or fail
+closed without being touched. Confirmed `--yes` runs apply safe `migrate`
+actions; they are not Conflict Resolution decisions.
+
 ## Flags
 
 `update` accepts the same path, selection, and safety flags as `install`:
@@ -76,7 +88,10 @@ Installed Repository can fast-forward a1b2c3d -> e4f5a6b:
 (dry run: working tree and managed files not modified)
 ```
 
-Because no fast-forward is applied in a dry run, the rendered plan reflects the **current** Source of Truth, not the post-update state. Run `update` without `--dry-run` to apply the fast-forward and compute the plan against the updated repository.
+The rendered plan reflects a temporary read-only snapshot of the incoming Source
+of Truth, including any `migrate` actions, while canonical target paths still
+refer to the Installed Repository. Dry-run does not change the checkout,
+targets, Installation Metadata, or Backup Sets.
 
 After a successful explicit install, an unattended update can reuse the
 Installed Selection:

--- a/internal/backups/set.go
+++ b/internal/backups/set.go
@@ -33,6 +33,27 @@ func MachineName() string {
 // destination. The created Backup Set is returned so callers can report or
 // restore it later.
 func CreateSet(stateRoot string, targets []string, opts CreateOptions) (BackupSet, error) {
+	return createSet(stateRoot, targets, opts, nil)
+}
+
+// CreateContentSet records one Backup Set whose preserved item is captured
+// regular-file content rather than the target's current filesystem type. This
+// is required for legacy symlink migrations: after repository refresh the link
+// no longer exposes the pre-refresh application content, but that exact content
+// was captured before the checkout changed.
+func CreateContentSet(stateRoot, target string, content []byte, mode fs.FileMode, opts CreateOptions) (BackupSet, error) {
+	return createSet(stateRoot, []string{target}, opts, func(backupFile string) error {
+		if err := os.MkdirAll(filepath.Dir(backupFile), 0o755); err != nil {
+			return fmt.Errorf("create Backup Set directory: %w", err)
+		}
+		if err := os.WriteFile(backupFile, content, mode.Perm()); err != nil {
+			return fmt.Errorf("backup captured content for %s: %w", target, err)
+		}
+		return nil
+	})
+}
+
+func createSet(stateRoot string, targets []string, opts CreateOptions, captured func(string) error) (BackupSet, error) {
 	now := time.Now().UTC()
 	set := BackupSet{
 		ID:        "backup-" + now.Format("20060102T150405.000000000Z"),
@@ -45,7 +66,13 @@ func CreateSet(stateRoot string, targets []string, opts CreateOptions) (BackupSe
 
 	for i, target := range targets {
 		backupFile := FilePath(stateRoot, set.ID, i+1, target)
-		if err := copyTarget(target, backupFile); err != nil {
+		var err error
+		if captured != nil {
+			err = captured(backupFile)
+		} else {
+			err = copyTarget(target, backupFile)
+		}
+		if err != nil {
 			return BackupSet{}, err
 		}
 	}

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -12,10 +12,9 @@ import (
 const DefaultRepositoryURL = "https://github.com/yersonargotev/dots.git"
 
 type Options struct {
-	SourceRoot     string
-	RepositoryURL  string
-	RepositoryRef  string
-	UpdateExisting bool
+	SourceRoot    string
+	RepositoryURL string
+	RepositoryRef string
 }
 
 type Result struct {
@@ -33,11 +32,6 @@ func Ensure(opts Options) (Result, error) {
 
 	result := Result{SourceRoot: opts.SourceRoot}
 	if validSourceRoot(opts.SourceRoot) {
-		if opts.UpdateExisting {
-			if err := ensureRepositoryRef(opts); err != nil {
-				return Result{}, err
-			}
-		}
 		return result, nil
 	}
 
@@ -68,35 +62,6 @@ func Ensure(opts Options) (Result, error) {
 	}
 	result.Cloned = true
 	return result, nil
-}
-
-func ensureRepositoryRef(opts Options) error {
-	ref := strings.TrimSpace(opts.RepositoryRef)
-	if ref == "" {
-		return nil
-	}
-	matches, err := repositoryRefMatches(opts.SourceRoot, ref, fmt.Sprintf("cannot update it to %s", ref))
-	if err != nil {
-		return err
-	}
-	if matches {
-		return nil
-	}
-	if dirty, err := repositoryDirty(opts.SourceRoot); err != nil {
-		return err
-	} else if dirty {
-		return fmt.Errorf("Installed Repository at %s has local changes; refusing to update to %s. Commit/stash them, move it aside, or pass --source-root", opts.SourceRoot, ref)
-	}
-	if err := fetchRepositoryRef(opts.SourceRoot, ref); err != nil {
-		return err
-	}
-	if err := checkoutFetchHead(opts.SourceRoot, ref); err != nil {
-		return err
-	}
-	if !validSourceRoot(opts.SourceRoot) {
-		return errors.New("updated Installed Repository does not contain a valid dots.yaml at repository root")
-	}
-	return nil
 }
 
 // RequireCurrentRef verifies a valid Installed Repository already matches the
@@ -137,28 +102,6 @@ func repositoryAtRef(sourceRoot, ref string) (bool, error) {
 		return false, nil
 	}
 	return strings.TrimSpace(head) == strings.TrimSpace(target), nil
-}
-
-func repositoryDirty(sourceRoot string) (bool, error) {
-	status, err := gitOutput(sourceRoot, "status", "--porcelain")
-	if err != nil {
-		return false, fmt.Errorf("inspect Installed Repository status: %w", err)
-	}
-	return strings.TrimSpace(status) != "", nil
-}
-
-func fetchRepositoryRef(sourceRoot, ref string) error {
-	if _, err := gitOutput(sourceRoot, "fetch", "--depth", "1", "origin", ref); err != nil {
-		return fmt.Errorf("update Installed Repository to %s: %w", ref, err)
-	}
-	return nil
-}
-
-func checkoutFetchHead(sourceRoot, ref string) error {
-	if _, err := gitOutput(sourceRoot, "checkout", "--detach", "FETCH_HEAD"); err != nil {
-		return fmt.Errorf("checkout Installed Repository ref %s: %w", ref, err)
-	}
-	return nil
 }
 
 func gitOutput(sourceRoot string, args ...string) (string, error) {

--- a/internal/bootstrap/bootstrap_cli_test.go
+++ b/internal/bootstrap/bootstrap_cli_test.go
@@ -56,48 +56,6 @@ func TestEnsureRejectsNonEmptyInvalidInstalledRepository(t *testing.T) {
 	}
 }
 
-func TestEnsureUpdatesExistingInstalledRepositoryToPinnedRef(t *testing.T) {
-	sourceRepo, sourceRoot := seedStaleBootstrapInstalledRepository(t)
-
-	_, err := bootstrap.Ensure(bootstrap.Options{
-		SourceRoot:     sourceRoot,
-		RepositoryURL:  sourceRepo,
-		RepositoryRef:  "v0.99.1",
-		UpdateExisting: true,
-	})
-	if err != nil {
-		t.Fatalf("Ensure() update error = %v", err)
-	}
-	manifest, err := os.ReadFile(filepath.Join(sourceRoot, "dots.yaml"))
-	if err != nil {
-		t.Fatalf("read updated manifest: %v", err)
-	}
-	if !strings.Contains(string(manifest), "configs/herdr/config.toml") {
-		t.Fatalf("updated manifest should come from v0.99.1, got:\n%s", manifest)
-	}
-	if err := bootstrap.RequireCurrentRef(bootstrap.Options{SourceRoot: sourceRoot, RepositoryRef: "v0.99.1"}); err != nil {
-		t.Fatalf("updated Installed Repository should satisfy dry-run ref verification: %v", err)
-	}
-}
-
-func TestEnsureRefusesToUpdateDirtyInstalledRepository(t *testing.T) {
-	sourceRepo, sourceRoot := seedStaleBootstrapInstalledRepository(t)
-	writeFile(t, filepath.Join(sourceRoot, "local.txt"), "local change\n", 0o600)
-
-	_, err := bootstrap.Ensure(bootstrap.Options{
-		SourceRoot:     sourceRoot,
-		RepositoryURL:  sourceRepo,
-		RepositoryRef:  "v0.99.1",
-		UpdateExisting: true,
-	})
-	if err == nil {
-		t.Fatal("Ensure() should refuse to update a dirty Installed Repository")
-	}
-	if !strings.Contains(err.Error(), "has local changes") {
-		t.Fatalf("dirty update error should be actionable, got: %v", err)
-	}
-}
-
 func TestEnsureLeavesExistingInstalledRepositoryUnlessUpdateRequested(t *testing.T) {
 	sourceRepo, sourceRoot := seedStaleBootstrapInstalledRepository(t)
 
@@ -113,7 +71,7 @@ func TestEnsureLeavesExistingInstalledRepositoryUnlessUpdateRequested(t *testing
 		t.Fatalf("read manifest: %v", err)
 	}
 	if strings.Contains(string(manifest), "configs/herdr/config.toml") {
-		t.Fatalf("Ensure() without UpdateExisting should not update an existing source root, got:\n%s", manifest)
+		t.Fatalf("Ensure() should not update an existing source root, got:\n%s", manifest)
 	}
 }
 

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -110,7 +110,7 @@ func writeCLISourceFile(t *testing.T, path, content string) {
 	}
 }
 
-func TestInstallDryRunRejectsStaleDefaultInstalledRepository(t *testing.T) {
+func TestInstallDryRunPreviewsStaleDefaultInstalledRepository(t *testing.T) {
 	sourceRepo := newCLISourceRepo(t)
 	if err := testrepo.TagWithHerdrManifest(sourceRepo, "v0.99.1"); err != nil {
 		t.Fatalf("tag Source of Truth with Herdr manifest: %v", err)
@@ -132,11 +132,11 @@ func TestInstallDryRunRejectsStaleDefaultInstalledRepository(t *testing.T) {
 
 	var out, errOut bytes.Buffer
 	code := cli.Run([]string{"install", "--dry-run", "--profile", "default", "--home", home}, &out, &errOut)
-	if code != 1 {
-		t.Fatalf("install --dry-run with stale source exit code = %d, want 1\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
+	if code != 0 {
+		t.Fatalf("install --dry-run with stale source exit code = %d, want 0\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
 	}
-	if !strings.Contains(errOut.String(), "not at v0.99.1") {
-		t.Fatalf("dry-run stale source error should explain release mismatch, got:\n%s", errOut.String())
+	if !strings.Contains(out.String(), "Installed Repository can fast-forward") || !strings.Contains(out.String(), "configs/herdr/config.toml") {
+		t.Fatalf("dry-run should preview the incoming ref and plan, got:\n%s", out.String())
 	}
 	manifest, err := os.ReadFile(filepath.Join(sourceRoot, "dots.yaml"))
 	if err != nil {
@@ -145,4 +145,51 @@ func TestInstallDryRunRejectsStaleDefaultInstalledRepository(t *testing.T) {
 	if strings.Contains(string(manifest), "configs/herdr/config.toml") {
 		t.Fatalf("dry-run must not update the Installed Repository, got:\n%s", manifest)
 	}
+}
+
+func TestInstallPreservesDirtyDefaultInstalledRepositoryDuringRefRefresh(t *testing.T) {
+	sourceRepo := newCLISourceRepo(t)
+	if err := testrepo.TagWithHerdrManifest(sourceRepo, "v0.99.1"); err != nil {
+		t.Fatal(err)
+	}
+	home := t.TempDir()
+	sourceRoot := filepath.Join(home, ".local", "share", "dots")
+	if _, err := bootstrap.Ensure(bootstrap.Options{SourceRoot: sourceRoot, RepositoryURL: sourceRepo, RepositoryRef: "v0.99.0"}); err != nil {
+		t.Fatal(err)
+	}
+	local := filepath.Join(sourceRoot, "local.txt")
+	if err := os.WriteFile(local, []byte("preserve me\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	oldVersion := version.Value
+	version.Value = "v0.99.1"
+	defer func() { version.Value = oldVersion }()
+
+	var out, errOut bytes.Buffer
+	code := cli.Run([]string{"install", "--yes", "--skip-deps", "--profile", "default", "--home", home}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("install exit = %d\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
+	}
+	if !strings.Contains(out.String(), "Preserved local Installed Repository changes in stash@{0}") {
+		t.Fatalf("install did not report preserved changes:\n%s", out.String())
+	}
+	stashes := runCLIGitOutput(t, sourceRoot, "stash", "list")
+	if !strings.Contains(stashes, "dots preserved local Installed Repository changes") {
+		t.Fatalf("install stash missing:\n%s", stashes)
+	}
+	if _, err := os.Stat(local); !os.IsNotExist(err) {
+		t.Fatalf("dirty file remained in refreshed checkout: %v", err)
+	}
+}
+
+func runCLIGitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL="+os.DevNull, "GIT_CONFIG_NOSYSTEM=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return string(out)
 }

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -15,7 +16,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/yersonargotev/dots/internal/agentinstructions"
 	"github.com/yersonargotev/dots/internal/backups"
-	"github.com/yersonargotev/dots/internal/bootstrap"
 	"github.com/yersonargotev/dots/internal/codexconfig"
 	"github.com/yersonargotev/dots/internal/deps"
 	"github.com/yersonargotev/dots/internal/deps/pkgmgr"
@@ -68,22 +68,22 @@ func newInstallCommand() *cobra.Command {
 				return fmt.Errorf("--backup-and-replace requires --yes for non-interactive conflict replacement")
 			}
 
-			if !cmd.Flags().Changed("file") && !cmd.Flags().Changed("source-root") {
-				bootstrapOpts := bootstrap.Options{
-					SourceRoot:     paths.SourceRoot,
-					RepositoryRef:  defaultInitRepositoryRef("", version.Value),
-					UpdateExisting: !dryRun,
-				}
-				if dryRun {
-					if err := bootstrap.RequireCurrentRef(bootstrapOpts); err != nil {
-						return err
-					}
-				} else if _, err := bootstrap.Ensure(bootstrapOpts); err != nil {
+			prep := installRepositoryPreparation{SourceReadRoot: paths.SourceRoot, LegacyMigrations: map[string]plan.LegacyMigration{}, cleanup: func() {}}
+			defaultRepository := !cmd.Flags().Changed("file") && !cmd.Flags().Changed("source-root")
+			if defaultRepository {
+				prep, err = prepareInstallRepository(cmd, paths, dryRun)
+				if err != nil {
 					return err
 				}
+				defer prep.cleanup()
 			}
 
-			m, err := loadManifestForCommand(cmd, file, paths.SourceRoot)
+			var m *manifest.Manifest
+			if defaultRepository && prep.SourceReadRoot != paths.SourceRoot {
+				m, err = manifest.LoadFile(filepath.Join(prep.SourceReadRoot, file))
+			} else {
+				m, err = loadManifestForCommand(cmd, file, paths.SourceRoot)
+			}
 			if err != nil {
 				return err
 			}
@@ -158,13 +158,13 @@ func newInstallCommand() *cobra.Command {
 			}
 
 			if dryRun {
-				p, provPlan, err := buildInstallPlanAndProvisioners(*m, meta, profiles, extraTags, hostOS, paths)
+				p, provPlan, err := buildInstallPlanAndProvisioners(*m, meta, profiles, extraTags, hostOS, paths, prep.SourceReadRoot, prep.LegacyMigrations)
 				if err != nil {
 					return err
 				}
 				p.Selection = &effective.Report
 				if wantsJSON(cmd) {
-					return emitOK(cmd, installReport{DryRun: true, Selection: effective.Report, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan})
+					return emitOK(cmd, installReport{RepositoryRefresh: prep.Refresh, DryRun: true, Selection: effective.Report, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan})
 				}
 				if err := renderInstallPlanAndProvisioners(cmd, *m, p, provPlan, profiles); err != nil {
 					return err
@@ -184,7 +184,7 @@ func newInstallCommand() *cobra.Command {
 						packageManagerSetup.Status = pkgmgr.StatusUnavailable
 						err := fmt.Errorf("Homebrew Package Manager Setup requires interactive confirmation; rerun without --yes or install Homebrew manually with %s", packageManagerSetup.Command.Display)
 						if wantsJSON(cmd) {
-							return installDependencyGateError{err: err, report: installReport{DryRun: false, Selection: effective.Report, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport}}
+							return installDependencyGateError{err: err, report: installReport{RepositoryRefresh: prep.Refresh, DryRun: false, Selection: effective.Report, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport}}
 						}
 						return err
 					}
@@ -220,7 +220,7 @@ func newInstallCommand() *cobra.Command {
 					renderDepsInstallPreview(cmd.OutOrStdout(), depPreview)
 					depsConfirmed = true
 				}
-				p, provPlan, err = buildInstallPlanAndProvisioners(*m, meta, profiles, extraTags, hostOS, paths)
+				p, provPlan, err = buildInstallPlanAndProvisioners(*m, meta, profiles, extraTags, hostOS, paths, prep.SourceReadRoot, prep.LegacyMigrations)
 				if err != nil {
 					return err
 				}
@@ -232,7 +232,7 @@ func newInstallCommand() *cobra.Command {
 				dependenciesReport.Result = &depReport
 				if err != nil {
 					if wantsJSON(cmd) {
-						return installDependencyGateError{err: err, report: installReport{DryRun: false, Selection: effective.Report, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan}}
+						return installDependencyGateError{err: err, report: installReport{RepositoryRefresh: prep.Refresh, DryRun: false, Selection: effective.Report, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan}}
 					}
 					return err
 				}
@@ -242,7 +242,7 @@ func newInstallCommand() *cobra.Command {
 			}
 
 			if !installPlanReady {
-				p, provPlan, err = buildInstallPlanAndProvisioners(*m, meta, profiles, extraTags, hostOS, paths)
+				p, provPlan, err = buildInstallPlanAndProvisioners(*m, meta, profiles, extraTags, hostOS, paths, prep.SourceReadRoot, prep.LegacyMigrations)
 				if err != nil {
 					return err
 				}
@@ -269,7 +269,7 @@ func newInstallCommand() *cobra.Command {
 			}
 			if !applied {
 				if wantsJSON(cmd) {
-					return emitOK(cmd, installReport{DryRun: false, Selection: effective.Report, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan})
+					return emitOK(cmd, installReport{RepositoryRefresh: prep.Refresh, DryRun: false, Selection: effective.Report, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan})
 				}
 				return nil
 			}
@@ -277,7 +277,7 @@ func newInstallCommand() *cobra.Command {
 			provResult, err := runProvisionersWithEnvironment(cmd, *m, profiles, extraTags, paths.Home, paths.StateRoot, paths.SourceRoot, dependencyEnvironment)
 			if err != nil {
 				if wantsJSON(cmd) {
-					return installProvisionerError{err: err, report: installReport{DryRun: false, Selection: effective.Report, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan, BackupSets: createdBackups, ProvisionerResults: &provResult}}
+					return installProvisionerError{err: err, report: installReport{RepositoryRefresh: prep.Refresh, DryRun: false, Selection: effective.Report, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan, BackupSets: createdBackups, ProvisionerResults: &provResult}}
 				}
 				return err
 			}
@@ -286,7 +286,7 @@ func newInstallCommand() *cobra.Command {
 				return err
 			}
 			if wantsJSON(cmd) {
-				return emitOK(cmd, installReport{DryRun: false, Selection: effective.Report, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan, BackupSets: createdBackups})
+				return emitOK(cmd, installReport{RepositoryRefresh: prep.Refresh, DryRun: false, Selection: effective.Report, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan, BackupSets: createdBackups})
 			}
 			return nil
 		},
@@ -316,14 +316,16 @@ func renderInstallPlanAndProvisioners(cmd *cobra.Command, m manifest.Manifest, p
 	return renderSkippedProvisionerHint(cmd.OutOrStdout(), m, profiles, runtime.GOOS)
 }
 
-func buildInstallPlanAndProvisioners(m manifest.Manifest, meta state.Metadata, profiles []string, extraTags []string, hostOS string, paths resolvedPaths) (plan.Plan, provision.Plan, error) {
+func buildInstallPlanAndProvisioners(m manifest.Manifest, meta state.Metadata, profiles []string, extraTags []string, hostOS string, paths resolvedPaths, sourceReadRoot string, legacyMigrations map[string]plan.LegacyMigration) (plan.Plan, provision.Plan, error) {
 	p, err := plan.Build(m, plan.Options{
-		Profiles:   profiles,
-		ExtraTags:  extraTags,
-		OS:         hostOS,
-		SourceRoot: paths.SourceRoot,
-		Home:       paths.Home,
-		Metadata:   meta,
+		Profiles:         profiles,
+		ExtraTags:        extraTags,
+		OS:               hostOS,
+		SourceRoot:       paths.SourceRoot,
+		SourceReadRoot:   sourceReadRoot,
+		Home:             paths.Home,
+		Metadata:         meta,
+		LegacyMigrations: legacyMigrations,
 	})
 	if err != nil {
 		return plan.Plan{}, provision.Plan{}, err

--- a/internal/cli/install_repository.go
+++ b/internal/cli/install_repository.go
@@ -1,0 +1,93 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/yersonargotev/dots/internal/bootstrap"
+	"github.com/yersonargotev/dots/internal/gitrepo"
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/plan"
+	"github.com/yersonargotev/dots/internal/repositoryrefresh"
+	"github.com/yersonargotev/dots/internal/version"
+)
+
+type installRepositoryPreparation struct {
+	SourceReadRoot   string
+	LegacyMigrations map[string]plan.LegacyMigration
+	Refresh          *gitrepo.Update
+	cleanup          func()
+}
+
+func prepareInstallRepository(cmd *cobra.Command, paths resolvedPaths, dryRun bool) (installRepositoryPreparation, error) {
+	result := installRepositoryPreparation{SourceReadRoot: paths.SourceRoot, LegacyMigrations: map[string]plan.LegacyMigration{}, cleanup: func() {}}
+	ref := defaultInitRepositoryRef("", version.Value)
+	existed := gitrepo.IsRepo(paths.SourceRoot)
+	if dryRun {
+		if !existed {
+			if err := bootstrap.RequireCurrentRef(bootstrap.Options{SourceRoot: paths.SourceRoot, RepositoryRef: ref}); err != nil {
+				return result, err
+			}
+			return result, nil
+		}
+	} else {
+		if _, err := bootstrap.Ensure(bootstrap.Options{SourceRoot: paths.SourceRoot, RepositoryRef: ref}); err != nil {
+			return result, err
+		}
+		if !existed || ref == "" {
+			return result, nil
+		}
+	}
+	if ref == "" {
+		return result, nil
+	}
+
+	oldManifest, err := manifest.LoadFile(filepath.Join(paths.SourceRoot, "dots.yaml"))
+	if err != nil {
+		return result, err
+	}
+	meta, err := loadInstallationMetadata(paths, paths.StateRoot)
+	if err != nil {
+		return result, err
+	}
+	preview, err := gitrepo.RefPreview(paths.SourceRoot, ref)
+	if err != nil {
+		return result, err
+	}
+	captures, err := repositoryrefresh.CaptureLegacyTargets(*oldManifest, meta, paths.SourceRoot, paths.Home, preview.OldRev)
+	if err != nil {
+		return result, err
+	}
+	result.LegacyMigrations = captures
+	result.Refresh = &preview
+	if dryRun {
+		if preview.Changed() {
+			snapshot, err := os.MkdirTemp("", "dots-install-preview-*")
+			if err != nil {
+				return result, fmt.Errorf("create install preview snapshot: %w", err)
+			}
+			result.cleanup = func() { _ = os.RemoveAll(snapshot) }
+			if err := gitrepo.ExportRevision(paths.SourceRoot, preview.NewRev, snapshot); err != nil {
+				result.cleanup()
+				return result, err
+			}
+			result.SourceReadRoot = snapshot
+		}
+		if !wantsJSON(cmd) {
+			renderUpdate(cmd.OutOrStdout(), preview, true)
+		}
+		return result, nil
+	}
+
+	applied, err := gitrepo.CheckoutRef(paths.SourceRoot, preview)
+	if err != nil {
+		return result, err
+	}
+	result.Refresh = &applied
+	if !wantsJSON(cmd) {
+		renderUpdate(cmd.OutOrStdout(), applied, false)
+	}
+	return result, nil
+}

--- a/internal/cli/json_reports.go
+++ b/internal/cli/json_reports.go
@@ -39,6 +39,7 @@ type manifestValidateReport struct {
 }
 
 type installReport struct {
+	RepositoryRefresh   *gitrepo.Update            `json:"repository_refresh,omitempty"`
 	DryRun              bool                       `json:"dry_run"`
 	Selection           selection.Report           `json:"selection"`
 	PackageManagerSetup *pkgmgr.Report             `json:"package_manager_setup,omitempty"`
@@ -60,11 +61,12 @@ type installBackupSetReport struct {
 }
 
 type updateReport struct {
-	DryRun       bool             `json:"dry_run"`
-	Selection    selection.Report `json:"selection"`
-	Update       gitrepo.Update   `json:"update"`
-	Plan         plan.Plan        `json:"plan"`
-	Provisioners provision.Plan   `json:"provisioners"`
+	DryRun       bool                     `json:"dry_run"`
+	Selection    selection.Report         `json:"selection"`
+	Update       gitrepo.Update           `json:"update"`
+	Plan         plan.Plan                `json:"plan"`
+	Provisioners provision.Plan           `json:"provisioners"`
+	BackupSets   []installBackupSetReport `json:"backup_sets,omitempty"`
 }
 
 type upgradeReport struct {

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -22,7 +22,7 @@ const (
 // binary. Renaming, removing, or repurposing a field in any command's JSON
 // `data` is a breaking change to the Agent Output Contract and must bump this
 // value.
-const schemaVersion = "5"
+const schemaVersion = "6"
 
 // Envelope statuses. They mirror the semantic exit codes: ok->0, findings->2,
 // error->1.

--- a/internal/cli/output_golden_test.go
+++ b/internal/cli/output_golden_test.go
@@ -168,6 +168,7 @@ func TestEnvelopeGolden(t *testing.T) {
 					Source: selection.SourceExplicit, Profiles: []string{"default"}, ExtraTags: []string{"work"}, EffectiveTags: []string{"core", "work"},
 				}, Actions: []plan.Action{
 					{Source: "configs/zsh/zshrc", ResolvedSource: "/abs/machine/local/path/MUST/NOT/APPEAR", Target: "/home/user/.zshrc", Strategy: "symlink", Status: plan.StatusCreate},
+					{Source: "configs/app/settings.json", ResolvedSource: "/abs/MUST/NOT/APPEAR", Target: "/home/user/.config/app/settings.json", Strategy: "copy", Status: plan.StatusMigrate, Migration: &plan.LegacyMigration{CapturedContent: []byte("MUST NOT APPEAR")}},
 					{Source: "configs/git/config", Sources: []string{"configs/git/config", "configs/git/work.json"}, ResolvedSource: "/abs/x", ResolvedSources: []string{"/abs/x", "/abs/y"}, Content: []byte(`MUST NOT APPEAR`), Target: "/home/user/.gitconfig", Strategy: "copy", Status: plan.StatusConflict, Reason: plan.ConflictReasonSourceOverrideNotSelected, MatchingTags: []string{"adaptive-theme"}},
 				}},
 			},
@@ -319,6 +320,7 @@ func TestEnvelopeGolden(t *testing.T) {
 					Provisioners: provision.Plan{
 						Profile: "core", Profiles: []string{"core"}, Tags: []string{"core", "desktop", "work"}, Steps: []provision.Step{},
 					},
+					BackupSets: []installBackupSetReport{{BackupSet: backups.BackupSet{ID: "backup-20260808T120000Z", CreatedAt: "2026-08-08T12:00:00Z", Reason: "pre-install legacy target migration", Targets: []string{"/home/user/.config/app/settings.json"}}, Path: "/home/user/.local/state/dots/backups/backup-20260808T120000Z"}},
 				},
 			},
 			golden: "envelope_update.golden",

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -86,8 +86,8 @@ func decodeEnvelope(t *testing.T, out string) testEnvelope {
 	if err := json.Unmarshal([]byte(out), &env); err != nil {
 		t.Fatalf("stdout is not a JSON envelope: %v\noutput:\n%s", err, out)
 	}
-	if env.SchemaVersion != "5" {
-		t.Fatalf("schema_version = %q, want \"4\"", env.SchemaVersion)
+	if env.SchemaVersion != "6" {
+		t.Fatalf("schema_version = %q, want \"6\"", env.SchemaVersion)
 	}
 	if env.Command != "status" {
 		t.Fatalf("command = %q, want \"status\"", env.Command)
@@ -101,8 +101,8 @@ func decodeEnvelopeForCommand(t *testing.T, out string, command string) testEnve
 	if err := json.Unmarshal([]byte(out), &env); err != nil {
 		t.Fatalf("stdout is not a JSON envelope: %v\noutput:\n%s", err, out)
 	}
-	if env.SchemaVersion != "5" {
-		t.Fatalf("schema_version = %q, want \"4\"", env.SchemaVersion)
+	if env.SchemaVersion != "6" {
+		t.Fatalf("schema_version = %q, want \"6\"", env.SchemaVersion)
 	}
 	if env.Command != command {
 		t.Fatalf("command = %q, want %q", env.Command, command)

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -22,7 +22,7 @@ func renderPlan(w io.Writer, p plan.Plan) {
 	}
 
 	var counts struct {
-		create, update, conflict, unchanged, missingSource int
+		create, update, migrate, conflict, unchanged, missingSource int
 	}
 	for _, a := range p.Actions {
 		fmt.Fprintf(w, "  %-15s %-9s %s -> %s\n", a.Status, a.Strategy, a.Source, a.Target)
@@ -32,6 +32,8 @@ func renderPlan(w io.Writer, p plan.Plan) {
 			counts.create++
 		case plan.StatusUpdate:
 			counts.update++
+		case plan.StatusMigrate:
+			counts.migrate++
 		case plan.StatusConflict:
 			counts.conflict++
 		case plan.StatusUnchanged:
@@ -45,9 +47,9 @@ func renderPlan(w io.Writer, p plan.Plan) {
 		}
 	}
 
-	if counts.update > 0 {
-		fmt.Fprintf(w, "\nSummary: %d create, %d update, %d conflict, %d unchanged, %d missing-source\n",
-			counts.create, counts.update, counts.conflict, counts.unchanged, counts.missingSource)
+	if counts.update > 0 || counts.migrate > 0 {
+		fmt.Fprintf(w, "\nSummary: %d create, %d update, %d migrate, %d conflict, %d unchanged, %d missing-source\n",
+			counts.create, counts.update, counts.migrate, counts.conflict, counts.unchanged, counts.missingSource)
 	} else {
 		fmt.Fprintf(w, "\nSummary: %d create, %d conflict, %d unchanged, %d missing-source\n",
 			counts.create, counts.conflict, counts.unchanged, counts.missingSource)

--- a/internal/cli/render_golden_test.go
+++ b/internal/cli/render_golden_test.go
@@ -25,6 +25,7 @@ func TestRenderPlanGolden(t *testing.T) {
 				Profile: "work",
 				Actions: []plan.Action{
 					{Source: "configs/zsh/zshrc", Target: "/home/user/.zshrc", Strategy: "symlink", Status: plan.StatusCreate},
+					{Source: "configs/app/settings.json", Target: "/home/user/.config/app/settings.json", Strategy: "copy", Status: plan.StatusMigrate},
 					{Source: "configs/git/gitconfig", Target: "/home/user/.gitconfig", Strategy: "symlink", Status: plan.StatusConflict, Reason: plan.ConflictReasonSourceOverrideNotSelected, MatchingTags: []string{"adaptive-theme"}},
 					{Source: "configs/starship.toml", Target: "/home/user/.config/starship.toml", Strategy: "copy", Status: plan.StatusUnchanged},
 					{Source: "configs/nvim/init.lua", Target: "/home/user/.config/nvim/init.lua", Strategy: "template", Status: plan.StatusMissingSource},

--- a/internal/cli/testdata/envelope_deps_check.golden
+++ b/internal/cli/testdata/envelope_deps_check.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "5",
+  "schema_version": "6",
   "command": "deps check",
   "status": "findings",
   "data": {

--- a/internal/cli/testdata/envelope_deps_plan.golden
+++ b/internal/cli/testdata/envelope_deps_plan.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "5",
+  "schema_version": "6",
   "command": "deps plan",
   "status": "findings",
   "data": {

--- a/internal/cli/testdata/envelope_doctor.golden
+++ b/internal/cli/testdata/envelope_doctor.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "5",
+  "schema_version": "6",
   "command": "doctor",
   "status": "findings",
   "data": {

--- a/internal/cli/testdata/envelope_install.golden
+++ b/internal/cli/testdata/envelope_install.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "5",
+  "schema_version": "6",
   "command": "install",
   "status": "ok",
   "data": {

--- a/internal/cli/testdata/envelope_installed.golden
+++ b/internal/cli/testdata/envelope_installed.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "5",
+  "schema_version": "6",
   "command": "installed",
   "status": "ok",
   "data": {

--- a/internal/cli/testdata/envelope_plan.golden
+++ b/internal/cli/testdata/envelope_plan.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "5",
+  "schema_version": "6",
   "command": "plan",
   "status": "findings",
   "data": {
@@ -23,6 +23,12 @@
         "target": "/home/user/.zshrc",
         "strategy": "symlink",
         "status": "create"
+      },
+      {
+        "source": "configs/app/settings.json",
+        "target": "/home/user/.config/app/settings.json",
+        "strategy": "copy",
+        "status": "migrate"
       },
       {
         "source": "configs/git/config",

--- a/internal/cli/testdata/envelope_selection_migration_required.golden
+++ b/internal/cli/testdata/envelope_selection_migration_required.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "5",
+  "schema_version": "6",
   "command": "status",
   "status": "error",
   "data": {

--- a/internal/cli/testdata/envelope_status.golden
+++ b/internal/cli/testdata/envelope_status.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "5",
+  "schema_version": "6",
   "command": "status",
   "status": "findings",
   "data": {

--- a/internal/cli/testdata/envelope_uninstall.golden
+++ b/internal/cli/testdata/envelope_uninstall.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "5",
+  "schema_version": "6",
   "command": "uninstall",
   "status": "ok",
   "data": {

--- a/internal/cli/testdata/envelope_update.golden
+++ b/internal/cli/testdata/envelope_update.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "5",
+  "schema_version": "6",
   "command": "update",
   "status": "ok",
   "data": {
@@ -160,6 +160,17 @@
         "work"
       ],
       "steps": []
-    }
+    },
+    "backup_sets": [
+      {
+        "id": "backup-20260808T120000Z",
+        "createdAt": "2026-08-08T12:00:00Z",
+        "reason": "pre-install legacy target migration",
+        "targets": [
+          "/home/user/.config/app/settings.json"
+        ],
+        "path": "/home/user/.local/state/dots/backups/backup-20260808T120000Z"
+      }
+    ]
   }
 }

--- a/internal/cli/testdata/envelope_update_selection_error.golden
+++ b/internal/cli/testdata/envelope_update_selection_error.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "5",
+  "schema_version": "6",
   "command": "update",
   "status": "error",
   "data": {

--- a/internal/cli/testdata/envelope_upgrade.golden
+++ b/internal/cli/testdata/envelope_upgrade.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "5",
+  "schema_version": "6",
   "command": "upgrade",
   "status": "ok",
   "data": {

--- a/internal/cli/testdata/plan_all_statuses.golden
+++ b/internal/cli/testdata/plan_all_statuses.golden
@@ -1,13 +1,14 @@
 Plan for profile "work"
 
   create          symlink   configs/zsh/zshrc -> /home/user/.zshrc
+  migrate         copy      configs/app/settings.json -> /home/user/.config/app/settings.json
   conflict        symlink   configs/git/gitconfig -> /home/user/.gitconfig
     source override matches omitted tag(s): adaptive-theme
     selection: omit explicit selection flags to reuse Installed Selection when available, or add --tag adaptive-theme
   unchanged       copy      configs/starship.toml -> /home/user/.config/starship.toml
   missing-source  template  configs/nvim/init.lua -> /home/user/.config/nvim/init.lua
 
-Summary: 1 create, 1 conflict, 1 unchanged, 1 missing-source
+Summary: 1 create, 0 update, 1 migrate, 1 conflict, 1 unchanged, 1 missing-source
 
 Conflict guidance:
   Conflicts mean this profile is only partially managed until you choose a resolution.

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -10,10 +10,12 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/yersonargotev/dots/internal/backups"
 	"github.com/yersonargotev/dots/internal/gitrepo"
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/provision"
+	"github.com/yersonargotev/dots/internal/repositoryrefresh"
 	"github.com/yersonargotev/dots/internal/selection"
 	"github.com/yersonargotev/dots/internal/state"
 	"github.com/yersonargotev/dots/internal/version"
@@ -196,6 +198,21 @@ func runUpdateWorkflow(cmd *cobra.Command, opts updateOptions, emit bool) (updat
 		return updateReport{DryRun: opts.dryRun, Selection: effective.Report}, nil
 	}
 	opts.changeAccepted = accepted
+	preRefresh, err := gitrepo.Preview(paths.SourceRoot)
+	if errors.Is(err, gitrepo.ErrNotFastForward) {
+		return updateReport{}, fmt.Errorf("installed repository %s has diverged from its upstream and cannot be fast-forwarded; resolve it manually with git", paths.SourceRoot)
+	}
+	if err != nil {
+		return updateReport{}, err
+	}
+	meta, err := loadInstallationMetadata(paths, opts.stateRoot)
+	if err != nil {
+		return updateReport{}, err
+	}
+	legacyMigrations, err := repositoryrefresh.CaptureLegacyTargets(*previousManifest, meta, paths.SourceRoot, paths.Home, preRefresh.OldRev)
+	if err != nil {
+		return updateReport{}, err
+	}
 
 	out := cmd.OutOrStdout()
 	var update gitrepo.Update
@@ -233,10 +250,6 @@ func runUpdateWorkflow(cmd *cobra.Command, opts updateOptions, emit bool) (updat
 		}
 		return updateReport{}, err
 	}
-	meta, err := loadInstallationMetadata(paths, opts.stateRoot)
-	if err != nil {
-		return updateReport{}, err
-	}
 	sourceReadRoot := paths.SourceRoot
 	if opts.dryRun && update.Changed() {
 		snapshotRoot, err := os.MkdirTemp("", "dots-update-preview-*")
@@ -249,7 +262,7 @@ func runUpdateWorkflow(cmd *cobra.Command, opts updateOptions, emit bool) (updat
 		}
 		sourceReadRoot = snapshotRoot
 	}
-	p, err := plan.Build(*m, plan.Options{Selection: &effective.Selection, OS: runtime.GOOS, SourceRoot: paths.SourceRoot, SourceReadRoot: sourceReadRoot, Home: paths.Home, Metadata: meta})
+	p, err := plan.Build(*m, plan.Options{Selection: &effective.Selection, OS: runtime.GOOS, SourceRoot: paths.SourceRoot, SourceReadRoot: sourceReadRoot, Home: paths.Home, Metadata: meta, LegacyMigrations: legacyMigrations})
 	if err != nil {
 		return updateReport{}, err
 	}
@@ -282,7 +295,15 @@ func runUpdateWorkflow(cmd *cobra.Command, opts updateOptions, emit bool) (updat
 	if opts.dryRun {
 		return report, nil
 	}
+	beforeBackups, err := backups.Load(backups.Path(paths.StateRoot))
+	if err != nil {
+		return updateReport{}, err
+	}
 	applied, err := resolveAndApply(cmd, p, paths, opts.yes, opts.noTUI, false)
+	if err != nil {
+		return updateReport{}, err
+	}
+	report.BackupSets, err = createdBackupSetReports(paths.StateRoot, beforeBackups)
 	if err != nil {
 		return updateReport{}, err
 	}

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -189,8 +189,89 @@ entries:
 		t.Fatalf("source after update = %q, want upstream content", got)
 	}
 	stashes := runGitOutput(t, sourceRoot, "stash", "list")
-	if !strings.Contains(stashes, "dots update preserved local Installed Repository changes") {
+	if !strings.Contains(stashes, "dots preserved local Installed Repository changes") {
 		t.Fatalf("local edit was not preserved in stash\nstash list:\n%s", stashes)
+	}
+}
+
+func TestUpdatePreviewsAndAppliesLegacyWritableTargetMigration(t *testing.T) {
+	requireGitCLI(t)
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	legacyManifest := `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/app/settings.json
+    target: ~/.config/app/settings.json
+    strategy: symlink
+    tags: [core]
+`
+	origin, sourceRoot := newInstalledRepo(t, map[string]string{"configs/app/settings.json": "{\"owned\":1}\n", "dots.yaml": legacyManifest})
+
+	installCmd := cli.NewRootCommand()
+	var installOut bytes.Buffer
+	installCmd.SetOut(&installOut)
+	installCmd.SetErr(&installOut)
+	installCmd.SetArgs([]string{"install", "--yes", "--skip-deps", "--profile", "default", "--file", filepath.Join(sourceRoot, "dots.yaml"), "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+	if err := installCmd.Execute(); err != nil {
+		t.Fatalf("initial install: %v\n%s", err, installOut.String())
+	}
+	target := filepath.Join(home, ".config", "app", "settings.json")
+	if err := os.WriteFile(target, []byte("{\"owned\":1,\"runtime\":true}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	advanceUpstream(t, origin, "materialize writable target", map[string]string{
+		"configs/app/settings.json": "{\"owned\":2}\n",
+		"dots.yaml": `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/app/settings.json
+    target: ~/.config/app/settings.json
+    strategy: copy
+    ownership: json-subset
+    tags: [core]
+`,
+	})
+	oldHead := strings.TrimSpace(runGitOutput(t, sourceRoot, "rev-parse", "HEAD"))
+	dryOutput := runUpdate(t, "--dry-run", "--profile", "default", "--file", filepath.Join(sourceRoot, "dots.yaml"), "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot)
+	if !strings.Contains(dryOutput, "migrate") {
+		t.Fatalf("dry-run output missing migrate:\n%s", dryOutput)
+	}
+	if got := strings.TrimSpace(runGitOutput(t, sourceRoot, "rev-parse", "HEAD")); got != oldHead {
+		t.Fatalf("dry-run changed checkout: %s != %s", got, oldHead)
+	}
+	if info, err := os.Lstat(target); err != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("dry-run changed target: mode=%v err=%v", info, err)
+	}
+	before, err := backups.Load(backups.Path(stateRoot))
+	if err != nil || len(before.Sets) != 0 {
+		t.Fatalf("dry-run created backup: %#v err=%v", before, err)
+	}
+
+	output := runUpdate(t, "--yes", "--profile", "default", "--file", filepath.Join(sourceRoot, "dots.yaml"), "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot)
+	if !strings.Contains(output, "migrate") || !strings.Contains(output, "stash@{0}") {
+		t.Fatalf("update output missing migration evidence:\n%s", output)
+	}
+	info, err := os.Lstat(target)
+	if err != nil || !info.Mode().IsRegular() {
+		t.Fatalf("target not migrated to regular file: mode=%v err=%v", info, err)
+	}
+	content, _ := os.ReadFile(target)
+	if string(content) != "{\n  \"owned\": 2,\n  \"runtime\": true\n}\n" {
+		t.Fatalf("migrated content = %q", content)
+	}
+	after, err := backups.Load(backups.Path(stateRoot))
+	if err != nil || len(after.Sets) != 1 {
+		t.Fatalf("migration backup sets = %#v err=%v", after, err)
+	}
+	preserved, err := os.ReadFile(backups.FilePath(stateRoot, after.Sets[0].ID, 1, target))
+	if err != nil || string(preserved) != "{\"owned\":1,\"runtime\":true}\n" {
+		t.Fatalf("migration backup = %q err=%v", preserved, err)
 	}
 }
 
@@ -249,7 +330,7 @@ entries:
 		t.Fatalf("dirty work tree was not preserved\nstatus:\n%s", status)
 	}
 	stashes := runGitOutput(t, sourceRoot, "stash", "list")
-	if strings.Contains(stashes, "dots update preserved local Installed Repository changes") {
+	if strings.Contains(stashes, "dots preserved local Installed Repository changes") {
 		t.Fatalf("diverged update stashed before proving fast-forwardability\nstash list:\n%s", stashes)
 	}
 }

--- a/internal/configsubset/subset.go
+++ b/internal/configsubset/subset.go
@@ -5,6 +5,7 @@ package configsubset
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -277,14 +278,6 @@ func TOMLFileContains(target, source string) (bool, error) {
 // more important than reformatting the whole file. Scalar/table value changes
 // remain conflicts unless a caller adds a dedicated migration.
 func MergeTOMLFile(target, source string) error {
-	contains, err := TOMLFileContains(target, source)
-	if err != nil {
-		return err
-	}
-	if contains {
-		return nil
-	}
-
 	sourceData, err := os.ReadFile(source)
 	if err != nil {
 		return fmt.Errorf("read %s: %w", source, err)
@@ -293,16 +286,50 @@ func MergeTOMLFile(target, source string) error {
 	if err != nil {
 		return fmt.Errorf("read %s: %w", target, err)
 	}
+	merged, err := MergeTOML(targetData, sourceData)
+	if err != nil {
+		return err
+	}
+	if bytes.Equal(merged, targetData) {
+		return nil
+	}
 	info, err := os.Stat(target)
 	if err != nil {
 		return fmt.Errorf("stat %s: %w", target, err)
 	}
+	if err := os.WriteFile(target, merged, info.Mode().Perm()); err != nil {
+		return fmt.Errorf("write %s: %w", target, err)
+	}
+	return nil
+}
+
+// MergeTOML returns the conservative co-owned TOML merge without touching the
+// filesystem. It is used by repository-refresh migration planning so dry-run
+// can prove the exact regular-file content before any checkout or target write.
+func MergeTOML(targetData, sourceData []byte) ([]byte, error) {
+	sourceValues, err := parseSimpleTOML(sourceData, nil)
+	if err != nil {
+		return nil, fmt.Errorf("parse source TOML: %w", err)
+	}
+	targetValues, err := parseSimpleTOML(targetData, sourceValuePaths(sourceValues))
+	if err == nil {
+		contains := true
+		for key, sourceValue := range sourceValues {
+			if targetValues[key] != sourceValue {
+				contains = false
+				break
+			}
+		}
+		if contains {
+			return append([]byte(nil), targetData...), nil
+		}
+	}
 	blocks, err := missingArrayTableBlocks(targetData, sourceData)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if len(blocks) == 0 {
-		return fmt.Errorf("source-owned TOML differences cannot be merged safely")
+		return nil, errors.New("source-owned TOML differences cannot be merged safely")
 	}
 
 	merged := append([]byte(nil), targetData...)
@@ -314,17 +341,16 @@ func MergeTOMLFile(target, source string) error {
 		merged = append(merged, strings.TrimRight(block, "\n")...)
 		merged = append(merged, '\n', '\n')
 	}
-	if err := os.WriteFile(target, merged, info.Mode().Perm()); err != nil {
-		return fmt.Errorf("write %s: %w", target, err)
-	}
-	contains, err = TOMLFileContains(target, source)
+	mergedValues, err := parseSimpleTOML(merged, sourceValuePaths(sourceValues))
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("parse merged TOML: %w", err)
 	}
-	if !contains {
-		return fmt.Errorf("merged TOML target still misses source-owned values")
+	for key, sourceValue := range sourceValues {
+		if mergedValues[key] != sourceValue {
+			return nil, errors.New("merged TOML target still misses source-owned values")
+		}
 	}
-	return nil
+	return merged, nil
 }
 
 type jsonMergeResult struct {

--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -33,6 +33,64 @@ type Update struct {
 	AttachedBranch   string   `json:"attached_branch,omitempty"`
 }
 
+// RefPreview resolves one requested remote ref without changing the Installed
+// Repository work tree. Callers can inspect the old and incoming revisions,
+// capture migration evidence, and then pass the result to CheckoutRef.
+func RefPreview(dir, ref string) (Update, error) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return Update{}, errors.New("repository ref is required")
+	}
+	old, err := head(dir)
+	if err != nil {
+		return Update{}, err
+	}
+	if _, err := run(dir, "fetch", "--depth", "1", "origin", ref); err != nil {
+		return Update{}, fmt.Errorf("fetch Installed Repository ref %s: %w", ref, err)
+	}
+	newRev, err := revision(dir, "FETCH_HEAD")
+	if err != nil {
+		return Update{}, fmt.Errorf("resolve Installed Repository ref %s: %w", ref, err)
+	}
+	var incoming []string
+	if old != newRev {
+		incoming, err = incomingCommitsBetween(dir, old, newRev)
+		if err != nil {
+			return Update{}, fmt.Errorf("inspect incoming Installed Repository commits: %w", err)
+		}
+	}
+	return Update{OldRev: old, NewRev: newRev, Incoming: incoming}, nil
+}
+
+// CheckoutRef applies an exact RefPreview after preserving local changes. It
+// checks both revisions before mutation so a stale preview cannot move an
+// unexpected checkout, and checks out only the already fetched requested
+// commit without merging or rebasing.
+func CheckoutRef(dir string, preview Update) (Update, error) {
+	current, err := head(dir)
+	if err != nil {
+		return Update{}, err
+	}
+	if current != preview.OldRev || !validRevision(preview.NewRev) {
+		return Update{}, errors.New("installed repository changed after ref preview")
+	}
+	preserved, stashed, err := PreserveLocalChanges(dir)
+	if err != nil {
+		return Update{}, err
+	}
+	result := preview
+	if stashed {
+		result.PreservedChanges = preserved
+	}
+	if preview.OldRev == preview.NewRev {
+		return result, nil
+	}
+	if _, err := run(dir, "checkout", "--detach", preview.NewRev); err != nil {
+		return Update{}, fmt.Errorf("checkout Installed Repository ref %s: %w", preview.NewRev, err)
+	}
+	return result, nil
+}
+
 type upstreamTarget struct {
 	Ref             string
 	Rev             string
@@ -150,6 +208,26 @@ func validRevision(revision string) bool {
 	return revision != "" && strings.Trim(revision, "0123456789abcdefABCDEF") == ""
 }
 
+func revision(dir, ref string) (string, error) {
+	out, err := run(dir, "rev-parse", "--verify", ref+"^{commit}")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}
+
+func incomingCommitsBetween(dir, oldRev, newRev string) ([]string, error) {
+	out, err := run(dir, "log", "--oneline", "--no-decorate", oldRev+".."+newRev)
+	if err != nil {
+		return nil, err
+	}
+	trimmed := strings.TrimSpace(out)
+	if trimmed == "" {
+		return nil, nil
+	}
+	return strings.Split(trimmed, "\n"), nil
+}
+
 func pathInside(path, root string) bool {
 	relative, err := filepath.Rel(root, path)
 	return err == nil && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
@@ -185,7 +263,7 @@ func PreserveLocalChanges(dir string) (string, bool, error) {
 	if clean {
 		return "", false, nil
 	}
-	if _, err := run(dir, "stash", "push", "--include-untracked", "-m", "dots update preserved local Installed Repository changes"); err != nil {
+	if _, err := run(dir, "stash", "push", "--include-untracked", "-m", "dots preserved local Installed Repository changes"); err != nil {
 		return "", false, fmt.Errorf("preserve local changes for %s: %w", dir, err)
 	}
 	return "stash@{0}", true, nil

--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -74,9 +74,6 @@ func CheckoutRef(dir string, preview Update) (Update, error) {
 	if current != preview.OldRev || !validRevision(preview.NewRev) {
 		return Update{}, errors.New("installed repository changed after ref preview")
 	}
-	if preview.OldRev == preview.NewRev {
-		return preview, nil
-	}
 	preserved, stashed, err := PreserveLocalChanges(dir)
 	if err != nil {
 		return Update{}, err
@@ -84,6 +81,9 @@ func CheckoutRef(dir string, preview Update) (Update, error) {
 	result := preview
 	if stashed {
 		result.PreservedChanges = preserved
+	}
+	if preview.OldRev == preview.NewRev {
+		return result, nil
 	}
 	if _, err := run(dir, "checkout", "--detach", preview.NewRev); err != nil {
 		return Update{}, fmt.Errorf("checkout Installed Repository ref %s: %w", preview.NewRev, err)

--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -48,7 +48,7 @@ func RefPreview(dir, ref string) (Update, error) {
 	if _, err := run(dir, "fetch", "--depth", "1", "origin", ref); err != nil {
 		return Update{}, fmt.Errorf("fetch Installed Repository ref %s: %w", ref, err)
 	}
-	newRev, err := resolveRevision(dir, "FETCH_HEAD")
+	newRev, err := shortRevision(dir, "FETCH_HEAD")
 	if err != nil {
 		return Update{}, fmt.Errorf("resolve Installed Repository ref %s: %w", ref, err)
 	}
@@ -74,6 +74,9 @@ func CheckoutRef(dir string, preview Update) (Update, error) {
 	if current != preview.OldRev || !validRevision(preview.NewRev) {
 		return Update{}, errors.New("installed repository changed after ref preview")
 	}
+	if preview.OldRev == preview.NewRev {
+		return preview, nil
+	}
 	preserved, stashed, err := PreserveLocalChanges(dir)
 	if err != nil {
 		return Update{}, err
@@ -81,9 +84,6 @@ func CheckoutRef(dir string, preview Update) (Update, error) {
 	result := preview
 	if stashed {
 		result.PreservedChanges = preserved
-	}
-	if preview.OldRev == preview.NewRev {
-		return result, nil
 	}
 	if _, err := run(dir, "checkout", "--detach", preview.NewRev); err != nil {
 		return Update{}, fmt.Errorf("checkout Installed Repository ref %s: %w", preview.NewRev, err)
@@ -221,6 +221,14 @@ func validRevision(revision string) bool {
 
 func resolveRevision(dir, ref string) (string, error) {
 	out, err := run(dir, "rev-parse", "--verify", ref+"^{commit}")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}
+
+func shortRevision(dir, ref string) (string, error) {
+	out, err := run(dir, "rev-parse", "--short", "--verify", ref+"^{commit}")
 	if err != nil {
 		return "", err
 	}

--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -48,7 +48,7 @@ func RefPreview(dir, ref string) (Update, error) {
 	if _, err := run(dir, "fetch", "--depth", "1", "origin", ref); err != nil {
 		return Update{}, fmt.Errorf("fetch Installed Repository ref %s: %w", ref, err)
 	}
-	newRev, err := revision(dir, "FETCH_HEAD")
+	newRev, err := resolveRevision(dir, "FETCH_HEAD")
 	if err != nil {
 		return Update{}, fmt.Errorf("resolve Installed Repository ref %s: %w", ref, err)
 	}
@@ -119,6 +119,17 @@ func ReadFileAtRevision(dir, revision, filePath string) ([]byte, error) {
 		return nil, fmt.Errorf("read %s at %s: %w", cleanPath, revision, err)
 	}
 	return []byte(content), nil
+}
+
+// ResolveRevision resolves one full or abbreviated hexadecimal commit name.
+// Ambiguous or missing abbreviations fail instead of authorizing callers to
+// treat a textual prefix as repository provenance.
+func ResolveRevision(dir, revision string) (string, error) {
+	revision = strings.TrimSpace(revision)
+	if !validRevision(revision) {
+		return "", fmt.Errorf("resolve repository revision: invalid revision %q", revision)
+	}
+	return resolveRevision(dir, revision)
 }
 
 // ExportRevision materializes a read-only snapshot of one resolved revision in
@@ -208,7 +219,7 @@ func validRevision(revision string) bool {
 	return revision != "" && strings.Trim(revision, "0123456789abcdefABCDEF") == ""
 }
 
-func revision(dir, ref string) (string, error) {
+func resolveRevision(dir, ref string) (string, error) {
 	out, err := run(dir, "rev-parse", "--verify", ref+"^{commit}")
 	if err != nil {
 		return "", err

--- a/internal/gitrepo/gitrepo_test.go
+++ b/internal/gitrepo/gitrepo_test.go
@@ -128,7 +128,7 @@ func TestPreviewReportsIncomingWithoutModifyingWorkingTree(t *testing.T) {
 	}
 }
 
-func TestCheckoutRefSameRevisionLeavesDirtyWorktreeInPlace(t *testing.T) {
+func TestCheckoutRefSameRevisionPreservesDirtyWorktreeWithoutDetaching(t *testing.T) {
 	requireGit(t)
 	_, clone := setupRemoteAndClone(t)
 	localPath := filepath.Join(clone, "configs", "zsh", "zshrc")
@@ -145,12 +145,12 @@ func TestCheckoutRefSameRevisionLeavesDirtyWorktreeInPlace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CheckoutRef() error = %v", err)
 	}
-	if result.PreservedChanges != "" {
-		t.Fatalf("same-ref checkout preserved changes in %q", result.PreservedChanges)
+	if result.PreservedChanges != "stash@{0}" {
+		t.Fatalf("same-ref checkout preserved changes in %q, want stash@{0}", result.PreservedChanges)
 	}
 	content, err := os.ReadFile(localPath)
-	if err != nil || string(content) != "local edit\n" {
-		t.Fatalf("dirty content = %q, err=%v", content, err)
+	if err != nil || string(content) == "local edit\n" {
+		t.Fatalf("dirty content remained in checkout: %q, err=%v", content, err)
 	}
 	if got := gitOutput(t, clone, "rev-parse", "--abbrev-ref", "HEAD"); got != "main" {
 		t.Fatalf("same-ref checkout detached branch: %s", got)

--- a/internal/gitrepo/gitrepo_test.go
+++ b/internal/gitrepo/gitrepo_test.go
@@ -128,6 +128,35 @@ func TestPreviewReportsIncomingWithoutModifyingWorkingTree(t *testing.T) {
 	}
 }
 
+func TestCheckoutRefSameRevisionLeavesDirtyWorktreeInPlace(t *testing.T) {
+	requireGit(t)
+	_, clone := setupRemoteAndClone(t)
+	localPath := filepath.Join(clone, "configs", "zsh", "zshrc")
+	writeFile(t, localPath, "local edit\n")
+
+	preview, err := gitrepo.RefPreview(clone, "main")
+	if err != nil {
+		t.Fatalf("RefPreview() error = %v", err)
+	}
+	if preview.Changed() {
+		t.Fatalf("same-ref preview = %#v, want unchanged", preview)
+	}
+	result, err := gitrepo.CheckoutRef(clone, preview)
+	if err != nil {
+		t.Fatalf("CheckoutRef() error = %v", err)
+	}
+	if result.PreservedChanges != "" {
+		t.Fatalf("same-ref checkout preserved changes in %q", result.PreservedChanges)
+	}
+	content, err := os.ReadFile(localPath)
+	if err != nil || string(content) != "local edit\n" {
+		t.Fatalf("dirty content = %q, err=%v", content, err)
+	}
+	if got := gitOutput(t, clone, "rev-parse", "--abbrev-ref", "HEAD"); got != "main" {
+		t.Fatalf("same-ref checkout detached branch: %s", got)
+	}
+}
+
 func TestReadFileAtRevisionReadsIncomingFileWithoutModifyingWorkingTree(t *testing.T) {
 	requireGit(t)
 	origin, clone := setupRemoteAndClone(t)

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -57,6 +57,10 @@ func Apply(p plan.Plan, opts Options) error {
 			if err := applyUpdate(action, source, opts); err != nil {
 				return err
 			}
+		case plan.StatusMigrate:
+			if err := applyMigration(action, source, opts); err != nil {
+				return err
+			}
 		case plan.StatusConflict:
 			switch conflictDecision(action, opts) {
 			case DecisionSkip:
@@ -253,6 +257,25 @@ func validatePlan(p plan.Plan, opts Options) ([][]string, error) {
 			if err := validateSource(action.Strategy, source, sourceRoot); err != nil {
 				return nil, err
 			}
+		case plan.StatusMigrate:
+			if opts.StateRoot == "" {
+				return nil, fmt.Errorf("migration for %s requires state root for Backup Set metadata", action.Target)
+			}
+			if action.Strategy != "copy" || action.Migration == nil {
+				return nil, fmt.Errorf("migration for %s requires captured copy content", action.Target)
+			}
+			if err := validateBackupStateRoot(opts.StateRoot, home); err != nil {
+				return nil, err
+			}
+			if err := validateTargetParentInsideHome(action.Target, home); err != nil {
+				return nil, err
+			}
+			if err := validateSource(action.Strategy, source, sourceRoot); err != nil {
+				return nil, err
+			}
+			if err := validateMigrationTarget(action); err != nil {
+				return nil, err
+			}
 		case plan.StatusConflict:
 			switch conflictDecision(action, opts) {
 			case DecisionSkip:
@@ -321,7 +344,7 @@ func conflictDecision(action plan.Action, opts Options) ConflictDecision {
 }
 
 func recordsMetadata(action plan.Action, decision ConflictDecision) bool {
-	if action.Status == plan.StatusCreate || action.Status == plan.StatusUpdate || action.Status == plan.StatusUnchanged {
+	if action.Status == plan.StatusCreate || action.Status == plan.StatusUpdate || action.Status == plan.StatusMigrate || action.Status == plan.StatusUnchanged {
 		return true
 	}
 	return action.Status == plan.StatusConflict && (decision == DecisionReplace || decision == DecisionAdopt)
@@ -507,6 +530,53 @@ func applyUpdate(action plan.Action, source string, opts Options) error {
 		}
 	default:
 		return fmt.Errorf("update ownership %q is not supported for %s", action.Ownership, action.Target)
+	}
+	return nil
+}
+
+func validateMigrationTarget(action plan.Action) error {
+	info, err := os.Lstat(action.Target)
+	if err != nil {
+		return fmt.Errorf("install plan is stale: migration target %s changed: %w", action.Target, err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		return fmt.Errorf("install plan is stale: migration target %s is no longer a symlink", action.Target)
+	}
+	destination, err := os.Readlink(action.Target)
+	if err != nil {
+		return fmt.Errorf("read migration target %s: %w", action.Target, err)
+	}
+	if filepath.Clean(destination) != filepath.Clean(action.Migration.LinkDestination) {
+		return fmt.Errorf("install plan is stale: migration target %s changed destination", action.Target)
+	}
+	content, err := os.ReadFile(action.Target)
+	if err != nil {
+		return fmt.Errorf("install plan is stale: read migration target %s: %w", action.Target, err)
+	}
+	if !bytes.Equal(content, action.Migration.ExpectedLinkContent) {
+		return fmt.Errorf("install plan is stale: migration target %s content changed", action.Target)
+	}
+	return nil
+}
+
+func applyMigration(action plan.Action, source string, opts Options) error {
+	if err := validateMigrationTarget(action); err != nil {
+		return err
+	}
+	info, err := os.Stat(source)
+	if err != nil {
+		return fmt.Errorf("stat migration source %s: %w", source, err)
+	}
+	if _, err := backups.CreateContentSet(opts.StateRoot, action.Target, action.Migration.CapturedContent, info.Mode(), backups.CreateOptions{
+		Reason: "pre-install legacy target migration", Machine: backups.MachineName(), Repo: opts.SourceRoot,
+	}); err != nil {
+		return err
+	}
+	if err := os.Remove(action.Target); err != nil {
+		return fmt.Errorf("remove legacy symlink %s: %w", action.Target, err)
+	}
+	if err := writeNewFileFromSourceMode(source, action.Target, action.Migration.FinalContent); err != nil {
+		return fmt.Errorf("materialize migrated target %s: %w", action.Target, err)
 	}
 	return nil
 }

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -122,6 +122,74 @@ func TestApplyComposedJSONSubsetCreatesAndUpdatesOneSharedTarget(t *testing.T) {
 	}
 }
 
+func TestApplyMigrationCreatesContentBackupAndRegularTarget(t *testing.T) {
+	sourceRoot := t.TempDir()
+	home := t.TempDir()
+	stateRoot := filepath.Join(home, ".local", "state", "dots")
+	source := filepath.Join(sourceRoot, "configs", "app.json")
+	if err := os.MkdirAll(filepath.Dir(source), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	current := []byte("{\"owned\":2}\n")
+	if err := os.WriteFile(source, current, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(home, ".config", "app.json")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(source, target); err != nil {
+		t.Fatal(err)
+	}
+	captured := []byte("{\"owned\":1,\"runtime\":true}\n")
+	final := []byte("{\n  \"owned\": 2,\n  \"runtime\": true\n}\n")
+	p := plan.Plan{Actions: []plan.Action{{
+		Source: "configs/app.json", ResolvedSource: source, Target: target, Strategy: "copy", Ownership: "json-subset", Status: plan.StatusMigrate,
+		Migration: &plan.LegacyMigration{LinkDestination: source, CapturedContent: captured, ExpectedLinkContent: current, FinalContent: final},
+	}}}
+	if err := install.Apply(p, install.Options{SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot}); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Lstat(target)
+	if err != nil || !info.Mode().IsRegular() {
+		t.Fatalf("migrated target mode = %v, err=%v", info, err)
+	}
+	got, _ := os.ReadFile(target)
+	if string(got) != string(final) {
+		t.Fatalf("target = %q", got)
+	}
+	metadata, err := backups.Load(backups.Path(stateRoot))
+	if err != nil || len(metadata.Sets) != 1 {
+		t.Fatalf("backup metadata = %#v, err=%v", metadata, err)
+	}
+	backup, err := os.ReadFile(backups.FilePath(stateRoot, metadata.Sets[0].ID, 1, target))
+	if err != nil || string(backup) != string(captured) {
+		t.Fatalf("backup = %q, err=%v", backup, err)
+	}
+}
+
+func TestApplyMigrationRejectsConcurrentTargetChangeBeforeBackup(t *testing.T) {
+	sourceRoot := t.TempDir()
+	home := t.TempDir()
+	stateRoot := filepath.Join(home, ".state")
+	source := filepath.Join(sourceRoot, "app")
+	if err := os.WriteFile(source, []byte("changed after plan\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(home, ".app")
+	if err := os.Symlink(source, target); err != nil {
+		t.Fatal(err)
+	}
+	p := plan.Plan{Actions: []plan.Action{{Source: "app", ResolvedSource: source, Target: target, Strategy: "copy", Status: plan.StatusMigrate, Migration: &plan.LegacyMigration{LinkDestination: source, CapturedContent: []byte("old\n"), ExpectedLinkContent: []byte("expected\n"), FinalContent: []byte("final\n")}}}}
+	err := install.Apply(p, install.Options{SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot})
+	if err == nil || !strings.Contains(err.Error(), "content changed") {
+		t.Fatalf("error = %v", err)
+	}
+	if _, statErr := os.Lstat(backups.Path(stateRoot)); !os.IsNotExist(statErr) {
+		t.Fatalf("backup metadata created after stale plan: %v", statErr)
+	}
+}
+
 func TestApplyCreatesSymlinkForCreateAction(t *testing.T) {
 	sourceRoot := t.TempDir()
 	home := t.TempDir()

--- a/internal/plan/findings_test.go
+++ b/internal/plan/findings_test.go
@@ -10,6 +10,7 @@ func TestPlanHasFindings(t *testing.T) {
 	}{
 		{"create is not a finding", StatusCreate, false},
 		{"update is not a finding", StatusUpdate, false},
+		{"migrate is not a finding", StatusMigrate, false},
 		{"unchanged is not a finding", StatusUnchanged, false},
 		{"conflict is a finding", StatusConflict, true},
 		{"missing-source is a finding", StatusMissingSource, true},

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -21,6 +21,7 @@ type Status string
 const (
 	StatusCreate        Status = "create"
 	StatusUpdate        Status = "update"
+	StatusMigrate       Status = "migrate"
 	StatusConflict      Status = "conflict"
 	StatusUnchanged     Status = "unchanged"
 	StatusMissingSource Status = "missing-source"
@@ -52,6 +53,21 @@ type Action struct {
 	Reason          string   `json:"reason,omitempty"`
 	MatchingTags    []string `json:"matching_tags,omitempty"`
 	Ownership       string   `json:"-"`
+	// Migration carries pre-refresh evidence for an ownership-changing legacy
+	// symlink. It is intentionally excluded from machine output; status is the
+	// portable contract and captured workstation content may be sensitive.
+	Migration *LegacyMigration `json:"-"`
+}
+
+// LegacyMigration is provenance-backed content captured before the Installed
+// Repository checkout changed. FinalContent is the exact regular-file content
+// apply may materialize after last-moment symlink and content revalidation.
+type LegacyMigration struct {
+	LinkDestination       string
+	CapturedContent       []byte
+	PreviousSourceContent []byte
+	ExpectedLinkContent   []byte
+	FinalContent          []byte
 }
 
 // Plan is the preview of changes the installer would apply for a Profile.
@@ -87,9 +103,10 @@ type Options struct {
 	SourceRoot string
 	// SourceReadRoot optionally supplies a snapshot used only to inspect source
 	// existence and content. Empty defaults to SourceRoot.
-	SourceReadRoot string
-	Home           string
-	Metadata       state.Metadata
+	SourceReadRoot   string
+	Home             string
+	Metadata         state.Metadata
+	LegacyMigrations map[string]LegacyMigration
 }
 
 // Build computes the Install Plan for the selected Profile without mutating
@@ -162,6 +179,20 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 			MatchingTags:   matchingTags,
 			Ownership:      entry.Ownership,
 		}
+		if actionStatus == StatusConflict {
+			if migration, ok := opts.LegacyMigrations[target]; ok {
+				planned, compatible, migrateErr := planLegacyMigration(entry, readSourceAbs, migration)
+				if migrateErr != nil {
+					return Plan{}, migrateErr
+				}
+				if compatible {
+					action.Status = StatusMigrate
+					action.Migration = &planned
+					action.Reason = ""
+					action.MatchingTags = nil
+				}
+			}
+		}
 		if rec, ok := opts.Metadata.FindByTarget(target); ok && rec.Ownership == "json-subset" && len(rec.OwnedContent) > 0 {
 			action.PreviousContent = append([]byte(nil), rec.OwnedContent...)
 		}
@@ -203,6 +234,41 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 	}
 
 	return plan, nil
+}
+
+func planLegacyMigration(entry manifest.Entry, currentSource string, migration LegacyMigration) (LegacyMigration, bool, error) {
+	if entry.Strategy != "copy" || migration.LinkDestination == "" {
+		return LegacyMigration{}, false, nil
+	}
+	current, err := os.ReadFile(currentSource)
+	if err != nil {
+		return LegacyMigration{}, false, fmt.Errorf("read migration source %s: %w", currentSource, err)
+	}
+	planned := migration
+	planned.ExpectedLinkContent = append([]byte(nil), current...)
+	switch entry.Ownership {
+	case "json-subset":
+		reconciliation, err := configsubset.ReconcileJSON(migration.CapturedContent, migration.PreviousSourceContent, current)
+		if err != nil {
+			return LegacyMigration{}, false, err
+		}
+		if !reconciliation.Compatible {
+			return LegacyMigration{}, false, nil
+		}
+		planned.FinalContent = reconciliation.Content
+	case "toml-subset":
+		merged, err := configsubset.MergeTOML(migration.CapturedContent, current)
+		if err != nil {
+			return LegacyMigration{}, false, nil
+		}
+		planned.FinalContent = merged
+	default:
+		if !bytes.Equal(migration.CapturedContent, migration.PreviousSourceContent) {
+			return LegacyMigration{}, false, nil
+		}
+		planned.FinalContent = append([]byte(nil), current...)
+	}
+	return planned, true, nil
 }
 
 func composedJSONStatus(action Action, meta state.Metadata) (Status, error) {

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -453,6 +453,56 @@ func TestBuildCopyJSONSubsetOwnership(t *testing.T) {
 	}
 }
 
+func TestBuildPlansProvenanceBackedLegacyJSONMigration(t *testing.T) {
+	sourceRoot := t.TempDir()
+	home := t.TempDir()
+	source := writeSource(t, sourceRoot, "configs/app.json", "{\"owned\":2}\n")
+	target := filepath.Join(home, ".config", "app.json")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(source, target); err != nil {
+		t.Fatal(err)
+	}
+	m := manifest.Manifest{
+		Profiles: map[string]manifest.Profile{"core": {Tags: []string{"core"}}},
+		Entries:  []manifest.Entry{{Source: "configs/app.json", Target: "~/.config/app.json", Strategy: "copy", Ownership: "json-subset", Tags: []string{"core"}}},
+	}
+	p, err := plan.Build(m, plan.Options{
+		Profiles: []string{"core"}, OS: "linux", SourceRoot: sourceRoot, Home: home,
+		LegacyMigrations: map[string]plan.LegacyMigration{target: {
+			LinkDestination: source, CapturedContent: []byte("{\"owned\":1,\"runtime\":true}\n"), PreviousSourceContent: []byte("{\"owned\":1}\n"),
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(p.Actions) != 1 || p.Actions[0].Status != plan.StatusMigrate || p.Actions[0].Migration == nil {
+		t.Fatalf("actions = %#v, want migrate", p.Actions)
+	}
+	if got := string(p.Actions[0].Migration.FinalContent); got != "{\n  \"owned\": 2,\n  \"runtime\": true\n}\n" {
+		t.Fatalf("migration content = %q", got)
+	}
+}
+
+func TestBuildKeepsAmbiguousLegacyContentAsConflict(t *testing.T) {
+	sourceRoot := t.TempDir()
+	home := t.TempDir()
+	source := writeSource(t, sourceRoot, "configs/app", "new\n")
+	target := filepath.Join(home, ".app")
+	if err := os.Symlink(source, target); err != nil {
+		t.Fatal(err)
+	}
+	m := manifest.Manifest{Profiles: map[string]manifest.Profile{"core": {Tags: []string{"core"}}}, Entries: []manifest.Entry{{Source: "configs/app", Target: "~/.app", Strategy: "copy", Tags: []string{"core"}}}}
+	p, err := plan.Build(m, plan.Options{Profiles: []string{"core"}, OS: "linux", SourceRoot: sourceRoot, Home: home, LegacyMigrations: map[string]plan.LegacyMigration{target: {LinkDestination: source, CapturedContent: []byte("locally changed\n"), PreviousSourceContent: []byte("old\n")}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Actions[0].Status != plan.StatusConflict {
+		t.Fatalf("status = %q, want conflict", p.Actions[0].Status)
+	}
+}
+
 func TestBuildJSONSubsetUsesRecordedContributionForReversibleRemoval(t *testing.T) {
 	sourceRoot := t.TempDir()
 	home := t.TempDir()

--- a/internal/repositoryrefresh/capture.go
+++ b/internal/repositoryrefresh/capture.go
@@ -1,0 +1,124 @@
+// Package repositoryrefresh captures provenance-backed workstation content
+// before an Installed Repository transition can move the symlinked source.
+package repositoryrefresh
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/yersonargotev/dots/internal/gitrepo"
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/plan"
+	"github.com/yersonargotev/dots/internal/state"
+)
+
+// CaptureLegacyTargets returns only unambiguous legacy symlinks backed by both
+// Installation Metadata provenance and the old Install Manifest. Missing or
+// stale evidence is deliberately omitted so the later Install Plan reports a
+// Conflict instead of guessing ownership.
+func CaptureLegacyTargets(oldManifest manifest.Manifest, meta state.Metadata, sourceRoot, home, oldRevision string) (map[string]plan.LegacyMigration, error) {
+	captures := map[string]plan.LegacyMigration{}
+	if !provenanceMatches(meta.Provenance, sourceRoot, oldRevision) {
+		return captures, nil
+	}
+	counts := map[string]int{}
+	for _, rec := range meta.Entries {
+		counts[filepath.Clean(rec.Target)]++
+	}
+	for _, rec := range meta.Entries {
+		if rec.Strategy != "symlink" || counts[filepath.Clean(rec.Target)] != 1 {
+			continue
+		}
+		target, source, ok, err := declaredLegacySymlink(oldManifest, rec, sourceRoot, home)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		info, err := os.Lstat(target)
+		if err != nil || info.Mode()&os.ModeSymlink == 0 {
+			continue
+		}
+		destination, err := os.Readlink(target)
+		if err != nil || filepath.Clean(destination) != filepath.Clean(source) {
+			continue
+		}
+		content, err := os.ReadFile(source)
+		if err != nil {
+			continue
+		}
+		currentDestination, err := os.Readlink(target)
+		if err != nil || filepath.Clean(currentDestination) != filepath.Clean(destination) {
+			continue
+		}
+		previous, err := gitrepo.ReadFileAtRevision(sourceRoot, oldRevision, rec.Source)
+		if err != nil {
+			continue
+		}
+		captures[target] = plan.LegacyMigration{
+			LinkDestination:       destination,
+			CapturedContent:       append([]byte(nil), content...),
+			PreviousSourceContent: append([]byte(nil), previous...),
+		}
+	}
+	return captures, nil
+}
+
+func provenanceMatches(provenance state.Provenance, sourceRoot, revision string) bool {
+	if provenance.SourceRoot == "" || provenance.SourceRevision == "" || revision == "" {
+		return false
+	}
+	wantRoot, err := filepath.Abs(sourceRoot)
+	if err != nil {
+		return false
+	}
+	gotRoot, err := filepath.Abs(provenance.SourceRoot)
+	if err != nil || filepath.Clean(gotRoot) != filepath.Clean(wantRoot) {
+		return false
+	}
+	return strings.HasPrefix(revision, provenance.SourceRevision)
+}
+
+func declaredLegacySymlink(m manifest.Manifest, rec state.Record, sourceRoot, home string) (target, source string, ok bool, err error) {
+	for _, entry := range m.Entries {
+		if entry.Strategy != "symlink" || !declaresSource(entry, rec.Source) {
+			continue
+		}
+		resolvedTarget, resolveErr := plan.ResolveTarget(entry.Target, home)
+		if resolveErr != nil {
+			return "", "", false, resolveErr
+		}
+		if filepath.Clean(resolvedTarget) != filepath.Clean(rec.Target) {
+			continue
+		}
+		resolvedSource, resolveErr := plan.ResolveSource(rec.Source, sourceRoot)
+		if resolveErr != nil {
+			return "", "", false, resolveErr
+		}
+		if validateErr := plan.ValidateResolvedSource(resolvedSource, sourceRoot); validateErr != nil {
+			return "", "", false, fmt.Errorf("validate legacy source %s: %w", rec.Source, validateErr)
+		}
+		return resolvedTarget, resolvedSource, true, nil
+	}
+	return "", "", false, nil
+}
+
+func declaresSource(entry manifest.Entry, source string) bool {
+	if entry.Source == source {
+		return true
+	}
+	for _, candidate := range entry.SourceOverrides {
+		if candidate == source {
+			return true
+		}
+	}
+	return false
+}
+
+// Describe returns a stable count for user-facing transition reporting.
+func Describe(captures map[string]plan.LegacyMigration) string {
+	return fmt.Sprintf("%d provenance-backed legacy target(s)", len(captures))
+}

--- a/internal/repositoryrefresh/capture.go
+++ b/internal/repositoryrefresh/capture.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/yersonargotev/dots/internal/gitrepo"
 	"github.com/yersonargotev/dots/internal/manifest"
@@ -68,7 +67,7 @@ func CaptureLegacyTargets(oldManifest manifest.Manifest, meta state.Metadata, so
 }
 
 func provenanceMatches(provenance state.Provenance, sourceRoot, revision string) bool {
-	if provenance.SourceRoot == "" || provenance.SourceRevision == "" || revision == "" {
+	if provenance.SourceRoot == "" || len(provenance.SourceRevision) < 7 || revision == "" {
 		return false
 	}
 	wantRoot, err := filepath.Abs(sourceRoot)
@@ -79,7 +78,12 @@ func provenanceMatches(provenance state.Provenance, sourceRoot, revision string)
 	if err != nil || filepath.Clean(gotRoot) != filepath.Clean(wantRoot) {
 		return false
 	}
-	return strings.HasPrefix(revision, provenance.SourceRevision)
+	recordedRevision, err := gitrepo.ResolveRevision(sourceRoot, provenance.SourceRevision)
+	if err != nil {
+		return false
+	}
+	currentRevision, err := gitrepo.ResolveRevision(sourceRoot, revision)
+	return err == nil && recordedRevision == currentRevision
 }
 
 func declaredLegacySymlink(m manifest.Manifest, rec state.Record, sourceRoot, home string) (target, source string, ok bool, err error) {

--- a/internal/repositoryrefresh/capture_test.go
+++ b/internal/repositoryrefresh/capture_test.go
@@ -56,6 +56,15 @@ func TestCaptureLegacyTargetsRequiresMatchingProvenanceAndDeclaredSymlink(t *tes
 	if len(captures) != 0 {
 		t.Fatalf("stale provenance captured targets: %#v", captures)
 	}
+
+	meta.Provenance.SourceRevision = revision[:1]
+	captures, err = repositoryrefresh.CaptureLegacyTargets(m, meta, sourceRoot, home, revision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(captures) != 0 {
+		t.Fatalf("ambiguous short provenance captured targets: %#v", captures)
+	}
 }
 
 func runGit(t *testing.T, dir string, args ...string) {

--- a/internal/repositoryrefresh/capture_test.go
+++ b/internal/repositoryrefresh/capture_test.go
@@ -1,0 +1,91 @@
+package repositoryrefresh_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/repositoryrefresh"
+	"github.com/yersonargotev/dots/internal/state"
+)
+
+func TestCaptureLegacyTargetsRequiresMatchingProvenanceAndDeclaredSymlink(t *testing.T) {
+	sourceRoot := t.TempDir()
+	home := t.TempDir()
+	runGit(t, sourceRoot, "init", "-b", "main")
+	runGit(t, sourceRoot, "config", "user.email", "dots@test.local")
+	runGit(t, sourceRoot, "config", "user.name", "dots test")
+	source := filepath.Join(sourceRoot, "configs", "app.json")
+	writeFile(t, source, "{\"owned\":1}\n")
+	runGit(t, sourceRoot, "add", ".")
+	runGit(t, sourceRoot, "commit", "-m", "legacy")
+	revision := gitOutput(t, sourceRoot, "rev-parse", "HEAD")
+	target := filepath.Join(home, ".config", "app.json")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(source, target); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, source, "{\"owned\":1,\"runtime\":true}\n")
+
+	m := manifest.Manifest{Entries: []manifest.Entry{{Source: "configs/app.json", Target: "~/.config/app.json", Strategy: "symlink", Tags: []string{"core"}}}}
+	meta := state.Metadata{
+		Provenance: state.Provenance{SourceRoot: sourceRoot, SourceRevision: revision[:12]},
+		Entries:    []state.Record{{Target: target, Source: "configs/app.json", Strategy: "symlink"}},
+	}
+	captures, err := repositoryrefresh.CaptureLegacyTargets(m, meta, sourceRoot, home, revision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	capture, ok := captures[target]
+	if !ok {
+		t.Fatal("expected provenance-backed legacy target capture")
+	}
+	if string(capture.CapturedContent) != "{\"owned\":1,\"runtime\":true}\n" || string(capture.PreviousSourceContent) != "{\"owned\":1}\n" {
+		t.Fatalf("capture = %#v", capture)
+	}
+
+	meta.Provenance.SourceRevision = "deadbeef"
+	captures, err = repositoryrefresh.CaptureLegacyTargets(m, meta, sourceRoot, home, revision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(captures) != 0 {
+		t.Fatalf("stale provenance captured targets: %#v", captures)
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL="+os.DevNull, "GIT_CONFIG_NOSYSTEM=1")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func gitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL="+os.DevNull, "GIT_CONFIG_NOSYSTEM=1")
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(out[:len(out)-1])
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Closes #386

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Unifies install and update repository refresh around capture, preservation, and ref transition primitives.
- Adds provenance-backed `migrate` planning and backup-backed apply behavior for legacy writable symlink targets.
- Fails closed for ambiguous, stale, manual, and concurrently changed targets and advances machine output to schema version 6.

## Changes

| File | Change |
|------|--------|
| `internal/repositoryrefresh/capture.go` | Captures legacy writable targets only when metadata and canonical Git provenance match. |
| `internal/plan/plan.go` | Exposes `migrate` actions and reconciles whole-file, JSON-subset, and TOML-subset ownership. |
| `internal/install/install.go` | Revalidates migrations immediately before replacement and creates content-backed Backup Sets. |
| `internal/gitrepo/gitrepo.go` | Shares safe repository preview, preservation, and exact-ref checkout behavior across install and update. |
| `internal/cli/install_repository.go` | Prepares default installs from an immutable incoming snapshot for dry-run and applies repository refresh otherwise. |
| `docs/agents/output-contract.md` | Documents schema version 6 and repository refresh/migration output. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go build ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan: `go run ./cmd/dots plan --file dots.yaml --profile core --source-root "$PWD" --home <tmp> --output json`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #386`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

- Agent Brief: https://github.com/yersonargotev/dots/issues/386#issuecomment-5226645676 (comment `5226645676`, updated `2026-08-08T14:56:34Z`, SHA-256 `32710950a4ff1bb18e7a9cb99691809e3e308f085e57ae32b8815bd88be8b23f`).
- Reviewed head: `8059cb0978fc4ce40db58f3102bece9412f14066` against `origin/main`.
- Acceptance coverage: install/update preservation, reported stash recovery, provenance-backed preview/apply migration, backup creation, conflict behavior for stale/ambiguous/manual/concurrent targets, and dry-run immutability are covered by focused and end-to-end tests.
- Automated validation: `gofmt -l .`, `go vet ./...`, `go build ./...`, `go test ./...`, manifest validation, and a sandboxed schema-v6 plan all passed.
- Manual real-binary validation: a temporary Installed Repository migrated a writable JSON symlink to a regular `json-subset` target, retained the runtime key, applied the new owned value, reported `stash@{0}`, and stored the exact pre-refresh content in a Backup Set. Its dry-run reported `migrate` without changing checkout, target, metadata, or backups.
- Same-ref real-binary validation: a release-version binary preserved an untracked repository change in `stash@{0}` while leaving the attached branch unchanged.
- Independent review: Spec and Standards reviewers both reported no actionable findings at `8059cb0` after all fixes.
- Delegation: implementation remained direct because the optional delegation skill/artifacts were unavailable; independent Spec and Standards reviews were performed with native sub-agents as required.
- Main-agent verification: all automated and manual gates were rerun after the final code change; the worktree is clean and `origin/main` has not advanced.
<!-- delivery-issue:evidence:end -->
