### PR TITLE
feat(herdr): materialize co-owned TOML config

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -196,7 +196,7 @@ Current Managed Entries:
 | `configs/dots/adaptive-theme` | `~/.config/dots/adaptive-theme` | `symlink` | `adaptive-theme` | `darwin`, `linux` | None |
 | `configs/starship/starship.toml` | `~/.config/starship.toml` | `symlink` | `core` | `darwin`, `linux` | `starship` |
 | `configs/tmux/tmux.conf` | `~/.tmux.conf` | `symlink` | `core` | `darwin`, `linux` | `tmux` |
-| `configs/herdr/config.toml` (`adaptive-theme` override: `configs/herdr/config-adaptive.toml`) | `~/.config/herdr/config.toml` | `symlink` | `core` | `darwin` | `herdr` |
+| `configs/herdr/config.toml` (`adaptive-theme` override: `configs/herdr/config-adaptive.toml`) | `~/.config/herdr/config.toml` | `copy` | `core` | `darwin` | `herdr`; owns TOML subset |
 | `configs/zellij/config.kdl` (`adaptive-theme` override: `configs/zellij/config-adaptive.kdl`) | `~/.config/zellij/config.kdl` | `symlink` | `core` | `darwin`, `linux` | `zellij` |
 | `configs/zellij/layouts/default.kdl` | `~/.config/zellij/layouts/default.kdl` | `symlink` | `core` | `darwin`, `linux` | `zellij` |
 | `configs/ghostty/config.ghostty` | `~/.config/ghostty/config.ghostty` | `symlink` | `desktop` | `darwin`, `linux` | `ghostty` |

--- a/dots.yaml
+++ b/dots.yaml
@@ -315,7 +315,8 @@ entries:
     source_overrides:
       adaptive-theme: configs/herdr/config-adaptive.toml
     target: ~/.config/herdr/config.toml
-    strategy: symlink
+    strategy: copy
+    ownership: toml-subset
     tags:
       - core
     os:

--- a/internal/install/issue396_herdr_test.go
+++ b/internal/install/issue396_herdr_test.go
@@ -1,0 +1,230 @@
+package install_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/backups"
+	"github.com/yersonargotev/dots/internal/install"
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/plan"
+	"github.com/yersonargotev/dots/internal/repositoryrefresh"
+	"github.com/yersonargotev/dots/internal/state"
+	"github.com/yersonargotev/dots/internal/status"
+	"github.com/yersonargotev/dots/internal/uninstall"
+)
+
+func TestHerdrTOMLSubsetLifecycleMigratesAdaptiveConfigAndPreservesExternalContent(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := filepath.Join(home, ".local", "state", "dots")
+	defaultSource := filepath.Join(sourceRoot, "configs", "herdr", "config.toml")
+	adaptiveSource := filepath.Join(sourceRoot, "configs", "herdr", "config-adaptive.toml")
+	target := filepath.Join(home, ".config", "herdr", "config.toml")
+	defaultBaseline := []byte("onboarding = true\n\n[theme]\nname = \"catppuccin\"\n\n[keys]\nprefix = \"ctrl+a\"\n")
+	oldAdaptiveBaseline := []byte("onboarding = true\n\n[theme]\nname = \"catppuccin\"\nauto_switch = true\n\n[keys]\nprefix = \"ctrl+a\"\nreset = \"prefix+r\"\n")
+	incomingAdaptiveBaseline := []byte("onboarding = true\n\n[theme]\nname = \"catppuccin\"\nauto_switch = true\nlight_name = \"catppuccin-latte\"\n\n[keys]\nprefix = \"ctrl+a\"\nreset = \"prefix+r\"\n")
+	external := []byte("\n# retained exactly for a Herdr-owned extension\n[local]\ncustom = \"value\" # keep inline comment\n")
+
+	writeMigrationFile(t, defaultSource, defaultBaseline)
+	writeMigrationFile(t, adaptiveSource, oldAdaptiveBaseline)
+	runMigrationGit(t, sourceRoot, "init")
+	runMigrationGit(t, sourceRoot, "config", "user.email", "dots@example.test")
+	runMigrationGit(t, sourceRoot, "config", "user.name", "dots test")
+	runMigrationGit(t, sourceRoot, "add", ".")
+	runMigrationGit(t, sourceRoot, "commit", "-m", "legacy Herdr baseline")
+	oldRevision := strings.TrimSpace(runMigrationGit(t, sourceRoot, "rev-parse", "HEAD"))
+
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target parent: %v", err)
+	}
+	if err := os.Symlink(adaptiveSource, target); err != nil {
+		t.Fatalf("symlink legacy Herdr config: %v", err)
+	}
+	if err := os.WriteFile(adaptiveSource, append(append([]byte(nil), oldAdaptiveBaseline...), external...), 0o600); err != nil {
+		t.Fatalf("simulate legacy Herdr target write: %v", err)
+	}
+
+	oldManifest := herdrManifest("symlink", "")
+	newManifest := herdrManifest("copy", "toml-subset")
+	meta := state.Metadata{
+		Version:    state.CurrentVersion,
+		Provenance: state.Provenance{SourceRoot: sourceRoot, SourceRevision: oldRevision},
+		Entries: []state.Record{{
+			Target: target, Source: "configs/herdr/config-adaptive.toml", Strategy: "symlink", Ownership: "whole",
+		}},
+	}
+	if err := state.Save(state.Path(stateRoot), meta); err != nil {
+		t.Fatalf("save legacy metadata: %v", err)
+	}
+	captures, err := repositoryrefresh.CaptureLegacyTargets(oldManifest, newManifest, meta, sourceRoot, home, "", oldRevision)
+	if err != nil {
+		t.Fatalf("CaptureLegacyTargets() error = %v", err)
+	}
+	if got := captures[target].CapturedContent; !bytes.Equal(got, append(append([]byte(nil), oldAdaptiveBaseline...), external...)) {
+		t.Fatalf("captured Herdr config = %q", got)
+	}
+
+	writeMigrationFile(t, adaptiveSource, incomingAdaptiveBaseline)
+	runMigrationGit(t, sourceRoot, "add", ".")
+	runMigrationGit(t, sourceRoot, "commit", "-m", "materialize Herdr config")
+	p, err := plan.Build(newManifest, plan.Options{
+		Profile: "default", ExtraTags: []string{"adaptive-theme"}, OS: "darwin", SourceRoot: sourceRoot, Home: home,
+		Metadata: meta, LegacyMigrations: captures,
+	})
+	if err != nil {
+		t.Fatalf("Build(migration) error = %v", err)
+	}
+	if len(p.Actions) != 1 || p.Actions[0].Status != plan.StatusMigrate || p.Actions[0].Source != "configs/herdr/config-adaptive.toml" {
+		t.Fatalf("migration plan = %#v, want one adaptive migrate action", p.Actions)
+	}
+	if err := install.Apply(p, install.Options{SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot}); err != nil {
+		t.Fatalf("Apply(migration) error = %v", err)
+	}
+	if info, err := os.Lstat(target); err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("materialized Herdr target = (%v, %v), want regular file", info, err)
+	}
+	assertContainsAll(t, target, []string{`light_name = "catppuccin-latte"`, `[keys]`, `prefix = "ctrl+a"`, string(external)})
+	if got := runMigrationGit(t, sourceRoot, "status", "--porcelain"); got != "" {
+		t.Fatalf("repository status after Herdr migration = %q, want clean", got)
+	}
+	backupMeta, err := backups.Load(backups.Path(stateRoot))
+	if err != nil || len(backupMeta.Sets) != 1 || len(backupMeta.Sets[0].Targets) != 1 || backupMeta.Sets[0].Targets[0] != target {
+		t.Fatalf("migration Backup Sets = (%#v, %v), want target backup", backupMeta, err)
+	}
+
+	meta, err = state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load migrated metadata: %v", err)
+	}
+	rec, ok := meta.FindByTarget(target)
+	if !ok || rec.Source != "configs/herdr/config-adaptive.toml" || rec.Ownership != "toml-subset" || !bytes.Equal(rec.OwnedBytes, incomingAdaptiveBaseline) {
+		t.Fatalf("Herdr ownership record = %#v, want adaptive TOML contribution", rec)
+	}
+	report, err := status.Build(newManifest, meta, status.Options{Profile: "default", ExtraTags: []string{"adaptive-theme"}, OS: "darwin", SourceRoot: sourceRoot, Home: home})
+	if err != nil || len(report.Entries) != 1 || report.Entries[0].State != status.StateOK {
+		t.Fatalf("status after migration = (%#v, %v), want ok", report, err)
+	}
+
+	live, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read materialized target: %v", err)
+	}
+	afterOnboarding := bytes.Replace(live, []byte("onboarding = true"), []byte("onboarding = false"), 1)
+	afterResetKeys := bytes.Replace(afterOnboarding, []byte("prefix = \"ctrl+a\"\nreset = \"prefix+r\"\n"), nil, 1)
+	if err := os.WriteFile(target, afterResetKeys, 0o600); err != nil {
+		t.Fatalf("simulate Herdr onboarding and config reset-keys: %v", err)
+	}
+	if got := runMigrationGit(t, sourceRoot, "status", "--porcelain"); got != "" {
+		t.Fatalf("Herdr-supported target writes changed the Source of Truth: %q", got)
+	}
+	report, err = status.Build(newManifest, meta, status.Options{Profile: "default", ExtraTags: []string{"adaptive-theme"}, OS: "darwin", SourceRoot: sourceRoot, Home: home})
+	if err != nil || report.Entries[0].State != status.StateDrifted {
+		t.Fatalf("status after Herdr-owned changes = (%#v, %v), want drifted", report, err)
+	}
+	conflictPlan, err := plan.Build(newManifest, plan.Options{Profile: "default", ExtraTags: []string{"adaptive-theme"}, OS: "darwin", SourceRoot: sourceRoot, Home: home, Metadata: meta})
+	if err != nil || conflictPlan.Actions[0].Status != plan.StatusConflict {
+		t.Fatalf("plan after Herdr-owned changes = (%#v, %v), want conflict", conflictPlan, err)
+	}
+	if got, err := os.ReadFile(target); err != nil || !bytes.Equal(got, afterResetKeys) {
+		t.Fatalf("owned Herdr changes were overwritten = (%q, %v)", got, err)
+	}
+	if err := os.WriteFile(target, live, 0o600); err != nil {
+		t.Fatalf("restore compatible Herdr target: %v", err)
+	}
+
+	updatedAdaptiveBaseline := []byte("onboarding = false\n\n[theme]\nname = \"catppuccin\"\nauto_switch = true\ndark_name = \"catppuccin\"\nlight_name = \"catppuccin-latte\"\n\n[keys]\nprefix = \"ctrl+a\"\n")
+	writeMigrationFile(t, adaptiveSource, updatedAdaptiveBaseline)
+	runMigrationGit(t, sourceRoot, "add", ".")
+	runMigrationGit(t, sourceRoot, "commit", "-m", "update Herdr adaptive baseline")
+	updatePlan, err := plan.Build(newManifest, plan.Options{Profile: "default", ExtraTags: []string{"adaptive-theme"}, OS: "darwin", SourceRoot: sourceRoot, Home: home, Metadata: meta})
+	if err != nil || updatePlan.Actions[0].Status != plan.StatusUpdate {
+		t.Fatalf("adaptive baseline update plan = (%#v, %v), want update", updatePlan, err)
+	}
+	if err := install.Apply(updatePlan, install.Options{SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot}); err != nil {
+		t.Fatalf("Apply(update) error = %v", err)
+	}
+	assertContainsAll(t, target, []string{`onboarding = false`, `dark_name = "catppuccin"`, `prefix = "ctrl+a"`, string(external)})
+	if got, _ := os.ReadFile(target); bytes.Contains(got, []byte(`reset = "prefix+r"`)) {
+		t.Fatalf("updated Herdr target retained retired owned key:\n%s", got)
+	}
+
+	meta, err = state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("reload updated metadata: %v", err)
+	}
+	rec, ok = meta.FindByTarget(target)
+	if !ok || rec.Source != "configs/herdr/config-adaptive.toml" || !bytes.Equal(rec.OwnedBytes, updatedAdaptiveBaseline) {
+		t.Fatalf("updated Herdr ownership record = %#v", rec)
+	}
+	uninstallPlan, err := plan.BuildUninstall(state.Metadata{Entries: []state.Record{rec}}, plan.UninstallOptions{SourceRoot: sourceRoot, Home: home})
+	if err != nil || len(uninstallPlan.Actions) != 1 || uninstallPlan.Actions[0].Status != plan.UninstallRemove {
+		t.Fatalf("BuildUninstall() = (%#v, %v), want partial removal", uninstallPlan, err)
+	}
+	result, err := uninstall.Apply(uninstallPlan, uninstall.Options{SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot, Force: true})
+	if err != nil {
+		t.Fatalf("uninstall Apply() error = %v", err)
+	}
+	if len(result.Updated) != 1 || result.Updated[0] != target || len(result.Removed) != 0 {
+		t.Fatalf("uninstall result = %#v, want preserved external Herdr config", result)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil || !bytes.Contains(got, external) {
+		t.Fatalf("external Herdr content after uninstall = (%q, %v), want retained exactly", got, err)
+	}
+	for _, removed := range []string{"onboarding", "prefix", "light_name", "dark_name"} {
+		if bytes.Contains(got, []byte(removed)) {
+			t.Fatalf("uninstalled target retained dots-owned %q:\n%s", removed, got)
+		}
+	}
+	if _, ok := loadInstallMetadata(t, stateRoot).FindByTarget(target); ok {
+		t.Fatal("Herdr metadata record not pruned after partial uninstall")
+	}
+}
+
+func TestHerdrLegacySymlinkWithoutProvenanceFailsClosed(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	source := filepath.Join(sourceRoot, "configs", "herdr", "config.toml")
+	target := filepath.Join(home, ".config", "herdr", "config.toml")
+	writeMigrationFile(t, source, []byte("onboarding = false\n"))
+	runMigrationGit(t, sourceRoot, "init")
+	runMigrationGit(t, sourceRoot, "config", "user.email", "dots@example.test")
+	runMigrationGit(t, sourceRoot, "config", "user.name", "dots test")
+	runMigrationGit(t, sourceRoot, "add", ".")
+	runMigrationGit(t, sourceRoot, "commit", "-m", "legacy Herdr baseline")
+	revision := strings.TrimSpace(runMigrationGit(t, sourceRoot, "rev-parse", "HEAD"))
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target parent: %v", err)
+	}
+	if err := os.Symlink(source, target); err != nil {
+		t.Fatalf("symlink legacy Herdr config: %v", err)
+	}
+	meta := state.Metadata{Version: state.CurrentVersion, Entries: []state.Record{{
+		Target: target, Source: "configs/herdr/config.toml", Strategy: "symlink", Ownership: "whole",
+	}}}
+	captures, err := repositoryrefresh.CaptureLegacyTargets(herdrManifest("symlink", ""), herdrManifest("copy", "toml-subset"), meta, sourceRoot, home, "", revision)
+	if err != nil {
+		t.Fatalf("CaptureLegacyTargets() error = %v", err)
+	}
+	if len(captures) != 0 {
+		t.Fatalf("captures without provenance = %#v, want none", captures)
+	}
+	p, err := plan.Build(herdrManifest("copy", "toml-subset"), plan.Options{Profile: "default", OS: "darwin", SourceRoot: sourceRoot, Home: home, Metadata: meta})
+	if err != nil || len(p.Actions) != 1 || p.Actions[0].Status != plan.StatusConflict {
+		t.Fatalf("plan without migration provenance = (%#v, %v), want conflict", p.Actions, err)
+	}
+	if info, err := os.Lstat(target); err != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("ambiguous legacy target changed = (%v, %v), want untouched symlink", info, err)
+	}
+}
+
+func herdrManifest(strategy, ownership string) manifest.Manifest {
+	return manifest.Manifest{Version: 1, Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}}, Entries: []manifest.Entry{{
+		Source: "configs/herdr/config.toml", SourceOverrides: map[string]string{"adaptive-theme": "configs/herdr/config-adaptive.toml"},
+		Target: "~/.config/herdr/config.toml", Strategy: strategy, Ownership: ownership, Tags: []string{"core"}, OS: []string{"darwin"},
+	}}}
+}

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -3430,6 +3430,9 @@ func TestRepositoryHerdrConfigSupportsAdaptiveThemeOverride(t *testing.T) {
 	if herdrEntry == nil {
 		t.Fatalf("manifest missing Herdr managed entry")
 	}
+	if herdrEntry.Strategy != "copy" || herdrEntry.Ownership != "toml-subset" {
+		t.Fatalf("Herdr config entry = %#v, want copy with TOML Subset Ownership", *herdrEntry)
+	}
 	if got := herdrEntry.SourceOverrides["adaptive-theme"]; got != "configs/herdr/config-adaptive.toml" {
 		t.Fatalf("Herdr adaptive source override = %q, want configs/herdr/config-adaptive.toml", got)
 	}


### PR DESCRIPTION
Closes #396

## PR Type

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Materialize Herdr's native configuration as a regular co-owned TOML file.
- Preserve target-only TOML while detecting changes to dots-owned values.
- Keep default and adaptive sources deterministic across migration, lifecycle updates, and uninstall.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Changes Herdr from a whole-target symlink to `copy` with `toml-subset` ownership. |
| `docs/manifest.md` | Documents the regular co-owned Herdr target. |
| `internal/manifest/manifest_test.go` | Locks the Herdr strategy, ownership, and adaptive source override. |
| `internal/install/issue396_herdr_test.go` | Covers adaptive migration, Backup Sets, app-like writes, reconciliation, fail-closed provenance, and partial uninstall. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: one built binary used explicit temporary `--home`, `--source-root`, and `--state-root`
- [x] `go build ./...`
- [x] `go test -race ./internal/configsubset ./internal/install ./internal/uninstall`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] All CLI validation targeting home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked an approved / `ready-for-agent` issue with `Closes #396`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

- Agent Brief: https://github.com/yersonargotev/dots/issues/396#issuecomment-5228282724; REST ID `5228282724`; node ID `IC_kwDOSzLlmM8AAAABN6FDZA`; SHA-256 `d78fa4edcbf2e473df20409c277f43dc86fb9172476f74ec5b53b819b92a85af`.
- Reviewed head: `b8e5ce0933777270aaac297be1b417606a6ef50d` (`origin/main...HEAD`).
- Acceptance coverage: the Herdr lifecycle tests cover regular materialization, app-like writes leaving the Source of Truth clean, external TOML/comment preservation, owned-value Drift/Conflict without overwrite, deterministic adaptive selection, provenance-backed migration with a Backup Set, fail-closed missing provenance, and ownership-scoped uninstall.
- Automated validation: `gofmt -l .` produced no output; `go vet ./...`, `go build ./...`, `go test ./...`, focused package tests, manifest validation, and focused race tests all passed. `govulncheck` was unavailable and is not a repository gate.
- Manual verification: one freshly built binary installed the `core` plus `adaptive-theme` selection with explicit temporary home/state roots and a sandboxed provisioner. Herdr was a regular file sourced from `configs/herdr/config-adaptive.toml`, status was aligned (exit 0), and the source hash remained `ec2c296e1b2cbd4826681cc8c2466055965ce78d`. Removing an owned key while adding an external key produced status Drift and plan Conflict (both exit 2) without changing target bytes or the source. Restoring the owned key returned status to exit 0; uninstall updated rather than removed the regular target and retained the external key while removing dots-owned assignments.
- Independent review: Spec and Standards reviewers examined the complete stable range at `b8e5ce0`; both reported no actionable findings. Standards noted only non-blocking similarity to the Atuin lifecycle test.
- Delegation: one read-only exploration slice mapped Herdr to the existing TOML subset engine, migration, adaptive selection, and tests; its recommendation was accepted. Implementation remained with the main agent because the change was one coherent module. The main agent inspected all changes and ran focused, full, security, manual, and independent-review gates. Dots-specific custom delegation agents were unavailable, so workflow-authorized native delegation was used.
<!-- delivery-issue:evidence:end -->
