### PR TITLE
feat(atuin): materialize co-owned TOML config

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -64,6 +64,10 @@ _Avoid_: JSON merge, partial sync, tolerate anything
 An Entry Ownership mode for co-owned JSON-with-comments targets where dots recursively owns baseline object keys while preserving target-only keys and untouched syntax trivia. Baseline scalars and arrays are atomic ordered values: a live difference is Drift or Conflict rather than an additive merge. Installation Metadata records the canonical semantic contribution, while updates and uninstall edit the regular target without reserializing unrelated comments, trailing commas, ordering, or formatting.
 _Avoid_: formatted JSON merge, unordered array merge, strip comments
 
+**TOML Subset Ownership**:
+An Entry Ownership mode for co-owned TOML targets where dots owns the baseline values declared at root or in ordinary tables while preserving target-only keys, tables, comments, and untouched formatting. Baseline scalars, arrays, and inline-table values are atomic. Installation Metadata records the exact prior dots contribution so updates can add new values, remove unchanged retired values, and reject externally changed owned values; uninstall subtracts only that proven contribution.
+_Avoid_: reformat TOML, merge array items, own the whole table
+
 **Marked Block Ownership**:
 An Entry Ownership mode for co-owned text entrypoints where dots owns exactly one initial, explicitly delimited block and preserves every external byte around it. Installation Metadata records the last dots-owned block so updates and uninstall fail closed when markers, placement, or prior contribution evidence are ambiguous.
 _Avoid_: append-only config, loose marker matching, shell parsing

--- a/configs/atuin/README.md
+++ b/configs/atuin/README.md
@@ -1,13 +1,16 @@
 # Atuin configuration
 
 `configs/atuin/config.toml` is the repository-managed Atuin configuration
-installed as `~/.config/atuin/config.toml` (symlink strategy, `core` tag,
-`darwin`+`linux`). The portable Catppuccin Mocha theme it references is installed
-alongside it as `~/.config/atuin/themes/catppuccin-mocha.toml`.
+materialized as a regular `~/.config/atuin/config.toml` file (`copy` strategy,
+TOML Subset Ownership, `core` tag, `darwin`+`linux`). The portable Catppuccin
+Mocha theme it references remains a dots-owned symlink at
+`~/.config/atuin/themes/catppuccin-mocha.toml`.
 
-The Source of Truth is this repository. The installed files are links to the
-tracked sources; shell history, sync/auth state, machine identity, generated
-files, and machine-local overrides stay outside version control.
+The Source of Truth owns only the baseline scalar and array values declared in
+the tracked config. Atuin may add other keys or tables to the regular live file
+without modifying the Installed Repository or creating Drift. Shell history,
+sync/auth state, machine identity, generated files, and machine-local overrides
+stay outside version control.
 
 ## Prerequisites
 
@@ -52,8 +55,9 @@ directory:
 - **Sync records** — `~/.local/share/atuin/records.db`
 - **Machine identity** — `~/.local/share/atuin/host_id`
 
-`dots` only symlinks the two tracked config files into `~/.config/atuin/`; it
-never reads, writes, or links anything in the data directory. The
+`dots` materializes the co-owned config and symlinks only the static theme into
+`~/.config/atuin/`; it never reads, writes, or links anything in the data
+directory. The
 `configs/atuin/.gitignore` additionally guards the config directory against any
 of these files being committed if a machine relocates them there via
 `ATUIN_CONFIG_DIR` or a custom `data_dir`.
@@ -122,5 +126,6 @@ go run ./cmd/dots status \
 
 The expected result is that `~/.config/atuin/config.toml` and
 `~/.config/atuin/themes/catppuccin-mocha.toml` are installed/aligned inside
-`$sandbox_home` as symlinks to the repository sources. The maintainer's real home
-directory must not be touched.
+`$sandbox_home`: the config is a regular co-owned TOML target and the static
+theme is a symlink to the repository source. The maintainer's real home directory
+must not be touched.

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -160,6 +160,14 @@ updates preserve target-only object keys plus untouched comments, trailing
 commas, ordering, and formatting. A changed owned scalar or array is Drift for
 a recorded target and a Conflict without trusted Installation Metadata.
 
+For a `toml-subset` target, dots owns baseline values declared at root or in
+ordinary tables. Scalars, arrays, and inline tables are atomic; target-only keys
+and tables remain outside dots ownership. Exact prior-contribution evidence
+allows compatible baseline additions, replacements, and removals without
+rewriting unrelated comments or formatting. Changed owned values remain Drift
+and are never overwritten. Uninstall subtracts only unchanged recorded values
+and preserves external content.
+
 For `seeded` ownership, dots stores the exact opaque baseline in Installation
 Metadata. Missing state is seeded; live state still equal to the prior baseline
 advances to the current baseline after a Backup Set; and locally evolved state
@@ -196,7 +204,7 @@ Current Managed Entries:
 | `configs/warp/keybindings.yaml` | `~/.warp/keybindings.yaml` | `copy` | `desktop` | `darwin` | None |
 | `configs/warp/settings.toml` | `~/.config/warp-terminal/settings.toml` | `copy` | `desktop` | `linux` | `Warp` |
 | `configs/warp/keybindings.yaml` | `~/.config/warp-terminal/keybindings.yaml` | `copy` | `desktop` | `linux` | `Warp` |
-| `configs/atuin/config.toml` | `~/.config/atuin/config.toml` | `symlink` | `core` | `darwin`, `linux` | `atuin` |
+| `configs/atuin/config.toml` | `~/.config/atuin/config.toml` | `copy` | `core` | `darwin`, `linux` | `atuin`; owns TOML subset |
 | `configs/atuin/themes/catppuccin-mocha.toml` | `~/.config/atuin/themes/catppuccin-mocha.toml` | `symlink` | `core` | `darwin`, `linux` | `atuin` |
 | `configs/bat/config` | `~/.config/bat/config` | `symlink` | `core` | `darwin`, `linux` | `bat` |
 | `configs/nvim/lazy-lock.json` | `$XDG_STATE_HOME/nvim/lazy-lock.json` | `copy` (`seeded`) | `core` | `darwin`, `linux` | None |

--- a/dots.yaml
+++ b/dots.yaml
@@ -420,7 +420,8 @@ entries:
         command: warp-terminal
   - source: configs/atuin/config.toml
     target: ~/.config/atuin/config.toml
-    strategy: symlink
+    strategy: copy
+    ownership: toml-subset
     tags:
       - core
     os:

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/exp/teatest v0.0.0-20260607010151-cd19a2bba55f
+	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/spf13/cobra v1.8.1
 	github.com/tailscale/hujson v0.0.0-20241010212012-29efb4a0184b
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELU
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
+github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=
+github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/internal/cli/atuin_config_test.go
+++ b/internal/cli/atuin_config_test.go
@@ -39,16 +39,19 @@ func TestAtuinDefaultProfileInstallsAndReportsAlignedInSandbox(t *testing.T) {
 	}
 
 	managed := []struct {
-		target string
-		source string
+		target  string
+		source  string
+		symlink bool
 	}{
 		{
-			target: filepath.Join(home, ".config", "atuin", "config.toml"),
-			source: filepath.Join(repoRoot, "configs", "atuin", "config.toml"),
+			target:  filepath.Join(home, ".config", "atuin", "config.toml"),
+			source:  filepath.Join(repoRoot, "configs", "atuin", "config.toml"),
+			symlink: false,
 		},
 		{
-			target: filepath.Join(home, ".config", "atuin", "themes", "catppuccin-mocha.toml"),
-			source: filepath.Join(repoRoot, "configs", "atuin", "themes", "catppuccin-mocha.toml"),
+			target:  filepath.Join(home, ".config", "atuin", "themes", "catppuccin-mocha.toml"),
+			source:  filepath.Join(repoRoot, "configs", "atuin", "themes", "catppuccin-mocha.toml"),
+			symlink: true,
 		},
 	}
 
@@ -57,16 +60,42 @@ func TestAtuinDefaultProfileInstallsAndReportsAlignedInSandbox(t *testing.T) {
 		if err != nil {
 			t.Fatalf("atuin target %q missing after sandbox install: %v\ninstall output:\n%s", entry.target, err, installOut.String())
 		}
-		if info.Mode()&os.ModeSymlink == 0 {
-			t.Fatalf("atuin target %q mode = %v, want symlink", entry.target, info.Mode())
+		if entry.symlink {
+			if info.Mode()&os.ModeSymlink == 0 {
+				t.Fatalf("atuin target %q mode = %v, want symlink", entry.target, info.Mode())
+			}
+			gotSource, err := os.Readlink(entry.target)
+			if err != nil {
+				t.Fatalf("read atuin symlink %q: %v", entry.target, err)
+			}
+			if gotSource != entry.source {
+				t.Fatalf("atuin symlink %q = %q, want %q", entry.target, gotSource, entry.source)
+			}
+		} else if !info.Mode().IsRegular() {
+			t.Fatalf("atuin target %q mode = %v, want regular file", entry.target, info.Mode())
 		}
-		gotSource, err := os.Readlink(entry.target)
-		if err != nil {
-			t.Fatalf("read atuin symlink %q: %v", entry.target, err)
-		}
-		if gotSource != entry.source {
-			t.Fatalf("atuin symlink %q = %q, want %q", entry.target, gotSource, entry.source)
-		}
+	}
+
+	sourceBefore, err := os.ReadFile(managed[0].source)
+	if err != nil {
+		t.Fatalf("read Atuin Source of Truth: %v", err)
+	}
+	target, err := os.OpenFile(managed[0].target, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("open live Atuin config: %v", err)
+	}
+	if _, err := target.WriteString("\n# written like atuin config set\nsearch_mode = \"fuzzy\"\n"); err != nil {
+		t.Fatalf("append live Atuin setting: %v", err)
+	}
+	if err := target.Close(); err != nil {
+		t.Fatalf("close live Atuin config: %v", err)
+	}
+	sourceAfter, err := os.ReadFile(managed[0].source)
+	if err != nil {
+		t.Fatalf("reread Atuin Source of Truth: %v", err)
+	}
+	if !bytes.Equal(sourceAfter, sourceBefore) {
+		t.Fatal("Atuin-like target write changed the repository Source of Truth")
 	}
 
 	// History/sync/auth state lives in the data dir, never the config dir, so a

--- a/internal/configsubset/subset.go
+++ b/internal/configsubset/subset.go
@@ -1,5 +1,5 @@
 // Package configsubset compares dots-owned configuration fragments against
-// co-owned agent configuration files.
+// co-owned structured configuration files.
 package configsubset
 
 import (
@@ -239,74 +239,9 @@ func MergeJSONFile(target, source string) error {
 	return nil
 }
 
-// TOMLFileContains reports whether target contains every scalar/array setting
-// present in source. The source is parsed strictly because it is the dots-owned
-// fragment. The target is parsed only for source-owned paths, so unrelated TOML
-// added by Codex or provisioners cannot make the dots-owned subset drift.
-func TOMLFileContains(target, source string) (bool, error) {
-	sourceData, err := os.ReadFile(source)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
-		}
-		return false, fmt.Errorf("read %s: %w", source, err)
-	}
-	targetData, err := os.ReadFile(target)
-	if err != nil {
-		return false, fmt.Errorf("read %s: %w", target, err)
-	}
-
-	sourceValues, err := parseSimpleTOML(sourceData, nil)
-	if err != nil {
-		return false, fmt.Errorf("parse source TOML %s: %w", source, err)
-	}
-	targetValues, err := parseSimpleTOML(targetData, sourceValuePaths(sourceValues))
-	if err != nil {
-		return false, nil
-	}
-	for key, sourceValue := range sourceValues {
-		if targetValues[key] != sourceValue {
-			return false, nil
-		}
-	}
-	return true, nil
-}
-
-// MergeTOMLFile appends missing source-owned array-of-table blocks to target.
-// It is intentionally narrower than a full TOML formatter: dots only needs this
-// for co-owned Codex config hooks, where preserving user/Codex-owned settings is
-// more important than reformatting the whole file. Scalar/table value changes
-// remain conflicts unless a caller adds a dedicated migration.
-func MergeTOMLFile(target, source string) error {
-	sourceData, err := os.ReadFile(source)
-	if err != nil {
-		return fmt.Errorf("read %s: %w", source, err)
-	}
-	targetData, err := os.ReadFile(target)
-	if err != nil {
-		return fmt.Errorf("read %s: %w", target, err)
-	}
-	merged, err := MergeTOML(targetData, sourceData)
-	if err != nil {
-		return err
-	}
-	if bytes.Equal(merged, targetData) {
-		return nil
-	}
-	info, err := os.Stat(target)
-	if err != nil {
-		return fmt.Errorf("stat %s: %w", target, err)
-	}
-	if err := os.WriteFile(target, merged, info.Mode().Perm()); err != nil {
-		return fmt.Errorf("write %s: %w", target, err)
-	}
-	return nil
-}
-
-// MergeTOML returns the conservative co-owned TOML merge without touching the
-// filesystem. It is used by repository-refresh migration planning so dry-run
-// can prove the exact regular-file content before any checkout or target write.
-func MergeTOML(targetData, sourceData []byte) ([]byte, error) {
+// mergeLegacyTOML preserves the existing array-of-table append behavior used by
+// Codex hook fragments. Ordinary table/scalar ownership uses toml.go.
+func mergeLegacyTOML(targetData, sourceData []byte) ([]byte, error) {
 	sourceValues, err := parseSimpleTOML(sourceData, nil)
 	if err != nil {
 		return nil, fmt.Errorf("parse source TOML: %w", err)

--- a/internal/configsubset/subset_test.go
+++ b/internal/configsubset/subset_test.go
@@ -540,7 +540,7 @@ name = "catppuccin-mocha"
 `)
 	target := []byte(`# Atuin local configuration.
 enter_accept    = true # keep inline note
-retired = "old"
+retired = "old" # preserve retired note
 external = "untouched"
 
 [sync]
@@ -558,6 +558,7 @@ runtime = false # Atuin wrote this
 	got := string(reconciliation.Content)
 	for _, want := range []string{
 		"# Atuin local configuration.\n",
+		"# preserve retired note\n",
 		"enter_accept = false # keep inline note\n",
 		"external = \"untouched\"\n",
 		"runtime = false # Atuin wrote this\n",
@@ -645,6 +646,24 @@ func TestRemoveTOMLRemovesWholeMultilineArrayExpression(t *testing.T) {
 	}
 	if !compatible || !changed || empty || string(content) != "external = true\n" {
 		t.Fatalf("RemoveTOML() = (%q, %v, %v, %v), want only external value", content, changed, empty, compatible)
+	}
+}
+
+func TestRemoveTOMLPreservesCommentsInsideRemovedMultilineArray(t *testing.T) {
+	owned := []byte("history_filter = [\n  \"pwd\",\n  \"ls\",\n]\n")
+	target := []byte("history_filter = [ # keep array note\n  \"pwd\", # keep item note\n  \"ls\",\n]\nexternal = true\n")
+
+	content, changed, empty, compatible, err := RemoveTOML(target, owned)
+	if err != nil {
+		t.Fatalf("RemoveTOML() error = %v", err)
+	}
+	if !compatible || !changed || empty {
+		t.Fatalf("RemoveTOML() = (%q, %v, %v, %v), want compatible partial removal", content, changed, empty, compatible)
+	}
+	for _, want := range []string{"# keep array note\n", "# keep item note\n", "external = true\n"} {
+		if !strings.Contains(string(content), want) {
+			t.Fatalf("TOML after removal missing %q:\n%s", want, content)
+		}
 	}
 }
 

--- a/internal/configsubset/subset_test.go
+++ b/internal/configsubset/subset_test.go
@@ -666,3 +666,39 @@ func TestMergeTOMLSupportsTargetOnlyTablesAndMultilineAtomicArrays(t *testing.T)
 		t.Fatalf("AnalyzeTOML() = (%#v, %v), want contains", relation, err)
 	}
 }
+
+func TestMergeTOMLExtendsExternalTableExpressedWithDottedKey(t *testing.T) {
+	source := []byte("[sync]\nrecords = true\n")
+	target := []byte("# external dotted table\nsync.runtime = false # untouched\n")
+
+	merged, err := MergeTOML(target, source)
+	if err != nil {
+		t.Fatalf("MergeTOML() error = %v", err)
+	}
+	for _, want := range []string{
+		"# external dotted table\n",
+		"sync.runtime = false # untouched\n",
+		"sync.records = true\n",
+	} {
+		if !strings.Contains(string(merged), want) {
+			t.Fatalf("merged TOML missing %q:\n%s", want, merged)
+		}
+	}
+	relation, err := AnalyzeTOML(merged, source)
+	if err != nil || !relation.Contains {
+		t.Fatalf("AnalyzeTOML() = (%#v, %v), want contains", relation, err)
+	}
+}
+
+func TestMergeTOMLRendersQuotedDottedOwnershipPath(t *testing.T) {
+	source := []byte("[sync]\n\"record=key\" = true\n")
+	target := []byte("sync.runtime = false\n")
+
+	merged, err := MergeTOML(target, source)
+	if err != nil {
+		t.Fatalf("MergeTOML() error = %v", err)
+	}
+	if !strings.Contains(string(merged), "sync.\"record=key\" = true\n") {
+		t.Fatalf("merged TOML did not render quoted dotted key safely:\n%s", merged)
+	}
+}

--- a/internal/configsubset/subset_test.go
+++ b/internal/configsubset/subset_test.go
@@ -1,6 +1,7 @@
 package configsubset
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -517,5 +518,151 @@ theme = "catppuccin-mocha"
 	}
 	if gotMode := info.Mode().Perm(); gotMode != 0o640 {
 		t.Fatalf("target mode = %v, want 0640", gotMode)
+	}
+}
+
+func TestReconcileTOMLPreservesFormattingWhileAddingRemovingAndChangingValues(t *testing.T) {
+	previous := []byte(`enter_accept = true
+retired = "old"
+
+[sync]
+records = true
+`)
+	current := []byte(`enter_accept = false
+new_root = 42
+
+[sync]
+records = true
+new_setting = ["one", "two"]
+
+[theme]
+name = "catppuccin-mocha"
+`)
+	target := []byte(`# Atuin local configuration.
+enter_accept    = true # keep inline note
+retired = "old"
+external = "untouched"
+
+[sync]
+records = true
+runtime = false # Atuin wrote this
+`)
+
+	reconciliation, err := ReconcileTOML(target, previous, current)
+	if err != nil {
+		t.Fatalf("ReconcileTOML() error = %v", err)
+	}
+	if !reconciliation.Compatible || !reconciliation.Changed {
+		t.Fatalf("ReconcileTOML() = %#v, want compatible change", reconciliation)
+	}
+	got := string(reconciliation.Content)
+	for _, want := range []string{
+		"# Atuin local configuration.\n",
+		"enter_accept = false # keep inline note\n",
+		"external = \"untouched\"\n",
+		"runtime = false # Atuin wrote this\n",
+		"new_root = 42\n",
+		"new_setting = [\"one\", \"two\"]\n",
+		"[theme]\nname = \"catppuccin-mocha\"\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("reconciled TOML missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, `retired = "old"`) {
+		t.Fatalf("reconciled TOML retained retired value:\n%s", got)
+	}
+}
+
+func TestReconcileTOMLRejectsChangedOwnedAtomicArray(t *testing.T) {
+	owned := []byte("history_filter = [\"pwd\", \"ls\"]\n")
+	target := []byte("history_filter = [\"pwd\"]\nexternal = true\n")
+
+	reconciliation, err := ReconcileTOML(target, owned, owned)
+	if err != nil {
+		t.Fatalf("ReconcileTOML() error = %v", err)
+	}
+	if reconciliation.Compatible {
+		t.Fatalf("ReconcileTOML() = %#v, want incompatible changed array", reconciliation)
+	}
+}
+
+func TestRemoveTOMLPreservesExternalKeysTablesCommentsAndFormatting(t *testing.T) {
+	owned := []byte(`enter_accept = true
+
+[sync]
+records = true
+`)
+	target := []byte(`# local note
+enter_accept = true
+external    = "keep"
+
+[sync]
+records = true
+runtime = false
+
+[external_table]
+value = 7
+`)
+
+	content, changed, empty, compatible, err := RemoveTOML(target, owned)
+	if err != nil {
+		t.Fatalf("RemoveTOML() error = %v", err)
+	}
+	if !compatible || !changed || empty {
+		t.Fatalf("RemoveTOML() = changed %v, empty %v, compatible %v", changed, empty, compatible)
+	}
+	got := string(content)
+	for _, want := range []string{"# local note\n", `external    = "keep"`, "runtime = false", "[external_table]\nvalue = 7"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("TOML after removal missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "enter_accept") || strings.Contains(got, "records = true") {
+		t.Fatalf("TOML after removal retained owned values:\n%s", got)
+	}
+}
+
+func TestRemoveTOMLReportsSemanticallyEmptyDocumentWithoutComments(t *testing.T) {
+	owned := []byte("enter_accept = true\n\n[sync]\nrecords = true\n")
+
+	content, changed, empty, compatible, err := RemoveTOML(owned, owned)
+	if err != nil {
+		t.Fatalf("RemoveTOML() error = %v", err)
+	}
+	if !compatible || !changed || !empty {
+		t.Fatalf("RemoveTOML() = (%q, %v, %v, %v), want changed compatible empty", content, changed, empty, compatible)
+	}
+}
+
+func TestRemoveTOMLRemovesWholeMultilineArrayExpression(t *testing.T) {
+	owned := []byte("history_filter = [\n  \"pwd\",\n  \"ls\",\n]\n")
+	target := append(append([]byte(nil), owned...), []byte("external = true\n")...)
+
+	content, changed, empty, compatible, err := RemoveTOML(target, owned)
+	if err != nil {
+		t.Fatalf("RemoveTOML() error = %v", err)
+	}
+	if !compatible || !changed || empty || string(content) != "external = true\n" {
+		t.Fatalf("RemoveTOML() = (%q, %v, %v, %v), want only external value", content, changed, empty, compatible)
+	}
+}
+
+func TestMergeTOMLSupportsTargetOnlyTablesAndMultilineAtomicArrays(t *testing.T) {
+	source := []byte("history_filter = [\n  \"pwd\",\n  \"ls\",\n]\n\n[sync]\nrecords = true\n")
+	target := []byte("# untouched\nexternal = 1\n\n[application]\nvalue = { enabled = true }\n")
+
+	merged, err := MergeTOML(target, source)
+	if err != nil {
+		t.Fatalf("MergeTOML() error = %v", err)
+	}
+	for _, untouched := range []string{"# untouched\nexternal = 1\n", "[application]\nvalue = { enabled = true }\n"} {
+		if !bytes.Contains(merged, []byte(untouched)) {
+			t.Fatalf("MergeTOML() changed existing bytes %q:\n%s", untouched, merged)
+		}
+	}
+	relation, err := AnalyzeTOML(merged, source)
+	if err != nil || !relation.Contains {
+		t.Fatalf("AnalyzeTOML() = (%#v, %v), want contains", relation, err)
 	}
 }

--- a/internal/configsubset/toml.go
+++ b/internal/configsubset/toml.go
@@ -240,7 +240,11 @@ func reconcileParsedTOML(targetData []byte, previous, current *tomlDocument) (TO
 			if !tomlValuesEqual(targetValue, previousValue) {
 				return TOMLReconciliation{}, nil
 			}
-			edits = append(edits, tomlEdit{start: targetEntry.lineStart, end: targetEntry.lineEnd})
+			edits = append(edits, tomlEdit{
+				start:   targetEntry.lineStart,
+				end:     targetEntry.lineEnd,
+				content: tomlCommentsForRemoval(targetData[targetEntry.lineStart:targetEntry.lineEnd]),
+			})
 			continue
 		}
 		currentValue, ok := tomlValueAt(current.values, currentEntry.path)
@@ -653,6 +657,46 @@ func tomlContainsComments(data []byte) bool {
 		}
 	}
 	return false
+}
+
+func tomlCommentsForRemoval(expression []byte) []byte {
+	parser := unstable.Parser{KeepComments: true}
+	parser.Reset(expression)
+	comments := map[int][]byte{}
+	var offsets []int
+	for parser.NextExpression() {
+		collectTOMLComments(parser.Expression(), comments, &offsets)
+	}
+	if parser.Error() != nil {
+		return nil
+	}
+	sort.Ints(offsets)
+	var result []byte
+	for _, offset := range offsets {
+		lineStart := bytes.LastIndexByte(expression[:offset], '\n') + 1
+		prefix := expression[lineStart:offset]
+		if len(bytes.TrimSpace(prefix)) == 0 {
+			result = append(result, prefix...)
+		}
+		result = append(result, comments[offset]...)
+		result = append(result, '\n')
+	}
+	return result
+}
+
+func collectTOMLComments(node *unstable.Node, comments map[int][]byte, offsets *[]int) {
+	if node == nil {
+		return
+	}
+	if node.Kind == unstable.Comment {
+		offset := int(node.Raw.Offset)
+		if _, exists := comments[offset]; !exists {
+			comments[offset] = append([]byte(nil), node.Data...)
+			*offsets = append(*offsets, offset)
+		}
+	}
+	collectTOMLComments(node.Child(), comments, offsets)
+	collectTOMLComments(node.Next(), comments, offsets)
 }
 
 func tomlNodeContainsComment(node *unstable.Node) bool {

--- a/internal/configsubset/toml.go
+++ b/internal/configsubset/toml.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/pelletier/go-toml/v2"
@@ -278,7 +279,12 @@ func reconcileParsedTOML(targetData []byte, previous, current *tomlDocument) (TO
 		if currentEntry.tableKey != "" {
 			if _, tableExists := tomlValueAt(target.values, current.sections[currentEntry.tableKey].path); tableExists {
 				if _, sectionExists := target.sections[currentEntry.tableKey]; !sectionExists {
-					return TOMLReconciliation{}, nil
+					dotted, ok := renderDottedTOMLEntry(currentEntry.path, currentEntry.raw)
+					if !ok {
+						return TOMLReconciliation{}, nil
+					}
+					currentEntry.tableKey = ""
+					currentEntry.raw = dotted
 				}
 			}
 		}
@@ -520,6 +526,58 @@ func joinTOMLEntries(entries []tomlEntry) []byte {
 		result = append(result, entry.raw...)
 	}
 	return result
+}
+
+func renderDottedTOMLEntry(path []string, expression []byte) ([]byte, bool) {
+	equals := tomlAssignmentEquals(expression)
+	if equals < 0 {
+		return nil, false
+	}
+	parts := make([]string, len(path))
+	for index, part := range path {
+		if isBareTOMLKey(part) {
+			parts[index] = part
+		} else {
+			parts[index] = strconv.Quote(part)
+		}
+	}
+	result := []byte(strings.Join(parts, ".") + " ")
+	result = append(result, expression[equals:]...)
+	return result, true
+}
+
+func tomlAssignmentEquals(expression []byte) int {
+	inBasicString := false
+	inLiteralString := false
+	escaped := false
+	for index, value := range expression {
+		switch {
+		case escaped:
+			escaped = false
+		case inBasicString && value == '\\':
+			escaped = true
+		case !inLiteralString && value == '"':
+			inBasicString = !inBasicString
+		case !inBasicString && value == '\'':
+			inLiteralString = !inLiteralString
+		case !inBasicString && !inLiteralString && value == '=':
+			return index
+		}
+	}
+	return -1
+}
+
+func isBareTOMLKey(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, char := range value {
+		if (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') || (char >= '0' && char <= '9') || char == '_' || char == '-' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func formatTOMLInsertion(data []byte, offset int, addition []byte, separate bool) []byte {

--- a/internal/configsubset/toml.go
+++ b/internal/configsubset/toml.go
@@ -1,0 +1,608 @@
+package configsubset
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/pelletier/go-toml/v2"
+	"github.com/pelletier/go-toml/v2/unstable"
+)
+
+// TOMLReconciliation describes a safe three-state update from a previously
+// recorded dots-owned TOML contribution to the current Source of Truth.
+type TOMLReconciliation struct {
+	Content    []byte
+	Changed    bool
+	Compatible bool
+}
+
+type tomlEntry struct {
+	path      []string
+	tableKey  string
+	exprStart int
+	exprEnd   int
+	lineStart int
+	lineEnd   int
+	raw       []byte
+}
+
+type tomlSection struct {
+	path      []string
+	headerRaw []byte
+	insertAt  int
+}
+
+type tomlDocument struct {
+	values         map[string]any
+	entries        map[string]tomlEntry
+	entryOrder     []string
+	sections       map[string]tomlSection
+	hasArrayTables bool
+}
+
+type tomlEdit struct {
+	start   int
+	end     int
+	content []byte
+}
+
+// AnalyzeTOML compares a live target with a source-owned TOML fragment. Tables
+// are containers whose declared values are owned individually; scalar, array,
+// and inline-table values are atomic. Target-only keys and tables are allowed.
+func AnalyzeTOML(targetData, sourceData []byte) (JSONFileRelation, error) {
+	source, err := parseTOMLDocument(sourceData)
+	if err != nil {
+		return JSONFileRelation{}, fmt.Errorf("parse source TOML: %w", err)
+	}
+	if source.hasArrayTables {
+		merged, mergeErr := mergeLegacyTOML(targetData, sourceData)
+		if mergeErr != nil {
+			return JSONFileRelation{}, nil
+		}
+		return JSONFileRelation{Contains: bytes.Equal(merged, targetData), Mergeable: !bytes.Equal(merged, targetData)}, nil
+	}
+	result, err := reconcileParsedTOML(targetData, nil, source)
+	if err != nil {
+		return JSONFileRelation{}, err
+	}
+	return JSONFileRelation{
+		Contains:  result.Compatible && !result.Changed,
+		Mergeable: result.Compatible && result.Changed,
+	}, nil
+}
+
+// TOMLFileContains reports whether target contains every source-owned value.
+func TOMLFileContains(target, source string) (bool, error) {
+	sourceData, err := os.ReadFile(source)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read %s: %w", source, err)
+	}
+	targetData, err := os.ReadFile(target)
+	if err != nil {
+		return false, fmt.Errorf("read %s: %w", target, err)
+	}
+	relation, err := AnalyzeTOML(targetData, sourceData)
+	if err != nil {
+		return false, fmt.Errorf("analyze source TOML %s: %w", source, err)
+	}
+	return relation.Contains, nil
+}
+
+// MergeTOML adds missing source-owned values while preserving all unrelated
+// target bytes. Existing incompatible values are never overwritten.
+func MergeTOML(targetData, sourceData []byte) ([]byte, error) {
+	source, err := parseTOMLDocument(sourceData)
+	if err != nil {
+		return nil, fmt.Errorf("parse source TOML: %w", err)
+	}
+	if source.hasArrayTables {
+		return mergeLegacyTOML(targetData, sourceData)
+	}
+	result, err := reconcileParsedTOML(targetData, nil, source)
+	if err != nil {
+		return nil, err
+	}
+	if !result.Compatible {
+		return nil, fmt.Errorf("source-owned TOML differences cannot be merged safely")
+	}
+	return result.Content, nil
+}
+
+// MergeTOMLFile applies MergeTOML without changing the target's permissions.
+func MergeTOMLFile(target, source string) error {
+	sourceData, err := os.ReadFile(source)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", source, err)
+	}
+	targetData, err := os.ReadFile(target)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", target, err)
+	}
+	merged, err := MergeTOML(targetData, sourceData)
+	if err != nil {
+		return fmt.Errorf("merge target TOML %s with source TOML %s: %w", target, source, err)
+	}
+	if bytes.Equal(merged, targetData) {
+		return nil
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", target, err)
+	}
+	if err := os.WriteFile(target, merged, info.Mode().Perm()); err != nil {
+		return fmt.Errorf("write %s: %w", target, err)
+	}
+	return nil
+}
+
+// ReconcileTOML adds new values, removes retired values that still match their
+// recorded contribution, and replaces changed baseline values only when the
+// live target still matches either the previous or current atomic value.
+func ReconcileTOML(targetData, previousData, currentData []byte) (TOMLReconciliation, error) {
+	previous, err := parseTOMLDocument(previousData)
+	if err != nil {
+		return TOMLReconciliation{}, fmt.Errorf("parse previous owned TOML: %w", err)
+	}
+	current, err := parseTOMLDocument(currentData)
+	if err != nil {
+		return TOMLReconciliation{}, fmt.Errorf("parse current owned TOML: %w", err)
+	}
+	if previous.hasArrayTables || current.hasArrayTables {
+		if !previous.hasArrayTables && current.hasArrayTables {
+			ordinary, reconcileErr := reconcileParsedTOML(targetData, previous, current)
+			if reconcileErr != nil || !ordinary.Compatible {
+				return TOMLReconciliation{}, reconcileErr
+			}
+			merged, mergeErr := mergeLegacyTOML(ordinary.Content, currentData)
+			if mergeErr != nil {
+				return TOMLReconciliation{}, nil
+			}
+			return TOMLReconciliation{Content: merged, Changed: !bytes.Equal(merged, targetData), Compatible: true}, nil
+		}
+		if !bytes.Equal(previousData, currentData) {
+			return TOMLReconciliation{}, nil
+		}
+		merged, mergeErr := mergeLegacyTOML(targetData, currentData)
+		if mergeErr != nil {
+			return TOMLReconciliation{}, nil
+		}
+		return TOMLReconciliation{Content: merged, Changed: !bytes.Equal(merged, targetData), Compatible: true}, nil
+	}
+	return reconcileParsedTOML(targetData, previous, current)
+}
+
+// RemoveTOML subtracts the exact recorded dots-owned TOML contribution. It
+// preserves target-only bytes and fails closed when a formerly owned value has
+// changed. Empty is false when comments remain, so uninstall never discards
+// unclassified human or application notes.
+func RemoveTOML(targetData, ownedData []byte) (content []byte, changed, empty, compatible bool, err error) {
+	owned, parseErr := parseTOMLDocument(ownedData)
+	if parseErr != nil {
+		return nil, false, false, false, fmt.Errorf("parse owned TOML: %w", parseErr)
+	}
+	if owned.hasArrayTables {
+		return nil, false, false, false, nil
+	}
+	result, reconcileErr := reconcileParsedTOML(targetData, owned, &tomlDocument{
+		values:     map[string]any{},
+		entries:    map[string]tomlEntry{},
+		sections:   map[string]tomlSection{"": {}},
+		entryOrder: nil,
+	})
+	if reconcileErr != nil {
+		return nil, false, false, false, reconcileErr
+	}
+	if !result.Compatible {
+		return nil, false, false, false, nil
+	}
+	document, parseErr := parseTOMLDocument(result.Content)
+	if parseErr != nil {
+		return nil, false, false, false, fmt.Errorf("parse TOML after removing owned content: %w", parseErr)
+	}
+	empty = tomlValueEmpty(document.values) && !tomlContainsComments(result.Content)
+	return result.Content, result.Changed, empty, true, nil
+}
+
+func reconcileParsedTOML(targetData []byte, previous, current *tomlDocument) (TOMLReconciliation, error) {
+	target, err := parseTOMLDocument(targetData)
+	if err != nil {
+		return TOMLReconciliation{}, nil
+	}
+	if previous == nil {
+		previous = &tomlDocument{values: map[string]any{}, entries: map[string]tomlEntry{}, sections: map[string]tomlSection{}}
+	}
+
+	var edits []tomlEdit
+	additions := map[string][]tomlEntry{}
+	var additionOrder []string
+	for _, pathKey := range previous.entryOrder {
+		previousEntry := previous.entries[pathKey]
+		previousValue, ok := tomlValueAt(previous.values, previousEntry.path)
+		if !ok {
+			return TOMLReconciliation{}, fmt.Errorf("previous owned TOML path %q has no semantic value", displayTOMLPath(previousEntry.path))
+		}
+		targetValue, targetExists := tomlValueAt(target.values, previousEntry.path)
+		targetEntry, targetHasExpression := target.entries[pathKey]
+		if !targetExists || !targetHasExpression {
+			return TOMLReconciliation{}, nil
+		}
+		currentEntry, remainsOwned := current.entries[pathKey]
+		if !remainsOwned {
+			if !tomlValuesEqual(targetValue, previousValue) {
+				return TOMLReconciliation{}, nil
+			}
+			edits = append(edits, tomlEdit{start: targetEntry.lineStart, end: targetEntry.lineEnd})
+			continue
+		}
+		currentValue, ok := tomlValueAt(current.values, currentEntry.path)
+		if !ok {
+			return TOMLReconciliation{}, fmt.Errorf("current owned TOML path %q has no semantic value", displayTOMLPath(currentEntry.path))
+		}
+		switch {
+		case tomlValuesEqual(targetValue, currentValue):
+			continue
+		case tomlValuesEqual(targetValue, previousValue):
+			if targetEntry.tableKey != currentEntry.tableKey {
+				return TOMLReconciliation{}, nil
+			}
+			edits = append(edits, tomlEdit{start: targetEntry.exprStart, end: targetEntry.exprEnd, content: append([]byte(nil), currentEntry.raw...)})
+		default:
+			return TOMLReconciliation{}, nil
+		}
+	}
+
+	for _, pathKey := range current.entryOrder {
+		if _, existed := previous.entries[pathKey]; existed {
+			continue
+		}
+		currentEntry := current.entries[pathKey]
+		currentValue, ok := tomlValueAt(current.values, currentEntry.path)
+		if !ok {
+			return TOMLReconciliation{}, fmt.Errorf("current owned TOML path %q has no semantic value", displayTOMLPath(currentEntry.path))
+		}
+		targetValue, targetExists := tomlValueAt(target.values, currentEntry.path)
+		if targetExists {
+			if !tomlValuesEqual(targetValue, currentValue) {
+				return TOMLReconciliation{}, nil
+			}
+			continue
+		}
+		if currentEntry.tableKey != "" {
+			if _, tableExists := tomlValueAt(target.values, current.sections[currentEntry.tableKey].path); tableExists {
+				if _, sectionExists := target.sections[currentEntry.tableKey]; !sectionExists {
+					return TOMLReconciliation{}, nil
+				}
+			}
+		}
+		if _, exists := additions[currentEntry.tableKey]; !exists {
+			additionOrder = append(additionOrder, currentEntry.tableKey)
+		}
+		additions[currentEntry.tableKey] = append(additions[currentEntry.tableKey], currentEntry)
+	}
+
+	for _, tableKey := range additionOrder {
+		entries := additions[tableKey]
+		section, exists := target.sections[tableKey]
+		var addition []byte
+		if exists {
+			addition = joinTOMLEntries(entries)
+			edits = append(edits, tomlEdit{start: section.insertAt, end: section.insertAt, content: formatTOMLInsertion(targetData, section.insertAt, addition, false)})
+			continue
+		}
+		sourceSection, ok := current.sections[tableKey]
+		if !ok || tableKey == "" {
+			return TOMLReconciliation{}, fmt.Errorf("current owned TOML section %q is missing", displayTOMLPath(entries[0].path[:len(entries[0].path)-1]))
+		}
+		addition = append(addition, sourceSection.headerRaw...)
+		addition = append(addition, '\n')
+		addition = append(addition, joinTOMLEntries(entries)...)
+		edits = append(edits, tomlEdit{start: len(targetData), end: len(targetData), content: formatTOMLInsertion(targetData, len(targetData), addition, true)})
+	}
+
+	content, err := applyTOMLEdits(targetData, edits)
+	if err != nil {
+		return TOMLReconciliation{}, err
+	}
+	final, err := parseTOMLDocument(content)
+	if err != nil {
+		return TOMLReconciliation{}, nil
+	}
+	for _, pathKey := range current.entryOrder {
+		entry := current.entries[pathKey]
+		want, _ := tomlValueAt(current.values, entry.path)
+		got, ok := tomlValueAt(final.values, entry.path)
+		if !ok || !tomlValuesEqual(got, want) {
+			return TOMLReconciliation{}, nil
+		}
+	}
+	return TOMLReconciliation{Content: content, Changed: !bytes.Equal(content, targetData), Compatible: true}, nil
+}
+
+func parseTOMLDocument(data []byte) (*tomlDocument, error) {
+	values := map[string]any{}
+	if err := toml.Unmarshal(data, &values); err != nil {
+		return nil, err
+	}
+	document := &tomlDocument{
+		values:   values,
+		entries:  map[string]tomlEntry{},
+		sections: map[string]tomlSection{"": {insertAt: len(data)}},
+	}
+	parser := unstable.Parser{}
+	parser.Reset(data)
+	var currentTable []string
+	currentTableKey := ""
+	skipArrayTable := false
+	activeSectionKey := ""
+	hasActiveSection := true
+	for parser.NextExpression() {
+		expression := parser.Expression()
+		switch expression.Kind {
+		case unstable.Table, unstable.ArrayTable:
+			path := tomlNodeKey(expression)
+			lineStart, lineEnd := tomlLineBounds(data, tomlNodeOffset(expression))
+			if hasActiveSection {
+				previous := document.sections[activeSectionKey]
+				previous.insertAt = tomlInsertionPoint(data, lineStart)
+				document.sections[activeSectionKey] = previous
+			}
+			currentTable = path
+			currentTableKey = tomlPathKey(path)
+			skipArrayTable = expression.Kind == unstable.ArrayTable
+			if skipArrayTable {
+				document.hasArrayTables = true
+				hasActiveSection = false
+				continue
+			}
+			section := tomlSection{
+				path:      append([]string(nil), path...),
+				headerRaw: bytes.TrimRight(data[lineStart:lineEnd], "\r\n"),
+				insertAt:  len(data),
+			}
+			document.sections[currentTableKey] = section
+			activeSectionKey = currentTableKey
+			hasActiveSection = true
+		case unstable.KeyValue:
+			if skipArrayTable {
+				continue
+			}
+			path := append(append([]string(nil), currentTable...), tomlNodeKey(expression)...)
+			pathKey := tomlPathKey(path)
+			if _, duplicate := document.entries[pathKey]; duplicate {
+				return nil, fmt.Errorf("duplicate TOML ownership path %q", displayTOMLPath(path))
+			}
+			exprStart := int(expression.Raw.Offset)
+			exprEnd := exprStart + int(expression.Raw.Length)
+			lineStart, lineEnd := tomlExpressionLineBounds(data, exprStart, exprEnd)
+			entry := tomlEntry{
+				path:      path,
+				tableKey:  currentTableKey,
+				exprStart: exprStart,
+				exprEnd:   exprEnd,
+				lineStart: lineStart,
+				lineEnd:   lineEnd,
+				raw:       append([]byte(nil), data[exprStart:exprEnd]...),
+			}
+			document.entries[pathKey] = entry
+			document.entryOrder = append(document.entryOrder, pathKey)
+		}
+	}
+	if err := parser.Error(); err != nil {
+		return nil, err
+	}
+	if hasActiveSection {
+		last := document.sections[activeSectionKey]
+		last.insertAt = len(data)
+		document.sections[activeSectionKey] = last
+	}
+	return document, nil
+}
+
+func tomlNodeKey(node *unstable.Node) []string {
+	iterator := node.Key()
+	var key []string
+	for iterator.Next() {
+		key = append(key, string(iterator.Node().Data))
+	}
+	return key
+}
+
+func tomlNodeOffset(node *unstable.Node) int {
+	key := node.Key()
+	if !key.Next() {
+		return 0
+	}
+	return int(key.Node().Raw.Offset)
+}
+
+func tomlLineBounds(data []byte, offset int) (int, int) {
+	start := bytes.LastIndexByte(data[:offset], '\n') + 1
+	endOffset := bytes.IndexByte(data[offset:], '\n')
+	if endOffset < 0 {
+		return start, len(data)
+	}
+	return start, offset + endOffset + 1
+}
+
+func tomlExpressionLineBounds(data []byte, startOffset, endOffset int) (int, int) {
+	lineStart := bytes.LastIndexByte(data[:startOffset], '\n') + 1
+	lineEndOffset := bytes.IndexByte(data[endOffset:], '\n')
+	if lineEndOffset < 0 {
+		return lineStart, len(data)
+	}
+	return lineStart, endOffset + lineEndOffset + 1
+}
+
+func tomlInsertionPoint(data []byte, nextHeader int) int {
+	point := nextHeader
+	for point > 0 {
+		lineEnd := point
+		lineStart := bytes.LastIndexByte(data[:lineEnd-1], '\n') + 1
+		line := strings.TrimSpace(string(data[lineStart:lineEnd]))
+		if line != "" && !strings.HasPrefix(line, "#") {
+			break
+		}
+		point = lineStart
+	}
+	return point
+}
+
+func tomlPathKey(path []string) string {
+	return strings.Join(path, "\x00")
+}
+
+func displayTOMLPath(path []string) string {
+	return strings.Join(path, ".")
+}
+
+func tomlValueAt(root map[string]any, path []string) (any, bool) {
+	var value any = root
+	for _, part := range path {
+		object, ok := value.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		value, ok = object[part]
+		if !ok {
+			return nil, false
+		}
+	}
+	return value, true
+}
+
+func tomlValuesEqual(left, right any) bool {
+	if reflect.DeepEqual(left, right) {
+		return true
+	}
+	leftFloat, leftIsFloat := left.(float64)
+	rightFloat, rightIsFloat := right.(float64)
+	if leftIsFloat && rightIsFloat {
+		return math.IsNaN(leftFloat) && math.IsNaN(rightFloat)
+	}
+	leftArray, leftIsArray := left.([]any)
+	rightArray, rightIsArray := right.([]any)
+	if leftIsArray && rightIsArray && len(leftArray) == len(rightArray) {
+		for index := range leftArray {
+			if !tomlValuesEqual(leftArray[index], rightArray[index]) {
+				return false
+			}
+		}
+		return true
+	}
+	leftObject, leftIsObject := left.(map[string]any)
+	rightObject, rightIsObject := right.(map[string]any)
+	if leftIsObject && rightIsObject && len(leftObject) == len(rightObject) {
+		for key, leftValue := range leftObject {
+			rightValue, exists := rightObject[key]
+			if !exists || !tomlValuesEqual(leftValue, rightValue) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func joinTOMLEntries(entries []tomlEntry) []byte {
+	var result []byte
+	for index, entry := range entries {
+		if index > 0 {
+			result = append(result, '\n')
+		}
+		result = append(result, entry.raw...)
+	}
+	return result
+}
+
+func formatTOMLInsertion(data []byte, offset int, addition []byte, separate bool) []byte {
+	var result []byte
+	if offset > 0 && data[offset-1] != '\n' {
+		result = append(result, '\n')
+	}
+	if separate && offset > 0 {
+		result = append(result, '\n')
+	}
+	result = append(result, addition...)
+	if len(result) == 0 || result[len(result)-1] != '\n' {
+		result = append(result, '\n')
+	}
+	return result
+}
+
+func applyTOMLEdits(data []byte, edits []tomlEdit) ([]byte, error) {
+	insertions := map[int][]byte{}
+	var coalesced []tomlEdit
+	var insertionOrder []int
+	for _, edit := range edits {
+		if edit.start != edit.end {
+			coalesced = append(coalesced, edit)
+			continue
+		}
+		if _, exists := insertions[edit.start]; !exists {
+			insertionOrder = append(insertionOrder, edit.start)
+		}
+		insertions[edit.start] = append(insertions[edit.start], edit.content...)
+	}
+	for _, offset := range insertionOrder {
+		coalesced = append(coalesced, tomlEdit{start: offset, end: offset, content: insertions[offset]})
+	}
+	edits = coalesced
+	sort.SliceStable(edits, func(i, j int) bool {
+		if edits[i].start == edits[j].start {
+			return edits[i].end > edits[j].end
+		}
+		return edits[i].start > edits[j].start
+	})
+	result := append([]byte(nil), data...)
+	lastStart := len(data)
+	for _, edit := range edits {
+		if edit.start < 0 || edit.end < edit.start || edit.end > len(data) || edit.end > lastStart {
+			return nil, fmt.Errorf("overlapping or invalid TOML edit at bytes %d:%d", edit.start, edit.end)
+		}
+		result = append(result[:edit.start], append(edit.content, result[edit.end:]...)...)
+		lastStart = edit.start
+	}
+	return result, nil
+}
+
+func tomlValueEmpty(value any) bool {
+	object, ok := value.(map[string]any)
+	if !ok {
+		return false
+	}
+	for _, child := range object {
+		if !tomlValueEmpty(child) {
+			return false
+		}
+	}
+	return true
+}
+
+func tomlContainsComments(data []byte) bool {
+	parser := unstable.Parser{KeepComments: true}
+	parser.Reset(data)
+	for parser.NextExpression() {
+		if tomlNodeContainsComment(parser.Expression()) {
+			return true
+		}
+	}
+	return false
+}
+
+func tomlNodeContainsComment(node *unstable.Node) bool {
+	if node == nil {
+		return false
+	}
+	if node.Kind == unstable.Comment {
+		return true
+	}
+	return tomlNodeContainsComment(node.Child()) || tomlNodeContainsComment(node.Next())
+}

--- a/internal/deps/plan_test.go
+++ b/internal/deps/plan_test.go
@@ -110,7 +110,7 @@ func TestPlanUsesAtuinUserLocalProviderOnLinuxWhenDistroProviderUnavailable(t *t
 		Version:  1,
 		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}},
 		Entries: []manifest.Entry{{
-			Source: "configs/atuin/config.toml", Target: "~/.config/atuin/config.toml", Strategy: "symlink", Tags: []string{"core"},
+			Source: "configs/atuin/config.toml", Target: "~/.config/atuin/config.toml", Strategy: "copy", Ownership: "toml-subset", Tags: []string{"core"},
 			Dependencies: []manifest.Dependency{{
 				Name:          "atuin",
 				Command:       "atuin",

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -146,6 +146,11 @@ func recordMetadata(p plan.Plan, resolvedSources [][]string, opts Options) error
 					if err != nil {
 						return fmt.Errorf("canonicalize owned JSONC contribution %s: %w", resolvedSources[i][0], err)
 					}
+				} else if action.Ownership == "toml-subset" {
+					ownedBytes, err = os.ReadFile(resolvedSources[i][0])
+					if err != nil {
+						return fmt.Errorf("read owned TOML contribution %s: %w", resolvedSources[i][0], err)
+					}
 				} else if action.Ownership == "seeded" {
 					if action.Migration != nil && action.Migration.RecordedBaseline != nil {
 						seededBaseline = append([]byte(nil), action.Migration.RecordedBaseline...)
@@ -605,6 +610,16 @@ func applyUpdate(action plan.Action, source string, opts Options) error {
 			return fmt.Errorf("merge JSONC update for %s: %w", action.Target, err)
 		}
 	case "toml-subset":
+		if len(action.PreviousContent) > 0 {
+			current, err := os.ReadFile(source)
+			if err != nil {
+				return fmt.Errorf("read current owned TOML %s: %w", source, err)
+			}
+			if err := reconcileTOMLContentFile(action.Target, action.PreviousContent, current); err != nil {
+				return fmt.Errorf("reconcile TOML update for %s: %w", action.Target, err)
+			}
+			return nil
+		}
 		if err := configsubset.MergeTOMLFile(action.Target, source); err != nil {
 			return fmt.Errorf("merge TOML update for %s: %w", action.Target, err)
 		}
@@ -927,6 +942,28 @@ func reconcileJSONCContentFile(target string, previousData, currentData []byte) 
 	}
 	if !reconciliation.Compatible {
 		return fmt.Errorf("live target changed a previously owned JSONC value")
+	}
+	if !reconciliation.Changed {
+		return nil
+	}
+	return os.WriteFile(target, reconciliation.Content, info.Mode().Perm())
+}
+
+func reconcileTOMLContentFile(target string, previousData, currentData []byte) error {
+	targetData, err := os.ReadFile(target)
+	if err != nil {
+		return err
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		return err
+	}
+	reconciliation, err := configsubset.ReconcileTOML(targetData, previousData, currentData)
+	if err != nil {
+		return err
+	}
+	if !reconciliation.Compatible {
+		return fmt.Errorf("live target changed a previously owned TOML value")
 	}
 	if !reconciliation.Changed {
 		return nil

--- a/internal/install/issue390_atuin_test.go
+++ b/internal/install/issue390_atuin_test.go
@@ -1,0 +1,250 @@
+package install_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/backups"
+	"github.com/yersonargotev/dots/internal/install"
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/plan"
+	"github.com/yersonargotev/dots/internal/repositoryrefresh"
+	"github.com/yersonargotev/dots/internal/state"
+	"github.com/yersonargotev/dots/internal/status"
+	"github.com/yersonargotev/dots/internal/uninstall"
+)
+
+func TestAtuinTOMLSubsetLifecycleMigratesReconcilesAndUninstallsSafely(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := filepath.Join(home, ".local", "state", "dots")
+	source := filepath.Join(sourceRoot, "configs", "atuin", "config.toml")
+	target := filepath.Join(home, ".config", "atuin", "config.toml")
+	dataDir := filepath.Join(home, ".local", "share", "atuin")
+	oldBaseline := []byte(`# portable baseline
+enter_accept = true
+retired = "old"
+
+[sync]
+records = true
+`)
+	incomingBaseline := []byte(`# portable baseline
+enter_accept = true
+
+[sync]
+records = true
+
+[theme]
+name = "catppuccin-mocha"
+`)
+	external := []byte(`
+# written by atuin config set
+search_mode = "fuzzy"
+
+[daemon]
+enabled = true
+`)
+
+	writeMigrationFile(t, source, oldBaseline)
+	runMigrationGit(t, sourceRoot, "init")
+	runMigrationGit(t, sourceRoot, "config", "user.email", "dots@example.test")
+	runMigrationGit(t, sourceRoot, "config", "user.name", "dots test")
+	runMigrationGit(t, sourceRoot, "add", ".")
+	runMigrationGit(t, sourceRoot, "commit", "-m", "legacy Atuin baseline")
+	oldRevision := strings.TrimSpace(runMigrationGit(t, sourceRoot, "rev-parse", "HEAD"))
+
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target parent: %v", err)
+	}
+	if err := os.Symlink(source, target); err != nil {
+		t.Fatalf("symlink legacy Atuin config: %v", err)
+	}
+	if err := os.WriteFile(source, append(append([]byte(nil), oldBaseline...), external...), 0o600); err != nil {
+		t.Fatalf("simulate Atuin write through symlink: %v", err)
+	}
+	for name, content := range map[string]string{
+		"history.db": "history",
+		"key":        "private-key",
+		"session":    "auth-token",
+		"host_id":    "host",
+		"records.db": "records",
+	} {
+		writeMigrationFile(t, filepath.Join(dataDir, name), []byte(content))
+	}
+
+	oldManifest := atuinManifest("symlink", "")
+	newManifest := atuinManifest("copy", "toml-subset")
+	meta := state.Metadata{
+		Version:    state.CurrentVersion,
+		Provenance: state.Provenance{SourceRoot: sourceRoot, SourceRevision: oldRevision},
+		Entries: []state.Record{{
+			Target: target, Source: "configs/atuin/config.toml", Strategy: "symlink", Ownership: "whole",
+		}},
+	}
+	if err := state.Save(state.Path(stateRoot), meta); err != nil {
+		t.Fatalf("save legacy metadata: %v", err)
+	}
+	captures, err := repositoryrefresh.CaptureLegacyTargets(oldManifest, newManifest, meta, sourceRoot, home, "", oldRevision)
+	if err != nil {
+		t.Fatalf("CaptureLegacyTargets() error = %v", err)
+	}
+	if got := captures[target].CapturedContent; !bytes.Equal(got, append(append([]byte(nil), oldBaseline...), external...)) {
+		t.Fatalf("captured Atuin config = %q", got)
+	}
+
+	writeMigrationFile(t, source, incomingBaseline)
+	runMigrationGit(t, sourceRoot, "add", ".")
+	runMigrationGit(t, sourceRoot, "commit", "-m", "materialize Atuin config")
+	p, err := plan.Build(newManifest, plan.Options{
+		Profile: "default", OS: "linux", SourceRoot: sourceRoot, Home: home,
+		Metadata: meta, LegacyMigrations: captures,
+	})
+	if err != nil {
+		t.Fatalf("Build(migration) error = %v", err)
+	}
+	if len(p.Actions) != 1 || p.Actions[0].Status != plan.StatusMigrate {
+		t.Fatalf("migration plan = %#v, want one migrate action", p.Actions)
+	}
+	if err := install.Apply(p, install.Options{SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot}); err != nil {
+		t.Fatalf("Apply(migration) error = %v", err)
+	}
+	if info, err := os.Lstat(target); err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("materialized Atuin target = (%v, %v), want regular file", info, err)
+	}
+	assertContainsAll(t, target, []string{
+		`enter_accept = true`, `search_mode = "fuzzy"`, `[daemon]`, `enabled = true`, `[theme]`, `name = "catppuccin-mocha"`,
+	})
+	if got := runMigrationGit(t, sourceRoot, "status", "--porcelain"); got != "" {
+		t.Fatalf("repository status after Atuin-like addition = %q, want clean", got)
+	}
+	backupMeta, err := backups.Load(backups.Path(stateRoot))
+	if err != nil || len(backupMeta.Sets) != 1 || len(backupMeta.Sets[0].Targets) != 1 || backupMeta.Sets[0].Targets[0] != target {
+		t.Fatalf("migration Backup Sets = (%#v, %v), want target backup", backupMeta, err)
+	}
+
+	meta, err = state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load migrated metadata: %v", err)
+	}
+	rec, ok := meta.FindByTarget(target)
+	if !ok || rec.Ownership != "toml-subset" || !bytes.Equal(rec.OwnedBytes, incomingBaseline) {
+		t.Fatalf("Atuin ownership record = %#v, want current TOML contribution", rec)
+	}
+	report, err := status.Build(newManifest, meta, status.Options{Profile: "default", OS: "linux", SourceRoot: sourceRoot, Home: home})
+	if err != nil || len(report.Entries) != 1 || report.Entries[0].State != status.StateOK {
+		t.Fatalf("status after migration = (%#v, %v), want ok", report, err)
+	}
+
+	live, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read materialized target: %v", err)
+	}
+	changedOwned := bytes.Replace(live, []byte("enter_accept = true"), []byte("enter_accept = false"), 1)
+	if err := os.WriteFile(target, changedOwned, 0o600); err != nil {
+		t.Fatalf("change owned Atuin value: %v", err)
+	}
+	report, err = status.Build(newManifest, meta, status.Options{Profile: "default", OS: "linux", SourceRoot: sourceRoot, Home: home})
+	if err != nil || report.Entries[0].State != status.StateDrifted {
+		t.Fatalf("status after owned change = (%#v, %v), want drifted", report, err)
+	}
+	conflictPlan, err := plan.Build(newManifest, plan.Options{Profile: "default", OS: "linux", SourceRoot: sourceRoot, Home: home, Metadata: meta})
+	if err != nil || conflictPlan.Actions[0].Status != plan.StatusConflict {
+		t.Fatalf("plan after owned change = (%#v, %v), want conflict", conflictPlan, err)
+	}
+	if got, err := os.ReadFile(target); err != nil || !bytes.Equal(got, changedOwned) {
+		t.Fatalf("owned Conflict was overwritten = (%q, %v)", got, err)
+	}
+	if err := os.WriteFile(target, live, 0o600); err != nil {
+		t.Fatalf("restore compatible Atuin target: %v", err)
+	}
+
+	updatedBaseline := []byte(`# portable baseline
+enter_accept = false
+filter_mode_shell_up_key_binding = "session"
+
+[theme]
+name = "catppuccin-mocha"
+`)
+	writeMigrationFile(t, source, updatedBaseline)
+	runMigrationGit(t, sourceRoot, "add", ".")
+	runMigrationGit(t, sourceRoot, "commit", "-m", "update Atuin baseline")
+	updatePlan, err := plan.Build(newManifest, plan.Options{Profile: "default", OS: "linux", SourceRoot: sourceRoot, Home: home, Metadata: meta})
+	if err != nil || updatePlan.Actions[0].Status != plan.StatusUpdate {
+		t.Fatalf("baseline update plan = (%#v, %v), want update", updatePlan, err)
+	}
+	if err := install.Apply(updatePlan, install.Options{SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot}); err != nil {
+		t.Fatalf("Apply(update) error = %v", err)
+	}
+	assertContainsAll(t, target, []string{
+		`enter_accept = false`, `filter_mode_shell_up_key_binding = "session"`, `search_mode = "fuzzy"`, `[daemon]`, `enabled = true`,
+	})
+	if got, _ := os.ReadFile(target); bytes.Contains(got, []byte("records = true")) {
+		t.Fatalf("updated Atuin target retained retired owned value:\n%s", got)
+	}
+
+	meta, err = state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("reload updated metadata: %v", err)
+	}
+	rec, ok = meta.FindByTarget(target)
+	if !ok || !bytes.Equal(rec.OwnedBytes, updatedBaseline) {
+		t.Fatalf("updated Atuin ownership record = %#v", rec)
+	}
+	uninstallPlan, err := plan.BuildUninstall(state.Metadata{Entries: []state.Record{rec}}, plan.UninstallOptions{SourceRoot: sourceRoot, Home: home})
+	if err != nil || len(uninstallPlan.Actions) != 1 || uninstallPlan.Actions[0].Status != plan.UninstallRemove {
+		t.Fatalf("BuildUninstall() = (%#v, %v), want partial removal", uninstallPlan, err)
+	}
+	result, err := uninstall.Apply(uninstallPlan, uninstall.Options{SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot, Force: true})
+	if err != nil {
+		t.Fatalf("uninstall Apply() error = %v", err)
+	}
+	if len(result.Updated) != 1 || result.Updated[0] != target || len(result.Removed) != 0 {
+		t.Fatalf("uninstall result = %#v, want preserved external Atuin config", result)
+	}
+	assertContainsAll(t, target, []string{`search_mode = "fuzzy"`, `[daemon]`, `enabled = true`})
+	if got, _ := os.ReadFile(target); bytes.Contains(got, []byte("enter_accept")) || bytes.Contains(got, []byte("filter_mode_shell_up_key_binding")) || bytes.Contains(got, []byte(`name = "catppuccin-mocha"`)) {
+		t.Fatalf("uninstalled target retained dots-owned values:\n%s", got)
+	}
+	for name, want := range map[string]string{
+		"history.db": "history", "key": "private-key", "session": "auth-token", "host_id": "host", "records.db": "records",
+	} {
+		got, err := os.ReadFile(filepath.Join(dataDir, name))
+		if err != nil || string(got) != want {
+			t.Fatalf("Atuin runtime state %s = (%q, %v), want unchanged", name, got, err)
+		}
+	}
+	if _, ok := loadInstallMetadata(t, stateRoot).FindByTarget(target); ok {
+		t.Fatal("Atuin metadata record not pruned after partial uninstall")
+	}
+}
+
+func atuinManifest(strategy, ownership string) manifest.Manifest {
+	return manifest.Manifest{Version: 1, Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}}, Entries: []manifest.Entry{{
+		Source: "configs/atuin/config.toml", Target: "~/.config/atuin/config.toml", Strategy: strategy, Ownership: ownership, Tags: []string{"core"}, OS: []string{"linux"},
+	}}}
+}
+
+func assertContainsAll(t *testing.T, path string, values []string) {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	for _, value := range values {
+		if !bytes.Contains(content, []byte(value)) {
+			t.Fatalf("%s missing %q:\n%s", path, value, content)
+		}
+	}
+}
+
+func loadInstallMetadata(t *testing.T, stateRoot string) state.Metadata {
+	t.Helper()
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load metadata: %v", err)
+	}
+	return meta
+}

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -2258,6 +2258,10 @@ func TestRepositoryManifestIncludesMVPConfigurationSet(t *testing.T) {
 	if got := entriesByTarget["~/.zshrc"].Ownership; got != "marked-block" {
 		t.Errorf("zsh ownership = %q, want marked-block", got)
 	}
+	atuin, ok := entriesByTarget["~/.config/atuin/config.toml"]
+	if !ok || atuin.Source != "configs/atuin/config.toml" || atuin.Strategy != "copy" || atuin.Ownership != "toml-subset" {
+		t.Errorf("Atuin config entry = %#v, want copy with TOML Subset Ownership", atuin)
+	}
 	portable, ok := entriesByTarget["~/.config/dots/zsh/zshrc"]
 	if !ok || portable.Source != "configs/zsh/zshrc" || portable.Strategy != "symlink" {
 		t.Errorf("portable zsh entry = %#v, want managed symlink", portable)

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -237,6 +237,8 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 		if rec, ok := opts.Metadata.FindByTarget(target); ok && rec.Ownership == action.Ownership {
 			if isJSONOwnership(rec.Ownership) && len(rec.OwnedContent) > 0 {
 				action.PreviousContent = append([]byte(nil), rec.OwnedContent...)
+			} else if rec.Ownership == "toml-subset" && len(rec.OwnedBytes) > 0 {
+				action.PreviousContent = append([]byte(nil), rec.OwnedBytes...)
 			} else if rec.Ownership == "seeded" {
 				action.PreviousContent = append([]byte(nil), rec.SeededBaseline...)
 			} else if rec.Ownership == "marked-block" {
@@ -334,11 +336,14 @@ func planLegacyMigration(entry manifest.Entry, currentSource string, migration L
 		}
 		planned.FinalContent = reconciliation.Content
 	case "toml-subset":
-		merged, err := configsubset.MergeTOML(migration.CapturedContent, current)
+		reconciliation, err := configsubset.ReconcileTOML(migration.CapturedContent, migration.PreviousSourceContent, current)
 		if err != nil {
+			return LegacyMigration{}, false, err
+		}
+		if !reconciliation.Compatible {
 			return LegacyMigration{}, false, nil
 		}
-		planned.FinalContent = merged
+		planned.FinalContent = reconciliation.Content
 	case "marked-block":
 		reconciliation := textblock.MigrateLegacyOwned(migration.CapturedContent, migration.PreviousSourceContent, current, textblock.DotsManagedMarkers())
 		if !reconciliation.Compatible {
@@ -785,7 +790,7 @@ func status(entry manifest.Entry, target, sourceAbs, sourceRoot, canonicalSource
 				}
 				return StatusUnchanged, nil
 			}
-			if isSubsetOwned(entry.Ownership) && meta.MatchesEntry(target, entry.Source, entry.Strategy) {
+			if isSubsetOwned(entry.Ownership) && (meta.MatchesEntry(target, entry.Source, entry.Strategy) || meta.MatchesEntry(target, defaultSource, entry.Strategy)) {
 				if isJSONOwnership(entry.Ownership) {
 					if rec, ok := meta.FindByTarget(target); ok && rec.Ownership == entry.Ownership && len(rec.OwnedContent) > 0 {
 						targetData, readErr := os.ReadFile(target)
@@ -837,6 +842,35 @@ func status(entry manifest.Entry, target, sourceAbs, sourceRoot, canonicalSource
 					}
 					if relation.Mergeable {
 						return StatusUpdate, nil
+					}
+				} else if entry.Ownership == "toml-subset" {
+					if rec, ok := meta.FindByTarget(target); ok && rec.Ownership == "toml-subset" && len(rec.OwnedBytes) > 0 {
+						targetData, readErr := os.ReadFile(target)
+						if readErr != nil {
+							return "", fmt.Errorf("read TOML target %s: %w", target, readErr)
+						}
+						currentData, readErr := os.ReadFile(sourceAbs)
+						if readErr != nil {
+							return "", fmt.Errorf("read source TOML %s: %w", sourceAbs, readErr)
+						}
+						reconciliation, reconcileErr := configsubset.ReconcileTOML(targetData, rec.OwnedBytes, currentData)
+						if reconcileErr != nil {
+							return "", fmt.Errorf("reconcile TOML target %s: %w", target, reconcileErr)
+						}
+						if reconciliation.Compatible {
+							if reconciliation.Changed {
+								return StatusUpdate, nil
+							}
+							return StatusUnchanged, nil
+						}
+						return StatusConflict, nil
+					}
+					subset, subsetErr := subsetContent(entry.Ownership, target, sourceAbs)
+					if subsetErr != nil {
+						return "", subsetErr
+					}
+					if subset {
+						return StatusUnchanged, nil
 					}
 				} else {
 					subset, subsetErr := subsetContent(entry.Ownership, target, sourceAbs)

--- a/internal/plan/uninstall.go
+++ b/internal/plan/uninstall.go
@@ -176,6 +176,20 @@ func uninstallStatus(rec state.Record, sourceRoot, home string) (UninstallStatus
 			}
 			return UninstallModified, nil
 		}
+		if rec.Ownership == "toml-subset" && len(rec.OwnedBytes) > 0 {
+			targetData, err := os.ReadFile(rec.Target)
+			if err != nil {
+				return "", fmt.Errorf("read uninstall target %s: %w", rec.Target, err)
+			}
+			_, _, _, compatible, err := configsubset.RemoveTOML(targetData, rec.OwnedBytes)
+			if err != nil {
+				return "", fmt.Errorf("analyze owned TOML for %s: %w", rec.Target, err)
+			}
+			if compatible {
+				return UninstallRemove, nil
+			}
+			return UninstallModified, nil
+		}
 		if rec.Ownership == "marked-block" && len(rec.OwnedBytes) > 0 {
 			targetData, err := os.ReadFile(rec.Target)
 			if err != nil {

--- a/internal/plan/uninstall_test.go
+++ b/internal/plan/uninstall_test.go
@@ -72,6 +72,40 @@ func TestBuildUninstallClassifiesChangedPartialJSONAsModified(t *testing.T) {
 	}
 }
 
+func TestBuildUninstallPlansPartialTOMLRemovalFromRecordedContribution(t *testing.T) {
+	f := newUninstallFixture(t)
+	target := f.target(".config/atuin/config.toml")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("enter_accept = true\nexternal = \"keep\"\n"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	p := f.build(t, state.Record{
+		Target: target, Source: "configs/atuin/config.toml", Strategy: "copy", Ownership: "toml-subset", OwnedBytes: []byte("enter_accept = true\n"),
+	})
+	if len(p.Actions) != 1 || p.Actions[0].Status != plan.UninstallRemove || p.Actions[0].Ownership != "toml-subset" {
+		t.Fatalf("action = %+v, want safe partial TOML remove", p.Actions)
+	}
+}
+
+func TestBuildUninstallRejectsChangedOwnedTOMLEvenWithForceEligiblePlan(t *testing.T) {
+	f := newUninstallFixture(t)
+	target := f.target(".config/atuin/config.toml")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("enter_accept = false\nexternal = \"keep\"\n"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	p := f.build(t, state.Record{
+		Target: target, Source: "configs/atuin/config.toml", Strategy: "copy", Ownership: "toml-subset", OwnedBytes: []byte("enter_accept = true\n"),
+	})
+	if len(p.Actions) != 1 || p.Actions[0].Status != plan.UninstallModified || p.Removable() {
+		t.Fatalf("plan = %+v, want non-removable modified TOML ownership", p)
+	}
+}
+
 func TestUninstallPlanRemovableRequiresExplicitWholeOwnershipForModifiedTarget(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -53,7 +53,8 @@ func (p Provenance) Empty() bool {
 
 // Record describes a single managed target the CLI installed. Version 4 records
 // explicit whole or partial Ownership; version 5 adds opaque seeded-baseline
-// evidence, and version 6 adds opaque marked-block contribution evidence. An
+// evidence, and version 6 adds opaque byte contribution evidence for TOML
+// subset and marked-block ownership. An
 // empty Ownership is legacy and grants no force-removal authority.
 // Copy-like strategies may record a source content hash; symlink records leave
 // Hash empty because drift is detected from the link destination.
@@ -64,7 +65,8 @@ type Record struct {
 	Strategy     string          `json:"strategy"`
 	Ownership    string          `json:"ownership,omitempty"`
 	OwnedContent json.RawMessage `json:"owned_content,omitempty"`
-	// OwnedBytes is the exact opaque contribution for non-JSON partial ownership.
+	// OwnedBytes is the exact opaque contribution for non-JSON partial ownership,
+	// including TOML subset and marked-block entries.
 	OwnedBytes []byte `json:"owned_bytes,omitempty"`
 	// SeededBaseline is the exact opaque Source of Truth baseline last applied
 	// to Seeded Runtime State. []byte uses JSON base64 encoding, so the state

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -274,6 +274,48 @@ func evaluate(entry manifest.Entry, target string, meta state.Metadata, sourceRo
 		}
 		return StateOK, nil
 	}
+	if entry.Ownership == "toml-subset" {
+		info, err := os.Lstat(target)
+		if err != nil {
+			return "", fmt.Errorf("stat TOML target %s: %w", target, err)
+		}
+		rec, recorded := meta.FindByTarget(target)
+		if !info.Mode().IsRegular() {
+			if recorded && rec.Strategy == entry.Strategy {
+				return StateDrifted, nil
+			}
+			return StateConflict, nil
+		}
+		targetData, err := os.ReadFile(target)
+		if err != nil {
+			return "", fmt.Errorf("read TOML target %s: %w", target, err)
+		}
+		sourceData, err := os.ReadFile(sourceAbs)
+		if err != nil {
+			return "", fmt.Errorf("read source TOML %s: %w", sourceAbs, err)
+		}
+		if meta.MatchesEntry(target, entry.Source, entry.Strategy) || meta.MatchesEntry(target, defaultSource, entry.Strategy) {
+			if rec.Ownership == "toml-subset" && len(rec.OwnedBytes) > 0 {
+				reconciliation, err := configsubset.ReconcileTOML(targetData, rec.OwnedBytes, sourceData)
+				if err != nil {
+					return "", fmt.Errorf("reconcile TOML target %s: %w", target, err)
+				}
+				if reconciliation.Compatible && !reconciliation.Changed {
+					return StateOK, nil
+				}
+				return StateDrifted, nil
+			}
+			relation, err := configsubset.AnalyzeTOML(targetData, sourceData)
+			if err != nil {
+				return "", fmt.Errorf("analyze TOML target %s: %w", target, err)
+			}
+			if relation.Contains {
+				return StateOK, nil
+			}
+			return StateDrifted, nil
+		}
+		return StateConflict, nil
+	}
 	if entry.Ownership == "json-subset" && len(currentJSON) > 0 {
 		info, err := os.Lstat(target)
 		if err != nil {

--- a/internal/uninstall/uninstall.go
+++ b/internal/uninstall/uninstall.go
@@ -100,6 +100,21 @@ func Apply(p plan.UninstallPlan, opts Options) (Result, error) {
 			}
 			continue
 		}
+		if rec.Ownership == "toml-subset" && len(rec.OwnedBytes) > 0 {
+			if action.Status != plan.UninstallRemove {
+				continue
+			}
+			applied, deleted, err := removeOwnedTOML(rec, home)
+			if err != nil {
+				return result, err
+			}
+			if applied && deleted {
+				result.Removed = append(result.Removed, action.Target)
+			} else if applied {
+				result.Updated = append(result.Updated, action.Target)
+			}
+			continue
+		}
 		if rec.Ownership == "marked-block" && len(rec.OwnedBytes) > 0 {
 			if action.Status != plan.UninstallRemove {
 				continue
@@ -239,6 +254,59 @@ func removeOwnedJSON(rec state.Record, home string) (applied, deleted bool, err 
 	}
 	if err := os.WriteFile(rec.Target, content, info.Mode().Perm()); err != nil {
 		return false, false, fmt.Errorf("write JSON target %s after removing owned content: %w", rec.Target, err)
+	}
+	return true, false, nil
+}
+
+// removeOwnedTOML revalidates and subtracts a TOML contribution at apply time.
+// It uses the same path and symlink-escape checks as other partial ownership
+// modes and never lets force broaden dots' ownership.
+func removeOwnedTOML(rec state.Record, home string) (applied, deleted bool, err error) {
+	if err := plan.ValidateResolvedTarget(rec.Target, home); err != nil {
+		return false, false, err
+	}
+	if err := plan.ValidateTargetParentInsideHome(rec.Target, home); err != nil {
+		return false, false, err
+	}
+	if err := plan.ValidateFilePathInsideHomeNoSymlinkEscape(rec.Target, home, "owned TOML target"); err != nil {
+		return false, false, err
+	}
+	leaf, err := os.Lstat(rec.Target)
+	if os.IsNotExist(err) {
+		return false, false, nil
+	}
+	if err != nil {
+		return false, false, fmt.Errorf("stat owned TOML target %s: %w", rec.Target, err)
+	}
+	if !leaf.Mode().IsRegular() {
+		return false, false, nil
+	}
+	targetData, err := os.ReadFile(rec.Target)
+	if err != nil {
+		return false, false, fmt.Errorf("read owned TOML target %s: %w", rec.Target, err)
+	}
+	info, err := os.Stat(rec.Target)
+	if err != nil {
+		return false, false, fmt.Errorf("stat owned TOML target %s: %w", rec.Target, err)
+	}
+	content, changed, empty, compatible, err := configsubset.RemoveTOML(targetData, rec.OwnedBytes)
+	if err != nil {
+		return false, false, fmt.Errorf("remove owned TOML from %s: %w", rec.Target, err)
+	}
+	if !compatible {
+		return false, false, nil
+	}
+	if empty {
+		if err := removeTarget(rec.Target); err != nil {
+			return false, false, fmt.Errorf("remove emptied TOML target %s: %w", rec.Target, err)
+		}
+		return true, true, nil
+	}
+	if !changed {
+		return true, false, nil
+	}
+	if err := os.WriteFile(rec.Target, content, info.Mode().Perm()); err != nil {
+		return false, false, fmt.Errorf("write TOML target %s after removing owned content: %w", rec.Target, err)
 	}
 	return true, false, nil
 }


### PR DESCRIPTION
Closes #390

## PR Type

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Materialize Atuin's config as a regular co-owned TOML file instead of a repository symlink.
- Reconcile owned scalar/array values against the previous contribution while preserving external TOML and comments.
- Migrate provenance-backed legacy config through a Backup Set and support ownership-scoped uninstall.

## Changes

| File | Change |
|------|--------|
| `internal/configsubset/toml.go` | Adds bounded, formatting-preserving TOML analysis, merge, reconciliation, and removal. |
| `internal/{plan,status,install,uninstall}` | Records prior TOML ownership and applies three-state planning, migration, drift, and partial uninstall behavior. |
| `dots.yaml`, `configs/atuin/README.md`, `docs/manifest.md`, `CONTEXT.md` | Declares and documents Atuin TOML subset ownership. |
| `internal/**/*test.go` | Covers lifecycle, migration, conflicts, comments, dotted keys, arrays, and temporary-home safety. |

## Acceptance Coverage

- Atuin-like target-only additions remain aligned and leave the Source of Truth unchanged.
- Owned scalar and array changes produce Drift/Conflict and are not overwritten.
- Compatible additions/removals preserve external keys, formatting, inline comments, dotted tables, and multiline-array comments.
- Legacy symlink migration requires repository provenance and creates a Backup Set.
- Partial uninstall removes only owned TOML values and preserves external config plus Atuin data/auth files.

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan/install/status/uninstall with one built binary, explicit temporary `--home`, `--source-root`, and `--state-root`
- [x] `go build ./...`
- [x] `go test -race ./internal/configsubset ./internal/install ./internal/uninstall`
- [x] `go run golang.org/x/vuln/cmd/govulncheck@latest ./...` (no reachable vulnerabilities)

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] All CLI validation targeting home/config paths used temporary directories and explicit `--home`, `--source-root`, and `--state-root` flags.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #390`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated documentation for the ownership behavior.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

- Agent Brief: https://github.com/yersonargotev/dots/issues/390#issuecomment-5226647233; REST ID `5226647233`; node ID `IC_kwDOSzLlmM8AAAABN4hOwQ`; SHA-256 `be18de6ba956e9f025e9e84a7f9ac3da43a30bc24631b36892b42b27f362932f`.
- Reviewed head: `a5fa769` (`origin/main...HEAD`).
- Acceptance criteria: covered by the lifecycle test plus focused reconciliation, plan, status, migration, uninstall, dotted-key, comment, and multiline-array tests; all six criteria pass.
- Automated validation: `gofmt -l .` produced no output; `go vet ./...`, `go build ./...`, and `go test ./...` passed. Race-focused tests and `govulncheck` also passed with no reachable vulnerabilities.
- Manual verification: a single freshly built binary validated the manifest and installed into temporary home/state roots; config was a regular file and initially aligned. Adding `search_mode = "fuzzy"` kept status OK (exit 0) and the source hash unchanged (`0af57f...b402ca`). Changing owned `enter_accept` produced Drift/Conflict (status and plan exit 2) without overwrite. Dry-run and actual uninstall reported remove/update, retained `search_mode` and its inline comment, retained the local comment from the removed owned setting, and removed owned assignments only.
- Independent review: Spec and Standards reviewers examined the complete stable range at `a5fa769`; both reported no actionable findings and independently passed formatting, vet, build, and the full test suite.
- Delegation: one read-only exploration slice mapped call flow, tests, migration, and safety risks; its findings were accepted. The main agent inspected the implementation, integrated all changes, ran focused/full/security/manual gates, and resolved every review finding. Managed delegation artifacts were unavailable, so workflow-authorized native delegation was used.
<!-- delivery-issue:evidence:end -->
