### PR TITLE
feat(zellij): isolate writable native config

### DIFF
--- a/configs/zellij/README.md
+++ b/configs/zellij/README.md
@@ -1,10 +1,11 @@
 # Zellij configuration
 
 `configs/zellij/config.kdl` is the default repository-managed Zellij configuration
-installed as `~/.config/zellij/config.kdl` (symlink strategy, `core` tag,
-`darwin`+`linux`). When the manifest selection includes `--tag adaptive-theme`,
-that same Managed Entry uses the `configs/zellij/config-adaptive.kdl` source
-override for the same target instead of adding a duplicate Install Plan action.
+materialized as the regular file `~/.config/zellij/config.kdl` (`copy` strategy
+with Whole-Target Ownership, `core` tag, `darwin`+`linux`). When the manifest
+selection includes `--tag adaptive-theme`, that same Managed Entry uses the
+`configs/zellij/config-adaptive.kdl` source override for the same target instead
+of adding a duplicate Install Plan action.
 `configs/zellij/layouts/default.kdl` is installed as
 `~/.config/zellij/layouts/default.kdl` and selected by `default_layout "default"`.
 
@@ -14,9 +15,12 @@ common pane/tab actions keep tmux-like keys, and the status bar uses a
 Catppuccin `zjstatus` layout at the top of the screen. `Ctrl+g` remains as a
 compatibility entry point for the classic Zellij command flow.
 
-The Source of Truth is this repository. The installed files are links to these
-tracked sources; runtime state and downloaded plugins stay outside version
-control.
+The Source of Truth is this repository. Zellij's supported persistence APIs may
+rewrite the regular native config without modifying the Installed Repository;
+dots reports that whole-target replacement as Drift and preserves it during
+non-interactive reconciliation and uninstall. The explicit-output default layout
+remains a link to its tracked source. Runtime state and downloaded plugins stay
+outside version control.
 
 ## Prerequisites
 
@@ -152,8 +156,9 @@ go run ./cmd/dots status \
   --state-root "$sandbox_state"
 ```
 
-The expected default result is that `~/.config/zellij/config.kdl` points at
-`configs/zellij/config.kdl` and `~/.config/zellij/layouts/default.kdl` points at
-`configs/zellij/layouts/default.kdl`. With `--tag adaptive-theme`, the config
-symlink points at `configs/zellij/config-adaptive.kdl` instead. The maintainer's
-real home directory must not be touched.
+The expected default result is that `~/.config/zellij/config.kdl` is a regular
+file matching `configs/zellij/config.kdl`, while
+`~/.config/zellij/layouts/default.kdl` points at its tracked source. With
+`--tag adaptive-theme`, the regular config instead matches
+`configs/zellij/config-adaptive.kdl`. The maintainer's real home directory must
+not be touched.

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -197,7 +197,7 @@ Current Managed Entries:
 | `configs/starship/starship.toml` | `~/.config/starship.toml` | `symlink` | `core` | `darwin`, `linux` | `starship` |
 | `configs/tmux/tmux.conf` | `~/.tmux.conf` | `symlink` | `core` | `darwin`, `linux` | `tmux` |
 | `configs/herdr/config.toml` (`adaptive-theme` override: `configs/herdr/config-adaptive.toml`) | `~/.config/herdr/config.toml` | `copy` | `core` | `darwin` | `herdr`; owns TOML subset |
-| `configs/zellij/config.kdl` (`adaptive-theme` override: `configs/zellij/config-adaptive.kdl`) | `~/.config/zellij/config.kdl` | `symlink` | `core` | `darwin`, `linux` | `zellij` |
+| `configs/zellij/config.kdl` (`adaptive-theme` override: `configs/zellij/config-adaptive.kdl`) | `~/.config/zellij/config.kdl` | `copy` | `core` | `darwin`, `linux` | `zellij`; whole-target ownership |
 | `configs/zellij/layouts/default.kdl` | `~/.config/zellij/layouts/default.kdl` | `symlink` | `core` | `darwin`, `linux` | `zellij` |
 | `configs/ghostty/config.ghostty` | `~/.config/ghostty/config.ghostty` | `symlink` | `desktop` | `darwin`, `linux` | `ghostty` |
 | `configs/ghostty/adaptive/adaptive-theme.ghostty` | `~/.config/ghostty/adaptive-theme.ghostty` | `symlink` | `adaptive-theme` | `darwin` | None |

--- a/dots.yaml
+++ b/dots.yaml
@@ -329,7 +329,7 @@ entries:
     source_overrides:
       adaptive-theme: configs/zellij/config-adaptive.kdl
     target: ~/.config/zellij/config.kdl
-    strategy: symlink
+    strategy: copy
     tags:
       - core
     os:

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1029,10 +1029,12 @@ func TestRepositoryGitConfigInstallsAndReportsAlignedInSandbox(t *testing.T) {
 		t.Fatalf("sandbox portable gitconfig symlink = %q, want %q", target, want)
 	}
 	zellijConfigTarget := filepath.Join(home, ".config/zellij/config.kdl")
-	if target, err := os.Readlink(zellijConfigTarget); err != nil {
-		t.Fatalf("sandbox Zellij config target is not a symlink: %v", err)
-	} else if want := filepath.Join(sourceRoot, "configs/zellij/config.kdl"); target != want {
-		t.Fatalf("sandbox Zellij config symlink = %q, want %q", target, want)
+	if info, err := os.Lstat(zellijConfigTarget); err != nil || !info.Mode().IsRegular() {
+		t.Fatalf("sandbox Zellij config is not a regular file: info=%v err=%v", info, err)
+	} else if got, readErr := os.ReadFile(zellijConfigTarget); readErr != nil {
+		t.Fatalf("read sandbox Zellij config: %v", readErr)
+	} else if want, sourceErr := os.ReadFile(filepath.Join(sourceRoot, "configs/zellij/config.kdl")); sourceErr != nil || !bytes.Equal(got, want) {
+		t.Fatalf("sandbox Zellij config = (%q, %v), want source (%q, %v)", got, readErr, want, sourceErr)
 	}
 	zellijLayoutTarget := filepath.Join(home, ".config/zellij/layouts/default.kdl")
 	if target, err := os.Readlink(zellijLayoutTarget); err != nil {

--- a/internal/cli/issue398_zellij_lifecycle_test.go
+++ b/internal/cli/issue398_zellij_lifecycle_test.go
@@ -1,0 +1,193 @@
+package cli_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/backups"
+	"github.com/yersonargotev/dots/internal/cli"
+	"github.com/yersonargotev/dots/internal/state"
+)
+
+func TestZellijConfigMigratesToWholeTargetAndPreservesPersistedDrift(t *testing.T) {
+	requireGitCLI(t)
+	home := t.TempDir()
+	stateRoot := filepath.Join(home, ".dots-state")
+	t.Setenv("HOME", t.TempDir())
+
+	baseline := "theme \"catppuccin-mocha\"\n"
+	persisted := "theme \"catppuccin-latte\"\nsimplified_ui true\n"
+	origin, sourceRoot := newInstalledRepo(t, map[string]string{
+		"configs/zellij/config.kdl":          baseline,
+		"configs/zellij/config-adaptive.kdl": "theme_light \"catppuccin-latte\"\n",
+		"dots.yaml":                          zellijManifest("symlink"),
+	})
+	manifestPath := filepath.Join(sourceRoot, "dots.yaml")
+
+	run := func(want int, args ...string) string {
+		t.Helper()
+		var stdout, stderr bytes.Buffer
+		code := cli.Run(args, &stdout, &stderr)
+		if code != want {
+			t.Fatalf("cli.Run(%v) code = %d, want %d\nstdout:\n%s\nstderr:\n%s", args, code, want, stdout.String(), stderr.String())
+		}
+		return stdout.String()
+	}
+	common := []string{"--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot}
+	run(0, append([]string{"install", "--yes", "--skip-deps"}, common...)...)
+
+	target := filepath.Join(home, ".config", "zellij", "config.kdl")
+	if info, err := os.Lstat(target); err != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("legacy Zellij config = (%v, %v), want symlink", info, err)
+	}
+
+	advanceUpstream(t, origin, "materialize Zellij config", map[string]string{"dots.yaml": zellijManifest("copy")})
+	updateOutput := runUpdate(t, "--yes", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot)
+	if !strings.Contains(updateOutput, "migrate") {
+		t.Fatalf("update output missing Zellij migration evidence:\n%s", updateOutput)
+	}
+	if info, err := os.Lstat(target); err != nil || !info.Mode().IsRegular() {
+		t.Fatalf("migrated Zellij config = (%v, %v), want regular file", info, err)
+	}
+	if got, err := os.ReadFile(target); err != nil || string(got) != baseline {
+		t.Fatalf("migrated Zellij config = (%q, %v), want baseline", got, err)
+	}
+	backupMeta, err := backups.Load(backups.Path(stateRoot))
+	if err != nil || len(backupMeta.Sets) != 1 {
+		t.Fatalf("migration Backup Sets = %#v, err = %v", backupMeta, err)
+	}
+	preserved, err := os.ReadFile(backups.FilePath(stateRoot, backupMeta.Sets[0].ID, 1, target))
+	if err != nil || string(preserved) != baseline {
+		t.Fatalf("migration backup = %q, err = %v", preserved, err)
+	}
+
+	if err := os.WriteFile(target, []byte(persisted), 0o600); err != nil {
+		t.Fatalf("simulate Zellij persisted reconfiguration: %v", err)
+	}
+	if dirty := strings.TrimSpace(runGitOutput(t, sourceRoot, "status", "--porcelain")); dirty != "" {
+		t.Fatalf("simulated Zellij persistence dirtied the Installed Repository: %q", dirty)
+	}
+	statusOutput := run(2, append([]string{"status", "--output", "json"}, common...)...)
+	if !strings.Contains(statusOutput, `"state": "drifted"`) {
+		t.Fatalf("status did not report persisted Zellij config as Drift:\n%s", statusOutput)
+	}
+	doctorOutput := run(2, append([]string{"doctor", "--output", "json"}, common...)...)
+	if !strings.Contains(doctorOutput, `"state": "drifted"`) || !strings.Contains(doctorOutput, `"source": "configs/zellij/config.kdl"`) {
+		t.Fatalf("doctor did not report persisted Zellij config as Drift:\n%s", doctorOutput)
+	}
+
+	installOutput := run(0, append([]string{"install", "--yes", "--skip-deps"}, common...)...)
+	if !strings.Contains(installOutput, "conflict") {
+		t.Fatalf("install output missing persisted-config finding:\n%s", installOutput)
+	}
+	updateOutput = runUpdate(t, "--yes", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot)
+	if !strings.Contains(updateOutput, "conflict") {
+		t.Fatalf("update output missing persisted-config finding:\n%s", updateOutput)
+	}
+	if got, err := os.ReadFile(target); err != nil || string(got) != persisted {
+		t.Fatalf("install/update changed persisted Zellij config = (%q, %v)", got, err)
+	}
+
+	uninstallOutput := run(0, "uninstall", "--yes", "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot)
+	if !strings.Contains(uninstallOutput, "modified target(s) will be skipped") {
+		t.Fatalf("uninstall output missing modified-target evidence:\n%s", uninstallOutput)
+	}
+	if got, err := os.ReadFile(target); err != nil || string(got) != persisted {
+		t.Fatalf("uninstall changed persisted Zellij config = (%q, %v)", got, err)
+	}
+}
+
+func TestZellijWholeTargetRetainsDefaultAndAdaptiveSources(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		extraArgs []string
+		want      string
+	}{
+		{name: "default", want: "theme \"catppuccin-mocha\"\n"},
+		{name: "adaptive", extraArgs: []string{"--tag", "adaptive-theme"}, want: "theme_light \"catppuccin-latte\"\n"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			stateRoot := filepath.Join(home, ".dots-state")
+			t.Setenv("HOME", t.TempDir())
+			_, sourceRoot := newInstalledRepo(t, map[string]string{
+				"configs/zellij/config.kdl":          "theme \"catppuccin-mocha\"\n",
+				"configs/zellij/config-adaptive.kdl": "theme_light \"catppuccin-latte\"\n",
+				"dots.yaml":                          zellijManifest("copy"),
+			})
+			args := []string{"install", "--yes", "--skip-deps", "--profile", "default"}
+			args = append(args, tt.extraArgs...)
+			args = append(args, "--file", filepath.Join(sourceRoot, "dots.yaml"), "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot)
+			var stdout, stderr bytes.Buffer
+			if code := cli.Run(args, &stdout, &stderr); code != 0 {
+				t.Fatalf("install code = %d\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+			}
+			target := filepath.Join(home, ".config", "zellij", "config.kdl")
+			if info, err := os.Lstat(target); err != nil || !info.Mode().IsRegular() {
+				t.Fatalf("Zellij config = (%v, %v), want regular file", info, err)
+			}
+			if got, err := os.ReadFile(target); err != nil || string(got) != tt.want {
+				t.Fatalf("Zellij config = (%q, %v), want %q", got, err, tt.want)
+			}
+		})
+	}
+}
+
+func TestZellijLegacySymlinkWithoutProvenanceFailsClosed(t *testing.T) {
+	requireGitCLI(t)
+	home := t.TempDir()
+	stateRoot := filepath.Join(home, ".dots-state")
+	t.Setenv("HOME", t.TempDir())
+
+	baseline := "theme \"catppuccin-mocha\"\n"
+	origin, sourceRoot := newInstalledRepo(t, map[string]string{
+		"configs/zellij/config.kdl":          baseline,
+		"configs/zellij/config-adaptive.kdl": "theme_light \"catppuccin-latte\"\n",
+		"dots.yaml":                          zellijManifest("symlink"),
+	})
+	manifestPath := filepath.Join(sourceRoot, "dots.yaml")
+	var stdout, stderr bytes.Buffer
+	if code := cli.Run([]string{"install", "--yes", "--skip-deps", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot}, &stdout, &stderr); code != 0 {
+		t.Fatalf("legacy install code = %d\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load legacy metadata: %v", err)
+	}
+	meta.Provenance = state.Provenance{}
+	if err := state.Save(state.Path(stateRoot), meta); err != nil {
+		t.Fatalf("remove provenance from legacy metadata: %v", err)
+	}
+
+	advanceUpstream(t, origin, "materialize Zellij config", map[string]string{"dots.yaml": zellijManifest("copy")})
+	output := runUpdate(t, "--yes", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot)
+	target := filepath.Join(home, ".config", "zellij", "config.kdl")
+	if !strings.Contains(output, "conflict") {
+		t.Fatalf("update output missing unproven migration conflict:\n%s", output)
+	}
+	if info, err := os.Lstat(target); err != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("unproven legacy target = (%v, %v), want preserved symlink", info, err)
+	}
+	backupMeta, err := backups.Load(backups.Path(stateRoot))
+	if err != nil || len(backupMeta.Sets) != 0 {
+		t.Fatalf("unproven migration Backup Sets = %#v, err = %v", backupMeta, err)
+	}
+}
+
+func zellijManifest(strategy string) string {
+	return `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/zellij/config.kdl
+    source_overrides:
+      adaptive-theme: configs/zellij/config-adaptive.kdl
+    target: ~/.config/zellij/config.kdl
+    strategy: ` + strategy + `
+    tags: [core]
+`
+}

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -2269,6 +2269,10 @@ func TestRepositoryManifestIncludesMVPConfigurationSet(t *testing.T) {
 	if !ok || bat.Source != "configs/bat/config" || bat.Strategy != "copy" || bat.Ownership != "" {
 		t.Errorf("bat config entry = %#v, want copy with implicit Whole-Target Ownership", bat)
 	}
+	zellij, ok := entriesByTarget["~/.config/zellij/config.kdl"]
+	if !ok || zellij.Source != "configs/zellij/config.kdl" || zellij.Strategy != "copy" || zellij.Ownership != "" {
+		t.Errorf("Zellij config entry = %#v, want copy with implicit Whole-Target Ownership", zellij)
+	}
 	portable, ok := entriesByTarget["~/.config/dots/zsh/zshrc"]
 	if !ok || portable.Source != "configs/zsh/zshrc" || portable.Strategy != "symlink" {
 		t.Errorf("portable zsh entry = %#v, want managed symlink", portable)
@@ -2742,8 +2746,12 @@ func TestRepositoryZellijConfigClassifiesPortableConfigSafely(t *testing.T) {
 			if entry.Source != tt.source {
 				t.Errorf("Source = %q, want %q", entry.Source, tt.source)
 			}
-			if entry.Strategy != "symlink" {
-				t.Errorf("Strategy = %q, want symlink", entry.Strategy)
+			wantStrategy := "symlink"
+			if tt.name == "config" {
+				wantStrategy = "copy"
+			}
+			if entry.Strategy != wantStrategy {
+				t.Errorf("Strategy = %q, want %s", entry.Strategy, wantStrategy)
 			}
 			if !hasString(entry.Tags, "core") {
 				t.Errorf("Tags = %#v, want core tag", entry.Tags)


### PR DESCRIPTION
Closes #398

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Materializes Zellij's writable native config as a regular Whole-Target Ownership target.
- Preserves default/adaptive source selection while leaving the explicit-output default layout as a symlink.
- Covers provenance-backed migration, Backup Sets, Drift, conservative reconciliation, and uninstall preservation.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Changes the Zellij config Managed Entry from `symlink` to `copy`. |
| `internal/cli/issue398_zellij_lifecycle_test.go` | Adds sandboxed lifecycle, source-selection, and fail-closed migration coverage. |
| `internal/cli/cli_test.go` | Verifies repository installation creates a regular Zellij config. |
| `internal/manifest/manifest_test.go` | Locks the config to implicit Whole-Target Ownership and keeps the layout symlink. |
| `configs/zellij/README.md`, `docs/manifest.md` | Documents regular materialization, Drift, preservation, and source overrides. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go build ./...`
- [x] `/tmp/dots-issue-398-manual.9aLVWy/bin/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan: `/tmp/dots-issue-398-manual.9aLVWy/bin/dots plan --file dots.yaml --profile core --source-root /tmp/dots-issue-398.CjQIE4 --home /tmp/dots-issue-398-manual.9aLVWy/default-home --state-root /tmp/dots-issue-398-manual.9aLVWy/plan-state --output json` (exit 2 for the intentionally modified Zellij target; reports `copy` + `conflict`).

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] All CLI validation used temporary home, source, and state roots.

## Contributor Checklist

- [x] Linked approved / `ready-for-agent` issue #398 with `Closes #398`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs for changed configuration behavior.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

- Agent Brief: [comment 5228283273](https://github.com/yersonargotev/dots/issues/398#issuecomment-5228283273); SHA-256 `d8b9e84f39b5fd510d165d119f059487532b809c68ebc2a497246fb1ba21c8ce`.
- Reviewed head: `635f8995a2fd65b01d6f4e2dce026c3f07571b7b` against `origin/main` (`e540a040417c9924d64b3b98bef0c2d97921fb2b`).
- Acceptance coverage: lifecycle tests prove repository cleanliness after a simulated persistence write, `status`/`doctor` Drift, default/adaptive source selection, conservative install/update/uninstall preservation, provenance-required migration, and Backup Set creation.
- Automated validation: `gofmt -l .`, `go vet ./...`, `go build ./...`, and `go test ./...` passed; focused `go test ./internal/cli/... ./internal/manifest/...` passed; manifest validation passed.
- Manual verification: a real temporary binary installed default and adaptive sources into separate Temporary Homes as regular files; `cmp` matched each selected source. A simulated persisted rewrite left `configs/zellij/config.kdl` unchanged, made `status` and `doctor` return exit 2 with `drifted`, remained after non-interactive install reported a Conflict, and remained after uninstall reported the modified-target skip.
- Independent Spec review: no actionable findings; all criteria covered and `layouts/default.kdl` remains out of scope.
- Independent Standards review: no actionable findings; ADR-0017, dotfiles safety, filesystem fail-closed behavior, docs, and tests conform.
- Delegation: one read-only exploration slice mapped analogous lifecycle behavior, relevant files/tests, and fail-closed boundaries; its recommendations were accepted. No implementation slice was delegated because the change is one coherent manifest/config lifecycle unit. The main agent inspected the diff and verified focused tests, full CI-equivalent gates, and manual binary scenarios.
<!-- delivery-issue:evidence:end -->
