### PR TITLE
feat(zsh): load config from co-owned entrypoint

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -64,6 +64,10 @@ _Avoid_: JSON merge, partial sync, tolerate anything
 An Entry Ownership mode for co-owned JSON-with-comments targets where dots recursively owns baseline object keys while preserving target-only keys and untouched syntax trivia. Baseline scalars and arrays are atomic ordered values: a live difference is Drift or Conflict rather than an additive merge. Installation Metadata records the canonical semantic contribution, while updates and uninstall edit the regular target without reserializing unrelated comments, trailing commas, ordering, or formatting.
 _Avoid_: formatted JSON merge, unordered array merge, strip comments
 
+**Marked Block Ownership**:
+An Entry Ownership mode for co-owned text entrypoints where dots owns exactly one initial, explicitly delimited block and preserves every external byte around it. Installation Metadata records the last dots-owned block so updates and uninstall fail closed when markers, placement, or prior contribution evidence are ambiguous.
+_Avoid_: append-only config, loose marker matching, shell parsing
+
 **Backup Set**:
 A timestamped collection of files preserved before an installation changes existing workstation targets. Backup sets live under `~/.local/state/dots/backups/` and include metadata describing what was protected and why.
 _Avoid_: old files, backup folder, snapshot

--- a/configs/zsh/README.md
+++ b/configs/zsh/README.md
@@ -5,23 +5,26 @@ workstation configuration slice (issue #38, epic #37).
 
 ## Managed targets
 
-`dots` symlinks exactly three files into your home directory:
+`dots` installs a co-owned native loader and three portable symlinks:
 
 | Source                | Target       |
 | --------------------- | ------------ |
-| `configs/zsh/zshrc`   | `~/.zshrc`   |
+| `configs/zsh/loader.zsh` | `~/.zshrc` (`copy`, marked block) |
+| `configs/zsh/zshrc`   | `~/.config/dots/zsh/zshrc` |
 | `configs/zsh/zimrc`   | `~/.zimrc`   |
 | `configs/zsh/zshenv`  | `~/.zshenv`  |
 
-The `symlink` strategy is **required**: `~/.zshrc` resolves its own real
-location to find the modular files under `rc.d/`. A copied `~/.zshrc` would not
-be able to locate them.
+The native `~/.zshrc` remains a regular file so third-party installers can
+append their own shell content without writing into the Installed Repository.
+Its initial dots-owned block loads the portable symlink; dots preserves all
+content outside that block.
 
 ## Layout
 
 ```
 configs/zsh/
-├── zshrc                  # entry point: pre-init → Zim → post-init → local
+├── loader.zsh             # native marked block loading the portable entrypoint
+├── zshrc                  # portable entrypoint: pre-init → Zim → post-init → local
 ├── zimrc                  # Zim module list
 ├── zshenv                 # environment for all shells (editor, cargo, foundry)
 ├── rc.d/

--- a/configs/zsh/loader.zsh
+++ b/configs/zsh/loader.zsh
@@ -1,0 +1,5 @@
+# >>> dots managed block >>>
+# Load the portable shell configuration while leaving this native entrypoint
+# writable for third-party installers.
+source "${HOME}/.config/dots/zsh/zshrc"
+# <<< dots managed block <<<

--- a/configs/zsh/zshrc
+++ b/configs/zsh/zshrc
@@ -2,9 +2,8 @@
 # Portable, modular, and safe to source on a fresh machine.
 # Machine-specific values and secrets live in ~/.zshrc.local (not managed).
 
-# Resolve this file's real directory even when sourced through a symlink, so the
+# Resolve this portable file's real directory through its managed symlink so the
 # modular config and the Zim runtime can be located relative to the repository.
-# This requires the symlink install strategy (see configs/zsh/README.md).
 ZSH_CONFIG_DIR="${${(%):-%x}:A:h}"
 
 # Pre-init modular config: must run before Zim loads its modules, because some

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -140,7 +140,7 @@ dots' own `--state-root`.
 | `target` | Yes | Home-relative `~` or `~/...`; with `target_root: xdg-state`, a confined relative path. |
 | `target_root` | No | `xdg-state`. It requires `ownership: seeded`; empty keeps home-target resolution. |
 | `strategy` | Yes | `symlink`, `copy`, or `template` in the manifest schema. Current install execution supports `symlink` and `copy`. |
-| `ownership` | No | Empty, `json-subset`, `jsonc-subset`, `toml-subset`, or `seeded`. Explicit ownership requires `strategy: copy`. |
+| `ownership` | No | Empty, `json-subset`, `jsonc-subset`, `toml-subset`, `marked-block`, or `seeded`. Explicit ownership requires `strategy: copy`. |
 | `tags` | Yes | Non-empty strings matched against the selected Profile. |
 | `os` | No | `darwin`, `linux`; empty means all supported operating systems. |
 | `dependencies` | No | Entry-level Dependencies. |
@@ -167,11 +167,19 @@ is preserved as aligned information with reason `seeded-local-evolution`.
 Uninstall retains the physical runtime state and removes only its ownership
 record.
 
+For `marked-block` ownership, dots records one exact initial delimited block in
+Installation Metadata. Blank lines and comments may precede it; executable
+content may not. Updates replace only an unchanged prior contribution after a
+Backup Set and preserve surrounding bytes. Duplicate, incomplete, moved, or
+edited blocks remain Conflicts. Uninstall subtracts only the recorded block and
+removes the regular-file container only when no external bytes remain.
+
 Current Managed Entries:
 
 | Source | Target | Strategy | Tags | OS | Dependencies |
 |--------|--------|----------|------|----|--------------|
-| `configs/zsh/zshrc` | `~/.zshrc` | `symlink` | `core` | `darwin`, `linux` | `zsh` |
+| `configs/zsh/loader.zsh` | `~/.zshrc` | `copy` (`marked-block`) | `core` | `darwin`, `linux` | `zsh` |
+| `configs/zsh/zshrc` | `~/.config/dots/zsh/zshrc` | `symlink` | `core` | `darwin`, `linux` | None |
 | `configs/zsh/zimrc` | `~/.zimrc` | `symlink` | `core` | `darwin`, `linux` | `zsh` |
 | `configs/zsh/zshenv` | `~/.zshenv` | `symlink` | `core` | `darwin`, `linux` | `zsh` |
 | `configs/git/gitconfig` | `~/.gitconfig` | `symlink` | `core` | `darwin`, `linux` | `git` |

--- a/dots.yaml
+++ b/dots.yaml
@@ -187,9 +187,10 @@ dependencies:
         dnf: jq
         pacman: jq
 entries:
-  - source: configs/zsh/zshrc
+  - source: configs/zsh/loader.zsh
     target: ~/.zshrc
-    strategy: symlink
+    strategy: copy
+    ownership: marked-block
     tags:
       - core
     os:
@@ -201,6 +202,14 @@ entries:
         apt: zsh
         dnf: zsh
         pacman: zsh
+  - source: configs/zsh/zshrc
+    target: ~/.config/dots/zsh/zshrc
+    strategy: symlink
+    tags:
+      - core
+    os:
+      - darwin
+      - linux
   - source: configs/zsh/zimrc
     target: ~/.zimrc
     strategy: symlink

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -11,6 +11,7 @@ import (
 	"github.com/yersonargotev/dots/internal/configsubset"
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/state"
+	"github.com/yersonargotev/dots/internal/textblock"
 	"github.com/yersonargotev/dots/internal/version"
 )
 
@@ -113,6 +114,7 @@ func recordMetadata(p plan.Plan, resolvedSources [][]string, opts Options) error
 		}
 		hash := ""
 		var ownedContent []byte
+		var ownedBytes []byte
 		var seededBaseline []byte
 		recordedOwnership := action.Ownership
 		if recordedOwnership == "" {
@@ -153,6 +155,11 @@ func recordMetadata(p plan.Plan, resolvedSources [][]string, opts Options) error
 							return fmt.Errorf("read seeded baseline %s: %w", resolvedSources[i][0], err)
 						}
 					}
+				} else if action.Ownership == "marked-block" {
+					ownedBytes, err = os.ReadFile(resolvedSources[i][0])
+					if err != nil {
+						return fmt.Errorf("read owned marked block %s: %w", resolvedSources[i][0], err)
+					}
 				}
 			}
 		}
@@ -163,6 +170,7 @@ func recordMetadata(p plan.Plan, resolvedSources [][]string, opts Options) error
 			Strategy:       action.Strategy,
 			Ownership:      recordedOwnership,
 			OwnedContent:   ownedContent,
+			OwnedBytes:     ownedBytes,
 			SeededBaseline: seededBaseline,
 			Hash:           hash,
 			InstalledAt:    now,
@@ -283,7 +291,7 @@ func validatePlan(p plan.Plan, opts Options) ([][]string, error) {
 			if opts.StateRoot == "" {
 				return nil, fmt.Errorf("update for %s requires state root for Backup Set metadata", action.Target)
 			}
-			if action.Strategy != "copy" || (action.Ownership != "json-subset" && action.Ownership != "jsonc-subset" && action.Ownership != "toml-subset" && action.Ownership != "seeded") {
+			if action.Strategy != "copy" || (action.Ownership != "json-subset" && action.Ownership != "jsonc-subset" && action.Ownership != "toml-subset" && action.Ownership != "marked-block" && action.Ownership != "seeded") {
 				return nil, fmt.Errorf("update for %s requires copy strategy with reconcilable ownership", action.Target)
 			}
 			if err := validateBackupStateRoot(opts.StateRoot, home); err != nil {
@@ -618,6 +626,26 @@ func applyUpdate(action plan.Action, source string, opts Options) error {
 		}
 		if err := os.WriteFile(action.Target, current, info.Mode().Perm()); err != nil {
 			return fmt.Errorf("advance seeded target %s: %w", action.Target, err)
+		}
+	case "marked-block":
+		live, err := os.ReadFile(action.Target)
+		if err != nil {
+			return fmt.Errorf("read marked-block target %s: %w", action.Target, err)
+		}
+		current, err := os.ReadFile(source)
+		if err != nil {
+			return fmt.Errorf("read marked-block source %s: %w", source, err)
+		}
+		reconciliation := textblock.ReconcileOwned(live, action.PreviousContent, current, textblock.DotsManagedMarkers())
+		if !reconciliation.Compatible {
+			return fmt.Errorf("install plan is stale: marked block %s changed before update", action.Target)
+		}
+		info, err := os.Stat(action.Target)
+		if err != nil {
+			return fmt.Errorf("stat marked-block target %s: %w", action.Target, err)
+		}
+		if err := os.WriteFile(action.Target, reconciliation.Content, info.Mode().Perm()); err != nil {
+			return fmt.Errorf("update marked block %s: %w", action.Target, err)
 		}
 	default:
 		return fmt.Errorf("update ownership %q is not supported for %s", action.Ownership, action.Target)

--- a/internal/install/issue389_markedblock_test.go
+++ b/internal/install/issue389_markedblock_test.go
@@ -1,0 +1,164 @@
+package install_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/backups"
+	"github.com/yersonargotev/dots/internal/install"
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/plan"
+	"github.com/yersonargotev/dots/internal/repositoryrefresh"
+	"github.com/yersonargotev/dots/internal/state"
+	"github.com/yersonargotev/dots/internal/status"
+	"github.com/yersonargotev/dots/internal/uninstall"
+)
+
+func TestZshMarkedBlockLifecycle(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := filepath.Join(home, ".local", "state", "dots")
+	legacySource := filepath.Join(sourceRoot, "configs/zsh/zshrc")
+	loaderSource := filepath.Join(sourceRoot, "configs/zsh/loader.zsh")
+	legacy := []byte("# legacy portable shell\nexport OLD=1\n")
+	loader := []byte("# >>> dots managed block >>>\nsource \"${HOME}/.config/dots/zsh/zshrc\"\n# <<< dots managed block <<<\n")
+	writeMigrationFile(t, legacySource, legacy)
+	runMigrationGit(t, sourceRoot, "init")
+	runMigrationGit(t, sourceRoot, "config", "user.email", "dots@example.test")
+	runMigrationGit(t, sourceRoot, "config", "user.name", "dots test")
+	runMigrationGit(t, sourceRoot, "add", ".")
+	runMigrationGit(t, sourceRoot, "commit", "-m", "legacy zsh")
+	revision := runMigrationGit(t, sourceRoot, "rev-parse", "HEAD")
+
+	target := filepath.Join(home, ".zshrc")
+	if err := os.Symlink(legacySource, target); err != nil {
+		t.Fatalf("symlink legacy zsh: %v", err)
+	}
+	external := []byte("\n# third-party installer\nexport TOOL_HOME=/tmp/tool\n")
+	if err := os.WriteFile(legacySource, append(append([]byte(nil), legacy...), external...), 0o600); err != nil {
+		t.Fatalf("append through legacy target: %v", err)
+	}
+	meta := state.Metadata{Version: state.CurrentVersion, Provenance: state.Provenance{SourceRoot: sourceRoot, SourceRevision: revision}, Entries: []state.Record{{
+		Target: target, Source: "configs/zsh/zshrc", Strategy: "symlink", Ownership: "whole",
+	}}}
+	if err := state.Save(state.Path(stateRoot), meta); err != nil {
+		t.Fatalf("save legacy metadata: %v", err)
+	}
+	oldManifest := zshManifest("configs/zsh/zshrc", "symlink", "")
+	newManifest := zshManifest("configs/zsh/loader.zsh", "copy", "marked-block")
+	captures, err := repositoryrefresh.CaptureLegacyTargets(oldManifest, newManifest, meta, sourceRoot, home, "", revision)
+	if err != nil {
+		t.Fatalf("CaptureLegacyTargets() error = %v", err)
+	}
+	writeMigrationFile(t, legacySource, legacy)
+	writeMigrationFile(t, loaderSource, loader)
+	runMigrationGit(t, sourceRoot, "add", ".")
+	runMigrationGit(t, sourceRoot, "commit", "-m", "marked zsh loader")
+
+	opts := plan.Options{Profile: "default", OS: "linux", SourceRoot: sourceRoot, Home: home, Metadata: meta, LegacyMigrations: captures}
+	p, err := plan.Build(newManifest, opts)
+	if err != nil {
+		t.Fatalf("Build(migrate) error = %v", err)
+	}
+	if len(p.Actions) != 1 || p.Actions[0].Status != plan.StatusMigrate {
+		t.Fatalf("migration plan = %#v", p.Actions)
+	}
+	if err := install.Apply(p, install.Options{SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot}); err != nil {
+		t.Fatalf("Apply(migrate) error = %v", err)
+	}
+	want := append(append([]byte(nil), loader...), external...)
+	if got, err := os.ReadFile(target); err != nil || !bytes.Equal(got, want) {
+		t.Fatalf("migrated target = (%q, %v), want %q", got, err, want)
+	}
+	if info, err := os.Lstat(target); err != nil || !info.Mode().IsRegular() {
+		t.Fatalf("native target = (%v, %v), want regular file", info, err)
+	}
+	backupMeta, err := backups.Load(backups.Path(stateRoot))
+	if err != nil || len(backupMeta.Sets) != 1 {
+		t.Fatalf("migration backups = (%#v, %v), want one", backupMeta, err)
+	}
+	if out := runMigrationGit(t, sourceRoot, "status", "--porcelain"); out != "" {
+		t.Fatalf("repository status after target append = %q, want clean", out)
+	}
+
+	meta, err = state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load marked-block metadata: %v", err)
+	}
+	report, err := status.Build(newManifest, meta, status.Options{Profile: "default", OS: "linux", SourceRoot: sourceRoot, Home: home})
+	if err != nil || len(report.Entries) != 1 || report.Entries[0].State != status.StateOK {
+		t.Fatalf("status after append = (%#v, %v), want ok", report, err)
+	}
+
+	for name, content := range map[string][]byte{
+		"duplicate":     append(append([]byte(nil), loader...), loader...),
+		"missing-close": []byte("# >>> dots managed block >>>\nsource bad\n"),
+		"moved":         append([]byte("export BEFORE=1\n"), loader...),
+		"modified":      []byte("# >>> dots managed block >>>\nsource changed\n# <<< dots managed block <<<\n"),
+	} {
+		t.Run(name+" conflict", func(t *testing.T) {
+			if err := os.WriteFile(target, content, 0o600); err != nil {
+				t.Fatalf("write fixture: %v", err)
+			}
+			conflictPlan, err := plan.Build(newManifest, plan.Options{Profile: "default", OS: "linux", SourceRoot: sourceRoot, Home: home, Metadata: meta})
+			if err != nil || len(conflictPlan.Actions) != 1 || conflictPlan.Actions[0].Status != plan.StatusConflict {
+				t.Fatalf("plan = (%#v, %v), want conflict", conflictPlan, err)
+			}
+			got, err := os.ReadFile(target)
+			if err != nil || !bytes.Equal(got, content) {
+				t.Fatalf("conflict fixture changed = (%q, %v)", got, err)
+			}
+		})
+	}
+	if err := os.WriteFile(target, want, 0o600); err != nil {
+		t.Fatalf("restore compatible target: %v", err)
+	}
+	updatedLoader := bytes.Replace(loader, []byte("source \""), []byte("# updated baseline\nsource \""), 1)
+	writeMigrationFile(t, loaderSource, updatedLoader)
+	updatePlan, err := plan.Build(newManifest, plan.Options{Profile: "default", OS: "linux", SourceRoot: sourceRoot, Home: home, Metadata: meta})
+	if err != nil || updatePlan.Actions[0].Status != plan.StatusUpdate {
+		t.Fatalf("update plan = (%#v, %v), want update", updatePlan, err)
+	}
+	if err := install.Apply(updatePlan, install.Options{SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot}); err != nil {
+		t.Fatalf("Apply(update) error = %v", err)
+	}
+	want = append(append([]byte(nil), updatedLoader...), external...)
+	if got, err := os.ReadFile(target); err != nil || !bytes.Equal(got, want) {
+		t.Fatalf("updated target = (%q, %v), want %q", got, err, want)
+	}
+	backupMeta, err = backups.Load(backups.Path(stateRoot))
+	if err != nil || len(backupMeta.Sets) != 2 {
+		t.Fatalf("update backups = (%#v, %v), want two total", backupMeta, err)
+	}
+
+	meta, err = state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("reload metadata: %v", err)
+	}
+	rec, ok := meta.FindByTarget(target)
+	if !ok {
+		t.Fatal("marked-block record missing")
+	}
+	uninstallPlan, err := plan.BuildUninstall(state.Metadata{Entries: []state.Record{rec}}, plan.UninstallOptions{SourceRoot: sourceRoot, Home: home})
+	if err != nil {
+		t.Fatalf("BuildUninstall() error = %v", err)
+	}
+	result, err := uninstall.Apply(uninstallPlan, uninstall.Options{SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot})
+	if err != nil {
+		t.Fatalf("uninstall Apply() error = %v", err)
+	}
+	if len(result.Updated) != 1 || result.Updated[0] != target {
+		t.Fatalf("uninstall result = %#v, want updated native target", result)
+	}
+	if got, err := os.ReadFile(target); err != nil || !bytes.Equal(got, external) {
+		t.Fatalf("uninstalled target = (%q, %v), want external bytes", got, err)
+	}
+}
+
+func zshManifest(source, strategy, ownership string) manifest.Manifest {
+	return manifest.Manifest{Version: 1, Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}}, Entries: []manifest.Entry{{
+		Source: source, Target: "~/.zshrc", Strategy: strategy, Ownership: ownership, Tags: []string{"core"}, OS: []string{"linux"},
+	}}}
+}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -466,7 +466,7 @@ func (m Manifest) Validate() error {
 			}
 		}
 		if !allowedOwnership(entry.Ownership) {
-			return fmt.Errorf("entries[%d].ownership must be one of json-subset, jsonc-subset, toml-subset, seeded", i)
+			return fmt.Errorf("entries[%d].ownership must be one of json-subset, jsonc-subset, toml-subset, marked-block, seeded", i)
 		}
 		if entry.Ownership != "" && entry.Strategy != "copy" {
 			return fmt.Errorf("entries[%d].ownership %s requires strategy copy", i, entry.Ownership)
@@ -1015,7 +1015,7 @@ func allowedStrategy(strategy string) bool {
 
 func allowedOwnership(ownership string) bool {
 	switch ownership {
-	case "", "json-subset", "jsonc-subset", "toml-subset", "seeded":
+	case "", "json-subset", "jsonc-subset", "toml-subset", "marked-block", "seeded":
 		return true
 	default:
 		return false

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -1723,7 +1723,7 @@ entries:
     ownership: merge
     tags: [core]
 `,
-			want: "entries[0].ownership must be one of json-subset, jsonc-subset, toml-subset, seeded",
+			want: "entries[0].ownership must be one of json-subset, jsonc-subset, toml-subset, marked-block, seeded",
 		},
 		{
 			name: "json subset ownership on non-copy strategy",
@@ -2226,7 +2226,7 @@ func TestRepositoryManifestIncludesMVPConfigurationSet(t *testing.T) {
 		strategy string
 		dep      string
 	}{
-		{name: "zsh", target: "~/.zshrc", source: "configs/zsh/zshrc", strategy: "symlink", dep: "zsh"},
+		{name: "zsh", target: "~/.zshrc", source: "configs/zsh/loader.zsh", strategy: "copy", dep: "zsh"},
 		{name: "git", target: "~/.gitconfig", source: "configs/git/gitconfig", strategy: "symlink", dep: "git"},
 		{name: "starship", target: "~/.config/starship.toml", source: "configs/starship/starship.toml", strategy: "symlink", dep: "starship"},
 		{name: "tmux", target: "~/.tmux.conf", source: "configs/tmux/tmux.conf", strategy: "symlink", dep: "tmux"},
@@ -2254,6 +2254,13 @@ func TestRepositoryManifestIncludesMVPConfigurationSet(t *testing.T) {
 				t.Errorf("Dependencies = %#v, want %q", entry.Dependencies, tt.dep)
 			}
 		})
+	}
+	if got := entriesByTarget["~/.zshrc"].Ownership; got != "marked-block" {
+		t.Errorf("zsh ownership = %q, want marked-block", got)
+	}
+	portable, ok := entriesByTarget["~/.config/dots/zsh/zshrc"]
+	if !ok || portable.Source != "configs/zsh/zshrc" || portable.Strategy != "symlink" {
+		t.Errorf("portable zsh entry = %#v, want managed symlink", portable)
 	}
 }
 

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -14,6 +14,7 @@ import (
 	"github.com/yersonargotev/dots/internal/seededstate"
 	"github.com/yersonargotev/dots/internal/selection"
 	"github.com/yersonargotev/dots/internal/state"
+	"github.com/yersonargotev/dots/internal/textblock"
 )
 
 // Status describes what installing an Action would do to its target.
@@ -238,6 +239,8 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 				action.PreviousContent = append([]byte(nil), rec.OwnedContent...)
 			} else if rec.Ownership == "seeded" {
 				action.PreviousContent = append([]byte(nil), rec.SeededBaseline...)
+			} else if rec.Ownership == "marked-block" {
+				action.PreviousContent = append([]byte(nil), rec.OwnedBytes...)
 			}
 		}
 		targetKey := filepath.Clean(target)
@@ -289,7 +292,15 @@ func planLegacyMigration(entry manifest.Entry, currentSource string, migration L
 		return LegacyMigration{}, false, fmt.Errorf("read migration source %s: %w", currentSource, err)
 	}
 	planned := migration
-	planned.ExpectedLinkContent = append([]byte(nil), current...)
+	expectedPath := migration.LinkDestination
+	if migration.LegacyContentTarget != "" {
+		expectedPath = migration.LegacyContentTarget
+	}
+	expected, err := os.ReadFile(expectedPath)
+	if err != nil {
+		return LegacyMigration{}, false, fmt.Errorf("read current legacy target %s: %w", expectedPath, err)
+	}
+	planned.ExpectedLinkContent = expected
 	switch entry.Ownership {
 	case "seeded":
 		reconciliation := seededstate.Reconcile(migration.CapturedContent, migration.PreviousSourceContent, current)
@@ -328,6 +339,12 @@ func planLegacyMigration(entry manifest.Entry, currentSource string, migration L
 			return LegacyMigration{}, false, nil
 		}
 		planned.FinalContent = merged
+	case "marked-block":
+		reconciliation := textblock.MigrateLegacyOwned(migration.CapturedContent, migration.PreviousSourceContent, current, textblock.DotsManagedMarkers())
+		if !reconciliation.Compatible {
+			return LegacyMigration{}, false, nil
+		}
+		planned.FinalContent = reconciliation.Content
 	default:
 		if !bytes.Equal(migration.CapturedContent, migration.PreviousSourceContent) {
 			return LegacyMigration{}, false, nil
@@ -695,6 +712,15 @@ func status(entry manifest.Entry, target, sourceAbs, sourceRoot, canonicalSource
 	} else if !exists {
 		return StatusMissingSource, nil
 	}
+	if entry.Ownership == "marked-block" {
+		source, err := os.ReadFile(sourceAbs)
+		if err != nil {
+			return "", fmt.Errorf("read marked-block source %s: %w", sourceAbs, err)
+		}
+		if !textblock.ValidOwnedSource(source, textblock.DotsManagedMarkers()) {
+			return "", fmt.Errorf("marked-block source %s must contain exactly one complete block and no external content", sourceAbs)
+		}
+	}
 
 	info, err := os.Lstat(target)
 	if os.IsNotExist(err) {
@@ -719,6 +745,28 @@ func status(entry manifest.Entry, target, sourceAbs, sourceRoot, canonicalSource
 			return StatusConflict, nil
 		}
 		if same, err := sameContent(target, sourceAbs); err != nil || !same {
+			if entry.Ownership == "marked-block" {
+				rec, ok := meta.FindByTarget(target)
+				if !ok || rec.Strategy != entry.Strategy || rec.Source != entry.Source || rec.Ownership != "marked-block" || len(rec.OwnedBytes) == 0 {
+					return StatusConflict, nil
+				}
+				live, readErr := os.ReadFile(target)
+				if readErr != nil {
+					return "", fmt.Errorf("read marked-block target %s: %w", target, readErr)
+				}
+				current, readErr := os.ReadFile(sourceAbs)
+				if readErr != nil {
+					return "", fmt.Errorf("read marked-block source %s: %w", sourceAbs, readErr)
+				}
+				reconciliation := textblock.ReconcileOwned(live, rec.OwnedBytes, current, textblock.DotsManagedMarkers())
+				if !reconciliation.Compatible {
+					return StatusConflict, nil
+				}
+				if reconciliation.Changed {
+					return StatusUpdate, nil
+				}
+				return StatusUnchanged, nil
+			}
 			if entry.Ownership == "seeded" {
 				rec, ok := meta.FindByTarget(target)
 				if !ok || rec.Strategy != entry.Strategy || rec.Source != entry.Source || rec.Ownership != "seeded" {

--- a/internal/plan/uninstall.go
+++ b/internal/plan/uninstall.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/yersonargotev/dots/internal/configsubset"
 	"github.com/yersonargotev/dots/internal/state"
+	"github.com/yersonargotev/dots/internal/textblock"
 )
 
 // UninstallStatus describes what removing a recorded target would do, mirroring
@@ -170,6 +171,17 @@ func uninstallStatus(rec state.Record, sourceRoot, home string) (UninstallStatus
 			if err != nil {
 				return "", fmt.Errorf("analyze owned JSON for %s: %w", rec.Target, err)
 			}
+			if compatible {
+				return UninstallRemove, nil
+			}
+			return UninstallModified, nil
+		}
+		if rec.Ownership == "marked-block" && len(rec.OwnedBytes) > 0 {
+			targetData, err := os.ReadFile(rec.Target)
+			if err != nil {
+				return "", fmt.Errorf("read uninstall target %s: %w", rec.Target, err)
+			}
+			_, _, _, compatible := textblock.RemoveOwned(targetData, rec.OwnedBytes, textblock.DotsManagedMarkers())
 			if compatible {
 				return UninstallRemove, nil
 			}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -18,7 +18,7 @@ import (
 )
 
 // CurrentVersion is the current Installation Metadata schema version.
-const CurrentVersion = 5
+const CurrentVersion = 6
 
 // Metadata is the machine-readable record of installed managed targets.
 type Metadata struct {
@@ -53,7 +53,8 @@ func (p Provenance) Empty() bool {
 
 // Record describes a single managed target the CLI installed. Version 4 records
 // explicit whole or partial Ownership; version 5 adds opaque seeded-baseline
-// evidence. An empty Ownership is legacy and grants no force-removal authority.
+// evidence, and version 6 adds opaque marked-block contribution evidence. An
+// empty Ownership is legacy and grants no force-removal authority.
 // Copy-like strategies may record a source content hash; symlink records leave
 // Hash empty because drift is detected from the link destination.
 type Record struct {
@@ -63,6 +64,8 @@ type Record struct {
 	Strategy     string          `json:"strategy"`
 	Ownership    string          `json:"ownership,omitempty"`
 	OwnedContent json.RawMessage `json:"owned_content,omitempty"`
+	// OwnedBytes is the exact opaque contribution for non-JSON partial ownership.
+	OwnedBytes []byte `json:"owned_bytes,omitempty"`
 	// SeededBaseline is the exact opaque Source of Truth baseline last applied
 	// to Seeded Runtime State. []byte uses JSON base64 encoding, so the state
 	// itself need not be JSON.

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -17,6 +17,7 @@ import (
 	"github.com/yersonargotev/dots/internal/seededstate"
 	"github.com/yersonargotev/dots/internal/selection"
 	"github.com/yersonargotev/dots/internal/state"
+	"github.com/yersonargotev/dots/internal/textblock"
 )
 
 // State classifies a managed target's alignment with the Source of Truth.
@@ -245,6 +246,32 @@ func evaluate(entry manifest.Entry, target string, meta state.Metadata, sourceRo
 		// Any trusted regular-file difference is either an advanceable old
 		// baseline or expected local evolution. Neither is Drift in status;
 		// install performs the conditional advancement.
+		return StateOK, nil
+	}
+	if entry.Ownership == "marked-block" {
+		info, err := os.Lstat(target)
+		if err != nil {
+			return "", fmt.Errorf("stat marked-block target %s: %w", target, err)
+		}
+		rec, recorded := meta.FindByTarget(target)
+		if !info.Mode().IsRegular() || !recorded || rec.Strategy != entry.Strategy || rec.Source != entry.Source || rec.Ownership != "marked-block" || len(rec.OwnedBytes) == 0 {
+			return StateConflict, nil
+		}
+		live, err := os.ReadFile(target)
+		if err != nil {
+			return "", fmt.Errorf("read marked-block target %s: %w", target, err)
+		}
+		current, err := os.ReadFile(sourceAbs)
+		if err != nil {
+			return "", fmt.Errorf("read marked-block source %s: %w", sourceAbs, err)
+		}
+		reconciliation := textblock.ReconcileOwned(live, rec.OwnedBytes, current, textblock.DotsManagedMarkers())
+		if !reconciliation.Compatible {
+			return StateConflict, nil
+		}
+		if reconciliation.Changed {
+			return StateDrifted, nil
+		}
 		return StateOK, nil
 	}
 	if entry.Ownership == "json-subset" && len(currentJSON) > 0 {

--- a/internal/textblock/textblock.go
+++ b/internal/textblock/textblock.go
@@ -3,10 +3,22 @@
 package textblock
 
 import (
+	"bytes"
 	"fmt"
 	"sort"
 	"strings"
 )
+
+const (
+	DotsManagedBlockStart = "# >>> dots managed block >>>"
+	DotsManagedBlockEnd   = "# <<< dots managed block <<<"
+)
+
+// DotsManagedMarkers returns the exact portable markers used by partial text
+// ownership in the Install Manifest.
+func DotsManagedMarkers() Markers {
+	return Markers{Start: DotsManagedBlockStart, End: DotsManagedBlockEnd}
+}
 
 // Markers identify the start and end comments around a managed block.
 type Markers struct {
@@ -96,6 +108,103 @@ func Remove(content string, markers ...Markers) (string, error) {
 type blockRange struct {
 	start int
 	end   int
+}
+
+// Reconciliation describes a strict three-way update of one recorded block.
+type Reconciliation struct {
+	Content    []byte
+	Changed    bool
+	Compatible bool
+}
+
+// ValidOwnedSource reports whether source is exactly one complete marked block.
+func ValidOwnedSource(source []byte, markers Markers) bool {
+	b, ok := parseOwned(source, markers)
+	return ok && b.start == 0 && b.end == len(source)
+}
+
+// ReconcileOwned replaces the exact recorded initial block and preserves every
+// byte before and after it. Ambiguous placement or markers fail closed.
+func ReconcileOwned(live, previous, current []byte, markers Markers) Reconciliation {
+	liveBlock, ok := parseOwned(live, markers)
+	if !ok || !ValidOwnedSource(previous, markers) || !ValidOwnedSource(current, markers) ||
+		!bytes.Equal(live[liveBlock.start:liveBlock.end], previous) {
+		return Reconciliation{}
+	}
+	content := replaceOwned(live, liveBlock.start, liveBlock.end, current)
+	return Reconciliation{Content: content, Changed: !bytes.Equal(content, live), Compatible: true}
+}
+
+// MigrateLegacyOwned converts an exact legacy whole-file contribution,
+// optionally followed by appended bytes, into the current marked block.
+func MigrateLegacyOwned(live, previous, current []byte, markers Markers) Reconciliation {
+	if !ValidOwnedSource(current, markers) || len(previous) == 0 || !bytes.HasPrefix(live, previous) {
+		return Reconciliation{}
+	}
+	content := append(append([]byte(nil), current...), live[len(previous):]...)
+	return Reconciliation{Content: content, Changed: !bytes.Equal(content, live), Compatible: true}
+}
+
+// RemoveOwned subtracts only the exact recorded block. Empty is true only when
+// no external bytes remain, allowing removal of the physical container.
+func RemoveOwned(live, owned []byte, markers Markers) (content []byte, changed, empty, compatible bool) {
+	b, ok := parseOwned(live, markers)
+	if !ok || !ValidOwnedSource(owned, markers) || !bytes.Equal(live[b.start:b.end], owned) {
+		return nil, false, false, false
+	}
+	content = replaceOwned(live, b.start, b.end, nil)
+	return content, true, len(content) == 0, true
+}
+
+func parseOwned(content []byte, markers Markers) (blockRange, bool) {
+	if markers.Start == "" || markers.End == "" {
+		return blockRange{}, false
+	}
+	var found blockRange
+	starts, ends := 0, 0
+	for offset := 0; offset < len(content); {
+		next := bytes.IndexByte(content[offset:], '\n')
+		lineEnd := len(content)
+		if next >= 0 {
+			lineEnd = offset + next + 1
+		}
+		text := strings.TrimSuffix(string(content[offset:lineEnd]), "\n")
+		switch text {
+		case markers.Start:
+			starts++
+			if starts == 1 {
+				found.start = offset
+			}
+		case markers.End:
+			ends++
+			if ends == 1 {
+				found.end = lineEnd
+			}
+		}
+		offset = lineEnd
+	}
+	if starts != 1 || ends != 1 || found.end <= found.start || !commentsOnly(content[:found.start]) {
+		return blockRange{}, false
+	}
+	return found, true
+}
+
+func commentsOnly(content []byte) bool {
+	for _, line := range strings.Split(string(content), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" && !strings.HasPrefix(trimmed, "#") {
+			return false
+		}
+	}
+	return true
+}
+
+func replaceOwned(content []byte, start, end int, replacement []byte) []byte {
+	result := make([]byte, 0, len(content)-(end-start)+len(replacement))
+	result = append(result, content[:start]...)
+	result = append(result, replacement...)
+	result = append(result, content[end:]...)
+	return result
 }
 
 func findRanges(content string, markers []Markers) ([]blockRange, error) {

--- a/internal/textblock/textblock_test.go
+++ b/internal/textblock/textblock_test.go
@@ -1,9 +1,57 @@
 package textblock
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 )
+
+func TestOwnedBlockReconciliationFailsClosedAndPreservesExternalBytes(t *testing.T) {
+	markers := DotsManagedMarkers()
+	previous := []byte(markers.Start + "\nsource old\n" + markers.End + "\n")
+	current := []byte(markers.Start + "\nsource new\n" + markers.End + "\n")
+	prefix := []byte("\n# installed by a tool\n")
+	suffix := []byte("export THIRD_PARTY=1\n")
+	live := append(append(append([]byte(nil), prefix...), previous...), suffix...)
+	got := ReconcileOwned(live, previous, current, markers)
+	want := append(append(append([]byte(nil), prefix...), current...), suffix...)
+	if !got.Compatible || !got.Changed || !bytes.Equal(got.Content, want) {
+		t.Fatalf("ReconcileOwned() = %#v, want %q", got, want)
+	}
+	invalid := map[string][]byte{
+		"duplicate":     append(append([]byte(nil), previous...), previous...),
+		"missing close": []byte(markers.Start + "\nsource old\n"),
+		"moved":         append([]byte("export BEFORE=1\n"), previous...),
+		"modified":      []byte(markers.Start + "\nsource changed\n" + markers.End + "\n"),
+	}
+	for name, content := range invalid {
+		t.Run(name, func(t *testing.T) {
+			if result := ReconcileOwned(content, previous, current, markers); result.Compatible {
+				t.Fatalf("ReconcileOwned() = %#v, want incompatible", result)
+			}
+		})
+	}
+}
+
+func TestOwnedBlockMigrationAndRemoval(t *testing.T) {
+	markers := DotsManagedMarkers()
+	legacy := []byte("source legacy\n")
+	current := []byte(markers.Start + "\nsource portable\n" + markers.End + "\n")
+	external := []byte("third-party init\n")
+	got := MigrateLegacyOwned(append(append([]byte(nil), legacy...), external...), legacy, current, markers)
+	want := append(append([]byte(nil), current...), external...)
+	if !got.Compatible || !bytes.Equal(got.Content, want) {
+		t.Fatalf("MigrateLegacyOwned() = %#v, want %q", got, want)
+	}
+	content, changed, empty, compatible := RemoveOwned(want, current, markers)
+	if !compatible || !changed || empty || !bytes.Equal(content, external) {
+		t.Fatalf("RemoveOwned() = (%q, %t, %t, %t)", content, changed, empty, compatible)
+	}
+	_, _, empty, compatible = RemoveOwned(current, current, markers)
+	if !compatible || !empty {
+		t.Fatalf("RemoveOwned(empty) = empty %t, compatible %t", empty, compatible)
+	}
+}
 
 func TestUpsertInsertsUpdatesAndMigratesBlocks(t *testing.T) {
 	primary := Markers{Start: "<!-- dots:block -->", End: "<!-- /dots:block -->"}

--- a/internal/uninstall/uninstall.go
+++ b/internal/uninstall/uninstall.go
@@ -14,6 +14,7 @@ import (
 	"github.com/yersonargotev/dots/internal/configsubset"
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/state"
+	"github.com/yersonargotev/dots/internal/textblock"
 )
 
 // Options carries the resolved inputs needed to apply an Uninstall Plan.
@@ -99,6 +100,21 @@ func Apply(p plan.UninstallPlan, opts Options) (Result, error) {
 			}
 			continue
 		}
+		if rec.Ownership == "marked-block" && len(rec.OwnedBytes) > 0 {
+			if action.Status != plan.UninstallRemove {
+				continue
+			}
+			applied, deleted, err := removeOwnedBlock(rec, home)
+			if err != nil {
+				return result, err
+			}
+			if applied && deleted {
+				result.Removed = append(result.Removed, action.Target)
+			} else if applied {
+				result.Updated = append(result.Updated, action.Target)
+			}
+			continue
+		}
 		remove, err := stillRemovable(rec, opts.SourceRoot, home, opts.Force)
 		if err != nil {
 			return result, err
@@ -129,6 +145,43 @@ func Apply(p plan.UninstallPlan, opts Options) (Result, error) {
 	}
 
 	return result, nil
+}
+
+func removeOwnedBlock(rec state.Record, home string) (applied, deleted bool, err error) {
+	if err := plan.ValidateResolvedTarget(rec.Target, home); err != nil {
+		return false, false, err
+	}
+	if err := plan.ValidateTargetParentInsideHome(rec.Target, home); err != nil {
+		return false, false, err
+	}
+	if err := plan.ValidateFilePathInsideHomeNoSymlinkEscape(rec.Target, home, "marked-block target"); err != nil {
+		return false, false, err
+	}
+	info, err := os.Stat(rec.Target)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, false, nil
+		}
+		return false, false, fmt.Errorf("stat marked-block target %s: %w", rec.Target, err)
+	}
+	live, err := os.ReadFile(rec.Target)
+	if err != nil {
+		return false, false, fmt.Errorf("read marked-block target %s: %w", rec.Target, err)
+	}
+	content, _, empty, compatible := textblock.RemoveOwned(live, rec.OwnedBytes, textblock.DotsManagedMarkers())
+	if !compatible {
+		return false, false, nil
+	}
+	if empty {
+		if err := removeTarget(rec.Target); err != nil {
+			return false, false, fmt.Errorf("remove empty marked-block target %s: %w", rec.Target, err)
+		}
+		return true, true, nil
+	}
+	if err := os.WriteFile(rec.Target, content, info.Mode().Perm()); err != nil {
+		return false, false, fmt.Errorf("write marked-block target %s after removal: %w", rec.Target, err)
+	}
+	return true, false, nil
 }
 
 // removeOwnedJSON revalidates and subtracts a partial contribution at apply


### PR DESCRIPTION
Closes #389

## PR Type

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Materializes `~/.zshrc` as a regular co-owned file with one strict initial dots block.
- Loads portable Zsh configuration from a separate managed symlink and preserves third-party content.
- Adds provenance-backed migration, backup-backed reconciliation, status, and narrow uninstall behavior.

## Changes

| File | Change |
|------|--------|
| `internal/textblock`, install/plan/status/uninstall/state | Add exact prior-contribution reconciliation for marked-block ownership. |
| `configs/zsh`, `dots.yaml` | Split the native loader from the portable shell entrypoint. |
| tests and domain/manifest docs | Cover and document migration, conflicts, updates, and uninstall. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go build ./...`
- [x] Built binary: `dots manifest validate --file <temporary-manifest>`
- [x] Built binary in temporary home: install, status, Zsh source, append, update, conflict preview, uninstall

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] All CLI validation used `/tmp/dots-issue-389-manual` with explicit `--home`, `--source-root`, and `--state-root`.

## Contributor Checklist

- [x] Linked approved / `ready-for-agent` issue #389.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated domain and manifest documentation.
- [x] Used conventional commit format.
- [x] Did not add AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

- Agent Brief: https://github.com/yersonargotev/dots/issues/389#issuecomment-5226647074 (ID `5226647074`, SHA-256 `566bb8be6bdaa304ace831f2ab1977f42efa88017f8de6bcbf81e2b5a9846f82`)
- Reviewed head: `df61d4b416a4a983237dceb86eea3a136c3a3728`
- Acceptance coverage: integrated temporary-home test covers provenance migration, clean-checkout append, initial placement, duplicate/unclosed/moved/modified conflicts, backup-backed byte-preserving update, status, and narrow uninstall.
- Automated validation: `gofmt -l .` (no output); `go vet ./...`, `go build ./...`, `go test ./...` (pass); focused race tests for textblock/plan/install/status/uninstall (pass).
- Manual verification: built `/tmp/dots-issue-389-manual/bin/dots`; temporary manifest validated; install and status returned aligned; `zsh -dfc` loaded portable plus third-party content; append left temporary Source of Truth clean; baseline update created one Backup Set and preserved external bytes; modified block previewed `conflict` without mutation; uninstall removed the owned block and portable symlink while retaining third-party bytes.
- Independent review: Spec pass, 0 findings; Standards pass, 0 findings; no observations.
- Delegation: implementation/exploration delegation skipped because the installed `dots:delegation` overlay and `dots-explorer`/`dots-worker` artifacts were absent (`tool-level permission required` workflow skip); main agent implemented and verified all changes. Independent review used two read-only native subagents as required.
<!-- delivery-issue:evidence:end -->
