### PR TITLE
feat(git): co-own native global config

### DIFF
--- a/configs/git/README.md
+++ b/configs/git/README.md
@@ -1,12 +1,19 @@
 # Git configuration
 
-`configs/git/gitconfig` is the repository-managed Git configuration installed as
-`~/.gitconfig`. It intentionally contains only portable defaults that are safe to
-share across machines.
+`configs/git/loader.gitconfig` is installed as a dots-owned initial block in the
+regular native `~/.gitconfig`. The block loads the portable
+`configs/git/gitconfig` symlink at `~/.config/dots/git/gitconfig`, then the
+established `~/.gitconfig.local` extension. Native content follows the block and
+therefore has final precedence.
 
-Machine-specific configuration belongs in `~/.gitconfig.local`, which is loaded
-through the managed `[include]` entry. Use `gitconfig.local.example` as a starting
-point for the local file; never commit the real local file.
+The native file remains writable by `git config --global` and other Git tooling
+without changing the Installed Repository. Dots preserves comments and values
+outside its exact marked block during install, update, migration, and uninstall.
+Duplicate, incomplete, moved, or edited blocks are Conflicts and are not mutated.
+
+Machine-specific configuration belongs in `~/.gitconfig.local`. Use
+`gitconfig.local.example` as a starting point for the local file; never commit the
+real local file.
 
 ## Classification from current machine evidence
 
@@ -15,14 +22,20 @@ private values. The resulting boundary is:
 
 | Category | Examples | Repository decision |
 | --- | --- | --- |
-| Portable | `init.defaultBranch`, `pull.rebase`, `merge.conflictStyle=diff3` | Managed in `configs/git/gitconfig`. |
+| Portable | `init.defaultBranch`, `pull.rebase`, `merge.conflictStyle=diff3` | Managed in `configs/git/gitconfig` and loaded first. |
 | Local/private | `user.name`, `user.email`, signing keys, credential helpers | Kept in `~/.gitconfig.local`. |
 | Generated | credential stores, tool caches, Git runtime state | Not managed by `dots`. |
-| Machine-specific | work/client `includeIf` rules, absolute local paths, optional pager/tool wiring such as delta | Kept in `~/.gitconfig.local` unless a later issue manages that tool explicitly. |
+| Machine-specific | work/client `includeIf` rules, absolute local paths, optional pager/tool wiring such as delta | Kept in `~/.gitconfig.local` or native content unless a later issue manages that tool explicitly. |
+
+Git reads the three layers in this order:
+
+1. portable baseline;
+2. machine-local extension;
+3. native additions after the dots block.
 
 ## Local extension point
 
-The managed config works when `~/.gitconfig.local` is absent. That is intentional:
+The managed loader works when `~/.gitconfig.local` is absent. That is intentional:
 sandbox validation must not require private material.
 
 For a real workstation only, create the local file deliberately and never
@@ -72,7 +85,8 @@ go run ./cmd/dots status \
   --state-root "$sandbox_state"
 ```
 
-The expected result is that `~/.gitconfig` is installed/aligned inside
-`$sandbox_home`. Both the Dotfiles CLI target paths and the Go toolchain caches
-are redirected into `$sandbox_root`; the maintainer's real home directory must
-not be touched.
+The expected result is that `~/.gitconfig` is a regular file containing the
+initial dots block and that `~/.config/dots/git/gitconfig` is the portable
+symlink. Both the Dotfiles CLI target paths and the Go toolchain caches are
+redirected into `$sandbox_root`; the maintainer's real home directory must not
+be touched.

--- a/configs/git/gitconfig
+++ b/configs/git/gitconfig
@@ -1,5 +1,4 @@
-# Repository-managed Git configuration.
-# Machine-specific identity belongs in ~/.gitconfig.local.
+# Portable repository-managed Git configuration.
 
 [init]
 	defaultBranch = main
@@ -9,6 +8,3 @@
 
 [merge]
 	conflictStyle = diff3
-
-[include]
-	path = ~/.gitconfig.local

--- a/configs/git/loader.gitconfig
+++ b/configs/git/loader.gitconfig
@@ -1,0 +1,6 @@
+# >>> dots managed block >>>
+# Load portable defaults before the established machine-local extension.
+[include]
+	path = ~/.config/dots/git/gitconfig
+	path = ~/.gitconfig.local
+# <<< dots managed block <<<

--- a/docs/application-writable-target-research.md
+++ b/docs/application-writable-target-research.md
@@ -37,7 +37,7 @@ documentation, official project documentation, or the repository under review.
 | 1 | `configs/zsh/zshrc` | `~/.zshrc` | Application-Writable Target | The official Zsh `zsh-newuser-install` guided configuration supports `~/.zshrc`; after choices, it offers to save the file and backs up an existing one. [Zsh User Configuration Functions](https://zsh.sourceforge.io/Doc/Release/User-Contributions.html#User-Configuration-Functions) |
 | 2 | `configs/zsh/zimrc` | `~/.zimrc` | Read under ordinary use | Zimfw calls this its plugin-manager configuration and uses it to build files in `$ZIM_HOME`; its documented install/update commands write modules and `init.zsh` there, not `.zimrc`. No first-party normal writer to `.zimrc` was found. [Zimfw commands](https://zimfw.sh/docs/commands/) |
 | 3 | `configs/zsh/zshenv` | `~/.zshenv` | Read under ordinary use | Zsh documents `.zshenv` as a startup file it tests/loads. The documented new-user configurator handles only `.zshrc`; no normal writer to `.zshenv` was found. [Zsh modules](https://zsh.sourceforge.io/Doc/Release/Zsh-Modules.html), [new-user function](https://zsh.sourceforge.io/Doc/Release/User-Contributions.html#User-Configuration-Functions) |
-| 4 | `configs/git/gitconfig` | `~/.gitconfig` | Application-Writable Target | `git config --global` writes the global user configuration; Git’s own manual says the command adds values to `.gitconfig` in the home directory. [Git user manual](https://git-scm.com/docs/user-manual#telling-git-your-name) |
+| 4 | `configs/git/gitconfig` | `~/.config/dots/git/gitconfig` | Read under ordinary use | The regular native `~/.gitconfig` loads this portable baseline through its dots-owned initial block. Git reads the fragment, while supported global writes remain in the native file. [Git user manual](https://git-scm.com/docs/user-manual#telling-git-your-name) |
 | 5 | `configs/dots/theme.sh` | `~/.config/dots/theme.sh` | Read under ordinary use | This repository documents it as the helper read by the adaptive-theme setup; `tmux.conf` and statusline scripts source it. It has no external owning application or documented writer in scope. [Repository adaptive-theme audit](adaptive-theme-audit.md) |
 | 6 | `configs/dots/adaptive-theme` | `~/.config/dots/adaptive-theme` | Read under ordinary use | The repository documents it as an opt-in marker read by `theme.sh`; installing the tag creates it. No application writer in scope was found. [Repository adaptive-theme audit](adaptive-theme-audit.md) |
 | 7 | `configs/starship/starship.toml` | `~/.config/starship.toml` | Explicit operator output | Starship documents presets with an explicit output target, e.g. `starship preset no-runtime-versions -o ~/.config/starship.toml`. This can overwrite through the symlink only when the operator selects that path; it is not a normal prompt-runtime write. [Starship preset](https://starship.rs/presets/no-runtimes) |
@@ -60,9 +60,10 @@ documentation, official project documentation, or the repository under review.
 ### Git
 
 Git is unambiguous: `git config --global user.name ...` and `user.email ...`
-write the home `.gitconfig` according to Git’s own manual. This is a supported,
-ordinary configuration command, so the symlink would expose the repository
-source to a normal Git configuration operation.
+write the home `.gitconfig` according to Git’s own manual. The native target is
+therefore a regular co-owned file whose initial marked block loads the portable
+symlink and local extension; normal Git writes no longer expose the repository
+source.
 
 ### Atuin
 

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -190,7 +190,8 @@ Current Managed Entries:
 | `configs/zsh/zshrc` | `~/.config/dots/zsh/zshrc` | `symlink` | `core` | `darwin`, `linux` | None |
 | `configs/zsh/zimrc` | `~/.zimrc` | `symlink` | `core` | `darwin`, `linux` | `zsh` |
 | `configs/zsh/zshenv` | `~/.zshenv` | `symlink` | `core` | `darwin`, `linux` | `zsh` |
-| `configs/git/gitconfig` | `~/.gitconfig` | `symlink` | `core` | `darwin`, `linux` | `git` |
+| `configs/git/loader.gitconfig` | `~/.gitconfig` | `copy` (`marked-block`) | `core` | `darwin`, `linux` | `git` |
+| `configs/git/gitconfig` | `~/.config/dots/git/gitconfig` | `symlink` | `core` | `darwin`, `linux` | None |
 | `configs/dots/theme.sh` | `~/.config/dots/theme.sh` | `symlink` | `core` | `darwin`, `linux` | None |
 | `configs/dots/adaptive-theme` | `~/.config/dots/adaptive-theme` | `symlink` | `adaptive-theme` | `darwin`, `linux` | None |
 | `configs/starship/starship.toml` | `~/.config/starship.toml` | `symlink` | `core` | `darwin`, `linux` | `starship` |

--- a/dots.yaml
+++ b/dots.yaml
@@ -238,9 +238,10 @@ entries:
         apt: zsh
         dnf: zsh
         pacman: zsh
-  - source: configs/git/gitconfig
+  - source: configs/git/loader.gitconfig
     target: ~/.gitconfig
-    strategy: symlink
+    strategy: copy
+    ownership: marked-block
     tags:
       - core
     os:
@@ -252,6 +253,14 @@ entries:
         apt: git
         dnf: git
         pacman: git
+  - source: configs/git/gitconfig
+    target: ~/.config/dots/git/gitconfig
+    strategy: symlink
+    tags:
+      - core
+    os:
+      - darwin
+      - linux
   - source: configs/dots/theme.sh
     target: ~/.config/dots/theme.sh
     strategy: symlink

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1013,10 +1013,20 @@ func TestRepositoryGitConfigInstallsAndReportsAlignedInSandbox(t *testing.T) {
 	}
 
 	gitconfigTarget := filepath.Join(home, ".gitconfig")
-	if target, err := os.Readlink(gitconfigTarget); err != nil {
-		t.Fatalf("sandbox gitconfig target is not a symlink: %v", err)
+	if info, err := os.Lstat(gitconfigTarget); err != nil || !info.Mode().IsRegular() {
+		t.Fatalf("sandbox native gitconfig is not a regular file: info=%v err=%v", info, err)
+	}
+	loaderSource := filepath.Join(sourceRoot, "configs/git/loader.gitconfig")
+	if got, err := os.ReadFile(gitconfigTarget); err != nil {
+		t.Fatalf("read sandbox native gitconfig: %v", err)
+	} else if want, readErr := os.ReadFile(loaderSource); readErr != nil || !bytes.Equal(got, want) {
+		t.Fatalf("sandbox native gitconfig = (%q, %v), want loader (%q, %v)", got, err, want, readErr)
+	}
+	portableGitTarget := filepath.Join(home, ".config/dots/git/gitconfig")
+	if target, err := os.Readlink(portableGitTarget); err != nil {
+		t.Fatalf("sandbox portable gitconfig target is not a symlink: %v", err)
 	} else if want := filepath.Join(sourceRoot, "configs/git/gitconfig"); target != want {
-		t.Fatalf("sandbox gitconfig symlink = %q, want %q", target, want)
+		t.Fatalf("sandbox portable gitconfig symlink = %q, want %q", target, want)
 	}
 	zellijConfigTarget := filepath.Join(home, ".config/zellij/config.kdl")
 	if target, err := os.Readlink(zellijConfigTarget); err != nil {
@@ -1097,7 +1107,8 @@ func TestRepositoryGitConfigInstallsAndReportsAlignedInSandbox(t *testing.T) {
 	got := statusOut.String()
 	for _, want := range []string{
 		"ok",
-		"configs/git/gitconfig -> " + gitconfigTarget,
+		"configs/git/loader.gitconfig -> " + gitconfigTarget,
+		"configs/git/gitconfig -> " + portableGitTarget,
 		"configs/zellij/config.kdl -> " + zellijConfigTarget,
 		"configs/zellij/layouts/default.kdl -> " + zellijLayoutTarget,
 		"configs/nvim/loader.lua -> " + nvimLoader,

--- a/internal/install/issue392_git_markedblock_test.go
+++ b/internal/install/issue392_git_markedblock_test.go
@@ -1,0 +1,212 @@
+package install_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/install"
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/plan"
+	"github.com/yersonargotev/dots/internal/repositoryrefresh"
+	"github.com/yersonargotev/dots/internal/state"
+	"github.com/yersonargotev/dots/internal/status"
+	"github.com/yersonargotev/dots/internal/uninstall"
+)
+
+func TestGitMarkedBlockLifecycle(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := filepath.Join(home, ".local", "state", "dots")
+	portableSource := filepath.Join(sourceRoot, "configs/git/gitconfig")
+	loaderSource := filepath.Join(sourceRoot, "configs/git/loader.gitconfig")
+	legacy := []byte("[dots]\n\tlayer = portable\n[include]\n\tpath = ~/.gitconfig.local\n")
+	portable := []byte("[dots]\n\tlayer = portable\n")
+	loader := []byte("# >>> dots managed block >>>\n[include]\n\tpath = ~/.config/dots/git/gitconfig\n\tpath = ~/.gitconfig.local\n# <<< dots managed block <<<\n")
+	writeMigrationFile(t, portableSource, legacy)
+	writeMigrationFile(t, filepath.Join(home, ".gitconfig.local"), []byte("[dots]\n\tlayer = local\n[user]\n\tname = Local User\n"))
+	runMigrationGit(t, sourceRoot, "init")
+	runMigrationGit(t, sourceRoot, "config", "user.email", "dots@example.test")
+	runMigrationGit(t, sourceRoot, "config", "user.name", "dots test")
+	runMigrationGit(t, sourceRoot, "add", ".")
+	runMigrationGit(t, sourceRoot, "commit", "-m", "legacy git config")
+	revision := runMigrationGit(t, sourceRoot, "rev-parse", "HEAD")
+
+	target := filepath.Join(home, ".gitconfig")
+	if err := os.Symlink(portableSource, target); err != nil {
+		t.Fatalf("symlink legacy gitconfig: %v", err)
+	}
+	runGlobalGitConfig(t, home, "user.email", "native@example.test")
+	legacyAfterGlobalWrite := mustReadFile(t, portableSource)
+	nativeAdditions := []byte("# native additions\n[dots]\n\tlayer = native\n[includeIf \"gitdir:~/work/\"]\n\tpath = ~/.gitconfig.work\n")
+	if err := os.WriteFile(portableSource, append(legacyAfterGlobalWrite, nativeAdditions...), 0o600); err != nil {
+		t.Fatalf("append native values: %v", err)
+	}
+	external := append([]byte(nil), mustTrimPrefix(t, mustReadFile(t, portableSource), legacy)...)
+	if len(external) == 0 {
+		t.Fatal("git config --global did not append native content to the legacy source")
+	}
+	meta := state.Metadata{Version: state.CurrentVersion, Provenance: state.Provenance{SourceRoot: sourceRoot, SourceRevision: revision}, Entries: []state.Record{{
+		Target: target, Source: "configs/git/gitconfig", Strategy: "symlink", Ownership: "whole",
+	}}}
+	if err := state.Save(state.Path(stateRoot), meta); err != nil {
+		t.Fatalf("save legacy metadata: %v", err)
+	}
+	oldManifest := gitManifest("configs/git/gitconfig", "~/.gitconfig", "symlink", "")
+	newManifest := manifest.Manifest{Version: 1, Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}}, Entries: []manifest.Entry{
+		{Source: "configs/git/loader.gitconfig", Target: "~/.gitconfig", Strategy: "copy", Ownership: "marked-block", Tags: []string{"core"}, OS: []string{"linux"}},
+		{Source: "configs/git/gitconfig", Target: "~/.config/dots/git/gitconfig", Strategy: "symlink", Tags: []string{"core"}, OS: []string{"linux"}},
+	}}
+	captures, err := repositoryrefresh.CaptureLegacyTargets(oldManifest, newManifest, meta, sourceRoot, home, "", revision)
+	if err != nil {
+		t.Fatalf("CaptureLegacyTargets() error = %v", err)
+	}
+	writeMigrationFile(t, portableSource, portable)
+	writeMigrationFile(t, loaderSource, loader)
+	runMigrationGit(t, sourceRoot, "add", ".")
+	runMigrationGit(t, sourceRoot, "commit", "-m", "co-own native git config")
+
+	p, err := plan.Build(newManifest, plan.Options{Profile: "default", OS: "linux", SourceRoot: sourceRoot, Home: home, Metadata: meta, LegacyMigrations: captures})
+	if err != nil {
+		t.Fatalf("Build(migrate) error = %v", err)
+	}
+	if action := actionForTarget(t, p, target); action.Status != plan.StatusMigrate {
+		t.Fatalf("native migration action = %#v, want migrate", action)
+	}
+	if err := install.Apply(p, install.Options{SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot}); err != nil {
+		t.Fatalf("Apply(migrate) error = %v", err)
+	}
+	want := append(append([]byte(nil), loader...), external...)
+	if got := mustReadFile(t, target); !bytes.Equal(got, want) {
+		t.Fatalf("migrated target = %q, want %q", got, want)
+	}
+	if info, err := os.Lstat(target); err != nil || !info.Mode().IsRegular() {
+		t.Fatalf("native target = (%v, %v), want regular file", info, err)
+	}
+	if got := runGitConfigGetAll(t, home, "dots.layer"); got != "portable\nlocal\nnative" {
+		t.Fatalf("effective precedence = %q, want portable, local, native", got)
+	}
+	runGlobalGitConfig(t, home, "user.name", "Native User")
+	if out := runMigrationGit(t, sourceRoot, "status", "--porcelain"); out != "" {
+		t.Fatalf("repository status after global write = %q, want clean", out)
+	}
+
+	meta, err = state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load marked-block metadata: %v", err)
+	}
+	report, err := status.Build(newManifest, meta, status.Options{Profile: "default", OS: "linux", SourceRoot: sourceRoot, Home: home})
+	if err != nil || statusForTarget(t, report, target) != status.StateOK {
+		t.Fatalf("status after native write = (%#v, %v), want ok", report, err)
+	}
+	compatible := mustReadFile(t, target)
+	for name, content := range map[string][]byte{
+		"duplicate":     append(append([]byte(nil), loader...), loader...),
+		"missing-close": []byte("# >>> dots managed block >>>\n[include]\n\tpath = bad\n"),
+		"moved":         append([]byte("[user]\n\tname = Before\n"), compatible...),
+		"modified":      []byte("# >>> dots managed block >>>\n[include]\n\tpath = changed\n# <<< dots managed block <<<\n"),
+	} {
+		t.Run(name+" conflict", func(t *testing.T) {
+			if err := os.WriteFile(target, content, 0o600); err != nil {
+				t.Fatalf("write fixture: %v", err)
+			}
+			conflictPlan, err := plan.Build(newManifest, plan.Options{Profile: "default", OS: "linux", SourceRoot: sourceRoot, Home: home, Metadata: meta})
+			if err != nil || actionForTarget(t, conflictPlan, target).Status != plan.StatusConflict {
+				t.Fatalf("plan = (%#v, %v), want conflict", conflictPlan, err)
+			}
+			if got := mustReadFile(t, target); !bytes.Equal(got, content) {
+				t.Fatalf("conflict fixture changed = %q", got)
+			}
+		})
+	}
+	if err := os.WriteFile(target, compatible, 0o600); err != nil {
+		t.Fatalf("restore compatible target: %v", err)
+	}
+
+	uninstallPlan, err := plan.BuildUninstall(meta, plan.UninstallOptions{SourceRoot: sourceRoot, Home: home})
+	if err != nil {
+		t.Fatalf("BuildUninstall() error = %v", err)
+	}
+	result, err := uninstall.Apply(uninstallPlan, uninstall.Options{SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot})
+	if err != nil {
+		t.Fatalf("uninstall Apply() error = %v", err)
+	}
+	if len(result.Updated) != 1 || result.Updated[0] != target {
+		t.Fatalf("uninstall result = %#v, want updated native target", result)
+	}
+	remaining := mustReadFile(t, target)
+	if bytes.Contains(remaining, []byte("dots managed block")) || !bytes.Contains(remaining, []byte("native@example.test")) || !bytes.Contains(remaining, []byte("Native User")) {
+		t.Fatalf("uninstalled native target = %q, want only preserved external content", remaining)
+	}
+	if got := mustReadFile(t, filepath.Join(home, ".gitconfig.local")); !bytes.Contains(got, []byte("Local User")) {
+		t.Fatalf("local extension changed during uninstall: %q", got)
+	}
+}
+
+func gitManifest(source, target, strategy, ownership string) manifest.Manifest {
+	return manifest.Manifest{Version: 1, Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}}, Entries: []manifest.Entry{{
+		Source: source, Target: target, Strategy: strategy, Ownership: ownership, Tags: []string{"core"}, OS: []string{"linux"},
+	}}}
+}
+
+func runGlobalGitConfig(t *testing.T, home, key, value string) {
+	t.Helper()
+	cmd := exec.Command("git", "config", "--global", key, value)
+	cmd.Env = append(os.Environ(), "HOME="+home, "GIT_CONFIG_GLOBAL="+filepath.Join(home, ".gitconfig"), "GIT_CONFIG_NOSYSTEM=1")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git config --global %s: %v\n%s", key, err, out)
+	}
+}
+
+func runGitConfigGetAll(t *testing.T, home, key string) string {
+	t.Helper()
+	cmd := exec.Command("git", "config", "--global", "--includes", "--get-all", key)
+	cmd.Env = append(os.Environ(), "HOME="+home, "GIT_CONFIG_GLOBAL="+filepath.Join(home, ".gitconfig"), "GIT_CONFIG_NOSYSTEM=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git config --get-all %s: %v\n%s", key, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func mustReadFile(t *testing.T, path string) []byte {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return content
+}
+
+func mustTrimPrefix(t *testing.T, content, prefix []byte) []byte {
+	t.Helper()
+	if !bytes.HasPrefix(content, prefix) {
+		t.Fatalf("content %q does not preserve prefix %q", content, prefix)
+	}
+	return content[len(prefix):]
+}
+
+func actionForTarget(t *testing.T, p plan.Plan, target string) plan.Action {
+	t.Helper()
+	for _, action := range p.Actions {
+		if action.Target == target {
+			return action
+		}
+	}
+	t.Fatalf("plan has no action for %s: %#v", target, p.Actions)
+	return plan.Action{}
+}
+
+func statusForTarget(t *testing.T, report status.Report, target string) status.State {
+	t.Helper()
+	for _, entry := range report.Entries {
+		if entry.Target == target {
+			return entry.State
+		}
+	}
+	t.Fatalf("status has no entry for %s: %#v", target, report.Entries)
+	return ""
+}

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -2227,7 +2227,7 @@ func TestRepositoryManifestIncludesMVPConfigurationSet(t *testing.T) {
 		dep      string
 	}{
 		{name: "zsh", target: "~/.zshrc", source: "configs/zsh/loader.zsh", strategy: "copy", dep: "zsh"},
-		{name: "git", target: "~/.gitconfig", source: "configs/git/gitconfig", strategy: "symlink", dep: "git"},
+		{name: "git", target: "~/.gitconfig", source: "configs/git/loader.gitconfig", strategy: "copy", dep: "git"},
 		{name: "starship", target: "~/.config/starship.toml", source: "configs/starship/starship.toml", strategy: "symlink", dep: "starship"},
 		{name: "tmux", target: "~/.tmux.conf", source: "configs/tmux/tmux.conf", strategy: "symlink", dep: "tmux"},
 	}
@@ -2258,6 +2258,9 @@ func TestRepositoryManifestIncludesMVPConfigurationSet(t *testing.T) {
 	if got := entriesByTarget["~/.zshrc"].Ownership; got != "marked-block" {
 		t.Errorf("zsh ownership = %q, want marked-block", got)
 	}
+	if got := entriesByTarget["~/.gitconfig"].Ownership; got != "marked-block" {
+		t.Errorf("git ownership = %q, want marked-block", got)
+	}
 	atuin, ok := entriesByTarget["~/.config/atuin/config.toml"]
 	if !ok || atuin.Source != "configs/atuin/config.toml" || atuin.Strategy != "copy" || atuin.Ownership != "toml-subset" {
 		t.Errorf("Atuin config entry = %#v, want copy with TOML Subset Ownership", atuin)
@@ -2265,6 +2268,10 @@ func TestRepositoryManifestIncludesMVPConfigurationSet(t *testing.T) {
 	portable, ok := entriesByTarget["~/.config/dots/zsh/zshrc"]
 	if !ok || portable.Source != "configs/zsh/zshrc" || portable.Strategy != "symlink" {
 		t.Errorf("portable zsh entry = %#v, want managed symlink", portable)
+	}
+	portableGit, ok := entriesByTarget["~/.config/dots/git/gitconfig"]
+	if !ok || portableGit.Source != "configs/git/gitconfig" || portableGit.Strategy != "symlink" {
+		t.Errorf("portable git entry = %#v, want managed symlink", portableGit)
 	}
 }
 
@@ -2334,9 +2341,9 @@ func TestRepositoryManagedConfigsExposeLocalExtensionPoints(t *testing.T) {
 		},
 		{
 			name: "git has private local include",
-			path: "configs/git/gitconfig",
+			path: "configs/git/loader.gitconfig",
 			contains: []string{
-				"Machine-specific identity belongs in ~/.gitconfig.local",
+				"established machine-local extension",
 				"path = ~/.gitconfig.local",
 			},
 		},
@@ -2403,11 +2410,25 @@ func TestRepositoryGitConfigClassifiesPortableAndLocalConcerns(t *testing.T) {
 		"defaultBranch = main",
 		"rebase = false",
 		"conflictStyle = diff3",
-		"path = ~/.gitconfig.local",
 	} {
 		if !strings.Contains(managed, want) {
 			t.Fatalf("managed gitconfig missing portable/local boundary %q:\n%s", want, managed)
 		}
+	}
+	if strings.Contains(managed, "gitconfig.local") {
+		t.Fatalf("portable gitconfig includes the local extension directly:\n%s", managed)
+	}
+
+	loaderPath := filepath.Join(root, "configs/git/loader.gitconfig")
+	loaderBytes, err := os.ReadFile(loaderPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", loaderPath, err)
+	}
+	loader := string(loaderBytes)
+	portableIndex := strings.Index(loader, "path = ~/.config/dots/git/gitconfig")
+	localIndex := strings.Index(loader, "path = ~/.gitconfig.local")
+	if portableIndex < 0 || localIndex < 0 || portableIndex >= localIndex {
+		t.Fatalf("git loader include order is not portable then local:\n%s", loader)
 	}
 
 	normalizedManaged := strings.ToLower(managed)


### PR DESCRIPTION
Closes #392

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Keeps Git's native global configuration as a regular, writable file.
- Loads the portable baseline, then the established local extension, before native additions.
- Reuses marked-block migration and uninstall semantics to preserve external Git content.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Replaces the native Git symlink with a marked-block copy and adds the portable symlink. |
| `configs/git/*` | Adds the native loader block and removes the local include from the portable baseline. |
| `internal/install/issue392_git_markedblock_test.go` | Covers migration, precedence, global writes, conflicts, and partial uninstall. |
| `internal/manifest/manifest_test.go` | Verifies the new ownership and include topology. |
| `configs/git/README.md`, `docs/manifest.md`, `docs/application-writable-target-research.md` | Documents the new co-owned entrypoint and lifecycle. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go build ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed real-binary install/status/uninstall with temporary `HOME`, source, state, and Git config paths

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #392`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

- Agent Brief: [comment 5226648030](https://github.com/yersonargotev/dots/issues/392#issuecomment-5226648030), SHA-256 `bd2e594bd0cb2e161efad0f72ca881877b8c30c8c8a5032da321b876fa5dd128`.
- Reviewed head: `f7d5860e6032907bf45a2e3d945ef3b165138774` against `origin/main` at `407b49f9d3aa689c073857b235222b986f92ce8c`.
- Acceptance coverage:
  - A real `git config --global` write targets only the regular native file; repository status is unchanged.
  - `git config --includes --get-all` observes portable, local, then native values in order.
  - Migration preserves native identity and conditional-include content; local identity remains supported.
  - Duplicate, incomplete, moved, and modified blocks are Conflicts with byte-for-byte no mutation.
  - Uninstall removes only the owned block and portable symlink while preserving native and local content.
- Automated validation: focused plan/install/status/uninstall/manifest/repository-refresh/CLI packages passed; `gofmt -l .`, `go vet ./...`, `go build ./...`, cache-disabled `go test -count=1 ./...`, and manifest validation all passed. A first remote run exposed and led to correction of one stale integration assertion that expected the old native symlink topology.
- Manual verification: built `./cmd/dots` to a temporary binary; sandboxed `install --yes --skip-deps --profile core`, `status --output json`, real Git precedence/write checks, and `uninstall --yes` all passed with temporary home/state/config paths.
- Independent review: Standards — no actionable findings; Spec — no actionable findings or scope creep. Both re-reviewed the complete `origin/main...f7d5860e6032907bf45a2e3d945ef3b165138774` range after the CI-driven test fix.
- Delegation: one read-only exploration slice inspected the existing marked-block lifecycle and recommended reusing it without production Go changes. The main agent accepted that result, inspected the referenced paths, implemented the change, and verified it through focused, full-suite, and real-binary tests. Installed delegation overlay/custom-agent artifacts were absent; native bounded subagent capability supplied the authorized slice and independent reviews.
<!-- delivery-issue:evidence:end -->
