### PR TITLE
feat(zed): seed ordered user keybindings

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -211,7 +211,7 @@ Current Managed Entries:
 | `configs/nvim/loader.lua` | `~/.config/nvim/init.lua` | `copy` | `core` | `darwin`, `linux` | `neovim` |
 | `configs/nvim` | `~/.config/dots/nvim` | `symlink` | `core` | `darwin`, `linux` | None |
 | `configs/zed/settings.json` | `~/.config/zed/settings.json` | `copy` (`jsonc-subset`) | `desktop` | `darwin`, `linux` | `zed` |
-| `configs/zed/keymap.json` | `~/.config/zed/keymap.json` | `symlink` | `desktop` | `darwin`, `linux` | `zed` |
+| `configs/zed/keymap.json` | `~/.config/zed/keymap.json` | `copy` (`seeded`) | `desktop` | `darwin`, `linux` | `zed` |
 | `configs/zed/themes/catppuccin-blue.json` | `~/.config/zed/themes/catppuccin-blue.json` | `symlink` | `desktop` | `darwin`, `linux` | `zed` |
 | `configs/claude/settings.json` | `~/.claude/settings.json` | `copy` | `agents` | `darwin`, `linux` | None; owns JSON subset |
 | `configs/claude/statusline-command.sh` | `~/.claude/statusline-command.sh` | `copy` | `agents` | `darwin`, `linux` | None |

--- a/dots.yaml
+++ b/dots.yaml
@@ -532,7 +532,8 @@ entries:
         brew: zed
   - source: configs/zed/keymap.json
     target: ~/.config/zed/keymap.json
-    strategy: symlink
+    strategy: copy
+    ownership: seeded
     tags:
       - desktop
     os:

--- a/internal/cli/issue391_zed_keymap_seeded_lifecycle_test.go
+++ b/internal/cli/issue391_zed_keymap_seeded_lifecycle_test.go
@@ -1,0 +1,136 @@
+package cli_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/cli"
+	"github.com/yersonargotev/dots/internal/state"
+)
+
+func TestZedKeymapMigratesToSeededStateAndPreservesOrderedLocalEvolution(t *testing.T) {
+	requireGitCLI(t)
+	home := t.TempDir()
+	stateRoot := filepath.Join(home, ".dots-state")
+	t.Setenv("HOME", t.TempDir())
+
+	legacyManifest := `version: 1
+profiles:
+  default:
+    tags: [desktop]
+entries:
+  - source: configs/zed/keymap.json
+    target: ~/.config/zed/keymap.json
+    strategy: symlink
+    tags: [desktop]
+`
+	seededManifest := `version: 1
+profiles:
+  default:
+    tags: [desktop]
+entries:
+  - source: configs/zed/keymap.json
+    target: ~/.config/zed/keymap.json
+    strategy: copy
+    ownership: seeded
+    tags: [desktop]
+`
+	oldBaseline := `// Ordered Zed baseline.
+[
+  { "context": "Workspace", "bindings": { "cmd-a": "action::First", }, },
+  { "context": "Workspace", "bindings": { "cmd-a": "action::Second", }, },
+]
+`
+	newBaseline := `// Updated ordered Zed baseline.
+[
+  { "context": "Workspace", "bindings": { "cmd-a": "action::First", }, },
+  { "context": "Editor", "bindings": { "cmd-b": "action::Current", }, },
+]
+`
+	localEvolution := `// Edited by Zed; later bindings retain precedence.
+[
+  { "context": "Workspace", "bindings": { "cmd-a": "action::Second", }, },
+  { "context": "Workspace", "bindings": { "cmd-a": "action::Local", }, },
+]
+`
+	origin, sourceRoot := newInstalledRepo(t, map[string]string{
+		"configs/zed/keymap.json": oldBaseline,
+		"dots.yaml":               legacyManifest,
+	})
+	manifestPath := filepath.Join(sourceRoot, "dots.yaml")
+
+	run := func(want int, args ...string) string {
+		t.Helper()
+		var stdout, stderr bytes.Buffer
+		code := cli.Run(args, &stdout, &stderr)
+		if code != want {
+			t.Fatalf("cli.Run(%v) code = %d, want %d\nstdout:\n%s\nstderr:\n%s", args, code, want, stdout.String(), stderr.String())
+		}
+		return stdout.String()
+	}
+	common := []string{"--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot}
+	run(0, append([]string{"install", "--yes", "--skip-deps"}, common...)...)
+
+	target := filepath.Join(home, ".config", "zed", "keymap.json")
+	if info, err := os.Lstat(target); err != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("legacy Zed keymap = (%v, %v), want symlink", info, err)
+	}
+	if err := os.WriteFile(target, []byte(localEvolution), 0o600); err != nil {
+		t.Fatalf("simulate Zed Keymap Editor write: %v", err)
+	}
+	advanceUpstream(t, origin, "seed ordered Zed keymap", map[string]string{
+		"configs/zed/keymap.json": newBaseline,
+		"dots.yaml":               seededManifest,
+	})
+
+	updateOutput := runUpdate(t, "--yes", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot)
+	if !strings.Contains(updateOutput, "migrate") {
+		t.Fatalf("update output missing seeded migration evidence:\n%s", updateOutput)
+	}
+	if info, err := os.Lstat(target); err != nil || !info.Mode().IsRegular() {
+		t.Fatalf("migrated Zed keymap = (%v, %v), want regular file", info, err)
+	}
+	if got, err := os.ReadFile(target); err != nil || string(got) != localEvolution {
+		t.Fatalf("migrated keymap = (%q, %v), want byte-exact local ordering", got, err)
+	}
+	if dirty := strings.TrimSpace(runGitOutput(t, sourceRoot, "status", "--porcelain")); dirty != "" {
+		t.Fatalf("simulated Zed edit dirtied the Installed Repository after migration: %q", dirty)
+	}
+
+	statusOutput := run(0, append([]string{"status", "--output", "json"}, common...)...)
+	if !strings.Contains(statusOutput, `"state": "ok"`) || !strings.Contains(statusOutput, `"reason": "seeded-local-evolution"`) {
+		t.Fatalf("status did not report aligned local evolution:\n%s", statusOutput)
+	}
+	run(0, append([]string{"install", "--yes", "--skip-deps"}, common...)...)
+	if got, err := os.ReadFile(target); err != nil || string(got) != localEvolution {
+		t.Fatalf("install changed locally evolved keymap = (%q, %v)", got, err)
+	}
+
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load seeded metadata: %v", err)
+	}
+	record, ok := meta.FindByTarget(target)
+	if !ok || record.Ownership != "seeded" || string(record.SeededBaseline) != oldBaseline {
+		t.Fatalf("seeded metadata = %#v, want previous byte-exact baseline", record)
+	}
+
+	if err := os.WriteFile(target, []byte(oldBaseline), 0o600); err != nil {
+		t.Fatalf("restore untouched prior seed: %v", err)
+	}
+	run(0, append([]string{"install", "--yes", "--skip-deps"}, common...)...)
+	if got, err := os.ReadFile(target); err != nil || string(got) != newBaseline {
+		t.Fatalf("untouched seeded keymap did not advance = (%q, %v)", got, err)
+	}
+
+	uninstallOutput := run(0, "uninstall", "--yes", "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot)
+	if !strings.Contains(uninstallOutput, "Retained Seeded Runtime State") {
+		t.Fatalf("uninstall output missing retained-state evidence:\n%s", uninstallOutput)
+	}
+	if got, err := os.ReadFile(target); err != nil || string(got) != newBaseline {
+		t.Fatalf("uninstall changed Zed keymap = (%q, %v)", got, err)
+	}
+}

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -3191,6 +3191,25 @@ func TestRepositoryManifestNeovimEntry(t *testing.T) {
 	}
 }
 
+func TestRepositoryManifestZedKeymapIsSeededRuntimeState(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", ".."))
+	got, err := manifest.LoadFile(filepath.Join(root, "dots.yaml"))
+	if err != nil {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+
+	for _, entry := range got.Entries {
+		if entry.Target != "~/.config/zed/keymap.json" {
+			continue
+		}
+		if entry.Source != "configs/zed/keymap.json" || entry.Strategy != "copy" || entry.Ownership != "seeded" {
+			t.Fatalf("Zed keymap entry = %#v, want seeded copy from configs/zed/keymap.json", entry)
+		}
+		return
+	}
+	t.Fatal("repository manifest missing Zed keymap entry")
+}
+
 func TestDirectorySourceSymlinkStrategyPassesValidation(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "dots.yaml")


### PR DESCRIPTION
Closes #391

## PR Type

- [x] Configuration change (`type:config`)

## Summary

- Materialize Zed's order-sensitive keymap as Seeded Runtime State instead of a symlink into the Installed Repository.
- Preserve byte-exact local keymap evolution while advancing only an untouched prior seed.
- Cover legacy migration, aligned status, repository cleanliness, baseline advancement, and uninstall retention.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Changes the Zed keymap Managed Entry to `copy` with `ownership: seeded`. |
| `docs/manifest.md` | Documents the Zed keymap as Seeded Runtime State. |
| `internal/manifest/manifest_test.go` | Locks the repository manifest contract for the Zed keymap. |
| `internal/cli/issue391_zed_keymap_seeded_lifecycle_test.go` | Exercises byte-exact legacy migration and the complete seeded lifecycle in temporary roots. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go build ./...`
- [x] Built binary: `dots manifest validate --file dots.yaml`
- [x] Built binary with temporary roots: `dots plan --output json --file dots.yaml --profile desktop --source-root "$PWD" --home <tmp> --state-root <tmp>`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] All CLI validation that targeted home/config paths used temporary directories and explicit `--home`, `--source-root`, and `--state-root` flags.

## Contributor Checklist

- [x] Linked approved issue #391 with `Closes #391`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated the manifest documentation.
- [x] Used Conventional Commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

- Agent Brief: [comment 5226647910](https://github.com/yersonargotev/dots/issues/391#issuecomment-5226647910), SHA-256 `82142e95937e2fdc29beca388bf4fff1e29f3b21e84e00d4637ac3c4dab3168d`.
- Reviewed head: `c1e7280fa54376868ad9d04d3127511b19382dc1` against `origin/main` at `dc0009fe31239d18ae421ae1d6f23983321b11f8`.
- Acceptance coverage: the CLI lifecycle test verifies initial legacy symlink installation, byte-exact migration of ordered JSONC with comments and trailing commas, regular-file materialization, aligned `seeded-local-evolution` status, preservation across reinstall, Installed Repository cleanliness, untouched baseline advancement, and uninstall retention. The manifest test verifies `copy` plus `ownership: seeded`; no semantic parser or merge path is introduced.
- Automated validation: `gofmt -l .` produced no output; `go vet ./...`, `go build ./...`, and `go test ./...` passed. Focused manifest and CLI lifecycle tests passed.
- Manual verification with one built binary and explicit temporary roots: `dots install --yes --skip-deps --profile desktop ...` created the keymap as a regular file matching the baseline; after a simulated Zed edit, `dots status --output json ...` exited 0 with `state: ok` and `reason: seeded-local-evolution`; reinstall preserved SHA-256 `b1307c764c27512622625b71819fe3384bb37207923421d1d584a7bf88237b3f`; `dots uninstall --yes ...` reported retained Seeded Runtime State and left the keymap present. `dots manifest validate --file dots.yaml` passed, and sandboxed `dots plan --output json ...` exited 0 with the Zed keymap as a `copy` create action.
- Independent review: Standards approved with 0 findings; Spec approved with 0 findings for the exact reviewed head.
- Delegation: one bounded read-only exploration slice identified reuse of the #388 seeded-state mechanism and the four-file change surface; its result was accepted after main-agent inspection. Optional repository custom Codex agents were absent, so native subagents were used. The main agent inspected all affected code, authored and ran the tests, validated the full diff, and retained all requirements, integration, and GitHub mutations.
<!-- delivery-issue:evidence:end -->
