### PR TITLE
feat(zed): materialize co-owned JSONC settings

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -60,6 +60,10 @@ _Avoid_: copied config, managed runtime file, drifted baseline
 An Entry Ownership mode for co-owned strict-JSON targets where the repository source is the dots-owned baseline and the workstation target may contain additional object keys or array elements added by another supported owner. Installation Metadata records the last dots-owned contribution so a later install can add new values, remove unchanged retired values, and reject externally changed former values. Uninstall subtracts only that proven contribution and preserves the target while external content remains.
 _Avoid_: JSON merge, partial sync, tolerate anything
 
+**JSONC Subset Ownership**:
+An Entry Ownership mode for co-owned JSON-with-comments targets where dots recursively owns baseline object keys while preserving target-only keys and untouched syntax trivia. Baseline scalars and arrays are atomic ordered values: a live difference is Drift or Conflict rather than an additive merge. Installation Metadata records the canonical semantic contribution, while updates and uninstall edit the regular target without reserializing unrelated comments, trailing commas, ordering, or formatting.
+_Avoid_: formatted JSON merge, unordered array merge, strip comments
+
 **Backup Set**:
 A timestamped collection of files preserved before an installation changes existing workstation targets. Backup sets live under `~/.local/state/dots/backups/` and include metadata describing what was protected and why.
 _Avoid_: old files, backup folder, snapshot

--- a/configs/zed/README.md
+++ b/configs/zed/README.md
@@ -1,18 +1,22 @@
 # Zed configuration
 
 `configs/zed/` is the repository-managed authored configuration for the
-[Zed](https://zed.dev) editor, installed under `~/.config/zed/` with the
-`symlink` strategy (`desktop` tag, `darwin`+`linux`). Managed files:
+[Zed](https://zed.dev) editor (`desktop` tag, `darwin`+`linux`). Zed settings
+are a regular co-owned JSONC target; keymaps and the authored theme remain
+repository-owned symlinks:
 
-| Source | Target |
-| --- | --- |
-| `configs/zed/settings.json` | `~/.config/zed/settings.json` |
-| `configs/zed/keymap.json` | `~/.config/zed/keymap.json` |
-| `configs/zed/themes/catppuccin-blue.json` | `~/.config/zed/themes/catppuccin-blue.json` |
+| Source | Target | Strategy / ownership |
+| --- | --- | --- |
+| `configs/zed/settings.json` | `~/.config/zed/settings.json` | `copy` / `jsonc-subset` |
+| `configs/zed/keymap.json` | `~/.config/zed/keymap.json` | `symlink` / whole target |
+| `configs/zed/themes/catppuccin-blue.json` | `~/.config/zed/themes/catppuccin-blue.json` | `symlink` / whole target |
 
-The Source of Truth is this repository. The installed files are links to the
-tracked sources; runtime state, generated files, conversations, prompts, and
-compiled extensions stay outside version control.
+The Source of Truth owns the portable settings baseline. Zed may add object
+keys to its regular target without writing through to the Installed Repository.
+Dots preserves those keys, comments, trailing commas, and untouched formatting;
+owned scalars and arrays remain atomic ordered values. Runtime state, generated
+files, conversations, prompts, and compiled extensions stay outside version
+control.
 
 ## Prerequisites
 
@@ -63,16 +67,17 @@ The live `~/.config/zed/` directory was classified before adoption:
 
 ## Resolving existing local Zed files
 
-If `dots status --profile desktop` reports the Zed targets as `conflict`, the
-profile is only partially managed: local files already exist where `dots` wants
-to install repository-owned symlinks. That is a safety stop, not a failure.
-Choose the resolution explicitly:
+If `dots status --profile desktop` reports a Zed target as `conflict`, the
+profile is only partially managed. A compatible regular `settings.json` can be
+reconciled only when Installation Metadata proves its prior dots contribution;
+untrusted or incompatible content remains a safety stop. Choose the resolution
+explicitly:
 
 | Choice | Effect | Tradeoff |
 | --- | --- | --- |
 | **Skip / keep local** | Leaves the existing `~/.config/zed/...` file untouched for this run. | Safest when you are unsure, but Zed remains outside the completed managed state. |
-| **Replace** | Creates a Backup Set, then replaces the local target with the repository-owned symlink. | Fastest path to repository ownership; review backups before deleting anything permanently. |
-| **Adopt** | For supported regular-file conflicts only: copies the existing local target into `configs/zed/...`, then installs the managed symlink. | Preserves your current local content, but it becomes shared Source of Truth and must be reviewed for machine-specific or private data. |
+| **Replace** | Creates a Backup Set, then replaces the local target with the selected managed form. | Fastest path to repository ownership; review backups before deleting anything permanently. |
+| **Adopt** | For supported regular-file conflicts only: copies the existing local target into `configs/zed/...`; symlink entries then install their link. | Preserves your current local content, but it becomes shared Source of Truth and must be reviewed for machine-specific or private data. |
 | **Diff** | Shows target versus source before choosing skip, replace, or adopt. | Read-only preview; it does not resolve the conflict by itself. |
 
 Non-interactive `dots install --profile desktop --yes` and `dots update --yes`
@@ -177,6 +182,6 @@ go run ./cmd/dots status \
   --state-root "$sandbox_state"
 ```
 
-The expected result is that the three Zed files are installed/aligned inside
-`$sandbox_home` as symlinks to the repository sources. The maintainer's real home
-directory must not be touched.
+The expected result is that `settings.json` is an aligned regular co-owned file,
+while keymap and theme are symlinks to the repository sources. The maintainer's
+real home directory must not be touched.

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -137,7 +137,7 @@ home directory.
 | `source_overrides` | No | Map of exact selected tag to alternate repository-relative source for the same target. The base `source` is used when no key matches; overrides do not alter entry tag selection or OS applicability. |
 | `target` | Yes | Home-relative target: `~` or `~/...`. |
 | `strategy` | Yes | `symlink`, `copy`, or `template` in the manifest schema. Current install execution supports `symlink` and `copy`. |
-| `ownership` | No | Empty, `json-subset`, or `toml-subset`. Subset ownership requires `strategy: copy`. |
+| `ownership` | No | Empty, `json-subset`, `jsonc-subset`, or `toml-subset`. Subset ownership requires `strategy: copy`. |
 | `tags` | Yes | Non-empty strings matched against the selected Profile. |
 | `os` | No | `darwin`, `linux`; empty means all supported operating systems. |
 | `dependencies` | No | Entry-level Dependencies. |
@@ -150,6 +150,12 @@ value remains a Conflict. Every applied update creates a Backup Set. Legacy
 metadata without prior-contribution evidence may establish a new baseline after
 a safe additive or unchanged install, but never authorizes removal retroactively;
 a compatible pre-existing target without matching metadata is still a Conflict.
+
+For a `jsonc-subset` target, object keys use the same recursive three-state
+ownership model, but scalars and arrays are atomic ordered values. Compatible
+updates preserve target-only object keys plus untouched comments, trailing
+commas, ordering, and formatting. A changed owned scalar or array is Drift for
+a recorded target and a Conflict without trusted Installation Metadata.
 
 Current Managed Entries:
 
@@ -176,7 +182,7 @@ Current Managed Entries:
 | `configs/atuin/themes/catppuccin-mocha.toml` | `~/.config/atuin/themes/catppuccin-mocha.toml` | `symlink` | `core` | `darwin`, `linux` | `atuin` |
 | `configs/bat/config` | `~/.config/bat/config` | `symlink` | `core` | `darwin`, `linux` | `bat` |
 | `configs/nvim` | `~/.config/nvim` | `symlink` | `core` | `darwin`, `linux` | `neovim` |
-| `configs/zed/settings.json` | `~/.config/zed/settings.json` | `symlink` | `desktop` | `darwin`, `linux` | `zed` |
+| `configs/zed/settings.json` | `~/.config/zed/settings.json` | `copy` (`jsonc-subset`) | `desktop` | `darwin`, `linux` | `zed` |
 | `configs/zed/keymap.json` | `~/.config/zed/keymap.json` | `symlink` | `desktop` | `darwin`, `linux` | `zed` |
 | `configs/zed/themes/catppuccin-blue.json` | `~/.config/zed/themes/catppuccin-blue.json` | `symlink` | `desktop` | `darwin`, `linux` | `zed` |
 | `configs/claude/settings.json` | `~/.claude/settings.json` | `copy` | `agents` | `darwin`, `linux` | None; owns JSON subset |

--- a/dots.yaml
+++ b/dots.yaml
@@ -491,7 +491,8 @@ entries:
             linux_arm64: e055af73fa9c72b37456da8d204fa5c09850bc07e80e9176fe3b87d4afb7a3fc
   - source: configs/zed/settings.json
     target: ~/.config/zed/settings.json
-    strategy: symlink
+    strategy: copy
+    ownership: jsonc-subset
     tags:
       - desktop
     os:

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/exp/teatest v0.0.0-20260607010151-cd19a2bba55f
 	github.com/spf13/cobra v1.8.1
+	github.com/tailscale/hujson v0.0.0-20241010212012-29efb4a0184b
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNE
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
@@ -47,6 +49,8 @@ github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/tailscale/hujson v0.0.0-20241010212012-29efb4a0184b h1:MNaGusDfB1qxEsl6iVb33Gbe777IKzPP5PDta0xGC8M=
+github.com/tailscale/hujson v0.0.0-20241010212012-29efb4a0184b/go.mod h1:EbW0wDK/qEUYI0A5bqq0C2kF8JTQwWONmGDBbzsxxHo=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=

--- a/internal/cli/issue387_jsonc_lifecycle_test.go
+++ b/internal/cli/issue387_jsonc_lifecycle_test.go
@@ -1,0 +1,152 @@
+package cli_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/cli"
+	"github.com/yersonargotev/dots/internal/state"
+)
+
+func TestJSONCSubsetLifecyclePreservesZedContentAndUninstallsOwnedContribution(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := filepath.Join(home, ".local", "state", "dots")
+	t.Setenv("HOME", t.TempDir())
+
+	source := filepath.Join(sourceRoot, "configs", "zed", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(source), 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	previous := `{
+  // Portable Zed baseline.
+  "theme": "dark",
+  "languages": {
+    "Go": { "format_on_save": "on", },
+  },
+  "features": ["one", "two"],
+}
+`
+	if err := os.WriteFile(source, []byte(previous), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	manifestPath := filepath.Join(sourceRoot, "dots.yaml")
+	manifestData := `version: 1
+profiles:
+  default:
+    tags: [desktop]
+entries:
+  - source: configs/zed/settings.json
+    target: ~/.config/zed/settings.json
+    strategy: copy
+    ownership: jsonc-subset
+    tags: [desktop]
+`
+	if err := os.WriteFile(manifestPath, []byte(manifestData), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	run := func(want int, args ...string) string {
+		t.Helper()
+		var stdout, stderr bytes.Buffer
+		code := cli.Run(args, &stdout, &stderr)
+		if code != want {
+			t.Fatalf("cli.Run(%v) code = %d, want %d\nstdout:\n%s\nstderr:\n%s", args, code, want, stdout.String(), stderr.String())
+		}
+		return stdout.String()
+	}
+	common := []string{"--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot}
+	installArgs := append([]string{"install", "--yes", "--skip-deps"}, common...)
+	statusArgs := append([]string{"status", "--output", "json"}, common...)
+	doctorArgs := append([]string{"doctor", "--output", "json"}, common...)
+	run(0, installArgs...)
+
+	target := filepath.Join(home, ".config", "zed", "settings.json")
+	zedEdited := `{
+  // Portable Zed baseline.
+  "theme": "dark",
+  "languages": {
+    "Go": { "format_on_save": "on", },
+    "Rust": { "language_servers": ["rust-analyzer"], },
+  },
+  "features": ["one", "two"],
+  // Written by Zed and not owned by dots.
+  "runtime": true,
+}
+`
+	if err := os.WriteFile(target, []byte(zedEdited), 0o640); err != nil {
+		t.Fatalf("simulate Zed write: %v", err)
+	}
+	run(0, statusArgs...)
+	run(0, doctorArgs...)
+
+	orderedArrayDrift := strings.Replace(zedEdited, `["one", "two"]`, `["two", "one"]`, 1)
+	if err := os.WriteFile(target, []byte(orderedArrayDrift), 0o640); err != nil {
+		t.Fatalf("write ordered array drift: %v", err)
+	}
+	run(2, statusArgs...)
+	if err := os.WriteFile(target, []byte(zedEdited), 0o640); err != nil {
+		t.Fatalf("restore compatible target: %v", err)
+	}
+
+	current := `{
+  // Portable Zed baseline.
+  "languages": {
+    "Go": { "format_on_save": "on", "tab_size": 2, },
+  },
+  "features": ["one", "two"],
+}
+`
+	if err := os.WriteFile(source, []byte(current), 0o600); err != nil {
+		t.Fatalf("update source: %v", err)
+	}
+	run(2, statusArgs...)
+	run(0, installArgs...)
+	run(0, statusArgs...)
+	run(0, doctorArgs...)
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read reconciled target: %v", err)
+	}
+	for _, want := range []string{`"Rust"`, `"runtime": true`, `Written by Zed`, `"tab_size": 2`} {
+		if !strings.Contains(string(got), want) {
+			t.Fatalf("reconciled target missing %s:\n%s", want, got)
+		}
+	}
+	if strings.Contains(string(got), `"theme"`) {
+		t.Fatalf("reconciled target retained retired owned theme:\n%s", got)
+	}
+
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load metadata: %v", err)
+	}
+	rec, ok := meta.FindByTarget(target)
+	if !ok || rec.Ownership != "jsonc-subset" || !json.Valid(rec.OwnedContent) {
+		t.Fatalf("JSONC ownership metadata = %#v, want strict JSON snapshot", rec)
+	}
+
+	uninstallOutput := run(0, "uninstall", "--yes", "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot)
+	if !strings.Contains(uninstallOutput, "Removed dots-owned content from 1 target.") {
+		t.Fatalf("uninstall output did not describe partial removal:\n%s", uninstallOutput)
+	}
+	got, err = os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target after partial uninstall: %v", err)
+	}
+	for _, want := range []string{`"Rust"`, `"runtime": true`, `Written by Zed`} {
+		if !strings.Contains(string(got), want) {
+			t.Fatalf("uninstall lost target-only content %s:\n%s", want, got)
+		}
+	}
+	for _, removed := range []string{`"Go"`, `"features"`, `"tab_size"`} {
+		if strings.Contains(string(got), removed) {
+			t.Fatalf("uninstall retained dots-owned content %s:\n%s", removed, got)
+		}
+	}
+}

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -275,6 +275,120 @@ entries:
 	}
 }
 
+func TestUpdateMigratesLegacyZedSymlinkToCoOwnedJSONC(t *testing.T) {
+	requireGitCLI(t)
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	legacyManifest := `version: 1
+profiles:
+  default:
+    tags: [desktop]
+entries:
+  - source: configs/zed/settings.json
+    target: ~/.config/zed/settings.json
+    strategy: symlink
+    tags: [desktop]
+`
+	previous := `// Zed settings
+{
+  "theme": "dark",
+  "languages": { "Go": { "format_on_save": "on", }, },
+  "features": ["one", "two"],
+}
+`
+	origin, sourceRoot := newInstalledRepo(t, map[string]string{"configs/zed/settings.json": previous, "dots.yaml": legacyManifest})
+
+	installCmd := cli.NewRootCommand()
+	var installOut bytes.Buffer
+	installCmd.SetOut(&installOut)
+	installCmd.SetErr(&installOut)
+	installCmd.SetArgs([]string{"install", "--yes", "--skip-deps", "--profile", "default", "--file", filepath.Join(sourceRoot, "dots.yaml"), "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+	if err := installCmd.Execute(); err != nil {
+		t.Fatalf("initial install: %v\n%s", err, installOut.String())
+	}
+	target := filepath.Join(home, ".config", "zed", "settings.json")
+	zedEdited := `// Zed settings
+{
+  "theme": "dark",
+  "languages": {
+    "Go": { "format_on_save": "on", },
+    "Rust": { "language_servers": ["rust-analyzer"], },
+  },
+  "features": ["one", "two"],
+  // Added by Zed.
+  "runtime": true,
+}
+`
+	if err := os.WriteFile(target, []byte(zedEdited), 0o600); err != nil {
+		t.Fatalf("simulate Zed write through legacy symlink: %v", err)
+	}
+	current := `// Zed settings
+{
+  "languages": { "Go": { "format_on_save": "on", "tab_size": 2, }, },
+  "features": ["one", "two"],
+}
+`
+	advanceUpstream(t, origin, "materialize Zed JSONC settings", map[string]string{
+		"configs/zed/settings.json": current,
+		"dots.yaml": `version: 1
+profiles:
+  default:
+    tags: [desktop]
+entries:
+  - source: configs/zed/settings.json
+    target: ~/.config/zed/settings.json
+    strategy: copy
+    ownership: jsonc-subset
+    tags: [desktop]
+`,
+	})
+
+	oldHead := strings.TrimSpace(runGitOutput(t, sourceRoot, "rev-parse", "HEAD"))
+	dryOutput := runUpdate(t, "--dry-run", "--profile", "default", "--file", filepath.Join(sourceRoot, "dots.yaml"), "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot)
+	if !strings.Contains(dryOutput, "migrate") {
+		t.Fatalf("dry-run output missing JSONC migration:\n%s", dryOutput)
+	}
+	if got := strings.TrimSpace(runGitOutput(t, sourceRoot, "rev-parse", "HEAD")); got != oldHead {
+		t.Fatalf("dry-run changed checkout: %s != %s", got, oldHead)
+	}
+	if info, err := os.Lstat(target); err != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("dry-run changed legacy target: mode=%v err=%v", info, err)
+	}
+
+	output := runUpdate(t, "--yes", "--profile", "default", "--file", filepath.Join(sourceRoot, "dots.yaml"), "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot)
+	if !strings.Contains(output, "migrate") || !strings.Contains(output, "stash@{0}") {
+		t.Fatalf("update output missing JSONC migration evidence:\n%s", output)
+	}
+	info, err := os.Lstat(target)
+	if err != nil || !info.Mode().IsRegular() {
+		t.Fatalf("Zed target not migrated to regular file: mode=%v err=%v", info, err)
+	}
+	content, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read migrated target: %v", err)
+	}
+	for _, want := range []string{`"Rust"`, `"runtime": true`, `Added by Zed`, `"tab_size": 2`, `"features": ["one", "two"]`} {
+		if !strings.Contains(string(content), want) {
+			t.Fatalf("migrated JSONC missing %s:\n%s", want, content)
+		}
+	}
+	if strings.Contains(string(content), `"theme"`) {
+		t.Fatalf("migrated JSONC retained retired theme:\n%s", content)
+	}
+	if dirty := strings.TrimSpace(runGitOutput(t, sourceRoot, "status", "--porcelain")); dirty != "" {
+		t.Fatalf("Installed Repository remains dirty after Zed migration:\n%s", dirty)
+	}
+	after, err := backups.Load(backups.Path(stateRoot))
+	if err != nil || len(after.Sets) != 1 {
+		t.Fatalf("migration backup sets = %#v err=%v", after, err)
+	}
+	preserved, err := os.ReadFile(backups.FilePath(stateRoot, after.Sets[0].ID, 1, target))
+	if err != nil || string(preserved) != zedEdited {
+		t.Fatalf("migration backup = %q err=%v", preserved, err)
+	}
+}
+
 func TestUpdateDirtyDivergedRepoDoesNotStash(t *testing.T) {
 	requireGitCLI(t)
 	home := t.TempDir()

--- a/internal/configsubset/jsonc.go
+++ b/internal/configsubset/jsonc.go
@@ -1,0 +1,384 @@
+package configsubset
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/tailscale/hujson"
+)
+
+// CanonicalJSONC parses JSONC and returns deterministic strict JSON. Numbers
+// remain json.Number values while canonicalizing, so large integer literals are
+// never converted through float64.
+func CanonicalJSONC(data []byte) ([]byte, error) {
+	value, err := decodeJSONC(data)
+	if err != nil {
+		return nil, err
+	}
+	encoded, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("encode canonical JSONC: %w", err)
+	}
+	return append(encoded, '\n'), nil
+}
+
+// AnalyzeJSONC compares a live JSONC target with a dots-owned JSONC source.
+// Object keys are recursively owned; scalar and array values are atomic.
+func AnalyzeJSONC(targetData, sourceData []byte) (JSONFileRelation, error) {
+	source, err := decodeJSONC(sourceData)
+	if err != nil {
+		return JSONFileRelation{}, fmt.Errorf("parse source JSONC: %w", err)
+	}
+	target, err := decodeJSONC(targetData)
+	if err != nil {
+		return JSONFileRelation{}, nil
+	}
+	_, changed, compatible := mergeJSONCValue(target, source)
+	return JSONFileRelation{Contains: compatible && !changed, Mergeable: compatible && changed}, nil
+}
+
+// MergeJSONC adds missing source-owned object keys while preserving the live
+// target's comments, whitespace, and trailing-comma style where HuJSON permits.
+func MergeJSONC(targetData, sourceData []byte) ([]byte, error) {
+	source, err := decodeJSONC(sourceData)
+	if err != nil {
+		return nil, fmt.Errorf("parse source JSONC: %w", err)
+	}
+	target, err := decodeJSONC(targetData)
+	if err != nil {
+		return nil, fmt.Errorf("parse target JSONC: %w", err)
+	}
+	desired, _, compatible := mergeJSONCValue(target, source)
+	if !compatible {
+		return nil, fmt.Errorf("source-owned JSONC differences cannot be merged safely")
+	}
+	return patchJSONC(targetData, target, desired)
+}
+
+// ReconcileJSONC updates JSONC using the last recorded dots-owned content.
+// previousData accepts either canonical strict JSON metadata or legacy JSONC.
+func ReconcileJSONC(targetData, previousData, currentData []byte) (JSONReconciliation, error) {
+	previous, err := decodeJSONC(previousData)
+	if err != nil {
+		return JSONReconciliation{}, fmt.Errorf("parse previous owned JSONC: %w", err)
+	}
+	current, err := decodeJSONC(currentData)
+	if err != nil {
+		return JSONReconciliation{}, fmt.Errorf("parse current owned JSONC: %w", err)
+	}
+	target, err := decodeJSONC(targetData)
+	if err != nil {
+		return JSONReconciliation{}, nil
+	}
+	desired, changed, compatible := reconcileJSONCValue(target, previous, current)
+	if !compatible {
+		return JSONReconciliation{}, nil
+	}
+	content, err := patchJSONC(targetData, target, desired)
+	if err != nil {
+		return JSONReconciliation{}, err
+	}
+	return JSONReconciliation{Content: content, Changed: changed, Compatible: true}, nil
+}
+
+// RemoveJSONC removes only the exact JSONC contribution proven by ownedData.
+func RemoveJSONC(targetData, ownedData []byte) (content []byte, changed, empty, compatible bool, err error) {
+	owned, decodeErr := decodeJSONC(ownedData)
+	if decodeErr != nil {
+		return nil, false, false, false, fmt.Errorf("parse owned JSONC: %w", decodeErr)
+	}
+	target, decodeErr := decodeJSONC(targetData)
+	if decodeErr != nil {
+		return nil, false, false, false, nil
+	}
+	desired, changed, compatible := subtractJSONCValue(target, owned)
+	if !compatible {
+		return nil, false, false, false, nil
+	}
+	content, err = patchJSONC(targetData, target, desired)
+	if err != nil {
+		return nil, false, false, false, err
+	}
+	return content, changed, jsonValueEmpty(desired), true, nil
+}
+
+func decodeJSONC(data []byte) (any, error) {
+	standard, err := hujson.Standardize(append([]byte(nil), data...))
+	if err != nil {
+		return nil, err
+	}
+	var value any
+	if err := decodeJSON(standard, &value); err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
+func mergeJSONCValue(target, source any) (any, bool, bool) {
+	sourceObject, sourceIsObject := source.(map[string]any)
+	if !sourceIsObject {
+		return target, false, reflect.DeepEqual(target, source)
+	}
+	targetObject, ok := target.(map[string]any)
+	if !ok {
+		return target, false, false
+	}
+	result := cloneJSONObject(targetObject)
+	changed := false
+	for key, sourceChild := range sourceObject {
+		targetChild, exists := targetObject[key]
+		if !exists {
+			result[key] = sourceChild
+			changed = true
+			continue
+		}
+		merged, childChanged, compatible := mergeJSONCValue(targetChild, sourceChild)
+		if !compatible {
+			return target, false, false
+		}
+		if childChanged {
+			result[key] = merged
+			changed = true
+		}
+	}
+	return result, changed, true
+}
+
+func reconcileJSONCValue(target, previous, current any) (any, bool, bool) {
+	previousObject, previousIsObject := previous.(map[string]any)
+	currentObject, currentIsObject := current.(map[string]any)
+	if previousIsObject && currentIsObject {
+		targetObject, ok := target.(map[string]any)
+		if !ok {
+			return target, false, false
+		}
+		result := cloneJSONObject(targetObject)
+		changed := false
+		for key, previousChild := range previousObject {
+			currentChild, remainsOwned := currentObject[key]
+			targetChild, exists := targetObject[key]
+			if !exists {
+				return target, false, false
+			}
+			if !remainsOwned {
+				value, childChanged, compatible := subtractJSONCValue(targetChild, previousChild)
+				if !compatible {
+					return target, false, false
+				}
+				if jsonValueEmpty(value) {
+					delete(result, key)
+				} else {
+					result[key] = value
+				}
+				changed = changed || childChanged
+				continue
+			}
+			value, childChanged, compatible := reconcileJSONCValue(targetChild, previousChild, currentChild)
+			if !compatible {
+				return target, false, false
+			}
+			result[key] = value
+			changed = changed || childChanged
+		}
+		for key, currentChild := range currentObject {
+			if _, existed := previousObject[key]; existed {
+				continue
+			}
+			targetChild, exists := targetObject[key]
+			if !exists {
+				result[key] = currentChild
+				changed = true
+				continue
+			}
+			value, childChanged, compatible := mergeJSONCValue(targetChild, currentChild)
+			if !compatible {
+				return target, false, false
+			}
+			result[key] = value
+			changed = changed || childChanged
+		}
+		return result, changed, true
+	}
+	if reflect.DeepEqual(previous, current) {
+		return target, false, reflect.DeepEqual(target, current)
+	}
+	if reflect.DeepEqual(target, current) {
+		return target, false, true
+	}
+	if reflect.DeepEqual(target, previous) {
+		return current, true, true
+	}
+	return target, false, false
+}
+
+func subtractJSONCValue(target, owned any) (any, bool, bool) {
+	ownedObject, ownedIsObject := owned.(map[string]any)
+	if !ownedIsObject {
+		if !reflect.DeepEqual(target, owned) {
+			return target, false, false
+		}
+		return nil, true, true
+	}
+	targetObject, ok := target.(map[string]any)
+	if !ok {
+		return target, false, false
+	}
+	result := cloneJSONObject(targetObject)
+	changed := false
+	for key, ownedChild := range ownedObject {
+		targetChild, exists := targetObject[key]
+		if !exists {
+			return target, false, false
+		}
+		value, childChanged, compatible := subtractJSONCValue(targetChild, ownedChild)
+		if !compatible {
+			return target, false, false
+		}
+		if jsonValueEmpty(value) {
+			delete(result, key)
+		} else {
+			result[key] = value
+		}
+		changed = changed || childChanged
+	}
+	return result, changed, true
+}
+
+func cloneJSONObject(input map[string]any) map[string]any {
+	result := make(map[string]any, len(input))
+	for key, value := range input {
+		result[key] = value
+	}
+	return result
+}
+
+func patchJSONC(original []byte, target, desired any) ([]byte, error) {
+	if reflect.DeepEqual(target, desired) {
+		return append([]byte(nil), original...), nil
+	}
+	tree, err := hujson.Parse(original)
+	if err != nil {
+		return nil, fmt.Errorf("parse target JSONC: %w", err)
+	}
+	if err := applyJSONCDesired(&tree, target, desired); err != nil {
+		return nil, err
+	}
+	return tree.Pack(), nil
+}
+
+func applyJSONCDesired(value *hujson.Value, target, desired any) error {
+	targetObject, targetIsObject := target.(map[string]any)
+	desiredObject, desiredIsObject := desired.(map[string]any)
+	object, treeIsObject := value.Value.(*hujson.Object)
+	if targetIsObject && desiredIsObject && treeIsObject {
+		for index := len(object.Members) - 1; index >= 0; index-- {
+			key := jsonCMemberName(object.Members[index])
+			desiredChild, keep := desiredObject[key]
+			if !keep {
+				moveJSONCMemberExtra(object, index)
+				object.Members = append(object.Members[:index], object.Members[index+1:]...)
+				continue
+			}
+			if err := applyJSONCDesired(&object.Members[index].Value, targetObject[key], desiredChild); err != nil {
+				return err
+			}
+		}
+		keys := make([]string, 0, len(desiredObject))
+		for key := range desiredObject {
+			if _, exists := targetObject[key]; !exists {
+				keys = append(keys, key)
+			}
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			member, err := newJSONCMember(key, desiredObject[key])
+			if err != nil {
+				return err
+			}
+			member.Name.BeforeExtra = jsonCMemberIndent(object)
+			if len(object.Members) > 0 {
+				member.Name.AfterExtra = append(hujson.Extra(nil), object.Members[len(object.Members)-1].Name.AfterExtra...)
+				member.Value.BeforeExtra = append(hujson.Extra(nil), object.Members[len(object.Members)-1].Value.BeforeExtra...)
+			}
+			object.Members = append(object.Members, member)
+		}
+		return nil
+	}
+	if reflect.DeepEqual(target, desired) {
+		return nil
+	}
+	encoded, err := json.Marshal(desired)
+	if err != nil {
+		return fmt.Errorf("encode JSONC replacement: %w", err)
+	}
+	replacement, err := hujson.Parse(encoded)
+	if err != nil {
+		return fmt.Errorf("parse JSONC replacement: %w", err)
+	}
+	value.Value = replacement.Value
+	return nil
+}
+
+func moveJSONCMemberExtra(object *hujson.Object, index int) {
+	extra := object.Members[index].Name.BeforeExtra
+	if len(extra) == 0 {
+		return
+	}
+	if index+1 < len(object.Members) {
+		object.Members[index+1].Name.BeforeExtra = append(extra, object.Members[index+1].Name.BeforeExtra...)
+		return
+	}
+	object.AfterExtra = append(extra, object.AfterExtra...)
+}
+
+func newJSONCMember(key string, value any) (hujson.ObjectMember, error) {
+	encodedKey, err := json.Marshal(key)
+	if err != nil {
+		return hujson.ObjectMember{}, fmt.Errorf("encode JSONC member name: %w", err)
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return hujson.ObjectMember{}, fmt.Errorf("encode JSONC member: %w", err)
+	}
+	data := append([]byte{'{'}, encodedKey...)
+	data = append(data, ':')
+	data = append(data, encoded...)
+	data = append(data, '}')
+	fragment, err := hujson.Parse(data)
+	if err != nil {
+		return hujson.ObjectMember{}, fmt.Errorf("parse JSONC member: %w", err)
+	}
+	object, ok := fragment.Value.(*hujson.Object)
+	if !ok || len(object.Members) != 1 {
+		return hujson.ObjectMember{}, fmt.Errorf("parse JSONC member: expected object")
+	}
+	return object.Members[0], nil
+}
+
+func jsonCMemberIndent(object *hujson.Object) hujson.Extra {
+	if len(object.Members) > 0 {
+		extra := object.Members[len(object.Members)-1].Name.BeforeExtra
+		if index := bytesIndexNewline(extra); index >= 0 {
+			return append(hujson.Extra(nil), extra[index:]...)
+		}
+	}
+	if bytesIndexNewline(object.AfterExtra) >= 0 {
+		extra := object.AfterExtra
+		return append(hujson.Extra(nil), extra[bytesIndexNewline(extra):]...)
+	}
+	return hujson.Extra(" ")
+}
+
+func bytesIndexNewline(extra hujson.Extra) int { return strings.IndexByte(string(extra), '\n') }
+
+func jsonCMemberName(member hujson.ObjectMember) string {
+	var name string
+	literal, ok := member.Name.Value.(hujson.Literal)
+	if !ok || json.Unmarshal(literal, &name) != nil {
+		return ""
+	}
+	return name
+}

--- a/internal/configsubset/jsonc.go
+++ b/internal/configsubset/jsonc.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
-	"strings"
 
 	"github.com/tailscale/hujson"
 )
@@ -362,7 +361,10 @@ func applyJSONCDesired(value *hujson.Value, target, desired any) error {
 }
 
 func moveJSONCMemberExtra(object *hujson.Object, index int) {
-	extra := object.Members[index].Name.BeforeExtra
+	member := object.Members[index]
+	extra := append(hujson.Extra(nil), member.Name.BeforeExtra...)
+	extra = appendJSONCCommentExtra(extra, member.Name.AfterExtra)
+	extra = appendJSONCValueComments(extra, member.Value)
 	if len(extra) == 0 {
 		return
 	}
@@ -371,6 +373,32 @@ func moveJSONCMemberExtra(object *hujson.Object, index int) {
 		return
 	}
 	object.AfterExtra = append(extra, object.AfterExtra...)
+}
+
+func appendJSONCValueComments(extra hujson.Extra, value hujson.Value) hujson.Extra {
+	extra = appendJSONCCommentExtra(extra, value.BeforeExtra)
+	extra = appendJSONCCommentExtra(extra, value.AfterExtra)
+	switch typed := value.Value.(type) {
+	case *hujson.Object:
+		extra = appendJSONCCommentExtra(extra, typed.AfterExtra)
+		for _, member := range typed.Members {
+			extra = appendJSONCValueComments(extra, member.Name)
+			extra = appendJSONCValueComments(extra, member.Value)
+		}
+	case *hujson.Array:
+		extra = appendJSONCCommentExtra(extra, typed.AfterExtra)
+		for _, element := range typed.Elements {
+			extra = appendJSONCValueComments(extra, element)
+		}
+	}
+	return extra
+}
+
+func appendJSONCCommentExtra(dst, src hujson.Extra) hujson.Extra {
+	if jsonCExtraContainsComment(src) {
+		return append(dst, src...)
+	}
+	return dst
 }
 
 func newJSONCMember(key string, value any) (hujson.ObjectMember, error) {
@@ -400,18 +428,18 @@ func newJSONCMember(key string, value any) (hujson.ObjectMember, error) {
 func jsonCMemberIndent(object *hujson.Object) hujson.Extra {
 	if len(object.Members) > 0 {
 		extra := object.Members[len(object.Members)-1].Name.BeforeExtra
-		if index := bytesIndexNewline(extra); index >= 0 {
+		if index := bytesLastIndexNewline(extra); index >= 0 {
 			return append(hujson.Extra(nil), extra[index:]...)
 		}
 	}
-	if bytesIndexNewline(object.AfterExtra) >= 0 {
+	if bytesLastIndexNewline(object.AfterExtra) >= 0 {
 		extra := object.AfterExtra
-		return append(hujson.Extra(nil), extra[bytesIndexNewline(extra):]...)
+		return append(hujson.Extra(nil), extra[bytesLastIndexNewline(extra):]...)
 	}
 	return hujson.Extra(" ")
 }
 
-func bytesIndexNewline(extra hujson.Extra) int { return strings.IndexByte(string(extra), '\n') }
+func bytesLastIndexNewline(extra hujson.Extra) int { return bytes.LastIndexByte(extra, '\n') }
 
 func jsonCMemberName(member hujson.ObjectMember) string {
 	var name string

--- a/internal/configsubset/jsonc.go
+++ b/internal/configsubset/jsonc.go
@@ -1,6 +1,7 @@
 package configsubset
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -102,7 +103,7 @@ func RemoveJSONC(targetData, ownedData []byte) (content []byte, changed, empty, 
 	if err != nil {
 		return nil, false, false, false, err
 	}
-	return content, changed, jsonValueEmpty(desired), true, nil
+	return content, changed, jsonValueEmpty(desired) && !jsonCContainsComments(content), true, nil
 }
 
 func decodeJSONC(data []byte) (any, error) {
@@ -170,10 +171,11 @@ func reconcileJSONCValue(target, previous, current any) (any, bool, bool) {
 				}
 				if jsonValueEmpty(value) {
 					delete(result, key)
+					changed = true
 				} else {
 					result[key] = value
+					changed = changed || childChanged
 				}
-				changed = changed || childChanged
 				continue
 			}
 			value, childChanged, compatible := reconcileJSONCValue(targetChild, previousChild, currentChild)
@@ -239,10 +241,11 @@ func subtractJSONCValue(target, owned any) (any, bool, bool) {
 		}
 		if jsonValueEmpty(value) {
 			delete(result, key)
+			changed = true
 		} else {
 			result[key] = value
+			changed = changed || childChanged
 		}
-		changed = changed || childChanged
 	}
 	return result, changed, true
 }
@@ -253,6 +256,42 @@ func cloneJSONObject(input map[string]any) map[string]any {
 		result[key] = value
 	}
 	return result
+}
+
+func jsonCContainsComments(data []byte) bool {
+	value, err := hujson.Parse(data)
+	return err == nil && jsonCValueContainsComments(value)
+}
+
+func jsonCValueContainsComments(value hujson.Value) bool {
+	if jsonCExtraContainsComment(value.BeforeExtra) || jsonCExtraContainsComment(value.AfterExtra) {
+		return true
+	}
+	switch typed := value.Value.(type) {
+	case *hujson.Object:
+		if jsonCExtraContainsComment(typed.AfterExtra) {
+			return true
+		}
+		for _, member := range typed.Members {
+			if jsonCValueContainsComments(member.Name) || jsonCValueContainsComments(member.Value) {
+				return true
+			}
+		}
+	case *hujson.Array:
+		if jsonCExtraContainsComment(typed.AfterExtra) {
+			return true
+		}
+		for _, element := range typed.Elements {
+			if jsonCValueContainsComments(element) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func jsonCExtraContainsComment(extra hujson.Extra) bool {
+	return bytes.Contains(extra, []byte("//")) || bytes.Contains(extra, []byte("/*"))
 }
 
 func patchJSONC(original []byte, target, desired any) ([]byte, error) {

--- a/internal/configsubset/jsonc_test.go
+++ b/internal/configsubset/jsonc_test.go
@@ -1,0 +1,118 @@
+package configsubset
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestMergeJSONCPreservesCommentsAndAddsNestedOwnedKey(t *testing.T) {
+	target := []byte("{\n  // kept\n  \"settings\": {\n    \"local\": true,\n  },\n}\n")
+	source := []byte(`{"settings":{"owned":9007199254740993}}`)
+
+	got, err := MergeJSONC(target, source)
+	if err != nil {
+		t.Fatalf("MergeJSONC() error = %v", err)
+	}
+	if !bytes.Contains(got, []byte("// kept")) || !bytes.Contains(got, []byte(`"local": true`)) || !bytes.Contains(got, []byte(`9007199254740993`)) {
+		t.Fatalf("MergeJSONC() = %s, want comment, local content, and precise owned number", got)
+	}
+	if got[len(got)-1] != '\n' {
+		t.Fatalf("MergeJSONC() did not preserve final newline: %q", got)
+	}
+}
+
+func TestAnalyzeJSONCUsesAtomicArraysAndScalars(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		target string
+		source string
+	}{
+		{name: "array content", target: `{"items":["local","owned"]}`, source: `{"items":["owned"]}`},
+		{name: "array order", target: `{"items":["two","one"]}`, source: `{"items":["one","two"]}`},
+		{name: "scalar", target: `{"theme":"light"}`, source: `{"theme":"dark"}`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			relation, err := AnalyzeJSONC([]byte(tt.target), []byte(tt.source))
+			if err != nil {
+				t.Fatalf("AnalyzeJSONC() error = %v", err)
+			}
+			if relation.Contains || relation.Mergeable {
+				t.Fatalf("AnalyzeJSONC() = %#v, want conflict for atomic value", relation)
+			}
+		})
+	}
+}
+
+func TestReconcileJSONCReplacesUnchangedAtomicArrayAndRejectsLiveDrift(t *testing.T) {
+	previous := []byte(`{"items":["one","two"]}`)
+	current := []byte(`{"items":["two","three"]}`)
+
+	got, err := ReconcileJSONC([]byte("{\n  // ordered\n  \"items\": [\"one\", \"two\"],\n}\n"), previous, current)
+	if err != nil {
+		t.Fatalf("ReconcileJSONC() error = %v", err)
+	}
+	if !got.Compatible || !got.Changed || !bytes.Contains(got.Content, []byte("// ordered")) || !bytes.Contains(got.Content, []byte(`["two","three"]`)) {
+		t.Fatalf("ReconcileJSONC() = %#v, want atomic replacement preserving comment", got)
+	}
+
+	drifted, err := ReconcileJSONC([]byte(`{"items":["local"]}`), previous, current)
+	if err != nil {
+		t.Fatalf("ReconcileJSONC(drifted) error = %v", err)
+	}
+	if drifted.Compatible {
+		t.Fatalf("ReconcileJSONC(drifted) = %#v, want incompatible live array", drifted)
+	}
+}
+
+func TestReconcileJSONCRemovesRetiredKeysAndPreservesTargetOnlyContent(t *testing.T) {
+	target := []byte("{\n  \"settings\": {\n    // local comment\n    \"retired\": \"old\",\n    \"local\": true,\n  },\n}\n")
+	previous := []byte(`{"settings":{"retired":"old"}}`)
+	current := []byte(`{"settings":{"added":"new"}}`)
+
+	got, err := ReconcileJSONC(target, previous, current)
+	if err != nil {
+		t.Fatalf("ReconcileJSONC() error = %v", err)
+	}
+	if !got.Compatible || !got.Changed || !bytes.Contains(got.Content, []byte("// local comment")) || !bytes.Contains(got.Content, []byte(`"local": true`)) || !bytes.Contains(got.Content, []byte(`"added"`)) {
+		t.Fatalf("ReconcileJSONC() = %#v, want compatible JSONC edit preserving target-only content", got)
+	}
+	if bytes.Contains(got.Content, []byte(`"retired"`)) {
+		t.Fatalf("ReconcileJSONC() = %s, retained removed key", got.Content)
+	}
+}
+
+func TestRemoveJSONCRemovesOnlyOwnedObjectValues(t *testing.T) {
+	target := []byte("{\n  // root\n  \"owned\": true,\n  \"local\": false,\n}\n")
+	content, changed, empty, compatible, err := RemoveJSONC(target, []byte(`{"owned":true}`))
+	if err != nil {
+		t.Fatalf("RemoveJSONC() error = %v", err)
+	}
+	if !compatible || !changed || empty || !bytes.Contains(content, []byte("// root")) || !bytes.Contains(content, []byte(`"local": false`)) {
+		t.Fatalf("RemoveJSONC() = %s, %t, %t, %t", content, changed, empty, compatible)
+	}
+}
+
+func TestJSONCRejectsInvalidOwnedDataAndTreatsInvalidTargetAsIncompatible(t *testing.T) {
+	if _, err := AnalyzeJSONC([]byte(`{`), []byte(`{`)); err == nil {
+		t.Fatal("AnalyzeJSONC() error = nil, want invalid source error")
+	}
+	got, err := ReconcileJSONC([]byte(`{`), []byte(`{}`), []byte(`{}`))
+	if err != nil || got.Compatible {
+		t.Fatalf("ReconcileJSONC() = %#v, %v; want invalid target incompatible", got, err)
+	}
+}
+
+func TestCanonicalJSONCStripsSyntaxExtensionsWithoutLosingLargeNumbers(t *testing.T) {
+	got, err := CanonicalJSONC([]byte("{ // comment\n \"counter\": 9007199254740993,\n}"))
+	if err != nil {
+		t.Fatalf("CanonicalJSONC() error = %v", err)
+	}
+	var decoded map[string]json.Number
+	if err := json.Unmarshal(got, &decoded); err != nil {
+		t.Fatalf("canonical output is not strict JSON: %v", err)
+	}
+	if gotNumber := decoded["counter"]; gotNumber != "9007199254740993" {
+		t.Fatalf("counter = %q, want original integer digits", gotNumber)
+	}
+}

--- a/internal/configsubset/jsonc_test.go
+++ b/internal/configsubset/jsonc_test.go
@@ -82,6 +82,20 @@ func TestReconcileJSONCRemovesRetiredKeysAndPreservesTargetOnlyContent(t *testin
 	}
 }
 
+func TestReconcileJSONCReportsRemovingEmptyOwnedObjectAsChange(t *testing.T) {
+	got, err := ReconcileJSONC(
+		[]byte(`{"settings":{},"local":true}`),
+		[]byte(`{"settings":{}}`),
+		[]byte(`{}`),
+	)
+	if err != nil {
+		t.Fatalf("ReconcileJSONC() error = %v", err)
+	}
+	if !got.Compatible || !got.Changed || bytes.Contains(got.Content, []byte(`"settings"`)) || !bytes.Contains(got.Content, []byte(`"local"`)) {
+		t.Fatalf("ReconcileJSONC() = %#v, want changed removal of empty owned object", got)
+	}
+}
+
 func TestRemoveJSONCRemovesOnlyOwnedObjectValues(t *testing.T) {
 	target := []byte("{\n  // root\n  \"owned\": true,\n  \"local\": false,\n}\n")
 	content, changed, empty, compatible, err := RemoveJSONC(target, []byte(`{"owned":true}`))
@@ -90,6 +104,17 @@ func TestRemoveJSONCRemovesOnlyOwnedObjectValues(t *testing.T) {
 	}
 	if !compatible || !changed || empty || !bytes.Contains(content, []byte("// root")) || !bytes.Contains(content, []byte(`"local": false`)) {
 		t.Fatalf("RemoveJSONC() = %s, %t, %t, %t", content, changed, empty, compatible)
+	}
+}
+
+func TestRemoveJSONCPreservesCommentOnlyExternalContent(t *testing.T) {
+	target := []byte("{\n  // Added locally and not proven dots-owned.\n  \"owned\": true,\n}\n")
+	content, changed, empty, compatible, err := RemoveJSONC(target, []byte(`{"owned":true}`))
+	if err != nil {
+		t.Fatalf("RemoveJSONC() error = %v", err)
+	}
+	if !compatible || !changed || empty || !bytes.Contains(content, []byte("Added locally")) {
+		t.Fatalf("RemoveJSONC() = %s, changed=%t empty=%t compatible=%t; want preserved comment-only target", content, changed, empty, compatible)
 	}
 }
 

--- a/internal/configsubset/jsonc_test.go
+++ b/internal/configsubset/jsonc_test.go
@@ -22,6 +22,17 @@ func TestMergeJSONCPreservesCommentsAndAddsNestedOwnedKey(t *testing.T) {
 	}
 }
 
+func TestMergeJSONCDoesNotDuplicateCommentBeforeLastTargetMember(t *testing.T) {
+	target := []byte("{\n  // local rationale\n  \"local\": true,\n}\n")
+	got, err := MergeJSONC(target, []byte(`{"owned":true}`))
+	if err != nil {
+		t.Fatalf("MergeJSONC() error = %v", err)
+	}
+	if count := bytes.Count(got, []byte("// local rationale")); count != 1 {
+		t.Fatalf("MergeJSONC() comment count = %d, want 1:\n%s", count, got)
+	}
+}
+
 func TestAnalyzeJSONCUsesAtomicArraysAndScalars(t *testing.T) {
 	for _, tt := range []struct {
 		name   string
@@ -115,6 +126,17 @@ func TestRemoveJSONCPreservesCommentOnlyExternalContent(t *testing.T) {
 	}
 	if !compatible || !changed || empty || !bytes.Contains(content, []byte("Added locally")) {
 		t.Fatalf("RemoveJSONC() = %s, changed=%t empty=%t compatible=%t; want preserved comment-only target", content, changed, empty, compatible)
+	}
+}
+
+func TestRemoveJSONCPreservesCommentNestedInsideRemovedOwnedObject(t *testing.T) {
+	target := []byte("{\n  \"owned\": { /* local note */ },\n}\n")
+	content, changed, empty, compatible, err := RemoveJSONC(target, []byte(`{"owned":{}}`))
+	if err != nil {
+		t.Fatalf("RemoveJSONC() error = %v", err)
+	}
+	if !compatible || !changed || empty || !bytes.Contains(content, []byte("local note")) || bytes.Contains(content, []byte(`"owned"`)) {
+		t.Fatalf("RemoveJSONC() = %s, changed=%t empty=%t compatible=%t; want lifted nested comment without owned key", content, changed, empty, compatible)
 	}
 }
 

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -127,6 +127,15 @@ func recordMetadata(p plan.Plan, resolvedSources [][]string, opts Options) error
 					if err != nil {
 						return fmt.Errorf("read owned JSON contribution %s: %w", resolvedSources[i][0], err)
 					}
+				} else if action.Ownership == "jsonc-subset" {
+					rawContent, readErr := os.ReadFile(resolvedSources[i][0])
+					if readErr != nil {
+						return fmt.Errorf("read owned JSONC contribution %s: %w", resolvedSources[i][0], readErr)
+					}
+					ownedContent, err = configsubset.CanonicalJSONC(rawContent)
+					if err != nil {
+						return fmt.Errorf("canonicalize owned JSONC contribution %s: %w", resolvedSources[i][0], err)
+					}
 				}
 			}
 		}
@@ -239,7 +248,7 @@ func validatePlan(p plan.Plan, opts Options) ([][]string, error) {
 			if opts.StateRoot == "" {
 				return nil, fmt.Errorf("update for %s requires state root for Backup Set metadata", action.Target)
 			}
-			if action.Strategy != "copy" || (action.Ownership != "json-subset" && action.Ownership != "toml-subset") {
+			if action.Strategy != "copy" || (action.Ownership != "json-subset" && action.Ownership != "jsonc-subset" && action.Ownership != "toml-subset") {
 				return nil, fmt.Errorf("update for %s requires copy strategy with subset ownership", action.Target)
 			}
 			if err := validateBackupStateRoot(opts.StateRoot, home); err != nil {
@@ -524,6 +533,20 @@ func applyUpdate(action plan.Action, source string, opts Options) error {
 		if err := configsubset.MergeJSONFile(action.Target, source); err != nil {
 			return fmt.Errorf("merge JSON update for %s: %w", action.Target, err)
 		}
+	case "jsonc-subset":
+		current, err := os.ReadFile(source)
+		if err != nil {
+			return fmt.Errorf("read current owned JSONC %s: %w", source, err)
+		}
+		if len(action.PreviousContent) > 0 {
+			if err := reconcileJSONCContentFile(action.Target, action.PreviousContent, current); err != nil {
+				return fmt.Errorf("reconcile JSONC update for %s: %w", action.Target, err)
+			}
+			return nil
+		}
+		if err := mergeJSONCContentFile(action.Target, current); err != nil {
+			return fmt.Errorf("merge JSONC update for %s: %w", action.Target, err)
+		}
 	case "toml-subset":
 		if err := configsubset.MergeTOMLFile(action.Target, source); err != nil {
 			return fmt.Errorf("merge TOML update for %s: %w", action.Target, err)
@@ -752,6 +775,47 @@ func reconcileJSONContentFile(target string, previousData, currentData []byte) e
 	}
 	if !reconciliation.Compatible {
 		return fmt.Errorf("live target changed a previously owned JSON value")
+	}
+	if !reconciliation.Changed {
+		return nil
+	}
+	return os.WriteFile(target, reconciliation.Content, info.Mode().Perm())
+}
+
+func mergeJSONCContentFile(target string, sourceData []byte) error {
+	targetData, err := os.ReadFile(target)
+	if err != nil {
+		return err
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		return err
+	}
+	merged, err := configsubset.MergeJSONC(targetData, sourceData)
+	if err != nil {
+		return err
+	}
+	if bytes.Equal(merged, targetData) {
+		return nil
+	}
+	return os.WriteFile(target, merged, info.Mode().Perm())
+}
+
+func reconcileJSONCContentFile(target string, previousData, currentData []byte) error {
+	targetData, err := os.ReadFile(target)
+	if err != nil {
+		return err
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		return err
+	}
+	reconciliation, err := configsubset.ReconcileJSONC(targetData, previousData, currentData)
+	if err != nil {
+		return err
+	}
+	if !reconciliation.Compatible {
+		return fmt.Errorf("live target changed a previously owned JSONC value")
 	}
 	if !reconciliation.Changed {
 		return nil

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -451,7 +451,7 @@ func (m Manifest) Validate() error {
 			return fmt.Errorf("entries[%d].strategy must be one of copy, symlink, template", i)
 		}
 		if !allowedOwnership(entry.Ownership) {
-			return fmt.Errorf("entries[%d].ownership must be one of json-subset, toml-subset", i)
+			return fmt.Errorf("entries[%d].ownership must be one of json-subset, jsonc-subset, toml-subset", i)
 		}
 		if entry.Ownership != "" && entry.Strategy != "copy" {
 			return fmt.Errorf("entries[%d].ownership %s requires strategy copy", i, entry.Ownership)
@@ -1000,7 +1000,7 @@ func allowedStrategy(strategy string) bool {
 
 func allowedOwnership(ownership string) bool {
 	switch ownership {
-	case "", "json-subset", "toml-subset":
+	case "", "json-subset", "jsonc-subset", "toml-subset":
 		return true
 	default:
 		return false

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -167,6 +167,33 @@ entries:
 	}
 }
 
+func TestLoadFileParsesJSONCSubsetOwnership(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dots.yaml")
+	content := []byte(`version: 1
+profiles:
+  default:
+    tags: [desktop]
+entries:
+  - source: configs/zed/settings.json
+    target: ~/.config/zed/settings.json
+    strategy: copy
+    ownership: jsonc-subset
+    tags: [desktop]
+`)
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	got, err := manifest.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+	if got.Entries[0].Ownership != "jsonc-subset" {
+		t.Fatalf("Entry.Ownership = %q, want jsonc-subset", got.Entries[0].Ownership)
+	}
+}
+
 func TestLoadFileParsesEntryDependencies(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "dots.yaml")
@@ -763,6 +790,14 @@ func TestRepositoryManifestDefinesNativeAgentCLIBaseline(t *testing.T) {
 	}
 	if opencodeEntry.Source != "configs/opencode/opencode.json" || opencodeEntry.Ownership != "json-subset" || !sameStrings(opencodeEntry.Tags, []string{"agents"}) {
 		t.Errorf("OpenCode Managed Entry = %#v, want agents-tagged configs/opencode/opencode.json with JSON Subset Ownership", *opencodeEntry)
+	}
+
+	zedSettings := findEntry(got.Entries, "~/.config/zed/settings.json")
+	if zedSettings == nil {
+		t.Fatal("desktop profile missing Zed settings Managed Entry")
+	}
+	if zedSettings.Source != "configs/zed/settings.json" || zedSettings.Strategy != "copy" || zedSettings.Ownership != "jsonc-subset" {
+		t.Errorf("Zed settings Managed Entry = %#v, want copy with JSONC Subset Ownership", *zedSettings)
 	}
 
 	selected, err := provision.Select(*got, provision.Options{Profile: "agents", OS: "darwin"})
@@ -1641,7 +1676,7 @@ entries:
     ownership: merge
     tags: [core]
 `,
-			want: "entries[0].ownership must be one of json-subset, toml-subset",
+			want: "entries[0].ownership must be one of json-subset, jsonc-subset, toml-subset",
 		},
 		{
 			name: "json subset ownership on non-copy strategy",

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -193,7 +193,7 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 				}
 			}
 		}
-		if rec, ok := opts.Metadata.FindByTarget(target); ok && rec.Ownership == "json-subset" && len(rec.OwnedContent) > 0 {
+		if rec, ok := opts.Metadata.FindByTarget(target); ok && rec.Ownership == action.Ownership && isJSONOwnership(rec.Ownership) && len(rec.OwnedContent) > 0 {
 			action.PreviousContent = append([]byte(nil), rec.OwnedContent...)
 		}
 		targetKey := filepath.Clean(target)
@@ -249,6 +249,15 @@ func planLegacyMigration(entry manifest.Entry, currentSource string, migration L
 	switch entry.Ownership {
 	case "json-subset":
 		reconciliation, err := configsubset.ReconcileJSON(migration.CapturedContent, migration.PreviousSourceContent, current)
+		if err != nil {
+			return LegacyMigration{}, false, err
+		}
+		if !reconciliation.Compatible {
+			return LegacyMigration{}, false, nil
+		}
+		planned.FinalContent = reconciliation.Content
+	case "jsonc-subset":
+		reconciliation, err := configsubset.ReconcileJSONC(migration.CapturedContent, migration.PreviousSourceContent, current)
 		if err != nil {
 			return LegacyMigration{}, false, err
 		}
@@ -605,8 +614,8 @@ func status(entry manifest.Entry, target, sourceAbs, sourceRoot, canonicalSource
 		}
 		if same, err := sameContent(target, sourceAbs); err != nil || !same {
 			if isSubsetOwned(entry.Ownership) && meta.MatchesEntry(target, entry.Source, entry.Strategy) {
-				if entry.Ownership == "json-subset" {
-					if rec, ok := meta.FindByTarget(target); ok && rec.Ownership == "json-subset" && len(rec.OwnedContent) > 0 {
+				if isJSONOwnership(entry.Ownership) {
+					if rec, ok := meta.FindByTarget(target); ok && rec.Ownership == entry.Ownership && len(rec.OwnedContent) > 0 {
 						targetData, readErr := os.ReadFile(target)
 						if readErr != nil {
 							return "", fmt.Errorf("read JSON target %s: %w", target, readErr)
@@ -615,7 +624,13 @@ func status(entry manifest.Entry, target, sourceAbs, sourceRoot, canonicalSource
 						if readErr != nil {
 							return "", fmt.Errorf("read source JSON %s: %w", sourceAbs, readErr)
 						}
-						reconciliation, reconcileErr := configsubset.ReconcileJSON(targetData, rec.OwnedContent, currentData)
+						var reconciliation configsubset.JSONReconciliation
+						var reconcileErr error
+						if entry.Ownership == "jsonc-subset" {
+							reconciliation, reconcileErr = configsubset.ReconcileJSONC(targetData, rec.OwnedContent, currentData)
+						} else {
+							reconciliation, reconcileErr = configsubset.ReconcileJSON(targetData, rec.OwnedContent, currentData)
+						}
 						if reconcileErr != nil {
 							return "", fmt.Errorf("reconcile JSON target %s: %w", target, reconcileErr)
 						}
@@ -627,7 +642,21 @@ func status(entry manifest.Entry, target, sourceAbs, sourceRoot, canonicalSource
 						}
 						return StatusConflict, nil
 					}
-					relation, relationErr := configsubset.AnalyzeJSONFiles(target, sourceAbs)
+					var relation configsubset.JSONFileRelation
+					var relationErr error
+					if entry.Ownership == "jsonc-subset" {
+						targetData, readErr := os.ReadFile(target)
+						if readErr != nil {
+							return "", fmt.Errorf("read JSONC target %s: %w", target, readErr)
+						}
+						sourceData, readErr := os.ReadFile(sourceAbs)
+						if readErr != nil {
+							return "", fmt.Errorf("read source JSONC %s: %w", sourceAbs, readErr)
+						}
+						relation, relationErr = configsubset.AnalyzeJSONC(targetData, sourceData)
+					} else {
+						relation, relationErr = configsubset.AnalyzeJSONFiles(target, sourceAbs)
+					}
 					if relationErr != nil {
 						return "", relationErr
 					}
@@ -728,13 +757,28 @@ func sameContent(a, b string) (bool, error) {
 }
 
 func isSubsetOwned(ownership string) bool {
-	return ownership == "json-subset" || ownership == "toml-subset"
+	return isJSONOwnership(ownership) || ownership == "toml-subset"
+}
+
+func isJSONOwnership(ownership string) bool {
+	return ownership == "json-subset" || ownership == "jsonc-subset"
 }
 
 func subsetContent(ownership, target, sourceAbs string) (bool, error) {
 	switch ownership {
 	case "json-subset":
 		return configsubset.JSONFileContains(target, sourceAbs)
+	case "jsonc-subset":
+		targetData, err := os.ReadFile(target)
+		if err != nil {
+			return false, fmt.Errorf("read %s: %w", target, err)
+		}
+		sourceData, err := os.ReadFile(sourceAbs)
+		if err != nil {
+			return false, fmt.Errorf("read %s: %w", sourceAbs, err)
+		}
+		relation, err := configsubset.AnalyzeJSONC(targetData, sourceData)
+		return relation.Contains, err
 	case "toml-subset":
 		return configsubset.TOMLFileContains(target, sourceAbs)
 	default:

--- a/internal/plan/uninstall.go
+++ b/internal/plan/uninstall.go
@@ -150,12 +150,17 @@ func uninstallStatus(rec state.Record, sourceRoot, home string) (UninstallStatus
 		if !info.Mode().IsRegular() {
 			return UninstallNotOwned, nil
 		}
-		if rec.Ownership == "json-subset" && len(rec.OwnedContent) > 0 {
+		if (rec.Ownership == "json-subset" || rec.Ownership == "jsonc-subset") && len(rec.OwnedContent) > 0 {
 			targetData, err := os.ReadFile(rec.Target)
 			if err != nil {
 				return "", fmt.Errorf("read uninstall target %s: %w", rec.Target, err)
 			}
-			_, _, _, compatible, err := configsubset.RemoveJSON(targetData, rec.OwnedContent)
+			var compatible bool
+			if rec.Ownership == "jsonc-subset" {
+				_, _, _, compatible, err = configsubset.RemoveJSONC(targetData, rec.OwnedContent)
+			} else {
+				_, _, _, compatible, err = configsubset.RemoveJSON(targetData, rec.OwnedContent)
+			}
 			if err != nil {
 				return "", fmt.Errorf("analyze owned JSON for %s: %w", rec.Target, err)
 			}

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -306,7 +306,8 @@ func evaluate(entry manifest.Entry, target string, meta state.Metadata, sourceRo
 		if err != nil {
 			return "", fmt.Errorf("read source JSONC %s: %w", sourceAbs, err)
 		}
-		if rec, recorded := meta.FindByTarget(target); recorded && rec.Strategy == entry.Strategy {
+		if meta.MatchesEntry(target, entry.Source, entry.Strategy) {
+			rec, _ := meta.FindByTarget(target)
 			if rec.Ownership == "jsonc-subset" && len(rec.OwnedContent) > 0 {
 				reconciliation, err := configsubset.ReconcileJSONC(targetData, rec.OwnedContent, sourceData)
 				if err != nil {

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -287,6 +287,47 @@ func evaluate(entry manifest.Entry, target string, meta state.Metadata, sourceRo
 		}
 		return StateConflict, nil
 	}
+	if entry.Ownership == "jsonc-subset" {
+		info, err := os.Lstat(target)
+		if err != nil {
+			return "", fmt.Errorf("stat target %s: %w", target, err)
+		}
+		if !info.Mode().IsRegular() {
+			if meta.MatchesEntry(target, entry.Source, entry.Strategy) {
+				return StateDrifted, nil
+			}
+			return StateConflict, nil
+		}
+		targetData, err := os.ReadFile(target)
+		if err != nil {
+			return "", fmt.Errorf("read JSONC target %s: %w", target, err)
+		}
+		sourceData, err := os.ReadFile(sourceAbs)
+		if err != nil {
+			return "", fmt.Errorf("read source JSONC %s: %w", sourceAbs, err)
+		}
+		if rec, recorded := meta.FindByTarget(target); recorded && rec.Strategy == entry.Strategy {
+			if rec.Ownership == "jsonc-subset" && len(rec.OwnedContent) > 0 {
+				reconciliation, err := configsubset.ReconcileJSONC(targetData, rec.OwnedContent, sourceData)
+				if err != nil {
+					return "", fmt.Errorf("reconcile JSONC target %s: %w", target, err)
+				}
+				if reconciliation.Compatible && !reconciliation.Changed {
+					return StateOK, nil
+				}
+				return StateDrifted, nil
+			}
+			relation, err := configsubset.AnalyzeJSONC(targetData, sourceData)
+			if err != nil {
+				return "", fmt.Errorf("analyze JSONC target %s: %w", target, err)
+			}
+			if relation.Contains {
+				return StateOK, nil
+			}
+			return StateDrifted, nil
+		}
+		return StateConflict, nil
+	}
 
 	if isSubsetOwned(entry.Ownership) && meta.MatchesEntry(target, entry.Source, entry.Strategy) {
 		subset, err := subsetContent(entry.Ownership, target, sourceAbs)
@@ -403,13 +444,24 @@ func sameContent(a, b string) (bool, error) {
 }
 
 func isSubsetOwned(ownership string) bool {
-	return ownership == "json-subset" || ownership == "toml-subset"
+	return ownership == "json-subset" || ownership == "jsonc-subset" || ownership == "toml-subset"
 }
 
 func subsetContent(ownership, target, sourceAbs string) (bool, error) {
 	switch ownership {
 	case "json-subset":
 		return configsubset.JSONFileContains(target, sourceAbs)
+	case "jsonc-subset":
+		targetData, err := os.ReadFile(target)
+		if err != nil {
+			return false, fmt.Errorf("read %s: %w", target, err)
+		}
+		sourceData, err := os.ReadFile(sourceAbs)
+		if err != nil {
+			return false, fmt.Errorf("read %s: %w", sourceAbs, err)
+		}
+		relation, err := configsubset.AnalyzeJSONC(targetData, sourceData)
+		return relation.Contains, err
 	case "toml-subset":
 		return configsubset.TOMLFileContains(target, sourceAbs)
 	default:

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -310,6 +310,33 @@ func TestBuildReportsConflictForClaudeSettingsSubsetWithoutInstallMetadata(t *te
 	}
 }
 
+func TestBuildReportsConflictForJSONCRecordFromDifferentSource(t *testing.T) {
+	f := newFixture(manifest.Entry{
+		Source:    "configs/zed/settings.json",
+		Target:    "~/.config/zed/settings.json",
+		Strategy:  "copy",
+		Ownership: "jsonc-subset",
+		Tags:      []string{"core"},
+	})
+	f.sourceRoot = t.TempDir()
+	f.home = t.TempDir()
+	writeSource(t, f.sourceRoot, "configs/zed/settings.json", `{"theme":"dark"}`)
+	target := filepath.Join(f.home, ".config", "zed", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target parent: %v", err)
+	}
+	if err := os.WriteFile(target, []byte(`{"theme":"dark","runtime":true}`), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	meta := state.Metadata{Entries: []state.Record{{
+		Target: target, Source: "configs/other/settings.json", Strategy: "copy", Ownership: "jsonc-subset", OwnedContent: []byte(`{"theme":"dark"}`),
+	}}}
+
+	if got := onlyEntry(t, f.build(t, meta)).State; got != status.StateConflict {
+		t.Fatalf("state = %q, want conflict because metadata belongs to a different Source of Truth", got)
+	}
+}
+
 func TestBuildEvaluatesEveryContributorRecordedForSharedJSONTarget(t *testing.T) {
 	sourceRoot := t.TempDir()
 	home := t.TempDir()

--- a/internal/uninstall/uninstall.go
+++ b/internal/uninstall/uninstall.go
@@ -77,7 +77,7 @@ func Apply(p plan.UninstallPlan, opts Options) (Result, error) {
 			// The plan references a target dots no longer records; never act on it.
 			continue
 		}
-		if rec.Ownership == "json-subset" && len(rec.OwnedContent) > 0 {
+		if (rec.Ownership == "json-subset" || rec.Ownership == "jsonc-subset") && len(rec.OwnedContent) > 0 {
 			if action.Status != plan.UninstallRemove {
 				continue
 			}
@@ -155,7 +155,13 @@ func removeOwnedJSON(rec state.Record, home string) (applied, deleted bool, err 
 	if err != nil {
 		return false, false, fmt.Errorf("stat owned JSON target %s: %w", rec.Target, err)
 	}
-	content, changed, empty, compatible, err := configsubset.RemoveJSON(targetData, rec.OwnedContent)
+	var content []byte
+	var changed, empty, compatible bool
+	if rec.Ownership == "jsonc-subset" {
+		content, changed, empty, compatible, err = configsubset.RemoveJSONC(targetData, rec.OwnedContent)
+	} else {
+		content, changed, empty, compatible, err = configsubset.RemoveJSON(targetData, rec.OwnedContent)
+	}
 	if err != nil {
 		return false, false, fmt.Errorf("remove owned JSON from %s: %w", rec.Target, err)
 	}


### PR DESCRIPTION
Closes #387

## PR Type

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Materializes Zed settings as a regular co-owned JSONC target.
- Preserves target-only keys, comments, trailing commas, ordering, and untouched formatting.
- Supports provenance-backed migration, three-state updates, diagnostics, Backup Sets, and partial uninstall.

## Changes

| File | Change |
|------|--------|
| `internal/configsubset/jsonc.go` | Adds syntax-preserving recursive JSONC subset reconciliation with atomic scalars and arrays. |
| `internal/{plan,install,status,uninstall}` | Wires JSONC ownership through planning, migration, metadata, diagnostics, updates, and uninstall. |
| `dots.yaml` | Changes only Zed settings from symlink to copy with `jsonc-subset` ownership. |
| Tests and docs | Covers the lifecycle, legacy migration, comment preservation, ownership edge cases, and operator guidance. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] Built binary: `dots manifest validate --file dots.yaml`
- [x] Sandboxed real-binary install/status/doctor/reinstall/uninstall with temporary home and state roots

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] All CLI validation used temporary directories and explicit `--home`, `--source-root`, and `--state-root` flags.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #387`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs for the new ownership behavior.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

### Agent Brief

- Comment: https://github.com/yersonargotev/dots/issues/387#issuecomment-5226646786
- Comment ID: `5226646786`
- SHA-256: `679d579959e56a15b4d8e423d65d317370065813f589bbc6832d8f3959452640`

### Reviewed head

- `0aa158d13d1d78585c2ae213b3c584ffe8f6a14f`

### Acceptance coverage

- Compatible Zed object additions stay aligned through `status`, `doctor`, reinstall, update, and partial uninstall.
- JSONC AST edits retain comments, trailing commas, untouched ordering/formatting, and precise large numbers.
- Scalars and arrays are atomic ordered values; divergent live values produce findings.
- Three-state reconciliation removes retired owned values only with matching evidence.
- Provenance-backed legacy symlink migration creates a Backup Set, preserves compatible Zed content, and leaves the Installed Repository clean.
- Temporary Home Tests cover the full lifecycle and migration.

### Automated validation

- `gofmt -l .` — pass, no output.
- `go vet ./...` — pass.
- `go build ./...` — pass.
- `go test ./...` — pass.
- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...` — no called vulnerabilities.
- Built binary `manifest validate --file dots.yaml` — pass.

### Manual verification

- Built one temporary binary and used it for `install`, `status --output json`, `doctor --output json`, reinstall, and `uninstall`.
- Used explicit temporary home/state roots; Zed settings were a regular file while keymap/theme remained symlinks.
- A simulated Zed object key and nested local comment remained aligned; reinstall preserved the exact target hash.
- Partial uninstall removed owned values and preserved the target-only key plus nested/root comments.
- `doctor` exited 2 only for the intentionally absent sandbox font dependency; its Zed configuration entry was `ok`.

### Independent review

- Spec: pass at `0aa158d`; no actionable findings.
- Standards: pass at `0aa158d`; no actionable findings.
- Earlier findings for empty-object retirement, source identity, comment deletion, and comment duplication were fixed and re-reviewed.

### Delegation

- Read-only slices mapped JSONC architecture, parser/dependency options, and legacy migration/test seams; main agent verified all findings.
- One bounded implementation slice added the JSONC module/tests; accepted after main-agent inspection, dependency upgrade, additional edge-case tests, full validation, and independent review.
- Portable delegation skill/native custom agents were unavailable; workflow-authorized native subagents were used. External project mutations remained with the main agent.
<!-- delivery-issue:evidence:end -->