### PR TITLE
feat(nvim): separate config from seeded state

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -133,7 +133,7 @@ The current alignment between a workstation and the repository-owned Source of T
 _Avoid_: health, sync state, installed state
 
 **Installation Metadata**:
-The state file stored under `~/.local/state/dots/installed.json` that records what the Dotfiles CLI installed, including Managed Entries, Provisioners, strategies, hashes, timestamps, optional structured-ownership evidence, and an optional Installed Selection. It lets the CLI detect Drift and reconcile or remove only proven contributions for copied subset-owned targets while preserving machine-level selection intent separately from historical inventory.
+The state file stored under `~/.local/state/dots/installed.json` that records what the Dotfiles CLI installed, including Managed Entries, Provisioners, strategies, hashes, timestamps, optional structured-ownership or seeded-baseline evidence, and an optional Installed Selection. It lets the CLI detect Drift, reconcile or remove only proven contributions for copied subset-owned targets, and advance Seeded Runtime State without conflating it with dots' own state root, while preserving machine-level selection intent separately from historical inventory.
 _Avoid_: install log, state file, tracking file
 
 **Installed Selection**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -125,7 +125,7 @@ The preview of filesystem changes, conflicts, dependency findings, and backup re
 _Avoid_: preview, dry run output, change list
 
 **Uninstall Plan**:
-The preview of removals the Dotfiles CLI computes from the Installation Metadata before reversing an install, classifying each recorded target as remove, skip, modified, or not-owned. It is the mirror of the Install Plan and is the output of `dots uninstall --dry-run`.
+The preview of removals the Dotfiles CLI computes from the Installation Metadata before reversing an install, classifying each recorded target as remove, retain, skip, modified, or not-owned. It is the mirror of the Install Plan and is the output of `dots uninstall --dry-run`.
 _Avoid_: removal preview, deletion list, reverse plan
 
 **Dotfiles Status**:

--- a/configs/nvim/README.md
+++ b/configs/nvim/README.md
@@ -9,3 +9,10 @@ tag absence keep Mocha.
 The check happens inside `lua/plugins/colorscheme.lua`; no real `$HOME` files are
 needed to validate it beyond a temporary marker path such as
 `DOTS_ADAPTIVE_THEME_MARKER=/tmp/.../adaptive-theme`.
+
+`~/.config/nvim/init.lua` is a regular loader that reads this Managed
+Configuration through `~/.config/dots/nvim`. lazy.nvim writes its lockfile to
+`stdpath("state")/lazy-lock.json`, which resolves beneath `$XDG_STATE_HOME`
+(normally `~/.local/state/nvim/lazy-lock.json`). dots seeds that runtime file,
+advances it only while it still matches the recorded baseline, and preserves
+local plugin revisions and the lockfile itself during uninstall.

--- a/configs/nvim/loader.lua
+++ b/configs/nvim/loader.lua
@@ -1,0 +1,4 @@
+-- Native regular-file entrypoint for dots-managed Neovim configuration.
+local managed = vim.fn.expand("~/.config/dots/nvim")
+vim.opt.runtimepath:prepend(managed)
+dofile(managed .. "/init.lua")

--- a/configs/nvim/lua/config/lazy.lua
+++ b/configs/nvim/lua/config/lazy.lua
@@ -19,6 +19,7 @@ end
 vim.opt.rtp:prepend(lazypath)
 
 require("lazy").setup({
+  lockfile = vim.fn.stdpath("state") .. "/lazy-lock.json",
   spec = {
     -- add LazyVim and import its plugins
     { "LazyVim/LazyVim", import = "lazyvim.plugins" },

--- a/docs/agents/output-contract.md
+++ b/docs/agents/output-contract.md
@@ -175,6 +175,10 @@ prose the text surface prints:
   `probe_detail`/`hint` (unstable human prose) are excluded. Agents key on the
   portable, structured fields (`source`, `present`, `warning`, and the
   `deps plan` install action).
+- Plan actions rooted in application XDG state add portable
+  `target_root: "xdg-state"`; the absolute `target` remains the resolved
+  sandbox path, while dots' Installation Metadata directory continues to be
+  reported separately as `state_root` where applicable.
 - `plan` action `status` values are portable intent, not prose. `create`,
   `update`, `migrate`, and `unchanged` are non-findings; `conflict` and `missing-source`
   are findings. `update` means dots has enough Installation Metadata and
@@ -193,6 +197,11 @@ prose the text surface prints:
   item's `conflict` state. To recover the intended selection, omit explicit
   selection flags so dots can reuse an available Installed Selection, or supply
   each intended exact tag with repeated `--tag <tag>`.
+- A seeded plan action or Status item may add reason
+  `seeded-local-evolution`. It means the regular runtime target differs from
+  its recorded seed baseline and is intentionally preserved. Its plan status is
+  `unchanged`, its Status state is `ok`, and it never produces exit code `2`.
+  Uninstall reports the corresponding action as `retain`.
 - Dependency provider availability is an internal planning check, not a JSON
   contract field. `deps plan` and dependency install previews expose the stable
   outcome (`status`, selected `provider`, executable action, `manual` guidance)

--- a/docs/agents/output-contract.md
+++ b/docs/agents/output-contract.md
@@ -38,7 +38,7 @@ state.
 
 ```json
 {
-  "schema_version": "6",
+  "schema_version": "7",
   "command": "doctor",
   "status": "ok",
   "data": { "...": "command-specific report" }
@@ -59,7 +59,7 @@ Schema version `3` introduced this partial-error report allowance:
 
 ```json
 {
-  "schema_version": "6",
+  "schema_version": "7",
   "command": "doctor",
   "status": "error",
   "error": "read manifest: open dots.yaml: no such file or directory"
@@ -189,6 +189,9 @@ prose the text surface prints:
   last-moment type and content revalidation. Schema version `6` adds this
   semantic status while preserving the conservative conflict model
   for unmanaged or incompatible targets.
+- Schema version `7` adds the allowlisted `xdg-state` target root, seeded local
+  evolution reason, and uninstall `retain` action. These values preserve
+  application-owned runtime state while keeping aligned status at exit code 0.
 - Plan actions and Status Managed Entry items may add the optional reason
   `source-override-not-selected` and a deterministic `matching_tags` array when
   a conflicting target exactly matches one or more alternate sources whose

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -127,17 +127,20 @@ Co-owned files are still documented in [`docs/adaptive-theme-audit.md`](adaptive
 when no safe dots-owned source can be selected.
 
 
-A Managed Entry declares one repository source and one target under `$HOME`.
-Targets must be `~` or `~/...`; `dots` rejects targets that escape the selected
-home directory.
+A Managed Entry declares one repository source and one confined target. Targets
+use `~` or `~/...` by default. The allowlisted `xdg-state` target root instead
+resolves a relative target beneath absolute `$XDG_STATE_HOME`, defaulting to
+`~/.local/state`; it remains confined to the selected home and is distinct from
+dots' own `--state-root`.
 
 | Field | Required | Supported values |
 |-------|----------|------------------|
 | `source` | Yes | Repository-relative path to Managed Configuration. |
 | `source_overrides` | No | Map of exact selected tag to alternate repository-relative source for the same target. The base `source` is used when no key matches; overrides do not alter entry tag selection or OS applicability. |
-| `target` | Yes | Home-relative target: `~` or `~/...`. |
+| `target` | Yes | Home-relative `~` or `~/...`; with `target_root: xdg-state`, a confined relative path. |
+| `target_root` | No | `xdg-state`. It requires `ownership: seeded`; empty keeps home-target resolution. |
 | `strategy` | Yes | `symlink`, `copy`, or `template` in the manifest schema. Current install execution supports `symlink` and `copy`. |
-| `ownership` | No | Empty, `json-subset`, `jsonc-subset`, or `toml-subset`. Subset ownership requires `strategy: copy`. |
+| `ownership` | No | Empty, `json-subset`, `jsonc-subset`, `toml-subset`, or `seeded`. Explicit ownership requires `strategy: copy`. |
 | `tags` | Yes | Non-empty strings matched against the selected Profile. |
 | `os` | No | `darwin`, `linux`; empty means all supported operating systems. |
 | `dependencies` | No | Entry-level Dependencies. |
@@ -156,6 +159,13 @@ ownership model, but scalars and arrays are atomic ordered values. Compatible
 updates preserve target-only object keys plus untouched comments, trailing
 commas, ordering, and formatting. A changed owned scalar or array is Drift for
 a recorded target and a Conflict without trusted Installation Metadata.
+
+For `seeded` ownership, dots stores the exact opaque baseline in Installation
+Metadata. Missing state is seeded; live state still equal to the prior baseline
+advances to the current baseline after a Backup Set; and locally evolved state
+is preserved as aligned information with reason `seeded-local-evolution`.
+Uninstall retains the physical runtime state and removes only its ownership
+record.
 
 Current Managed Entries:
 
@@ -181,7 +191,9 @@ Current Managed Entries:
 | `configs/atuin/config.toml` | `~/.config/atuin/config.toml` | `symlink` | `core` | `darwin`, `linux` | `atuin` |
 | `configs/atuin/themes/catppuccin-mocha.toml` | `~/.config/atuin/themes/catppuccin-mocha.toml` | `symlink` | `core` | `darwin`, `linux` | `atuin` |
 | `configs/bat/config` | `~/.config/bat/config` | `symlink` | `core` | `darwin`, `linux` | `bat` |
-| `configs/nvim` | `~/.config/nvim` | `symlink` | `core` | `darwin`, `linux` | `neovim` |
+| `configs/nvim/lazy-lock.json` | `$XDG_STATE_HOME/nvim/lazy-lock.json` | `copy` (`seeded`) | `core` | `darwin`, `linux` | None |
+| `configs/nvim/loader.lua` | `~/.config/nvim/init.lua` | `copy` | `core` | `darwin`, `linux` | `neovim` |
+| `configs/nvim` | `~/.config/dots/nvim` | `symlink` | `core` | `darwin`, `linux` | None |
 | `configs/zed/settings.json` | `~/.config/zed/settings.json` | `copy` (`jsonc-subset`) | `desktop` | `darwin`, `linux` | `zed` |
 | `configs/zed/keymap.json` | `~/.config/zed/keymap.json` | `symlink` | `desktop` | `darwin`, `linux` | `zed` |
 | `configs/zed/themes/catppuccin-blue.json` | `~/.config/zed/themes/catppuccin-blue.json` | `symlink` | `desktop` | `darwin`, `linux` | `zed` |

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -11,11 +11,11 @@ dots uninstall --yes       # remove owned targets without prompting
 ## What it does
 
 1. **Reads the Installation Metadata.** Each newly recorded target carries its source, install strategy, explicit whole/partial ownership, and — for copied files — a content hash. Strict-JSON subset records also carry the prior dots-owned contribution. A run with no recorded targets reports that and stops.
-2. **Builds the Uninstall Plan.** Every recorded target is classified against current disk state into one of four actions (see below).
+2. **Builds the Uninstall Plan.** Every recorded target is classified against current disk state into one of five actions (see below).
 3. **Previews by default.** The plan is printed before anything is removed. Without `--yes`, the command then asks for confirmation; answering anything other than `y`/`yes` cancels with no changes.
 4. **Removes only owned content.** Symlinks are deleted only when they still resolve to the recorded repository source; whole-owned copies only when their content still matches the recorded hash. Strict-JSON subset targets lose only the recorded contribution and remain in place while external content survives.
 5. **Optionally restores backups.** With `--restore-backups`, each removed target's most recent Backup Set is restored, returning the workstation to its pre-install state.
-6. **Prunes the metadata.** Records for successfully removed targets are dropped, and the metadata file is deleted entirely once nothing remains.
+6. **Prunes the metadata.** Records for successfully removed contributions and retained Seeded Runtime State are dropped, and the metadata file is deleted entirely once nothing remains.
 
 ## Plan actions
 
@@ -25,6 +25,7 @@ dots uninstall --yes       # remove owned targets without prompting
 | `modified` | A whole-owned copy drifted, or a recorded partial contribution changed externally. | Whole-owned copies may be forced; partial targets are always preserved. |
 | `not-owned` | A symlink that is missing or now points elsewhere, or a target whose type changed. `dots` can no longer prove it owns it. | Skipped, always. |
 | `skip` | A copied target that is already absent. | Nothing to do. |
+| `retain` | Seeded Runtime State is application-owned after materialization. | Preserves the target and removes only its dots ownership record. |
 
 ```
 Uninstall Plan
@@ -43,6 +44,7 @@ Uninstall is conservative by design: it would rather leave a file in place than 
 - **Symlinks** are verified by destination, not by name. A link is removed only if `readlink` still resolves to the source `dots` recorded (resolved against `--source-root`). A link the user repointed, or replaced with a real file, is `not-owned` and left untouched.
 - **Whole-owned copies** are verified by content hash. A file whose hash still matches the recorded value is removed; a file you edited is `modified` and preserved unless you pass `--force`.
 - **Strict-JSON subsets** are reconciled against their recorded contribution. Matching owned values are removed recursively, target-only keys and array items survive, and the physical file is deleted only when no external content remains. Changed owned values are `modified`; `--force` never broadens partial ownership or deletes the whole co-owned target. Legacy Installation Metadata without contribution evidence may remove an unchanged hash match, but cannot force-remove a modified copy; a safe install must first record current ownership evidence.
+- **Seeded Runtime State** is always retained, whether unchanged or locally evolved. `--force` never removes it; uninstall prunes only the ownership record.
 - **Re-verification at apply time.** The classification shown in the preview is recomputed against disk immediately before each removal, so a target that changed between preview and apply is never removed by surprise.
 - **No removal escapes HOME.** Every target is validated to stay inside the home sandbox, with the same no-symlink-escape guards install uses, before it is deleted.
 

--- a/dots.yaml
+++ b/dots.yaml
@@ -468,9 +468,19 @@ entries:
           checksums:
             linux_amd64: 726f04c8f576a7fd18b7634f1bbf2f915c43494c1c0f013baa3287edb0d5a2a3
             linux_arm64: 422eb73e11c854fddd99f5ca8461c2f1d6e6dce0a2a8c3d5daade5ffcb6564aa
-  - source: configs/nvim
-    target: ~/.config/nvim
-    strategy: symlink
+  - source: configs/nvim/lazy-lock.json
+    target: nvim/lazy-lock.json
+    target_root: xdg-state
+    strategy: copy
+    ownership: seeded
+    tags:
+      - core
+    os:
+      - darwin
+      - linux
+  - source: configs/nvim/loader.lua
+    target: ~/.config/nvim/init.lua
+    strategy: copy
     tags:
       - core
     os:
@@ -489,6 +499,14 @@ entries:
           checksums:
             linux_amd64: c441b547142860bf01bcce39e36cbed185c41112813e15443b16e5237750724d
             linux_arm64: e055af73fa9c72b37456da8d204fa5c09850bc07e80e9176fe3b87d4afb7a3fc
+  - source: configs/nvim
+    target: ~/.config/dots/nvim
+    strategy: symlink
+    tags:
+      - core
+    os:
+      - darwin
+      - linux
   - source: configs/zed/settings.json
     target: ~/.config/zed/settings.json
     strategy: copy

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1047,11 +1047,18 @@ func TestRepositoryGitConfigInstallsAndReportsAlignedInSandbox(t *testing.T) {
 		t.Fatalf("status Execute() error = %v\noutput:\n%s", err, statusOut.String())
 	}
 
-	nvimTarget := filepath.Join(home, ".config/nvim")
-	if target, err := os.Readlink(nvimTarget); err != nil {
-		t.Fatalf("sandbox nvim target is not a symlink: %v", err)
+	nvimLoader := filepath.Join(home, ".config/nvim/init.lua")
+	if info, err := os.Lstat(nvimLoader); err != nil || !info.Mode().IsRegular() {
+		t.Fatalf("sandbox Neovim loader is not a regular file: info=%v err=%v", info, err)
+	}
+	nvimManaged := filepath.Join(home, ".config/dots/nvim")
+	if target, err := os.Readlink(nvimManaged); err != nil {
+		t.Fatalf("sandbox managed Neovim target is not a symlink: %v", err)
 	} else if want := filepath.Join(sourceRoot, "configs/nvim"); target != want {
-		t.Fatalf("sandbox nvim symlink = %q, want %q", target, want)
+		t.Fatalf("sandbox managed Neovim symlink = %q, want %q", target, want)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".local/state/nvim/lazy-lock.json")); err != nil {
+		t.Fatalf("sandbox seeded Neovim lockfile missing: %v", err)
 	}
 
 	// Derive the expected counts from the loaded manifest rather than hardcoded
@@ -1064,11 +1071,13 @@ func TestRepositoryGitConfigInstallsAndReportsAlignedInSandbox(t *testing.T) {
 		t.Fatalf("LoadFile(%q) error = %v", manifestPath, err)
 	}
 	coreProfile := loaded.Profiles["core"]
+	countHome := t.TempDir()
 	countPlan, err := plan.Build(*loaded, plan.Options{
-		Profile:    "core",
-		OS:         runtime.GOOS,
-		SourceRoot: sourceRoot,
-		Home:       t.TempDir(),
+		Profile:      "core",
+		OS:           runtime.GOOS,
+		SourceRoot:   sourceRoot,
+		Home:         countHome,
+		XDGStateHome: filepath.Join(countHome, ".local", "state"),
 	})
 	if err != nil {
 		t.Fatalf("Build() error = %v", err)
@@ -1091,7 +1100,9 @@ func TestRepositoryGitConfigInstallsAndReportsAlignedInSandbox(t *testing.T) {
 		"configs/git/gitconfig -> " + gitconfigTarget,
 		"configs/zellij/config.kdl -> " + zellijConfigTarget,
 		"configs/zellij/layouts/default.kdl -> " + zellijLayoutTarget,
-		"configs/nvim -> " + nvimTarget,
+		"configs/nvim/loader.lua -> " + nvimLoader,
+		"configs/nvim -> " + nvimManaged,
+		"configs/nvim/lazy-lock.json -> " + filepath.Join(home, ".local/state/nvim/lazy-lock.json"),
 		wantSummary,
 	} {
 		if !strings.Contains(got, want) {

--- a/internal/cli/deps.go
+++ b/internal/cli/deps.go
@@ -282,6 +282,7 @@ func resolveDepsReadOnlySelection(m manifest.Manifest, home string, profiles, ex
 	}
 	return resolveReadOnlySelection(m, meta, profiles, extraTags, readOnlySelectionOptions{
 		Home: paths.Home, SourceRoot: paths.SourceRoot, StatePath: state.Path(paths.StateRoot),
+		XDGStateHome: paths.XDGStateHome,
 	})
 }
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -53,20 +53,22 @@ func newDoctorCommand() *cobra.Command {
 
 			effective, err := resolveReadOnlySelection(*m, meta, profiles, extraTags, readOnlySelectionOptions{
 				Home: paths.Home, SourceRoot: paths.SourceRoot, StatePath: state.Path(paths.StateRoot),
+				XDGStateHome: paths.XDGStateHome,
 			})
 			if err != nil {
 				return err
 			}
 
 			report, err := doctor.Build(*m, meta, doctor.Options{
-				Profiles:   effective.Profiles,
-				ExtraTags:  effective.ExtraTags,
-				Selection:  &effective.Selection,
-				OS:         runtime.GOOS,
-				SourceRoot: paths.SourceRoot,
-				Home:       paths.Home,
-				ToolRunner: commandOutput,
-				AppLookup:  appInstalled(runtime.GOOS, paths.Home),
+				Profiles:     effective.Profiles,
+				ExtraTags:    effective.ExtraTags,
+				Selection:    &effective.Selection,
+				OS:           runtime.GOOS,
+				SourceRoot:   paths.SourceRoot,
+				Home:         paths.Home,
+				XDGStateHome: paths.XDGStateHome,
+				ToolRunner:   commandOutput,
+				AppLookup:    appInstalled(runtime.GOOS, paths.Home),
 			}, lookupCommand, fontInstalled(runtime.GOOS, paths.Home))
 			if err != nil {
 				return err

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -324,6 +324,7 @@ func buildInstallPlanAndProvisioners(m manifest.Manifest, meta state.Metadata, p
 		SourceRoot:       paths.SourceRoot,
 		SourceReadRoot:   sourceReadRoot,
 		Home:             paths.Home,
+		XDGStateHome:     paths.XDGStateHome,
 		Metadata:         meta,
 		LegacyMigrations: legacyMigrations,
 	})

--- a/internal/cli/install_repository.go
+++ b/internal/cli/install_repository.go
@@ -56,7 +56,15 @@ func prepareInstallRepository(cmd *cobra.Command, paths resolvedPaths, dryRun bo
 	if err != nil {
 		return result, err
 	}
-	captures, err := repositoryrefresh.CaptureLegacyTargets(*oldManifest, meta, paths.SourceRoot, paths.Home, preview.OldRev)
+	incomingManifestData, err := gitrepo.ReadFileAtRevision(paths.SourceRoot, preview.NewRev, "dots.yaml")
+	if err != nil {
+		return result, err
+	}
+	incomingManifest, err := manifest.Parse(incomingManifestData)
+	if err != nil {
+		return result, err
+	}
+	captures, err := repositoryrefresh.CaptureLegacyTargets(*oldManifest, *incomingManifest, meta, paths.SourceRoot, paths.Home, paths.XDGStateHome, preview.OldRev)
 	if err != nil {
 		return result, err
 	}

--- a/internal/cli/installed.go
+++ b/internal/cli/installed.go
@@ -58,7 +58,7 @@ func newInstalledCommand() *cobra.Command {
 				return err
 			}
 			analysis, err := selectionmigration.Analyze(*m, meta, selectionmigration.Options{
-				OS: runtime.GOOS, Home: paths.Home, SourceRoot: paths.SourceRoot, StatePath: state.Path(paths.StateRoot),
+				OS: runtime.GOOS, Home: paths.Home, SourceRoot: paths.SourceRoot, StatePath: state.Path(paths.StateRoot), XDGStateHome: paths.XDGStateHome,
 			})
 			if err != nil {
 				return err

--- a/internal/cli/issue388_nvim_seeded_lifecycle_test.go
+++ b/internal/cli/issue388_nvim_seeded_lifecycle_test.go
@@ -1,0 +1,140 @@
+package cli_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/cli"
+)
+
+func TestNeovimSeededStateLifecycleUsesConfinedXDGStateAndPreservesLocalEvolution(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	dotsStateRoot := filepath.Join(home, ".dots-state")
+	xdgStateHome := filepath.Join(home, "xdg", "state")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_STATE_HOME", xdgStateHome)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "xdg", "data"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, "xdg", "cache"))
+
+	write := func(path, content string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	oldBaseline := "{\n  \"plugin-a\": \"old\",\n  \"plugin-b\": \"retired\"\n}\n"
+	newBaseline := "{\n  \"plugin-a\": \"new\"\n}\n"
+	localEvolution := "{\n  \"plugin-a\": \"local-update\",\n  \"plugin-b\": \"retired\"\n}\n"
+	write(filepath.Join(sourceRoot, "configs/nvim/lazy-lock.json"), oldBaseline)
+	write(filepath.Join(sourceRoot, "configs/nvim/loader.lua"), "local managed = vim.fn.expand('~/.config/dots/nvim')\n")
+	write(filepath.Join(sourceRoot, "configs/nvim/init.lua"), "vim.g.dots_managed = true\n")
+	manifestPath := filepath.Join(sourceRoot, "dots.yaml")
+	write(manifestPath, `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/nvim/lazy-lock.json
+    target: nvim/lazy-lock.json
+    target_root: xdg-state
+    strategy: copy
+    ownership: seeded
+    tags: [core]
+  - source: configs/nvim/loader.lua
+    target: ~/.config/nvim/init.lua
+    strategy: copy
+    tags: [core]
+  - source: configs/nvim
+    target: ~/.config/dots/nvim
+    strategy: symlink
+    tags: [core]
+`)
+
+	runIssue388Git(t, sourceRoot, "init")
+	runIssue388Git(t, sourceRoot, "config", "user.email", "dots@example.test")
+	runIssue388Git(t, sourceRoot, "config", "user.name", "dots test")
+	runIssue388Git(t, sourceRoot, "add", ".")
+	runIssue388Git(t, sourceRoot, "commit", "-m", "test baseline")
+
+	run := func(want int, args ...string) string {
+		t.Helper()
+		var stdout, stderr bytes.Buffer
+		code := cli.Run(args, &stdout, &stderr)
+		if code != want {
+			t.Fatalf("cli.Run(%v) code = %d, want %d\nstdout:\n%s\nstderr:\n%s", args, code, want, stdout.String(), stderr.String())
+		}
+		return stdout.String()
+	}
+	common := []string{"--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", dotsStateRoot}
+	installArgs := append([]string{"install", "--yes", "--skip-deps"}, common...)
+	statusArgs := append([]string{"status", "--output", "json"}, common...)
+	run(0, installArgs...)
+
+	loader := filepath.Join(home, ".config/nvim/init.lua")
+	if info, err := os.Lstat(loader); err != nil || !info.Mode().IsRegular() {
+		t.Fatalf("native loader = (%v, %v), want regular file", info, err)
+	}
+	managed := filepath.Join(home, ".config/dots/nvim")
+	if target, err := os.Readlink(managed); err != nil || target != filepath.Join(sourceRoot, "configs/nvim") {
+		t.Fatalf("managed config symlink = (%q, %v)", target, err)
+	}
+	lock := filepath.Join(xdgStateHome, "nvim/lazy-lock.json")
+	if got, err := os.ReadFile(lock); err != nil || string(got) != oldBaseline {
+		t.Fatalf("seeded lock = (%q, %v), want old baseline", got, err)
+	}
+
+	write(filepath.Join(sourceRoot, "configs/nvim/lazy-lock.json"), newBaseline)
+	runIssue388Git(t, sourceRoot, "add", "configs/nvim/lazy-lock.json")
+	runIssue388Git(t, sourceRoot, "commit", "-m", "advance lock baseline")
+	write(lock, localEvolution)
+	statusOutput := run(0, statusArgs...)
+	if !strings.Contains(statusOutput, `"state": "ok"`) || !strings.Contains(statusOutput, `"reason": "seeded-local-evolution"`) {
+		t.Fatalf("status did not report aligned local evolution:\n%s", statusOutput)
+	}
+	run(0, installArgs...)
+	if got, err := os.ReadFile(lock); err != nil || string(got) != localEvolution {
+		t.Fatalf("install changed local evolution = (%q, %v)", got, err)
+	}
+	if got := strings.TrimSpace(runIssue388Git(t, sourceRoot, "status", "--porcelain")); got != "" {
+		t.Fatalf("simulated lazy.nvim write dirtied the repository: %q", got)
+	}
+
+	write(lock, oldBaseline)
+	run(0, installArgs...)
+	if got, err := os.ReadFile(lock); err != nil || string(got) != newBaseline {
+		t.Fatalf("unchanged seeded state did not advance with baseline removal = (%q, %v)", got, err)
+	}
+
+	uninstallOutput := run(0, "uninstall", "--yes", "--home", home, "--source-root", sourceRoot, "--state-root", dotsStateRoot)
+	if !strings.Contains(uninstallOutput, "Retained Seeded Runtime State") {
+		t.Fatalf("uninstall did not report retained state:\n%s", uninstallOutput)
+	}
+	if got, err := os.ReadFile(lock); err != nil || string(got) != newBaseline {
+		t.Fatalf("uninstall changed seeded state = (%q, %v)", got, err)
+	}
+	if _, err := os.Lstat(loader); !os.IsNotExist(err) {
+		t.Fatalf("native loader still exists after uninstall: %v", err)
+	}
+	if _, err := os.Lstat(managed); !os.IsNotExist(err) {
+		t.Fatalf("managed config symlink still exists after uninstall: %v", err)
+	}
+}
+
+func runIssue388Git(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return string(out)
+}

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -22,7 +22,7 @@ const (
 // binary. Renaming, removing, or repurposing a field in any command's JSON
 // `data` is a breaking change to the Agent Output Contract and must bump this
 // value.
-const schemaVersion = "6"
+const schemaVersion = "7"
 
 // Envelope statuses. They mirror the semantic exit codes: ok->0, findings->2,
 // error->1.

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -86,8 +86,8 @@ func decodeEnvelope(t *testing.T, out string) testEnvelope {
 	if err := json.Unmarshal([]byte(out), &env); err != nil {
 		t.Fatalf("stdout is not a JSON envelope: %v\noutput:\n%s", err, out)
 	}
-	if env.SchemaVersion != "6" {
-		t.Fatalf("schema_version = %q, want \"6\"", env.SchemaVersion)
+	if env.SchemaVersion != "7" {
+		t.Fatalf("schema_version = %q, want \"7\"", env.SchemaVersion)
 	}
 	if env.Command != "status" {
 		t.Fatalf("command = %q, want \"status\"", env.Command)
@@ -101,8 +101,8 @@ func decodeEnvelopeForCommand(t *testing.T, out string, command string) testEnve
 	if err := json.Unmarshal([]byte(out), &env); err != nil {
 		t.Fatalf("stdout is not a JSON envelope: %v\noutput:\n%s", err, out)
 	}
-	if env.SchemaVersion != "6" {
-		t.Fatalf("schema_version = %q, want \"6\"", env.SchemaVersion)
+	if env.SchemaVersion != "7" {
+		t.Fatalf("schema_version = %q, want \"7\"", env.SchemaVersion)
 	}
 	if env.Command != command {
 		t.Fatalf("command = %q, want %q", env.Command, command)

--- a/internal/cli/paths.go
+++ b/internal/cli/paths.go
@@ -11,9 +11,10 @@ import (
 )
 
 type resolvedPaths struct {
-	Home       string
-	SourceRoot string
-	StateRoot  string
+	Home         string
+	SourceRoot   string
+	StateRoot    string
+	XDGStateHome string
 }
 
 func resolvePaths(home, sourceRoot, stateRoot string) (resolvedPaths, error) {
@@ -32,8 +33,12 @@ func resolvePaths(home, sourceRoot, stateRoot string) (resolvedPaths, error) {
 	if stateRoot == "" {
 		stateRoot = defaultStateRoot(home)
 	}
+	xdgStateHome := os.Getenv("XDG_STATE_HOME")
+	if xdgStateHome == "" {
+		xdgStateHome = filepath.Join(home, ".local", "state")
+	}
 
-	return resolvedPaths{Home: home, SourceRoot: sourceRoot, StateRoot: stateRoot}, nil
+	return resolvedPaths{Home: home, SourceRoot: sourceRoot, StateRoot: stateRoot, XDGStateHome: xdgStateHome}, nil
 }
 
 // defaultSourceRoot is the default location of the Installed Repository: the

--- a/internal/cli/plan.go
+++ b/internal/cli/plan.go
@@ -43,6 +43,7 @@ func newPlanCommand() *cobra.Command {
 
 			effective, err := resolveReadOnlySelection(*m, meta, profiles, extraTags, readOnlySelectionOptions{
 				Home: paths.Home, SourceRoot: paths.SourceRoot, StatePath: state.Path(paths.StateRoot),
+				XDGStateHome: paths.XDGStateHome,
 			})
 			if err != nil {
 				return err
@@ -52,13 +53,14 @@ func newPlanCommand() *cobra.Command {
 			// (e.g. plan a Linux install from macOS); for now the OS is locked
 			// to the host so the dry-run reflects this machine.
 			p, err := plan.Build(*m, plan.Options{
-				Profiles:   effective.Profiles,
-				ExtraTags:  effective.ExtraTags,
-				Selection:  &effective.Selection,
-				OS:         runtime.GOOS,
-				SourceRoot: paths.SourceRoot,
-				Home:       paths.Home,
-				Metadata:   meta,
+				Profiles:     effective.Profiles,
+				ExtraTags:    effective.ExtraTags,
+				Selection:    &effective.Selection,
+				OS:           runtime.GOOS,
+				SourceRoot:   paths.SourceRoot,
+				Home:         paths.Home,
+				XDGStateHome: paths.XDGStateHome,
+				Metadata:     meta,
 			})
 			if err != nil {
 				return err

--- a/internal/cli/render_uninstall.go
+++ b/internal/cli/render_uninstall.go
@@ -15,7 +15,7 @@ func renderUninstallPlan(w io.Writer, p plan.UninstallPlan) {
 	fmt.Fprintln(w, "Uninstall Plan")
 	fmt.Fprintln(w)
 
-	var remove, modified, notOwned, skip int
+	var remove, modified, notOwned, skip, retain int
 	for _, action := range p.Actions {
 		fmt.Fprintf(w, "  %-10s %s\n", action.Status, action.Target)
 		switch action.Status {
@@ -27,8 +27,14 @@ func renderUninstallPlan(w io.Writer, p plan.UninstallPlan) {
 			notOwned++
 		case plan.UninstallSkip:
 			skip++
+		case plan.UninstallRetain:
+			retain++
 		}
 	}
 
-	fmt.Fprintf(w, "\nSummary: %d to remove, %d modified, %d not-owned, %d skipped\n", remove, modified, notOwned, skip)
+	if retain > 0 {
+		fmt.Fprintf(w, "\nSummary: %d to remove, %d retained, %d modified, %d not-owned, %d skipped\n", remove, retain, modified, notOwned, skip)
+	} else {
+		fmt.Fprintf(w, "\nSummary: %d to remove, %d modified, %d not-owned, %d skipped\n", remove, modified, notOwned, skip)
+	}
 }

--- a/internal/cli/selection_migration.go
+++ b/internal/cli/selection_migration.go
@@ -53,9 +53,10 @@ func (e *selectionMigrationRequiredError) JSONErrorData() any {
 }
 
 type readOnlySelectionOptions struct {
-	Home       string
-	SourceRoot string
-	StatePath  string
+	Home         string
+	SourceRoot   string
+	StatePath    string
+	XDGStateHome string
 }
 
 func resolveReadOnlySelection(m manifest.Manifest, meta state.Metadata, profiles, extraTags []string, opts readOnlySelectionOptions) (selection.Effective, error) {
@@ -70,10 +71,11 @@ func resolveReadOnlySelection(m manifest.Manifest, meta state.Metadata, profiles
 	}
 
 	analysis, err := selectionmigration.Analyze(m, meta, selectionmigration.Options{
-		OS:         runtime.GOOS,
-		Home:       opts.Home,
-		SourceRoot: opts.SourceRoot,
-		StatePath:  opts.StatePath,
+		OS:           runtime.GOOS,
+		Home:         opts.Home,
+		SourceRoot:   opts.SourceRoot,
+		StatePath:    opts.StatePath,
+		XDGStateHome: opts.XDGStateHome,
 	})
 	if err != nil {
 		return selection.Effective{}, err

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -54,18 +54,20 @@ func newStatusCommand() *cobra.Command {
 
 			effective, err := resolveReadOnlySelection(*m, meta, profiles, extraTags, readOnlySelectionOptions{
 				Home: paths.Home, SourceRoot: paths.SourceRoot, StatePath: state.Path(paths.StateRoot),
+				XDGStateHome: paths.XDGStateHome,
 			})
 			if err != nil {
 				return err
 			}
 
 			report, err := status.Build(*m, meta, status.Options{
-				Profiles:   effective.Profiles,
-				ExtraTags:  effective.ExtraTags,
-				Selection:  &effective.Selection,
-				OS:         runtime.GOOS,
-				SourceRoot: paths.SourceRoot,
-				Home:       paths.Home,
+				Profiles:     effective.Profiles,
+				ExtraTags:    effective.ExtraTags,
+				Selection:    &effective.Selection,
+				OS:           runtime.GOOS,
+				SourceRoot:   paths.SourceRoot,
+				Home:         paths.Home,
+				XDGStateHome: paths.XDGStateHome,
 			})
 			if err != nil {
 				return err

--- a/internal/cli/testdata/envelope_deps_check.golden
+++ b/internal/cli/testdata/envelope_deps_check.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "6",
+  "schema_version": "7",
   "command": "deps check",
   "status": "findings",
   "data": {

--- a/internal/cli/testdata/envelope_deps_plan.golden
+++ b/internal/cli/testdata/envelope_deps_plan.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "6",
+  "schema_version": "7",
   "command": "deps plan",
   "status": "findings",
   "data": {

--- a/internal/cli/testdata/envelope_doctor.golden
+++ b/internal/cli/testdata/envelope_doctor.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "6",
+  "schema_version": "7",
   "command": "doctor",
   "status": "findings",
   "data": {

--- a/internal/cli/testdata/envelope_install.golden
+++ b/internal/cli/testdata/envelope_install.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "6",
+  "schema_version": "7",
   "command": "install",
   "status": "ok",
   "data": {

--- a/internal/cli/testdata/envelope_installed.golden
+++ b/internal/cli/testdata/envelope_installed.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "6",
+  "schema_version": "7",
   "command": "installed",
   "status": "ok",
   "data": {

--- a/internal/cli/testdata/envelope_plan.golden
+++ b/internal/cli/testdata/envelope_plan.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "6",
+  "schema_version": "7",
   "command": "plan",
   "status": "findings",
   "data": {

--- a/internal/cli/testdata/envelope_selection_migration_required.golden
+++ b/internal/cli/testdata/envelope_selection_migration_required.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "6",
+  "schema_version": "7",
   "command": "status",
   "status": "error",
   "data": {

--- a/internal/cli/testdata/envelope_status.golden
+++ b/internal/cli/testdata/envelope_status.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "6",
+  "schema_version": "7",
   "command": "status",
   "status": "findings",
   "data": {

--- a/internal/cli/testdata/envelope_uninstall.golden
+++ b/internal/cli/testdata/envelope_uninstall.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "6",
+  "schema_version": "7",
   "command": "uninstall",
   "status": "ok",
   "data": {

--- a/internal/cli/testdata/envelope_update.golden
+++ b/internal/cli/testdata/envelope_update.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "6",
+  "schema_version": "7",
   "command": "update",
   "status": "ok",
   "data": {

--- a/internal/cli/testdata/envelope_update_selection_error.golden
+++ b/internal/cli/testdata/envelope_update_selection_error.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "6",
+  "schema_version": "7",
   "command": "update",
   "status": "error",
   "data": {

--- a/internal/cli/testdata/envelope_upgrade.golden
+++ b/internal/cli/testdata/envelope_upgrade.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "6",
+  "schema_version": "7",
   "command": "upgrade",
   "status": "ok",
   "data": {

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -105,6 +105,9 @@ func newUninstallCommand() *cobra.Command {
 			if len(res.Updated) > 0 {
 				fmt.Fprintf(out, "\nRemoved dots-owned content from %s.\n", pluralizeTargets(len(res.Updated)))
 			}
+			if len(res.Retained) > 0 {
+				fmt.Fprintf(out, "\nRetained Seeded Runtime State at %s.\n", pluralizeTargets(len(res.Retained)))
+			}
 			if restoreBackups && len(res.RestoredSets) > 0 {
 				fmt.Fprintf(out, "Restored %s from preserved Backup Sets.\n", pluralizeBackupSets(len(res.RestoredSets)))
 			}
@@ -129,6 +132,8 @@ func willRemove(p plan.UninstallPlan, force bool) bool {
 	for _, action := range p.Actions {
 		switch action.Status {
 		case plan.UninstallRemove:
+			return true
+		case plan.UninstallRetain:
 			return true
 		case plan.UninstallModified:
 			if force && action.ForceRemovable {

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -209,7 +209,15 @@ func runUpdateWorkflow(cmd *cobra.Command, opts updateOptions, emit bool) (updat
 	if err != nil {
 		return updateReport{}, err
 	}
-	legacyMigrations, err := repositoryrefresh.CaptureLegacyTargets(*previousManifest, meta, paths.SourceRoot, paths.Home, preRefresh.OldRev)
+	incomingManifestData, err := gitrepo.ReadFileAtRevision(paths.SourceRoot, preRefresh.NewRev, "dots.yaml")
+	if err != nil {
+		return updateReport{}, err
+	}
+	incomingManifest, err := manifest.Parse(incomingManifestData)
+	if err != nil {
+		return updateReport{}, err
+	}
+	legacyMigrations, err := repositoryrefresh.CaptureLegacyTargets(*previousManifest, *incomingManifest, meta, paths.SourceRoot, paths.Home, paths.XDGStateHome, preRefresh.OldRev)
 	if err != nil {
 		return updateReport{}, err
 	}
@@ -262,7 +270,7 @@ func runUpdateWorkflow(cmd *cobra.Command, opts updateOptions, emit bool) (updat
 		}
 		sourceReadRoot = snapshotRoot
 	}
-	p, err := plan.Build(*m, plan.Options{Selection: &effective.Selection, OS: runtime.GOOS, SourceRoot: paths.SourceRoot, SourceReadRoot: sourceReadRoot, Home: paths.Home, Metadata: meta, LegacyMigrations: legacyMigrations})
+	p, err := plan.Build(*m, plan.Options{Selection: &effective.Selection, OS: runtime.GOOS, SourceRoot: paths.SourceRoot, SourceReadRoot: sourceReadRoot, Home: paths.Home, XDGStateHome: paths.XDGStateHome, Metadata: meta, LegacyMigrations: legacyMigrations})
 	if err != nil {
 		return updateReport{}, err
 	}

--- a/internal/cli/update_migration.go
+++ b/internal/cli/update_migration.go
@@ -16,10 +16,11 @@ import (
 
 func resolveLegacyUpdateSelection(cmd *cobra.Command, m manifest.Manifest, meta state.Metadata, paths resolvedPaths, opts updateOptions) (selection.Effective, error) {
 	analysis, err := selectionmigration.Analyze(m, meta, selectionmigration.Options{
-		OS:         runtime.GOOS,
-		Home:       paths.Home,
-		SourceRoot: paths.SourceRoot,
-		StatePath:  state.Path(paths.StateRoot),
+		OS:           runtime.GOOS,
+		Home:         paths.Home,
+		SourceRoot:   paths.SourceRoot,
+		StatePath:    state.Path(paths.StateRoot),
+		XDGStateHome: paths.XDGStateHome,
 	})
 	if err != nil {
 		return selection.Effective{}, err

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -23,15 +23,16 @@ import (
 
 // Options carries the resolved inputs needed to build read-only diagnostics.
 type Options struct {
-	Profile    string
-	Profiles   []string
-	ExtraTags  []string
-	Selection  *manifest.Selection
-	OS         string
-	SourceRoot string
-	Home       string
-	ToolRunner deps.CommandRunner
-	AppLookup  deps.AppLookup
+	Profile      string
+	Profiles     []string
+	ExtraTags    []string
+	Selection    *manifest.Selection
+	OS           string
+	SourceRoot   string
+	Home         string
+	XDGStateHome string
+	ToolRunner   deps.CommandRunner
+	AppLookup    deps.AppLookup
 }
 
 // Report is the consolidated doctor diagnostic output for a profile.
@@ -114,13 +115,14 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options, look deps.Loo
 	report.Dependencies = depReport
 
 	statusReport, err := status.Build(m, meta, status.Options{
-		Profile:    opts.Profile,
-		Profiles:   opts.Profiles,
-		ExtraTags:  opts.ExtraTags,
-		Selection:  resolved,
-		OS:         opts.OS,
-		SourceRoot: opts.SourceRoot,
-		Home:       opts.Home,
+		Profile:      opts.Profile,
+		Profiles:     opts.Profiles,
+		ExtraTags:    opts.ExtraTags,
+		Selection:    resolved,
+		OS:           opts.OS,
+		SourceRoot:   opts.SourceRoot,
+		Home:         opts.Home,
+		XDGStateHome: opts.XDGStateHome,
 	})
 	if err != nil {
 		return Report{}, err

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -100,12 +100,20 @@ func recordMetadata(p plan.Plan, resolvedSources [][]string, opts Options) error
 	meta.Provenance = state.CaptureProvenance(opts.SourceRoot, version.Value)
 
 	now := time.Now().UTC().Format(time.RFC3339)
+	legacyTargets := map[string]struct{}{}
 	for i, action := range p.Actions {
 		if !recordsMetadata(action, conflictDecision(action, opts)) {
 			continue
 		}
+		if action.Ownership == "seeded" && action.Reason == plan.ReasonSeededLocalEvolution {
+			// Preserve the baseline that originally seeded locally evolved state.
+			// Replacing it with the new Source of Truth baseline would destroy the
+			// evidence needed to recognize a later reset and advance safely.
+			continue
+		}
 		hash := ""
 		var ownedContent []byte
+		var seededBaseline []byte
 		recordedOwnership := action.Ownership
 		if recordedOwnership == "" {
 			recordedOwnership = "whole"
@@ -136,21 +144,37 @@ func recordMetadata(p plan.Plan, resolvedSources [][]string, opts Options) error
 					if err != nil {
 						return fmt.Errorf("canonicalize owned JSONC contribution %s: %w", resolvedSources[i][0], err)
 					}
+				} else if action.Ownership == "seeded" {
+					if action.Migration != nil && action.Migration.RecordedBaseline != nil {
+						seededBaseline = append([]byte(nil), action.Migration.RecordedBaseline...)
+					} else {
+						seededBaseline, err = os.ReadFile(resolvedSources[i][0])
+						if err != nil {
+							return fmt.Errorf("read seeded baseline %s: %w", resolvedSources[i][0], err)
+						}
+					}
 				}
 			}
 		}
 		upsertRecord(&meta, state.Record{
-			Target:       action.Target,
-			Source:       action.Source,
-			Sources:      append([]string(nil), action.Sources...),
-			Strategy:     action.Strategy,
-			Ownership:    recordedOwnership,
-			OwnedContent: ownedContent,
-			Hash:         hash,
-			InstalledAt:  now,
-			Profiles:     append([]string(nil), p.Profiles...),
-			Tags:         append([]string(nil), p.Tags...),
+			Target:         action.Target,
+			Source:         action.Source,
+			Sources:        append([]string(nil), action.Sources...),
+			Strategy:       action.Strategy,
+			Ownership:      recordedOwnership,
+			OwnedContent:   ownedContent,
+			SeededBaseline: seededBaseline,
+			Hash:           hash,
+			InstalledAt:    now,
+			Profiles:       append([]string(nil), p.Profiles...),
+			Tags:           append([]string(nil), p.Tags...),
 		})
+		if action.Migration != nil && action.Migration.LegacyTarget != "" {
+			legacyTargets[action.Migration.LegacyTarget] = struct{}{}
+		}
+	}
+	for target := range legacyTargets {
+		meta = meta.Remove(target)
 	}
 
 	return state.Save(path, meta)
@@ -186,6 +210,7 @@ func validatePlan(p plan.Plan, opts Options) ([][]string, error) {
 	}
 
 	seenTargets := map[string]struct{}{}
+	validatedLegacyRemovals := map[string]struct{}{}
 	resolvedSources := make([][]string, len(p.Actions))
 	for i, action := range p.Actions {
 		if err := plan.ValidateResolvedTarget(action.Target, home); err != nil {
@@ -239,7 +264,17 @@ func validatePlan(p plan.Plan, opts Options) ([][]string, error) {
 			if !supportedStrategy(action.Strategy) {
 				return nil, fmt.Errorf("install strategy %q is not supported for %s", action.Strategy, action.Target)
 			}
-			if err := validateCreate(action, source, sourceRoot, home); err != nil {
+			if action.LegacyParent != "" {
+				if _, ok := validatedLegacyRemovals[action.LegacyParent]; !ok {
+					return nil, fmt.Errorf("create target %s requires an earlier validated migration of %s", action.Target, action.LegacyParent)
+				}
+				if !plan.InsideRoot(action.Target, action.LegacyParent) {
+					return nil, fmt.Errorf("unsafe create target %s outside legacy parent %s", action.Target, action.LegacyParent)
+				}
+				if err := validateSource(action.Strategy, source, sourceRoot); err != nil {
+					return nil, err
+				}
+			} else if err := validateCreate(action, source, sourceRoot, home); err != nil {
 				return nil, err
 			}
 		case plan.StatusUnchanged:
@@ -248,8 +283,8 @@ func validatePlan(p plan.Plan, opts Options) ([][]string, error) {
 			if opts.StateRoot == "" {
 				return nil, fmt.Errorf("update for %s requires state root for Backup Set metadata", action.Target)
 			}
-			if action.Strategy != "copy" || (action.Ownership != "json-subset" && action.Ownership != "jsonc-subset" && action.Ownership != "toml-subset") {
-				return nil, fmt.Errorf("update for %s requires copy strategy with subset ownership", action.Target)
+			if action.Strategy != "copy" || (action.Ownership != "json-subset" && action.Ownership != "jsonc-subset" && action.Ownership != "toml-subset" && action.Ownership != "seeded") {
+				return nil, fmt.Errorf("update for %s requires copy strategy with reconcilable ownership", action.Target)
 			}
 			if err := validateBackupStateRoot(opts.StateRoot, home); err != nil {
 				return nil, err
@@ -279,11 +314,25 @@ func validatePlan(p plan.Plan, opts Options) ([][]string, error) {
 			if err := validateTargetParentInsideHome(action.Target, home); err != nil {
 				return nil, err
 			}
+			if action.Migration.LegacyTarget != "" {
+				if err := plan.ValidateResolvedTarget(action.Migration.LegacyTarget, home); err != nil {
+					return nil, err
+				}
+				if err := plan.ValidateTargetParentInsideHome(action.Migration.LegacyTarget, home); err != nil {
+					return nil, err
+				}
+				if !plan.InsideRoot(action.Migration.LegacyContentTarget, action.Migration.LegacyTarget) {
+					return nil, fmt.Errorf("unsafe legacy content target %s", action.Migration.LegacyContentTarget)
+				}
+			}
 			if err := validateSource(action.Strategy, source, sourceRoot); err != nil {
 				return nil, err
 			}
 			if err := validateMigrationTarget(action); err != nil {
 				return nil, err
+			}
+			if action.Migration.LegacyTarget != "" {
+				validatedLegacyRemovals[action.Migration.LegacyTarget] = struct{}{}
 			}
 		case plan.StatusConflict:
 			switch conflictDecision(action, opts) {
@@ -551,6 +600,25 @@ func applyUpdate(action plan.Action, source string, opts Options) error {
 		if err := configsubset.MergeTOMLFile(action.Target, source); err != nil {
 			return fmt.Errorf("merge TOML update for %s: %w", action.Target, err)
 		}
+	case "seeded":
+		live, err := os.ReadFile(action.Target)
+		if err != nil {
+			return fmt.Errorf("read seeded target %s: %w", action.Target, err)
+		}
+		if !bytes.Equal(live, action.PreviousContent) {
+			return fmt.Errorf("install plan is stale: seeded target %s evolved before baseline advancement", action.Target)
+		}
+		current, err := os.ReadFile(source)
+		if err != nil {
+			return fmt.Errorf("read seeded baseline %s: %w", source, err)
+		}
+		info, err := os.Stat(action.Target)
+		if err != nil {
+			return fmt.Errorf("stat seeded target %s: %w", action.Target, err)
+		}
+		if err := os.WriteFile(action.Target, current, info.Mode().Perm()); err != nil {
+			return fmt.Errorf("advance seeded target %s: %w", action.Target, err)
+		}
 	default:
 		return fmt.Errorf("update ownership %q is not supported for %s", action.Ownership, action.Target)
 	}
@@ -558,26 +626,32 @@ func applyUpdate(action plan.Action, source string, opts Options) error {
 }
 
 func validateMigrationTarget(action plan.Action) error {
-	info, err := os.Lstat(action.Target)
+	target := action.Target
+	contentTarget := action.Target
+	if action.Migration.LegacyTarget != "" {
+		target = action.Migration.LegacyTarget
+		contentTarget = action.Migration.LegacyContentTarget
+	}
+	info, err := os.Lstat(target)
 	if err != nil {
-		return fmt.Errorf("install plan is stale: migration target %s changed: %w", action.Target, err)
+		return fmt.Errorf("install plan is stale: migration target %s changed: %w", target, err)
 	}
 	if info.Mode()&os.ModeSymlink == 0 {
-		return fmt.Errorf("install plan is stale: migration target %s is no longer a symlink", action.Target)
+		return fmt.Errorf("install plan is stale: migration target %s is no longer a symlink", target)
 	}
-	destination, err := os.Readlink(action.Target)
+	destination, err := os.Readlink(target)
 	if err != nil {
-		return fmt.Errorf("read migration target %s: %w", action.Target, err)
+		return fmt.Errorf("read migration target %s: %w", target, err)
 	}
 	if filepath.Clean(destination) != filepath.Clean(action.Migration.LinkDestination) {
-		return fmt.Errorf("install plan is stale: migration target %s changed destination", action.Target)
+		return fmt.Errorf("install plan is stale: migration target %s changed destination", target)
 	}
-	content, err := os.ReadFile(action.Target)
+	content, err := os.ReadFile(contentTarget)
 	if err != nil {
-		return fmt.Errorf("install plan is stale: read migration target %s: %w", action.Target, err)
+		return fmt.Errorf("install plan is stale: read migration target %s: %w", contentTarget, err)
 	}
 	if !bytes.Equal(content, action.Migration.ExpectedLinkContent) {
-		return fmt.Errorf("install plan is stale: migration target %s content changed", action.Target)
+		return fmt.Errorf("install plan is stale: migration target %s content changed", contentTarget)
 	}
 	return nil
 }
@@ -590,13 +664,22 @@ func applyMigration(action plan.Action, source string, opts Options) error {
 	if err != nil {
 		return fmt.Errorf("stat migration source %s: %w", source, err)
 	}
-	if _, err := backups.CreateContentSet(opts.StateRoot, action.Target, action.Migration.CapturedContent, info.Mode(), backups.CreateOptions{
+	backupTarget := action.Target
+	removeTarget := action.Target
+	if action.Migration.LegacyTarget != "" {
+		backupTarget = action.Migration.LegacyContentTarget
+		removeTarget = action.Migration.LegacyTarget
+	}
+	if _, err := backups.CreateContentSet(opts.StateRoot, backupTarget, action.Migration.CapturedContent, info.Mode(), backups.CreateOptions{
 		Reason: "pre-install legacy target migration", Machine: backups.MachineName(), Repo: opts.SourceRoot,
 	}); err != nil {
 		return err
 	}
-	if err := os.Remove(action.Target); err != nil {
-		return fmt.Errorf("remove legacy symlink %s: %w", action.Target, err)
+	if err := os.Remove(removeTarget); err != nil {
+		return fmt.Errorf("remove legacy symlink %s: %w", removeTarget, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(action.Target), 0o755); err != nil {
+		return fmt.Errorf("create migrated target parent %s: %w", filepath.Dir(action.Target), err)
 	}
 	if err := writeNewFileFromSourceMode(source, action.Target, action.Migration.FinalContent); err != nil {
 		return fmt.Errorf("materialize migrated target %s: %w", action.Target, err)

--- a/internal/install/issue388_migration_test.go
+++ b/internal/install/issue388_migration_test.go
@@ -1,0 +1,159 @@
+package install_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/backups"
+	"github.com/yersonargotev/dots/internal/install"
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/plan"
+	"github.com/yersonargotev/dots/internal/repositoryrefresh"
+	"github.com/yersonargotev/dots/internal/state"
+)
+
+func TestLegacyNeovimDirectorySymlinkMigratesLockWithBackupAndProvenance(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	dotsStateRoot := filepath.Join(home, ".dots-state")
+	xdgStateHome := filepath.Join(home, "xdg-state")
+	legacyTarget := filepath.Join(home, ".config/nvim")
+	legacySource := filepath.Join(sourceRoot, "configs/nvim")
+	oldBaseline := []byte("{\"plugin\":\"old\"}\n")
+	newBaseline := []byte("{\"plugin\":\"new\"}\n")
+	localEvolution := []byte("{\"plugin\":\"local\"}\n")
+
+	writeMigrationFile(t, filepath.Join(legacySource, "init.lua"), []byte("require('config.lazy')\n"))
+	writeMigrationFile(t, filepath.Join(legacySource, "lazy-lock.json"), oldBaseline)
+	oldManifest := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}},
+		Entries:  []manifest.Entry{{Source: "configs/nvim", Target: "~/.config/nvim", Strategy: "symlink", Tags: []string{"core"}}},
+	}
+	newManifest := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}},
+		Entries: []manifest.Entry{
+			{Source: "configs/nvim/lazy-lock.json", Target: "nvim/lazy-lock.json", TargetRoot: "xdg-state", Strategy: "copy", Ownership: "seeded", Tags: []string{"core"}},
+			{Source: "configs/nvim/loader.lua", Target: "~/.config/nvim/init.lua", Strategy: "copy", Tags: []string{"core"}},
+			{Source: "configs/nvim", Target: "~/.config/dots/nvim", Strategy: "symlink", Tags: []string{"core"}},
+		},
+	}
+
+	runMigrationGit(t, sourceRoot, "init")
+	runMigrationGit(t, sourceRoot, "config", "user.email", "dots@example.test")
+	runMigrationGit(t, sourceRoot, "config", "user.name", "dots test")
+	runMigrationGit(t, sourceRoot, "add", ".")
+	runMigrationGit(t, sourceRoot, "commit", "-m", "legacy baseline")
+	revision := runMigrationGit(t, sourceRoot, "rev-parse", "HEAD")
+
+	if err := os.MkdirAll(filepath.Dir(legacyTarget), 0o755); err != nil {
+		t.Fatalf("mkdir legacy parent: %v", err)
+	}
+	if err := os.Symlink(legacySource, legacyTarget); err != nil {
+		t.Fatalf("symlink legacy Neovim directory: %v", err)
+	}
+	writeMigrationFile(t, filepath.Join(legacySource, "lazy-lock.json"), localEvolution)
+	meta := state.Metadata{
+		Version:    state.CurrentVersion,
+		Provenance: state.Provenance{SourceRoot: sourceRoot, SourceRevision: revision},
+		Entries: []state.Record{{
+			Target: legacyTarget, Source: "configs/nvim", Strategy: "symlink", Ownership: "whole",
+		}},
+	}
+	if err := state.Save(state.Path(dotsStateRoot), meta); err != nil {
+		t.Fatalf("save legacy metadata: %v", err)
+	}
+
+	captures, err := repositoryrefresh.CaptureLegacyTargets(oldManifest, newManifest, meta, sourceRoot, home, xdgStateHome, revision)
+	if err != nil {
+		t.Fatalf("CaptureLegacyTargets() error = %v", err)
+	}
+	seedTarget := filepath.Join(xdgStateHome, "nvim/lazy-lock.json")
+	capture, ok := captures[seedTarget]
+	if !ok || capture.LegacyTarget != legacyTarget || string(capture.CapturedContent) != string(localEvolution) {
+		t.Fatalf("seeded directory capture = %#v", capture)
+	}
+
+	// Simulate repository refresh after capture: the legacy symlink now exposes
+	// the incoming baseline, while the captured local revisions remain durable.
+	writeMigrationFile(t, filepath.Join(legacySource, "lazy-lock.json"), newBaseline)
+	writeMigrationFile(t, filepath.Join(legacySource, "loader.lua"), []byte("local managed = true\n"))
+	p, err := plan.Build(newManifest, plan.Options{
+		Profile: "default", OS: "linux", SourceRoot: sourceRoot, Home: home,
+		XDGStateHome: xdgStateHome, Metadata: meta, LegacyMigrations: captures,
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if len(p.Actions) != 3 || p.Actions[0].Status != plan.StatusMigrate || p.Actions[1].Status != plan.StatusCreate {
+		t.Fatalf("migration plan = %#v", p.Actions)
+	}
+	if err := install.Apply(p, install.Options{SourceRoot: sourceRoot, Home: home, StateRoot: dotsStateRoot}); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	if info, err := os.Lstat(legacyTarget); err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("native Neovim directory = (%v, %v), want regular directory", info, err)
+	}
+	if got, err := os.ReadFile(seedTarget); err != nil || string(got) != string(localEvolution) {
+		t.Fatalf("migrated lock = (%q, %v), want local revisions", got, err)
+	}
+	backupMeta, err := backups.Load(backups.Path(dotsStateRoot))
+	if err != nil || len(backupMeta.Sets) != 1 {
+		t.Fatalf("Backup Metadata = (%#v, %v), want one set", backupMeta, err)
+	}
+	legacyLock := filepath.Join(legacyTarget, "lazy-lock.json")
+	if len(backupMeta.Sets[0].Targets) != 1 || backupMeta.Sets[0].Targets[0] != legacyLock {
+		t.Fatalf("backup targets = %#v, want %s", backupMeta.Sets[0].Targets, legacyLock)
+	}
+	backupFile := backups.FilePath(dotsStateRoot, backupMeta.Sets[0].ID, 1, legacyLock)
+	if got, err := os.ReadFile(backupFile); err != nil || string(got) != string(localEvolution) {
+		t.Fatalf("backup content = (%q, %v), want local revisions", got, err)
+	}
+
+	gotMeta, err := state.Load(state.Path(dotsStateRoot))
+	if err != nil {
+		t.Fatalf("load migrated metadata: %v", err)
+	}
+	if _, ok := gotMeta.FindByTarget(legacyTarget); ok {
+		t.Fatal("legacy directory ownership record was not pruned")
+	}
+	seedRecord, ok := gotMeta.FindByTarget(seedTarget)
+	if !ok || seedRecord.Ownership != "seeded" || string(seedRecord.SeededBaseline) != string(oldBaseline) {
+		t.Fatalf("seeded ownership record = %#v, want preserved old baseline evidence", seedRecord)
+	}
+}
+
+func writeMigrationFile(t *testing.T, path string, content []byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func runMigrationGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return string(bytesTrimSpace(out))
+}
+
+func bytesTrimSpace(value []byte) []byte {
+	start, end := 0, len(value)
+	for start < end && (value[start] == ' ' || value[start] == '\n' || value[start] == '\r' || value[start] == '\t') {
+		start++
+	}
+	for end > start && (value[end-1] == ' ' || value[end-1] == '\n' || value[end-1] == '\r' || value[end-1] == '\t') {
+		end--
+	}
+	return value[start:end]
+}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -34,11 +35,14 @@ type Entry struct {
 	Source          string            `yaml:"source"`
 	SourceOverrides map[string]string `yaml:"source_overrides,omitempty"`
 	Target          string            `yaml:"target"`
-	Strategy        string            `yaml:"strategy"`
-	Ownership       string            `yaml:"ownership,omitempty"`
-	Tags            []string          `yaml:"tags"`
-	OS              []string          `yaml:"os,omitempty"`
-	Dependencies    []Dependency      `yaml:"dependencies,omitempty"`
+	// TargetRoot selects an allowlisted non-home root for relative targets.
+	// Empty preserves the traditional ~/... target contract.
+	TargetRoot   string       `yaml:"target_root,omitempty"`
+	Strategy     string       `yaml:"strategy"`
+	Ownership    string       `yaml:"ownership,omitempty"`
+	Tags         []string     `yaml:"tags"`
+	OS           []string     `yaml:"os,omitempty"`
+	Dependencies []Dependency `yaml:"dependencies,omitempty"`
 }
 
 // DependencySet declares Dependencies selected directly by tags rather than by
@@ -450,8 +454,19 @@ func (m Manifest) Validate() error {
 		if !allowedStrategy(entry.Strategy) {
 			return fmt.Errorf("entries[%d].strategy must be one of copy, symlink, template", i)
 		}
+		if !allowedTargetRoot(entry.TargetRoot) {
+			return fmt.Errorf("entries[%d].target_root must be xdg-state when set", i)
+		}
+		if entry.TargetRoot == "xdg-state" {
+			if filepath.IsAbs(entry.Target) || !filepath.IsLocal(entry.Target) || entry.Target == "." {
+				return fmt.Errorf("entries[%d].target must be a confined relative path for target_root xdg-state", i)
+			}
+			if entry.Ownership != "seeded" {
+				return fmt.Errorf("entries[%d].target_root xdg-state requires seeded ownership", i)
+			}
+		}
 		if !allowedOwnership(entry.Ownership) {
-			return fmt.Errorf("entries[%d].ownership must be one of json-subset, jsonc-subset, toml-subset", i)
+			return fmt.Errorf("entries[%d].ownership must be one of json-subset, jsonc-subset, toml-subset, seeded", i)
 		}
 		if entry.Ownership != "" && entry.Strategy != "copy" {
 			return fmt.Errorf("entries[%d].ownership %s requires strategy copy", i, entry.Ownership)
@@ -1000,11 +1015,15 @@ func allowedStrategy(strategy string) bool {
 
 func allowedOwnership(ownership string) bool {
 	switch ownership {
-	case "", "json-subset", "jsonc-subset", "toml-subset":
+	case "", "json-subset", "jsonc-subset", "toml-subset", "seeded":
 		return true
 	default:
 		return false
 	}
+}
+
+func allowedTargetRoot(root string) bool {
+	return root == "" || root == "xdg-state"
 }
 
 func allowedOS(osName string) bool {

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -1664,6 +1664,53 @@ entries:
 			want: "entries[0].target is required",
 		},
 		{
+			name: "unsupported target root",
+			content: `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/nvim/lazy-lock.json
+    target: nvim/lazy-lock.json
+    target_root: arbitrary
+    strategy: copy
+    ownership: seeded
+    tags: [core]
+`,
+			want: "entries[0].target_root must be xdg-state when set",
+		},
+		{
+			name: "xdg state target traversal",
+			content: `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/nvim/lazy-lock.json
+    target: ../lazy-lock.json
+    target_root: xdg-state
+    strategy: copy
+    ownership: seeded
+    tags: [core]
+`,
+			want: "entries[0].target must be a confined relative path for target_root xdg-state",
+		},
+		{
+			name: "xdg state target requires seeded ownership",
+			content: `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/nvim/lazy-lock.json
+    target: nvim/lazy-lock.json
+    target_root: xdg-state
+    strategy: copy
+    tags: [core]
+`,
+			want: "entries[0].target_root xdg-state requires seeded ownership",
+		},
+		{
 			name: "unsupported ownership",
 			content: `version: 1
 profiles:
@@ -1676,7 +1723,7 @@ entries:
     ownership: merge
     tags: [core]
 `,
-			want: "entries[0].ownership must be one of json-subset, jsonc-subset, toml-subset",
+			want: "entries[0].ownership must be one of json-subset, jsonc-subset, toml-subset, seeded",
 		},
 		{
 			name: "json subset ownership on non-copy strategy",
@@ -3009,11 +3056,13 @@ func TestRepositoryManifestPlansMVPConfigurationSetSafely(t *testing.T) {
 		t.Fatalf("LoadFile(%q) error = %v", manifestPath, err)
 	}
 
+	home := t.TempDir()
 	p, err := plan.Build(*got, plan.Options{
-		Profile:    "core",
-		OS:         "darwin",
-		SourceRoot: root,
-		Home:       t.TempDir(),
+		Profile:      "core",
+		OS:           "darwin",
+		SourceRoot:   root,
+		Home:         home,
+		XDGStateHome: filepath.Join(home, ".local", "state"),
 	})
 	if err != nil {
 		t.Fatalf("Build() error = %v", err)
@@ -3092,15 +3141,15 @@ func TestRepositoryManifestNeovimEntry(t *testing.T) {
 		entriesByTarget[entry.Target] = entry
 	}
 
-	entry, ok := entriesByTarget["~/.config/nvim"]
+	entry, ok := entriesByTarget["~/.config/nvim/init.lua"]
 	if !ok {
-		t.Fatal("repository manifest missing Neovim entry for target ~/.config/nvim")
+		t.Fatal("repository manifest missing Neovim loader entry")
 	}
-	if entry.Source != "configs/nvim" {
-		t.Errorf("Source = %q, want %q", entry.Source, "configs/nvim")
+	if entry.Source != "configs/nvim/loader.lua" {
+		t.Errorf("Source = %q, want %q", entry.Source, "configs/nvim/loader.lua")
 	}
-	if entry.Strategy != "symlink" {
-		t.Errorf("Strategy = %q, want symlink", entry.Strategy)
+	if entry.Strategy != "copy" {
+		t.Errorf("Strategy = %q, want copy", entry.Strategy)
 	}
 	if !hasString(entry.Tags, "core") {
 		t.Errorf("Tags = %#v, want core tag", entry.Tags)
@@ -3111,15 +3160,23 @@ func TestRepositoryManifestNeovimEntry(t *testing.T) {
 	if !hasDependency(entry.Dependencies, "neovim") {
 		t.Errorf("Dependencies = %#v, want neovim dependency", entry.Dependencies)
 	}
+	managed, ok := entriesByTarget["~/.config/dots/nvim"]
+	if !ok || managed.Source != "configs/nvim" || managed.Strategy != "symlink" {
+		t.Fatalf("managed Neovim entry = %#v, want configs/nvim symlink", managed)
+	}
+	lock, ok := entriesByTarget["nvim/lazy-lock.json"]
+	if !ok || lock.TargetRoot != "xdg-state" || lock.Ownership != "seeded" || lock.Strategy != "copy" {
+		t.Fatalf("Neovim lock entry = %#v, want xdg-state seeded copy", lock)
+	}
 
-	// The source directory must exist in the repository.
-	sourcePath := filepath.Join(root, entry.Source)
+	// The separately Managed Configuration directory must exist in the repository.
+	sourcePath := filepath.Join(root, managed.Source)
 	info, err := os.Stat(sourcePath)
 	if err != nil {
 		t.Fatalf("source %q does not exist: %v", sourcePath, err)
 	}
 	if !info.IsDir() {
-		t.Fatalf("source %q is not a directory, want directory for symlink entry", sourcePath)
+		t.Fatalf("source %q is not a directory, want managed Neovim directory", sourcePath)
 	}
 }
 

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -149,6 +149,7 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 	plan := Plan{Profile: resolved.Profile, Profiles: resolved.Profiles, Tags: resolved.Tags}
 	actionByTarget := map[string]int{}
 	readSourcesByTarget := map[string][]string{}
+	scheduledLegacyParents := map[string]struct{}{}
 	for _, entry := range m.Entries {
 		if !manifest.SharesTag(entry.Tags, tags) {
 			continue
@@ -178,7 +179,7 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 		}
 		legacyParent := ""
 		if actionStatus == StatusConflict {
-			legacyParent = legacyParentRemovedByMigration(target, opts.LegacyMigrations)
+			legacyParent = scheduledLegacyParent(target, scheduledLegacyParents)
 			if legacyParent != "" {
 				actionStatus = StatusCreate
 			}
@@ -216,7 +217,7 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 			LegacyParent:   legacyParent,
 		}
 		if actionStatus == StatusConflict || actionStatus == StatusCreate {
-			if migration, ok := opts.LegacyMigrations[target]; ok && (actionStatus == StatusConflict || migration.LegacyTarget != "") {
+			if migration, ok := opts.LegacyMigrations[target]; ok && ((migration.LegacyTarget == "" && actionStatus == StatusConflict) || (migration.LegacyTarget != "" && actionStatus == StatusCreate)) {
 				planned, compatible, migrateErr := planLegacyMigration(entry, readSourceAbs, migration)
 				if migrateErr != nil {
 					return Plan{}, migrateErr
@@ -226,6 +227,9 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 					action.Migration = &planned
 					action.Reason = ""
 					action.MatchingTags = nil
+					if planned.LegacyTarget != "" {
+						scheduledLegacyParents[planned.LegacyTarget] = struct{}{}
+					}
 				}
 			}
 		}
@@ -333,10 +337,10 @@ func planLegacyMigration(entry manifest.Entry, currentSource string, migration L
 	return planned, true, nil
 }
 
-func legacyParentRemovedByMigration(target string, migrations map[string]LegacyMigration) string {
-	for _, migration := range migrations {
-		if migration.LegacyTarget != "" && InsideRoot(target, migration.LegacyTarget) && filepath.Clean(target) != filepath.Clean(migration.LegacyTarget) {
-			return migration.LegacyTarget
+func scheduledLegacyParent(target string, parents map[string]struct{}) string {
+	for parent := range parents {
+		if InsideRoot(target, parent) && filepath.Clean(target) != filepath.Clean(parent) {
+			return parent
 		}
 	}
 	return ""

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/yersonargotev/dots/internal/configsubset"
 	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/seededstate"
 	"github.com/yersonargotev/dots/internal/selection"
 	"github.com/yersonargotev/dots/internal/state"
 )
@@ -28,6 +29,8 @@ const (
 )
 
 const ConflictReasonSourceOverrideNotSelected = "source-override-not-selected"
+
+const ReasonSeededLocalEvolution = "seeded-local-evolution"
 
 // Action is a single planned filesystem change for a Managed Entry.
 type Action struct {
@@ -48,6 +51,7 @@ type Action struct {
 	// used only to revalidate a reversible update at apply time.
 	PreviousContent []byte   `json:"-"`
 	Target          string   `json:"target"`
+	TargetRoot      string   `json:"target_root,omitempty"`
 	Strategy        string   `json:"strategy"`
 	Status          Status   `json:"status"`
 	Reason          string   `json:"reason,omitempty"`
@@ -57,17 +61,27 @@ type Action struct {
 	// symlink. It is intentionally excluded from machine output; status is the
 	// portable contract and captured workstation content may be sensitive.
 	Migration *LegacyMigration `json:"-"`
+	// LegacyParent is a proven directory symlink removed by an earlier migrate
+	// action in the same plan. It lets apply validate a later child create
+	// without treating the pre-removal view as an unrelated conflict.
+	LegacyParent string `json:"-"`
 }
 
 // LegacyMigration is provenance-backed content captured before the Installed
 // Repository checkout changed. FinalContent is the exact regular-file content
 // apply may materialize after last-moment symlink and content revalidation.
 type LegacyMigration struct {
-	LinkDestination       string
+	LinkDestination string
+	// LegacyTarget is set when the captured content lived beneath a proven
+	// directory symlink that must be removed before new native targets can be
+	// materialized. Empty retains the single-file migration behavior.
+	LegacyTarget          string
+	LegacyContentTarget   string
 	CapturedContent       []byte
 	PreviousSourceContent []byte
 	ExpectedLinkContent   []byte
 	FinalContent          []byte
+	RecordedBaseline      []byte
 }
 
 // Plan is the preview of changes the installer would apply for a Profile.
@@ -103,8 +117,12 @@ type Options struct {
 	SourceRoot string
 	// SourceReadRoot optionally supplies a snapshot used only to inspect source
 	// existence and content. Empty defaults to SourceRoot.
-	SourceReadRoot   string
-	Home             string
+	SourceReadRoot string
+	Home           string
+	// XDGStateHome is the resolved application state root. It is distinct from
+	// dots' Installation Metadata state root and is required only by entries
+	// whose allowlisted target_root is xdg-state.
+	XDGStateHome     string
 	Metadata         state.Metadata
 	LegacyMigrations map[string]LegacyMigration
 }
@@ -141,7 +159,7 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 
 		defaultSource := entry.Source
 		source := manifest.EntrySource(entry, tags)
-		target, err := ResolveTarget(entry.Target, opts.Home)
+		target, err := ResolveEntryTarget(entry, opts.Home, opts.XDGStateHome)
 		if err != nil {
 			return Plan{}, err
 		}
@@ -158,7 +176,23 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 		if err != nil {
 			return Plan{}, err
 		}
+		legacyParent := ""
+		if actionStatus == StatusConflict {
+			legacyParent = legacyParentRemovedByMigration(target, opts.LegacyMigrations)
+			if legacyParent != "" {
+				actionStatus = StatusCreate
+			}
+		}
 		var reason string
+		if actionStatus == StatusUnchanged && entry.Ownership == "seeded" {
+			local, localErr := seededLocalEvolution(entry, target, readSourceAbs, opts.Metadata)
+			if localErr != nil {
+				return Plan{}, localErr
+			}
+			if local {
+				reason = ReasonSeededLocalEvolution
+			}
+		}
 		var matchingTags []string
 		if actionStatus == StatusConflict {
 			matchingTags, err = matchingUnselectedSourceOverrideTags(entry, tags, target, readRoot, opts.SourceRoot)
@@ -173,14 +207,16 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 			Source:         source,
 			ResolvedSource: sourceAbs,
 			Target:         target,
+			TargetRoot:     entry.TargetRoot,
 			Strategy:       entry.Strategy,
 			Status:         actionStatus,
 			Reason:         reason,
 			MatchingTags:   matchingTags,
 			Ownership:      entry.Ownership,
+			LegacyParent:   legacyParent,
 		}
-		if actionStatus == StatusConflict {
-			if migration, ok := opts.LegacyMigrations[target]; ok {
+		if actionStatus == StatusConflict || actionStatus == StatusCreate {
+			if migration, ok := opts.LegacyMigrations[target]; ok && (actionStatus == StatusConflict || migration.LegacyTarget != "") {
 				planned, compatible, migrateErr := planLegacyMigration(entry, readSourceAbs, migration)
 				if migrateErr != nil {
 					return Plan{}, migrateErr
@@ -193,8 +229,12 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 				}
 			}
 		}
-		if rec, ok := opts.Metadata.FindByTarget(target); ok && rec.Ownership == action.Ownership && isJSONOwnership(rec.Ownership) && len(rec.OwnedContent) > 0 {
-			action.PreviousContent = append([]byte(nil), rec.OwnedContent...)
+		if rec, ok := opts.Metadata.FindByTarget(target); ok && rec.Ownership == action.Ownership {
+			if isJSONOwnership(rec.Ownership) && len(rec.OwnedContent) > 0 {
+				action.PreviousContent = append([]byte(nil), rec.OwnedContent...)
+			} else if rec.Ownership == "seeded" {
+				action.PreviousContent = append([]byte(nil), rec.SeededBaseline...)
+			}
 		}
 		targetKey := filepath.Clean(target)
 		if index, ok := actionByTarget[targetKey]; ok {
@@ -247,6 +287,19 @@ func planLegacyMigration(entry manifest.Entry, currentSource string, migration L
 	planned := migration
 	planned.ExpectedLinkContent = append([]byte(nil), current...)
 	switch entry.Ownership {
+	case "seeded":
+		reconciliation := seededstate.Reconcile(migration.CapturedContent, migration.PreviousSourceContent, current)
+		if reconciliation.Changed {
+			planned.FinalContent = reconciliation.Content
+			planned.RecordedBaseline = append([]byte(nil), current...)
+		} else {
+			planned.FinalContent = append([]byte(nil), migration.CapturedContent...)
+			if reconciliation.Classification == seededstate.LocalEvolution {
+				planned.RecordedBaseline = append([]byte(nil), migration.PreviousSourceContent...)
+			} else {
+				planned.RecordedBaseline = append([]byte(nil), current...)
+			}
+		}
 	case "json-subset":
 		reconciliation, err := configsubset.ReconcileJSON(migration.CapturedContent, migration.PreviousSourceContent, current)
 		if err != nil {
@@ -278,6 +331,15 @@ func planLegacyMigration(entry manifest.Entry, currentSource string, migration L
 		planned.FinalContent = append([]byte(nil), current...)
 	}
 	return planned, true, nil
+}
+
+func legacyParentRemovedByMigration(target string, migrations map[string]LegacyMigration) string {
+	for _, migration := range migrations {
+		if migration.LegacyTarget != "" && InsideRoot(target, migration.LegacyTarget) && filepath.Clean(target) != filepath.Clean(migration.LegacyTarget) {
+			return migration.LegacyTarget
+		}
+	}
+	return ""
 }
 
 func composedJSONStatus(action Action, meta state.Metadata) (Status, error) {
@@ -434,6 +496,46 @@ func ResolveTarget(target, home string) (string, error) {
 		return "", fmt.Errorf("unsafe target %q: resolved target escapes home %q", target, resolvedHome)
 	}
 	return resolvedTarget, nil
+}
+
+// ResolveEntryTarget resolves a Managed Entry against its allowlisted target
+// root. Home targets retain the ~/... contract; xdg-state targets must be local
+// relative paths beneath the already resolved XDG state home.
+func ResolveEntryTarget(entry manifest.Entry, home, xdgStateHome string) (string, error) {
+	if entry.TargetRoot == "" {
+		return ResolveTarget(entry.Target, home)
+	}
+	if entry.TargetRoot != "xdg-state" {
+		return "", fmt.Errorf("unsupported target root %q", entry.TargetRoot)
+	}
+	if xdgStateHome == "" {
+		return "", fmt.Errorf("xdg-state target %q requires an XDG state home", entry.Target)
+	}
+	if !filepath.IsAbs(xdgStateHome) {
+		return "", fmt.Errorf("unsafe XDG state home %q: XDG_STATE_HOME must be absolute", xdgStateHome)
+	}
+	if filepath.IsAbs(entry.Target) || !filepath.IsLocal(entry.Target) || entry.Target == "." {
+		return "", fmt.Errorf("unsafe xdg-state target %q: target must be a confined relative path", entry.Target)
+	}
+	root, err := filepath.Abs(xdgStateHome)
+	if err != nil {
+		return "", fmt.Errorf("resolve XDG state home: %w", err)
+	}
+	root = filepath.Clean(root)
+	if err := ValidateResolvedTarget(root, home); err != nil {
+		return "", fmt.Errorf("unsafe XDG state home %q: %w", root, err)
+	}
+	target := filepath.Clean(filepath.Join(root, entry.Target))
+	if !InsideRoot(target, root) {
+		return "", fmt.Errorf("unsafe xdg-state target %q: resolved target escapes XDG state home %q", entry.Target, root)
+	}
+	if err := ValidateResolvedTarget(target, home); err != nil {
+		return "", err
+	}
+	if err := ValidateTargetParentInsideHome(target, home); err != nil {
+		return "", err
+	}
+	return target, nil
 }
 
 // ValidateResolvedTarget verifies that an already-resolved plan target remains
@@ -613,6 +715,24 @@ func status(entry manifest.Entry, target, sourceAbs, sourceRoot, canonicalSource
 			return StatusConflict, nil
 		}
 		if same, err := sameContent(target, sourceAbs); err != nil || !same {
+			if entry.Ownership == "seeded" {
+				rec, ok := meta.FindByTarget(target)
+				if !ok || rec.Strategy != entry.Strategy || rec.Source != entry.Source || rec.Ownership != "seeded" {
+					return StatusConflict, nil
+				}
+				live, readErr := os.ReadFile(target)
+				if readErr != nil {
+					return "", fmt.Errorf("read seeded target %s: %w", target, readErr)
+				}
+				current, readErr := os.ReadFile(sourceAbs)
+				if readErr != nil {
+					return "", fmt.Errorf("read seeded source %s: %w", sourceAbs, readErr)
+				}
+				if seededstate.Reconcile(live, rec.SeededBaseline, current).Classification == seededstate.AdvanceBaseline {
+					return StatusUpdate, nil
+				}
+				return StatusUnchanged, nil
+			}
 			if isSubsetOwned(entry.Ownership) && meta.MatchesEntry(target, entry.Source, entry.Strategy) {
 				if isJSONOwnership(entry.Ownership) {
 					if rec, ok := meta.FindByTarget(target); ok && rec.Ownership == entry.Ownership && len(rec.OwnedContent) > 0 {
@@ -685,6 +805,22 @@ func status(entry manifest.Entry, target, sourceAbs, sourceRoot, canonicalSource
 	default:
 		return StatusConflict, nil
 	}
+}
+
+func seededLocalEvolution(entry manifest.Entry, target, sourceAbs string, meta state.Metadata) (bool, error) {
+	rec, ok := meta.FindByTarget(target)
+	if !ok || rec.Strategy != entry.Strategy || rec.Source != entry.Source || rec.Ownership != "seeded" {
+		return false, nil
+	}
+	live, err := os.ReadFile(target)
+	if err != nil {
+		return false, fmt.Errorf("read seeded target %s: %w", target, err)
+	}
+	current, err := os.ReadFile(sourceAbs)
+	if err != nil {
+		return false, fmt.Errorf("read seeded source %s: %w", sourceAbs, err)
+	}
+	return seededstate.Reconcile(live, rec.SeededBaseline, current).Classification == seededstate.LocalEvolution, nil
 }
 
 func targetContainsCompatibleRecordedSource(entry manifest.Entry, target, sourceRoot string, meta state.Metadata, defaultSource string) bool {

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -781,6 +781,55 @@ func TestResolveEntryTargetConfinesAllowlistedXDGStateRoot(t *testing.T) {
 	}
 }
 
+func TestBuildDoesNotScheduleLegacyDirectoryRemovalWhenXDGSeedTargetExists(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	xdgStateHome := filepath.Join(home, "xdg-state")
+	legacySource := filepath.Join(sourceRoot, "configs/nvim")
+	writeSource(t, sourceRoot, "configs/nvim/lazy-lock.json", "baseline\n")
+	writeSource(t, sourceRoot, "configs/nvim/loader.lua", "loader\n")
+	writeSource(t, sourceRoot, "configs/nvim/init.lua", "managed\n")
+	legacyTarget := filepath.Join(home, ".config/nvim")
+	if err := os.MkdirAll(filepath.Dir(legacyTarget), 0o755); err != nil {
+		t.Fatalf("mkdir legacy parent: %v", err)
+	}
+	if err := os.Symlink(legacySource, legacyTarget); err != nil {
+		t.Fatalf("symlink legacy target: %v", err)
+	}
+	seedTarget := filepath.Join(xdgStateHome, "nvim/lazy-lock.json")
+	if err := os.MkdirAll(filepath.Dir(seedTarget), 0o755); err != nil {
+		t.Fatalf("mkdir seed target parent: %v", err)
+	}
+	if err := os.WriteFile(seedTarget, []byte("pre-existing\n"), 0o600); err != nil {
+		t.Fatalf("write pre-existing seed target: %v", err)
+	}
+	m := manifest.Manifest{
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}},
+		Entries: []manifest.Entry{
+			{Source: "configs/nvim/lazy-lock.json", Target: "nvim/lazy-lock.json", TargetRoot: "xdg-state", Strategy: "copy", Ownership: "seeded", Tags: []string{"core"}},
+			{Source: "configs/nvim/loader.lua", Target: "~/.config/nvim/init.lua", Strategy: "copy", Tags: []string{"core"}},
+			{Source: "configs/nvim", Target: "~/.config/dots/nvim", Strategy: "symlink", Tags: []string{"core"}},
+		},
+	}
+	p, err := plan.Build(m, plan.Options{
+		Profile: "default", OS: "linux", SourceRoot: sourceRoot, Home: home, XDGStateHome: xdgStateHome,
+		LegacyMigrations: map[string]plan.LegacyMigration{seedTarget: {
+			LinkDestination: legacySource, LegacyTarget: legacyTarget,
+			LegacyContentTarget: filepath.Join(legacyTarget, "lazy-lock.json"),
+			CapturedContent:     []byte("local\n"), PreviousSourceContent: []byte("baseline\n"),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if len(p.Actions) != 3 || p.Actions[0].Status != plan.StatusConflict || p.Actions[1].Status != plan.StatusConflict {
+		t.Fatalf("plan actions = %#v, want seed and loader conflicts", p.Actions)
+	}
+	if p.Actions[0].Migration != nil || p.Actions[1].LegacyParent != "" {
+		t.Fatalf("unsafe legacy removal scheduled: %#v", p.Actions)
+	}
+}
+
 func TestBuildRejectsAbsoluteTarget(t *testing.T) {
 	sourceRoot := t.TempDir()
 	home := t.TempDir()

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -741,6 +741,46 @@ func TestBuildResolvesTarget(t *testing.T) {
 	}
 }
 
+func TestResolveEntryTargetConfinesAllowlistedXDGStateRoot(t *testing.T) {
+	home := t.TempDir()
+	validRoot := filepath.Join(home, "xdg-state")
+	entry := manifest.Entry{Target: "nvim/lazy-lock.json", TargetRoot: "xdg-state"}
+
+	got, err := plan.ResolveEntryTarget(entry, home, validRoot)
+	if err != nil {
+		t.Fatalf("ResolveEntryTarget() error = %v", err)
+	}
+	if want := filepath.Join(validRoot, "nvim/lazy-lock.json"); got != want {
+		t.Fatalf("ResolveEntryTarget() = %q, want %q", got, want)
+	}
+
+	for name, root := range map[string]string{
+		"relative root": "relative/state",
+		"outside home":  t.TempDir(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := plan.ResolveEntryTarget(entry, home, root); err == nil {
+				t.Fatal("ResolveEntryTarget() error = nil, want confinement error")
+			}
+		})
+	}
+
+	escapingEntry := entry
+	escapingEntry.Target = "../outside"
+	if _, err := plan.ResolveEntryTarget(escapingEntry, home, validRoot); err == nil {
+		t.Fatal("ResolveEntryTarget() accepted traversing target")
+	}
+
+	outside := t.TempDir()
+	symlinkRoot := filepath.Join(home, "linked-state")
+	if err := os.Symlink(outside, symlinkRoot); err != nil {
+		t.Fatalf("symlink XDG state root: %v", err)
+	}
+	if _, err := plan.ResolveEntryTarget(entry, home, symlinkRoot); err == nil {
+		t.Fatal("ResolveEntryTarget() accepted XDG state symlink escape")
+	}
+}
+
 func TestBuildRejectsAbsoluteTarget(t *testing.T) {
 	sourceRoot := t.TempDir()
 	home := t.TempDir()

--- a/internal/plan/uninstall.go
+++ b/internal/plan/uninstall.go
@@ -29,6 +29,9 @@ const (
 	// symlink that is missing or points elsewhere, or a path whose type changed),
 	// so removing it could destroy something dots does not own.
 	UninstallNotOwned UninstallStatus = "not-owned"
+	// UninstallRetain removes only dots' ownership record while preserving
+	// application-owned Seeded Runtime State at its native path.
+	UninstallRetain UninstallStatus = "retain"
 )
 
 // UninstallAction is a single planned removal for a recorded Managed Entry.
@@ -113,6 +116,9 @@ func uninstallStatus(rec state.Record, sourceRoot, home string) (UninstallStatus
 	}
 	if err := ValidateTargetParentInsideHome(rec.Target, home); err != nil {
 		return UninstallNotOwned, nil
+	}
+	if rec.Ownership == "seeded" {
+		return UninstallRetain, nil
 	}
 
 	info, err := os.Lstat(rec.Target)

--- a/internal/repositoryrefresh/capture.go
+++ b/internal/repositoryrefresh/capture.go
@@ -3,9 +3,11 @@
 package repositoryrefresh
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/yersonargotev/dots/internal/gitrepo"
 	"github.com/yersonargotev/dots/internal/manifest"
@@ -17,7 +19,7 @@ import (
 // Installation Metadata provenance and the old Install Manifest. Missing or
 // stale evidence is deliberately omitted so the later Install Plan reports a
 // Conflict instead of guessing ownership.
-func CaptureLegacyTargets(oldManifest manifest.Manifest, meta state.Metadata, sourceRoot, home, oldRevision string) (map[string]plan.LegacyMigration, error) {
+func CaptureLegacyTargets(oldManifest, newManifest manifest.Manifest, meta state.Metadata, sourceRoot, home, xdgStateHome, oldRevision string) (map[string]plan.LegacyMigration, error) {
 	captures := map[string]plan.LegacyMigration{}
 	if !provenanceMatches(meta.Provenance, sourceRoot, oldRevision) {
 		return captures, nil
@@ -45,6 +47,16 @@ func CaptureLegacyTargets(oldManifest manifest.Manifest, meta state.Metadata, so
 		if err != nil || filepath.Clean(destination) != filepath.Clean(source) {
 			continue
 		}
+		sourceInfo, err := os.Stat(source)
+		if err != nil {
+			continue
+		}
+		if sourceInfo.IsDir() {
+			if err := captureSeededChildren(captures, newManifest, rec, target, source, destination, sourceRoot, home, xdgStateHome, oldRevision); err != nil {
+				return nil, err
+			}
+			continue
+		}
 		content, err := os.ReadFile(source)
 		if err != nil {
 			continue
@@ -64,6 +76,51 @@ func CaptureLegacyTargets(oldManifest manifest.Manifest, meta state.Metadata, so
 		}
 	}
 	return captures, nil
+}
+
+func captureSeededChildren(captures map[string]plan.LegacyMigration, newManifest manifest.Manifest, rec state.Record, legacyTarget, legacySource, destination, sourceRoot, home, xdgStateHome, oldRevision string) error {
+	legacyPrefix := strings.TrimSuffix(filepath.ToSlash(rec.Source), "/") + "/"
+	for _, entry := range newManifest.Entries {
+		if entry.Strategy != "copy" || entry.Ownership != "seeded" || !strings.HasPrefix(filepath.ToSlash(entry.Source), legacyPrefix) {
+			continue
+		}
+		rel := strings.TrimPrefix(filepath.ToSlash(entry.Source), legacyPrefix)
+		if rel == "" || !filepath.IsLocal(filepath.FromSlash(rel)) {
+			continue
+		}
+		livePath := filepath.Join(legacySource, filepath.FromSlash(rel))
+		content, err := os.ReadFile(livePath)
+		if err != nil {
+			continue
+		}
+		previous, err := gitrepo.ReadFileAtRevision(sourceRoot, oldRevision, entry.Source)
+		if err != nil {
+			continue
+		}
+		currentDestination, err := os.Readlink(legacyTarget)
+		if err != nil || filepath.Clean(currentDestination) != filepath.Clean(destination) {
+			continue
+		}
+		currentContent, err := os.ReadFile(livePath)
+		if err != nil || !bytes.Equal(currentContent, content) {
+			continue
+		}
+		resolvedTarget, err := plan.ResolveEntryTarget(entry, home, xdgStateHome)
+		if err != nil {
+			return err
+		}
+		if _, exists := captures[resolvedTarget]; exists {
+			continue
+		}
+		captures[resolvedTarget] = plan.LegacyMigration{
+			LinkDestination:       destination,
+			LegacyTarget:          legacyTarget,
+			LegacyContentTarget:   filepath.Join(legacyTarget, filepath.FromSlash(rel)),
+			CapturedContent:       append([]byte(nil), content...),
+			PreviousSourceContent: append([]byte(nil), previous...),
+		}
+	}
+	return nil
 }
 
 func provenanceMatches(provenance state.Provenance, sourceRoot, revision string) bool {

--- a/internal/repositoryrefresh/capture_test.go
+++ b/internal/repositoryrefresh/capture_test.go
@@ -36,7 +36,7 @@ func TestCaptureLegacyTargetsRequiresMatchingProvenanceAndDeclaredSymlink(t *tes
 		Provenance: state.Provenance{SourceRoot: sourceRoot, SourceRevision: revision[:12]},
 		Entries:    []state.Record{{Target: target, Source: "configs/app.json", Strategy: "symlink"}},
 	}
-	captures, err := repositoryrefresh.CaptureLegacyTargets(m, meta, sourceRoot, home, revision)
+	captures, err := repositoryrefresh.CaptureLegacyTargets(m, m, meta, sourceRoot, home, filepath.Join(home, ".local", "state"), revision)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +49,7 @@ func TestCaptureLegacyTargetsRequiresMatchingProvenanceAndDeclaredSymlink(t *tes
 	}
 
 	meta.Provenance.SourceRevision = "deadbeef"
-	captures, err = repositoryrefresh.CaptureLegacyTargets(m, meta, sourceRoot, home, revision)
+	captures, err = repositoryrefresh.CaptureLegacyTargets(m, m, meta, sourceRoot, home, filepath.Join(home, ".local", "state"), revision)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,7 +58,7 @@ func TestCaptureLegacyTargetsRequiresMatchingProvenanceAndDeclaredSymlink(t *tes
 	}
 
 	meta.Provenance.SourceRevision = revision[:1]
-	captures, err = repositoryrefresh.CaptureLegacyTargets(m, meta, sourceRoot, home, revision)
+	captures, err = repositoryrefresh.CaptureLegacyTargets(m, m, meta, sourceRoot, home, filepath.Join(home, ".local", "state"), revision)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/seededstate/seededstate.go
+++ b/internal/seededstate/seededstate.go
@@ -1,0 +1,43 @@
+// Package seededstate reconciles opaque runtime state seeded by dots.
+package seededstate
+
+import "bytes"
+
+// Classification describes how live seeded state relates to its baselines.
+type Classification string
+
+const (
+	// AlignedCurrent means live state already matches the current baseline.
+	AlignedCurrent Classification = "aligned-current"
+	// AdvanceBaseline means live state remains at the previous baseline and can
+	// safely advance to the current one.
+	AdvanceBaseline Classification = "advance-baseline"
+	// LocalEvolution means live state contains trusted local changes and must be
+	// left untouched.
+	LocalEvolution Classification = "local-evolution"
+)
+
+// Result is the outcome of reconciling seeded runtime state. Content is set
+// only when Changed is true, and is a copy of the current baseline.
+type Result struct {
+	Classification Classification
+	Changed        bool
+	Content        []byte
+}
+
+// Reconcile compares opaque live state with the recorded previous and current
+// Source of Truth baselines. It never mutates its inputs. A baseline advances
+// only when the live state still exactly matches the previous baseline.
+func Reconcile(live, previous, current []byte) Result {
+	if bytes.Equal(live, current) {
+		return Result{Classification: AlignedCurrent}
+	}
+	if bytes.Equal(live, previous) && !bytes.Equal(previous, current) {
+		return Result{
+			Classification: AdvanceBaseline,
+			Changed:        true,
+			Content:        bytes.Clone(current),
+		}
+	}
+	return Result{Classification: LocalEvolution}
+}

--- a/internal/seededstate/seededstate_test.go
+++ b/internal/seededstate/seededstate_test.go
@@ -1,0 +1,103 @@
+package seededstate
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestReconcile(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		live       []byte
+		previous   []byte
+		current    []byte
+		wantClass  Classification
+		wantChange bool
+		wantData   []byte
+	}{
+		{
+			name:      "live matches current baseline",
+			live:      []byte("revision: current\n"),
+			previous:  []byte("revision: previous\n"),
+			current:   []byte("revision: current\n"),
+			wantClass: AlignedCurrent,
+		},
+		{
+			name:       "unchanged live state advances to new baseline",
+			live:       []byte("revision: previous\n"),
+			previous:   []byte("revision: previous\n"),
+			current:    []byte("revision: current\n"),
+			wantClass:  AdvanceBaseline,
+			wantChange: true,
+			wantData:   []byte("revision: current\n"),
+		},
+		{
+			name:      "local evolution remains untouched",
+			live:      []byte("revision: local\n"),
+			previous:  []byte("revision: previous\n"),
+			current:   []byte("revision: current\n"),
+			wantClass: LocalEvolution,
+		},
+		{
+			name:      "equal baselines are aligned",
+			live:      []byte("revision: stable\n"),
+			previous:  []byte("revision: stable\n"),
+			current:   []byte("revision: stable\n"),
+			wantClass: AlignedCurrent,
+		},
+		{
+			name:      "difference from equal baselines is local evolution",
+			live:      []byte("revision: local\n"),
+			previous:  []byte("revision: stable\n"),
+			current:   []byte("revision: stable\n"),
+			wantClass: LocalEvolution,
+		},
+		{
+			name:       "current baseline removes old content",
+			live:       []byte("plugin = old\n"),
+			previous:   []byte("plugin = old\n"),
+			current:    []byte("plugin = current\n"),
+			wantClass:  AdvanceBaseline,
+			wantChange: true,
+			wantData:   []byte("plugin = current\n"),
+		},
+		{
+			name:       "current baseline may be empty",
+			live:       []byte("plugin = old\n"),
+			previous:   []byte("plugin = old\n"),
+			current:    []byte{},
+			wantClass:  AdvanceBaseline,
+			wantChange: true,
+			wantData:   []byte{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := Reconcile(tt.live, tt.previous, tt.current)
+			if got.Classification != tt.wantClass {
+				t.Fatalf("classification = %q, want %q", got.Classification, tt.wantClass)
+			}
+			if got.Changed != tt.wantChange {
+				t.Fatalf("changed = %t, want %t", got.Changed, tt.wantChange)
+			}
+			if !bytes.Equal(got.Content, tt.wantData) {
+				t.Fatalf("content = %q, want %q", got.Content, tt.wantData)
+			}
+		})
+	}
+}
+
+func TestReconcileCopiesAdvanceContent(t *testing.T) {
+	current := []byte("revision: current\n")
+	result := Reconcile([]byte("revision: previous\n"), []byte("revision: previous\n"), current)
+	result.Content[0] = 'R'
+
+	if string(current) != "revision: current\n" {
+		t.Fatalf("current baseline was mutated: %q", current)
+	}
+}

--- a/internal/selectionmigration/migration.go
+++ b/internal/selectionmigration/migration.go
@@ -56,10 +56,11 @@ type Analysis struct {
 }
 
 type Options struct {
-	OS         string
-	Home       string
-	SourceRoot string
-	StatePath  string
+	OS           string
+	Home         string
+	SourceRoot   string
+	StatePath    string
+	XDGStateHome string
 }
 
 func (c Candidate) Unambiguous() bool {
@@ -180,7 +181,7 @@ func Analyze(m manifest.Manifest, meta state.Metadata, opts Options) (Analysis, 
 	} else {
 		candidate.EffectiveTags = append([]string{}, selection.Tags...)
 		statusReport, statusErr := status.Build(m, meta, status.Options{
-			Selection: &selection, OS: opts.OS, Home: opts.Home, SourceRoot: opts.SourceRoot,
+			Selection: &selection, OS: opts.OS, Home: opts.Home, SourceRoot: opts.SourceRoot, XDGStateHome: opts.XDGStateHome,
 		})
 		if statusErr != nil {
 			if errors.Is(statusErr, os.ErrNotExist) {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -18,7 +18,7 @@ import (
 )
 
 // CurrentVersion is the current Installation Metadata schema version.
-const CurrentVersion = 4
+const CurrentVersion = 5
 
 // Metadata is the machine-readable record of installed managed targets.
 type Metadata struct {
@@ -52,10 +52,10 @@ func (p Provenance) Empty() bool {
 }
 
 // Record describes a single managed target the CLI installed. Version 4 records
-// explicit whole or partial Ownership; an empty value is legacy and grants no
-// force-removal authority. Copy-like strategies may record a source content
-// hash; symlink records leave Hash empty because drift is detected from the link
-// destination.
+// explicit whole or partial Ownership; version 5 adds opaque seeded-baseline
+// evidence. An empty Ownership is legacy and grants no force-removal authority.
+// Copy-like strategies may record a source content hash; symlink records leave
+// Hash empty because drift is detected from the link destination.
 type Record struct {
 	Target       string          `json:"target"`
 	Source       string          `json:"source"`
@@ -63,10 +63,14 @@ type Record struct {
 	Strategy     string          `json:"strategy"`
 	Ownership    string          `json:"ownership,omitempty"`
 	OwnedContent json.RawMessage `json:"owned_content,omitempty"`
-	Hash         string          `json:"hash"`
-	InstalledAt  string          `json:"installedAt"`
-	Profiles     []string        `json:"profiles,omitempty"`
-	Tags         []string        `json:"tags,omitempty"`
+	// SeededBaseline is the exact opaque Source of Truth baseline last applied
+	// to Seeded Runtime State. []byte uses JSON base64 encoding, so the state
+	// itself need not be JSON.
+	SeededBaseline []byte   `json:"seeded_baseline,omitempty"`
+	Hash           string   `json:"hash"`
+	InstalledAt    string   `json:"installedAt"`
+	Profiles       []string `json:"profiles,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
 }
 
 // SourceList returns every Source of Truth contribution for the managed target.

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -133,6 +133,30 @@ func TestSaveThenLoadRoundTripsOwnedJSONContributionV4(t *testing.T) {
 	}
 }
 
+func TestSaveThenLoadRoundTripsOpaqueSeededBaselineV5(t *testing.T) {
+	path := state.Path(t.TempDir())
+	want := state.Metadata{
+		Version: state.CurrentVersion,
+		Entries: []state.Record{{
+			Target:         "/home/user/.local/state/app/runtime.lock",
+			Source:         "configs/app/runtime.lock",
+			Strategy:       "copy",
+			Ownership:      "seeded",
+			SeededBaseline: []byte{0xff, 0x00, 'a', '\n'},
+		}},
+	}
+	if err := state.Save(path, want); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	got, err := state.Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Load() metadata = %+v, want %+v", got, want)
+	}
+}
+
 func TestLoadLegacyRecordDoesNotGainPartialOwnershipEvidence(t *testing.T) {
 	path := state.Path(t.TempDir())
 	data := `{"version":3,"entries":[{"target":"/home/user/.config/shared.json","source":"configs/shared.json","strategy":"copy","hash":"abc","installedAt":"now"}]}`

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -14,6 +14,7 @@ import (
 	"github.com/yersonargotev/dots/internal/configsubset"
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/plan"
+	"github.com/yersonargotev/dots/internal/seededstate"
 	"github.com/yersonargotev/dots/internal/selection"
 	"github.com/yersonargotev/dots/internal/state"
 )
@@ -75,13 +76,14 @@ func (r Report) HasFindings() bool {
 
 // Options carries the resolved inputs needed to evaluate status.
 type Options struct {
-	Profile    string
-	Profiles   []string
-	ExtraTags  []string
-	Selection  *manifest.Selection
-	OS         string
-	SourceRoot string
-	Home       string
+	Profile      string
+	Profiles     []string
+	ExtraTags    []string
+	Selection    *manifest.Selection
+	OS           string
+	SourceRoot   string
+	Home         string
+	XDGStateHome string
 }
 
 // Build evaluates the Dotfiles Status for the selected Profile. It does not
@@ -116,7 +118,7 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options) (Report, erro
 			continue
 		}
 
-		target, err := plan.ResolveTarget(entry.Target, opts.Home)
+		target, err := plan.ResolveEntryTarget(entry, opts.Home, opts.XDGStateHome)
 		if err != nil {
 			return Report{}, err
 		}
@@ -131,6 +133,15 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options) (Report, erro
 			return Report{}, err
 		}
 		evaluated.State = st
+		if st == StateOK && entry.Ownership == "seeded" {
+			local, localErr := seededLocalEvolution(entry, target, source, opts.SourceRoot, meta)
+			if localErr != nil {
+				return Report{}, localErr
+			}
+			if local {
+				evaluated.Reason = plan.ReasonSeededLocalEvolution
+			}
+		}
 		if st == StateConflict {
 			matchingTags, err := plan.MatchingUnselectedSourceOverrideTags(entry, tags, target, opts.SourceRoot)
 			if err != nil {
@@ -155,7 +166,7 @@ func selectedJSONContributions(m manifest.Manifest, tags []string, opts Options)
 			continue
 		}
 		source := manifest.EntrySource(entry, tags)
-		target, err := plan.ResolveTarget(entry.Target, opts.Home)
+		target, err := plan.ResolveEntryTarget(entry, opts.Home, opts.XDGStateHome)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -217,6 +228,23 @@ func evaluate(entry manifest.Entry, target string, meta state.Metadata, sourceRo
 		return "", err
 	}
 	if aligned {
+		return StateOK, nil
+	}
+	if entry.Ownership == "seeded" {
+		info, err := os.Lstat(target)
+		if err != nil {
+			return "", fmt.Errorf("stat seeded target %s: %w", target, err)
+		}
+		rec, recorded := meta.FindByTarget(target)
+		if !info.Mode().IsRegular() || !recorded || rec.Strategy != entry.Strategy || rec.Source != entry.Source || rec.Ownership != "seeded" {
+			if recorded && rec.Strategy == entry.Strategy {
+				return StateDrifted, nil
+			}
+			return StateConflict, nil
+		}
+		// Any trusted regular-file difference is either an advanceable old
+		// baseline or expected local evolution. Neither is Drift in status;
+		// install performs the conditional advancement.
 		return StateOK, nil
 	}
 	if entry.Ownership == "json-subset" && len(currentJSON) > 0 {
@@ -350,6 +378,26 @@ func evaluate(entry manifest.Entry, target string, meta state.Metadata, sourceRo
 		return StateDrifted, nil
 	}
 	return StateConflict, nil
+}
+
+func seededLocalEvolution(entry manifest.Entry, target, source, sourceRoot string, meta state.Metadata) (bool, error) {
+	rec, ok := meta.FindByTarget(target)
+	if !ok || rec.Strategy != entry.Strategy || rec.Source != source || rec.Ownership != "seeded" {
+		return false, nil
+	}
+	sourceAbs, err := plan.ResolveSource(source, sourceRoot)
+	if err != nil {
+		return false, err
+	}
+	live, err := os.ReadFile(target)
+	if err != nil {
+		return false, fmt.Errorf("read seeded target %s: %w", target, err)
+	}
+	current, err := os.ReadFile(sourceAbs)
+	if err != nil {
+		return false, fmt.Errorf("read seeded source %s: %w", sourceAbs, err)
+	}
+	return seededstate.Reconcile(live, rec.SeededBaseline, current).Classification == seededstate.LocalEvolution, nil
 }
 
 func trustedJSONRecord(meta state.Metadata, target, strategy string, currentSources []string) bool {

--- a/internal/uninstall/uninstall.go
+++ b/internal/uninstall/uninstall.go
@@ -38,6 +38,9 @@ type Result struct {
 	// Updated lists co-owned targets that remained after dots removed or pruned
 	// its recorded contribution.
 	Updated []string `json:"updated,omitempty"`
+	// Retained lists Seeded Runtime State left untouched while its dots
+	// ownership metadata was removed.
+	Retained []string `json:"retained,omitempty"`
 	// RestoredSets lists the IDs of Backup Sets restored when RestoreBackups is
 	// set, each restored at most once even if it covers several removed targets.
 	RestoredSets []string `json:"restored_sets"`
@@ -75,6 +78,10 @@ func Apply(p plan.UninstallPlan, opts Options) (Result, error) {
 		rec, ok := meta.FindByTarget(action.Target)
 		if !ok {
 			// The plan references a target dots no longer records; never act on it.
+			continue
+		}
+		if rec.Ownership == "seeded" && action.Status == plan.UninstallRetain {
+			result.Retained = append(result.Retained, action.Target)
 			continue
 		}
 		if (rec.Ownership == "json-subset" || rec.Ownership == "jsonc-subset") && len(rec.OwnedContent) > 0 {
@@ -116,7 +123,7 @@ func Apply(p plan.UninstallPlan, opts Options) (Result, error) {
 		}
 	}
 
-	prunedTargets := append(append([]string(nil), result.Removed...), result.Updated...)
+	prunedTargets := append(append(append([]string(nil), result.Removed...), result.Updated...), result.Retained...)
 	if err := pruneMetadata(opts.StateRoot, meta, prunedTargets); err != nil {
 		return result, err
 	}


### PR DESCRIPTION
Closes #388

## PR Type

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Move lazy.nvim's writable lockfile out of the Installed Repository and into allowlisted XDG Seeded Runtime State.
- Install a regular native Neovim loader that delegates to separately managed configuration.
- Preserve locally evolved state across status, repository migration, updates, and uninstall.

## Changes

| File | Change |
|------|--------|
| `internal/seededstate/` | Add opaque-byte baseline reconciliation for aligned, advancing, and locally evolved state. |
| `internal/manifest/`, `internal/plan/`, `internal/install/` | Add confined `xdg-state` targets, seeded ownership, conditional advancement, and migration safety. |
| `internal/status/`, `internal/uninstall/`, `internal/cli/` | Report local evolution as aligned, retain seeded state on uninstall, and publish output schema 7. |
| `internal/repositoryrefresh/` | Capture the legacy Neovim lock from the verified directory symlink with provenance. |
| `configs/nvim/`, `dots.yaml` | Split the regular loader, managed module tree, and XDG lock target. |
| `CONTEXT.md`, `docs/` | Document Seeded Runtime State, XDG target roots, output values, and retained uninstall state. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go build ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed real-binary install/status/uninstall with explicit temporary `--home`, `--source-root`, `--state-root`, and `XDG_STATE_HOME`
- [x] `go test -race ./internal/seededstate ./internal/plan ./internal/install ./internal/repositoryrefresh`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #388`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

## Delivery Evidence

- Agent Brief: https://github.com/yersonargotev/dots/issues/388#issuecomment-5226646941 (comment `5226646941`, updated `2026-08-08T14:56:55Z`, SHA-256 `11c86ed64017e11853e63c8c494d36cd7c79aa6c4341284d6890c6ec3beeb306`).
- Reviewed HEAD: `6c6e9a0554c60d0123476a10882cf315aa1ca0ac` against `origin/main` at `cb479550d95e18b148562ef173d3019159e440f7`.
- Acceptance coverage: tests exercise initial seed, baseline advancement/removal, local evolution with exit 0, legacy lock migration with Backup Set/provenance, uninstall retention, XDG confinement, and clean repository status after simulated lazy.nvim writes.
- Automated validation: `gofmt -l .`, `go vet ./...`, `go build ./...`, `go test ./...`, focused race tests, and manifest validation all passed.
- Manual validation: a freshly built binary installed the three-entry Neovim split into a temporary HOME; the loader was regular, managed config was separate, local lock evolution produced schema 7 `seeded-local-evolution` with status `ok`, repository status remained clean, and uninstall removed both managed contributions while retaining the lock.
- Independent reviews: Spec and Standards reviewers reported no actionable findings on the reviewed HEAD after the glossary correction.
- Delegation: two read-only architecture explorations informed the implementation; one bounded seeded-state implementation contribution was inspected and accepted; all integration, validation, and final review remained with the primary delivery agent.
