### PR TITLE
fix(installed): resolve xdg-state inventory targets

### DIFF
--- a/docs/installed-target-root-research.md
+++ b/docs/installed-target-root-research.md
@@ -13,7 +13,7 @@ migration with:
 unsafe target "nvim/lazy-lock.json": target must be ~ or ~/...
 ```
 
-and what contract must the eventual correction preserve?
+and what contract must the correction preserve?
 
 ## Sources and scope
 
@@ -24,6 +24,15 @@ introduced by [`c207c09` (`feat(nvim): separate config from seeded state
 in [`v0.68.0`](https://github.com/yersonargotev/dots/releases/tag/v0.68.0),
 whose tagged commit is `2f3f5fe`.
 
+## Delivery status
+
+Issue #413 corrects the defect by threading the resolved XDG state home through
+both direct inventory construction and legacy Installed Selection analysis,
+then using the entry-aware resolver for metadata matching and Profile coverage
+identity. Package and sandboxed CLI regression tests now cover the successful
+match and complete coverage. The diagnosis below describes the pre-fix
+`v0.68.0` implementation; links to that implementation are pinned to its tag.
+
 ## Symptom and minimal triggering state
 
 v0.68.0 declares the lazy.nvim lockfile as a Managed Entry with the relative
@@ -33,12 +42,14 @@ Metadata records its resolved target beneath `$XDG_STATE_HOME`, `dots installed`
 must match that record against the current Install Manifest to build its
 read-only inventory.
 
-Instead, its first match attempt fails before JSON rendering: `matchEntry`
+In the affected version, its first match attempt fails before JSON rendering: `matchEntry`
 calls `plan.ResolveTarget(entry.Target, opts.Home)`
-([`internal/installed/installed.go`](../internal/installed/installed.go#L249-L266)).
+([`internal/installed/installed.go` at
+`v0.68.0`](https://github.com/yersonargotev/dots/blob/2f3f5fe/internal/installed/installed.go#L249-L266)).
 `ResolveTarget` deliberately accepts only `~` and `~/...`, producing the
 reported error for the relative XDG-state target
-([`internal/plan/plan.go`](../internal/plan/plan.go#L505-L524)). This is a
+([`internal/plan/plan.go` at
+`v0.68.0`](https://github.com/yersonargotev/dots/blob/2f3f5fe/internal/plan/plan.go#L505-L524)). This is a
 deterministic input-validation mismatch, not a damaged lockfile or an unsafe
 target accepted by the manifest.
 
@@ -66,33 +77,37 @@ its command help promises that it never evaluates or mutates managed targets
 
 ## Root cause
 
-`installed.Options` has `Home` but no `XDGStateHome`
-([`internal/installed/installed.go`](../internal/installed/installed.go#L91-L96)),
+In `v0.68.0`, `installed.Options` has `Home` but no `XDGStateHome`
+([`internal/installed/installed.go` at
+`v0.68.0`](https://github.com/yersonargotev/dots/blob/2f3f5fe/internal/installed/installed.go#L91-L96)),
 and the CLI does not pass the already-resolved `paths.XDGStateHome` into
-`installed.Build` ([`internal/cli/installed.go`](../internal/cli/installed.go#L51-L56)).
+`installed.Build` ([`internal/cli/installed.go` at
+`v0.68.0`](https://github.com/yersonargotev/dots/blob/2f3f5fe/internal/cli/installed.go#L51-L56)).
 Consequently, `matchEntry` cannot call the entry-aware resolver and still uses
 the old home-only resolver.
 
 The adjacent `entryKey` repeats the same home-only call
-([`internal/installed/installed.go`](../internal/installed/installed.go#L280-L286)).
+([`internal/installed/installed.go` at
+`v0.68.0`](https://github.com/yersonargotev/dots/blob/2f3f5fe/internal/installed/installed.go#L280-L286)).
 It participates in profile-entry coverage, so changing only `matchEntry` would
 avoid the immediate error but would leave XDG-state entries unable to contribute
 their resolved key reliably.
 
 The migration commit updated `selectionmigration.Analyze` to receive
-`XDGStateHome`, but did not make the corresponding `installed.Build` input
-entry-aware (see the v0.68.0 source above). This explains why installation,
-status, doctor, and selection migration can operate on the new target model
-while `installed` fails.
+`XDGStateHome`, but its nested `installed.Build` call also omitted that value.
+That secondary propagation gap affected legacy metadata requiring Installed
+Selection analysis. Installation, status, and doctor already used the new
+target model, while both direct and nested installed-inventory construction did
+not.
 
-## Existing coverage and regression seam
+## Pre-fix coverage and regression seam
 
 `TestInstalledJSONEnvelope` constructs only a `~/.zshrc` record
 ([`internal/cli/installed_test.go`](../internal/cli/installed_test.go#L13-L49)).
 The Neovim lifecycle test does construct the XDG-state Managed Entry and
 exercises install, status, update preservation, and uninstall
 ([`internal/cli/issue388_nvim_seeded_lifecycle_test.go`](../internal/cli/issue388_nvim_seeded_lifecycle_test.go#L41-L113)),
-but never invokes `installed`. Thus no current test drives this exact command
+but never invokes `installed`. Thus no pre-fix test drives this exact command
 path.
 
 The focused existing tests pass:
@@ -108,8 +123,10 @@ absolute temporary `XDG_STATE_HOME`, a manifest containing the seeded entry,
 and Installation Metadata containing the resolved XDG-state target. It should
 assert that `installed --output json` exits `0`, emits the `installed` envelope,
 and reports that entry as `manifest_matched: true` with complete coverage where
-otherwise represented. In the current version that test is red with the exact
-error in the symptom section.
+otherwise represented. Against `v0.68.0`, that test is red with the exact error
+in the symptom section. After the #413 correction, package-level and CLI
+variants are green, including legacy metadata that exercises Installed
+Selection analysis.
 
 ## Scope and implications
 
@@ -122,5 +139,6 @@ error in the symptom section.
 - Every use of a resolved Managed Entry identity in the installed inventory
   should use the same root-aware resolution, so a successful match and profile
   coverage describe the same target.
-- The remediation should add the dedicated regression test described above;
-  no implementation is made by this research note.
+- The remediation includes the dedicated regression tests described above;
+  this note records the evidence and preserved contract rather than serving as
+  an implementation mechanism.

--- a/docs/installed-target-root-research.md
+++ b/docs/installed-target-root-research.md
@@ -1,0 +1,126 @@
+# Installed `xdg-state` target research
+
+Date: 2026-08-09
+
+Tracking issue: [#413](https://github.com/yersonargotev/dots/issues/413)
+
+## Question
+
+Why does `dots installed --output json` fail after the v0.68.0 Neovim
+migration with:
+
+```text
+unsafe target "nvim/lazy-lock.json": target must be ~ or ~/...
+```
+
+and what contract must the eventual correction preserve?
+
+## Sources and scope
+
+This note uses primary repository sources only: the v0.68.0 tag, its Git
+history, source, tests, manifest, and project documentation. The migration was
+introduced by [`c207c09` (`feat(nvim): separate config from seeded state
+(#403)`)](https://github.com/yersonargotev/dots/commit/c207c09) and is included
+in [`v0.68.0`](https://github.com/yersonargotev/dots/releases/tag/v0.68.0),
+whose tagged commit is `2f3f5fe`.
+
+## Symptom and minimal triggering state
+
+v0.68.0 declares the lazy.nvim lockfile as a Managed Entry with the relative
+target `nvim/lazy-lock.json`, `target_root: xdg-state`, `strategy: copy`, and
+`ownership: seeded` ([`dots.yaml`](../dots.yaml#L491-L500)). After Installation
+Metadata records its resolved target beneath `$XDG_STATE_HOME`, `dots installed`
+must match that record against the current Install Manifest to build its
+read-only inventory.
+
+Instead, its first match attempt fails before JSON rendering: `matchEntry`
+calls `plan.ResolveTarget(entry.Target, opts.Home)`
+([`internal/installed/installed.go`](../internal/installed/installed.go#L249-L266)).
+`ResolveTarget` deliberately accepts only `~` and `~/...`, producing the
+reported error for the relative XDG-state target
+([`internal/plan/plan.go`](../internal/plan/plan.go#L505-L524)). This is a
+deterministic input-validation mismatch, not a damaged lockfile or an unsafe
+target accepted by the manifest.
+
+## Expected contract
+
+The manifest contract explicitly allows the sole non-home target root:
+`target_root: xdg-state` resolves a confined relative target beneath an
+absolute `$XDG_STATE_HOME`, requires `ownership: seeded`, remains inside the
+selected home, and is separate from dots' `--state-root`
+([`docs/manifest.md`](manifest.md#L131-L143);
+[`internal/manifest/manifest.go`](../internal/manifest/manifest.go#L457-L466)).
+
+The planner already implements that contract in
+`ResolveEntryTarget(entry, home, xdgStateHome)`
+([`internal/plan/plan.go`](../internal/plan/plan.go#L527-L565)). It selects the
+home resolver for ordinary entries and validates/constrains `xdg-state` entries
+under the provided state-home. The machine-readable output contract also states
+that XDG-state plan actions retain the absolute resolved target and expose
+`target_root: "xdg-state"` ([`docs/agents/output-contract.md`](agents/output-contract.md#L179-L205)).
+
+Therefore, `installed` must use the same entry-aware resolution contract when
+matching metadata and deriving profile coverage. It remains a read-only report:
+its command help promises that it never evaluates or mutates managed targets
+([`internal/cli/installed.go`](../internal/cli/installed.go#L31-L34)).
+
+## Root cause
+
+`installed.Options` has `Home` but no `XDGStateHome`
+([`internal/installed/installed.go`](../internal/installed/installed.go#L91-L96)),
+and the CLI does not pass the already-resolved `paths.XDGStateHome` into
+`installed.Build` ([`internal/cli/installed.go`](../internal/cli/installed.go#L51-L56)).
+Consequently, `matchEntry` cannot call the entry-aware resolver and still uses
+the old home-only resolver.
+
+The adjacent `entryKey` repeats the same home-only call
+([`internal/installed/installed.go`](../internal/installed/installed.go#L280-L286)).
+It participates in profile-entry coverage, so changing only `matchEntry` would
+avoid the immediate error but would leave XDG-state entries unable to contribute
+their resolved key reliably.
+
+The migration commit updated `selectionmigration.Analyze` to receive
+`XDGStateHome`, but did not make the corresponding `installed.Build` input
+entry-aware (see the v0.68.0 source above). This explains why installation,
+status, doctor, and selection migration can operate on the new target model
+while `installed` fails.
+
+## Existing coverage and regression seam
+
+`TestInstalledJSONEnvelope` constructs only a `~/.zshrc` record
+([`internal/cli/installed_test.go`](../internal/cli/installed_test.go#L13-L49)).
+The Neovim lifecycle test does construct the XDG-state Managed Entry and
+exercises install, status, update preservation, and uninstall
+([`internal/cli/issue388_nvim_seeded_lifecycle_test.go`](../internal/cli/issue388_nvim_seeded_lifecycle_test.go#L41-L113)),
+but never invokes `installed`. Thus no current test drives this exact command
+path.
+
+The focused existing tests pass:
+
+```text
+go test ./internal/cli -run 'TestInstalledJSONEnvelope|TestNeovimSeededStateLifecycleUsesConfinedXDGStateAndPreservesLocalEvolution' -count=1
+ok   github.com/yersonargotev/dots/internal/cli
+```
+
+That green result confirms the coverage gap; it is not a reproduction of the
+defect. The correct regression seam is a CLI test with a temporary home and
+absolute temporary `XDG_STATE_HOME`, a manifest containing the seeded entry,
+and Installation Metadata containing the resolved XDG-state target. It should
+assert that `installed --output json` exits `0`, emits the `installed` envelope,
+and reports that entry as `manifest_matched: true` with complete coverage where
+otherwise represented. In the current version that test is red with the exact
+error in the symptom section.
+
+## Scope and implications
+
+- The defect is limited to manifest-to-metadata matching and its derived
+  profile coverage in `dots installed`; it does not invalidate the security
+  confinement rules for XDG state.
+- The correction must retain `ResolveEntryTarget`'s checks rather than relaxing
+  `ResolveTarget` to accept arbitrary relative paths, because the latter is the
+  home-only safety boundary.
+- Every use of a resolved Managed Entry identity in the installed inventory
+  should use the same root-aware resolution, so a successful match and profile
+  coverage describe the same target.
+- The remediation should add the dedicated regression test described above;
+  no implementation is made by this research note.

--- a/internal/cli/installed.go
+++ b/internal/cli/installed.go
@@ -49,10 +49,11 @@ func newInstalledCommand() *cobra.Command {
 				return err
 			}
 			report, err := inst.Build(*m, meta, inst.Options{
-				StatePath:  state.Path(paths.StateRoot),
-				SourceRoot: paths.SourceRoot,
-				Home:       paths.Home,
-				OS:         runtime.GOOS,
+				StatePath:    state.Path(paths.StateRoot),
+				SourceRoot:   paths.SourceRoot,
+				Home:         paths.Home,
+				XDGStateHome: paths.XDGStateHome,
+				OS:           runtime.GOOS,
 			})
 			if err != nil {
 				return err

--- a/internal/cli/installed_test.go
+++ b/internal/cli/installed_test.go
@@ -3,6 +3,7 @@ package cli_test
 import (
 	"bytes"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -55,6 +56,7 @@ func TestInstalledJSONMatchesXDGStateEntryWithCompleteCoverage(t *testing.T) {
 	stateRoot := t.TempDir()
 	sourceRoot := t.TempDir()
 	xdgStateHome := filepath.Join(home, ".local", "state")
+	target := filepath.Join(xdgStateHome, "nvim", "lazy-lock.json")
 	t.Setenv("XDG_STATE_HOME", xdgStateHome)
 	writeCLISource(t, sourceRoot, "configs/nvim/lazy-lock.json", "baseline\n")
 	manifestPath := writeCLIManifest(t, home, `version: 1
@@ -71,13 +73,16 @@ entries:
     os: [darwin, linux]
 `)
 	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: 2, Entries: []state.Record{{
-		Target:   filepath.Join(xdgStateHome, "nvim", "lazy-lock.json"),
+		Target:   target,
 		Source:   "configs/nvim/lazy-lock.json",
 		Strategy: "copy",
 		Profiles: []string{"default"},
 		Tags:     []string{"editor"},
 	}}}); err != nil {
 		t.Fatalf("save metadata: %v", err)
+	}
+	if _, err := os.Stat(xdgStateHome); !os.IsNotExist(err) {
+		t.Fatalf("XDG state home exists before read-only command: %v", err)
 	}
 
 	var out, errOut bytes.Buffer
@@ -109,6 +114,9 @@ entries:
 	}
 	if len(data.Profiles) != 1 || data.Profiles[0].Name != "default" || data.Profiles[0].State != "complete" || data.Profiles[0].CoveredEntries != 1 || data.Profiles[0].TotalEntries != 1 {
 		t.Fatalf("profiles = %+v, want default complete 1/1 coverage", data.Profiles)
+	}
+	if _, err := os.Stat(xdgStateHome); !os.IsNotExist(err) {
+		t.Fatalf("read-only installed command mutated XDG state home: %v", err)
 	}
 }
 

--- a/internal/cli/installed_test.go
+++ b/internal/cli/installed_test.go
@@ -70,7 +70,7 @@ entries:
     tags: [editor]
     os: [darwin, linux]
 `)
-	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, Entries: []state.Record{{
+	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: 2, Entries: []state.Record{{
 		Target:   filepath.Join(xdgStateHome, "nvim", "lazy-lock.json"),
 		Source:   "configs/nvim/lazy-lock.json",
 		Strategy: "copy",

--- a/internal/cli/installed_test.go
+++ b/internal/cli/installed_test.go
@@ -2,6 +2,7 @@ package cli_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -46,6 +47,68 @@ func TestInstalledJSONEnvelope(t *testing.T) {
 	}
 	if strings.Contains(out.String(), "Installed inventory") {
 		t.Fatalf("JSON mode leaked human prose:\n%s", out.String())
+	}
+}
+
+func TestInstalledJSONMatchesXDGStateEntryWithCompleteCoverage(t *testing.T) {
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	sourceRoot := t.TempDir()
+	xdgStateHome := filepath.Join(home, ".local", "state")
+	t.Setenv("XDG_STATE_HOME", xdgStateHome)
+	writeCLISource(t, sourceRoot, "configs/nvim/lazy-lock.json", "baseline\n")
+	manifestPath := writeCLIManifest(t, home, `version: 1
+profiles:
+  default:
+    tags: [editor]
+entries:
+  - source: configs/nvim/lazy-lock.json
+    target: nvim/lazy-lock.json
+    target_root: xdg-state
+    strategy: copy
+    ownership: seeded
+    tags: [editor]
+    os: [darwin, linux]
+`)
+	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, Entries: []state.Record{{
+		Target:   filepath.Join(xdgStateHome, "nvim", "lazy-lock.json"),
+		Source:   "configs/nvim/lazy-lock.json",
+		Strategy: "copy",
+		Profiles: []string{"default"},
+		Tags:     []string{"editor"},
+	}}}); err != nil {
+		t.Fatalf("save metadata: %v", err)
+	}
+
+	var out, errOut bytes.Buffer
+	code := cli.Run([]string{
+		"installed", "--output", "json", "--file", manifestPath,
+		"--source-root", sourceRoot, "--home", home, "--state-root", stateRoot,
+	}, &out, &errOut)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
+	}
+	env := decodeEnvelopeForCommand(t, out.String(), "installed")
+	var data struct {
+		ManagedEntries []struct {
+			ManifestMatched bool `json:"manifest_matched"`
+		} `json:"managed_entries"`
+		Profiles []struct {
+			Name           string `json:"name"`
+			State          string `json:"state"`
+			CoveredEntries int    `json:"covered_entries"`
+			TotalEntries   int    `json:"total_entries"`
+		} `json:"profiles"`
+	}
+	if err := json.Unmarshal(env.Data, &data); err != nil {
+		t.Fatalf("decode installed data: %v", err)
+	}
+	if len(data.ManagedEntries) != 1 || !data.ManagedEntries[0].ManifestMatched {
+		t.Fatalf("managed entries = %+v, want one manifest match", data.ManagedEntries)
+	}
+	if len(data.Profiles) != 1 || data.Profiles[0].Name != "default" || data.Profiles[0].State != "complete" || data.Profiles[0].CoveredEntries != 1 || data.Profiles[0].TotalEntries != 1 {
+		t.Fatalf("profiles = %+v, want default complete 1/1 coverage", data.Profiles)
 	}
 }
 

--- a/internal/installed/installed.go
+++ b/internal/installed/installed.go
@@ -89,10 +89,11 @@ type Report struct {
 func (r Report) HasFindings() bool { return false }
 
 type Options struct {
-	StatePath  string
-	SourceRoot string
-	Home       string
-	OS         string
+	StatePath    string
+	SourceRoot   string
+	Home         string
+	XDGStateHome string
+	OS           string
 }
 
 // Build joins Installation Metadata with the current Install Manifest to infer
@@ -121,7 +122,7 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options) (Report, erro
 			return Report{}, err
 		}
 		if matched {
-			matchedEntryKeys[entryKey(entry, opts.Home)] = true
+			matchedEntryKeys[entryKey(entry, opts)] = true
 		}
 
 		tags := append([]string(nil), rec.Tags...)
@@ -251,7 +252,7 @@ func matchEntry(m manifest.Manifest, rec state.Record, opts Options) (manifest.E
 		if !manifest.MatchesOS(entry.OS, opts.OS) {
 			continue
 		}
-		target, err := plan.ResolveTarget(entry.Target, opts.Home)
+		target, err := plan.ResolveEntryTarget(entry, opts.Home, opts.XDGStateHome)
 		if err != nil {
 			return manifest.Entry{}, false, err
 		}
@@ -277,8 +278,8 @@ func compatibleEntrySource(entry manifest.Entry, source string) bool {
 	return false
 }
 
-func entryKey(entry manifest.Entry, home string) string {
-	target, err := plan.ResolveTarget(entry.Target, home)
+func entryKey(entry manifest.Entry, opts Options) string {
+	target, err := plan.ResolveEntryTarget(entry, opts.Home, opts.XDGStateHome)
 	if err != nil {
 		return entry.Target + "\x00" + entry.Strategy
 	}
@@ -344,7 +345,7 @@ func entryCoverageForProfile(m manifest.Manifest, profileName string, opts Optio
 			continue
 		}
 		total++
-		if matchedEntryKeys[entryKey(entry, opts.Home)] {
+		if matchedEntryKeys[entryKey(entry, opts)] {
 			covered++
 		}
 	}

--- a/internal/installed/installed_test.go
+++ b/internal/installed/installed_test.go
@@ -48,6 +48,45 @@ func TestBuildExposesEverySharedTargetContributor(t *testing.T) {
 	}
 }
 
+func TestBuildMatchesXDGStateTargetRoot(t *testing.T) {
+	home := t.TempDir()
+	xdgStateHome := filepath.Join(home, ".local", "state")
+	target := filepath.Join(xdgStateHome, "nvim", "lazy-lock.json")
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"editor"}}},
+		Entries: []manifest.Entry{{
+			Source:     "configs/nvim/lazy-lock.json",
+			Target:     "nvim/lazy-lock.json",
+			TargetRoot: "xdg-state",
+			Strategy:   "copy",
+			Ownership:  "seeded",
+			Tags:       []string{"editor"},
+		}},
+	}
+	meta := state.Metadata{Version: state.CurrentVersion, Entries: []state.Record{{
+		Target: target, Source: "configs/nvim/lazy-lock.json", Strategy: "copy",
+		Profiles: []string{"default"}, Tags: []string{"editor"},
+	}}}
+
+	report, err := inst.Build(m, meta, inst.Options{
+		StatePath:    filepath.Join(home, "installed.json"),
+		Home:         home,
+		XDGStateHome: xdgStateHome,
+		OS:           "linux",
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if len(report.ManagedEntries) != 1 || !report.ManagedEntries[0].ManifestMatched {
+		t.Fatalf("ManagedEntries = %+v, want one manifest match", report.ManagedEntries)
+	}
+	coverage := findProfile(t, report.Profiles, "default")
+	if coverage.TotalEntries != 1 || coverage.CoveredEntries != 1 || coverage.State != inst.CoverageComplete {
+		t.Fatalf("default coverage = %+v, want complete 1/1 coverage", coverage)
+	}
+}
+
 func TestBuildInfersLegacyMetadataAndPartialProfiles(t *testing.T) {
 	home := t.TempDir()
 	m := inventoryManifest()

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -765,10 +765,22 @@ func TestResolveEntryTargetConfinesAllowlistedXDGStateRoot(t *testing.T) {
 		})
 	}
 
-	escapingEntry := entry
-	escapingEntry.Target = "../outside"
-	if _, err := plan.ResolveEntryTarget(escapingEntry, home, validRoot); err == nil {
-		t.Fatal("ResolveEntryTarget() accepted traversing target")
+	for name, target := range map[string]string{
+		"absolute target":   filepath.Join(home, "absolute"),
+		"traversing target": "../outside",
+		"current directory": ".",
+	} {
+		t.Run(name, func(t *testing.T) {
+			invalidEntry := entry
+			invalidEntry.Target = target
+			if _, err := plan.ResolveEntryTarget(invalidEntry, home, validRoot); err == nil {
+				t.Fatalf("ResolveEntryTarget() accepted invalid target %q", target)
+			}
+		})
+	}
+
+	if _, err := plan.ResolveTarget(entry.Target, home); err == nil {
+		t.Fatalf("ResolveTarget() accepted arbitrary relative target %q", entry.Target)
 	}
 
 	outside := t.TempDir()

--- a/internal/selectionmigration/migration.go
+++ b/internal/selectionmigration/migration.go
@@ -85,7 +85,10 @@ func Analyze(m manifest.Manifest, meta state.Metadata, opts Options) (Analysis, 
 	}
 
 	report, err := installed.Build(m, meta, installed.Options{
-		OS: opts.OS, Home: opts.Home, StatePath: opts.StatePath,
+		OS:           opts.OS,
+		Home:         opts.Home,
+		XDGStateHome: opts.XDGStateHome,
+		StatePath:    opts.StatePath,
 	})
 	if err != nil {
 		return Analysis{}, err


### PR DESCRIPTION
Closes #413

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Resolve installed-inventory targets through the existing entry-aware target-root contract.
- Thread the resolved XDG state home through direct inventory construction and legacy Installed Selection analysis.
- Add package, CLI, security-boundary, and read-only regression coverage.
- Include `docs/installed-target-root-research.md` with the historical diagnosis and delivered outcome.

## Changes

| File | Change |
|------|--------|
| `internal/installed/installed.go` | Carry XDG state home and use entry-aware resolution for matching and coverage identity. |
| `internal/cli/installed.go` | Pass the resolved XDG state home into inventory construction. |
| `internal/selectionmigration/migration.go` | Preserve XDG state home in the nested legacy inventory build. |
| `internal/installed/installed_test.go` | Cover XDG-state matching and complete Profile coverage. |
| `internal/cli/installed_test.go` | Cover JSON success, legacy analysis, match/coverage, and read-only behavior in a sandbox. |
| `internal/plan/plan_test.go` | Preserve invalid/absolute/traversing/symlink-escape rejection and the home-only resolver boundary. |
| `docs/installed-target-root-research.md` | Record the pinned v0.68.0 diagnosis, preserved contract, and delivery status. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go build ./...`
- [ ] `go run ./cmd/dots manifest validate --file dots.yaml` (not applicable; the repository manifest is unchanged)
- [ ] Sandboxed plan (not applicable; no install-plan behavior changed)

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] CLI validation used temporary home, source, state, and XDG state roots.

## Contributor Checklist

- [x] Linked approved issue with `Closes #413`.
- [x] Added exactly one `type:*` label.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated the requested research documentation.
- [x] Used Conventional Commits.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

- Agent Brief: [comment 5231667972](https://github.com/yersonargotev/dots/issues/413#issuecomment-5231667972)
  - Updated: `2026-08-09T13:05:21Z`
  - SHA-256: `24cb4249f049c99f761ddac254e67d92a64710a2489bbe75dfc391c475d4bc84`
- Reviewed head: `be79d136bdbdf46b529c4bc2abb87506c7bfc6b3`
- Acceptance coverage:
  - Package inventory test proves an XDG-state metadata record matches and yields complete `1/1` Profile coverage.
  - Sandboxed CLI test uses explicit home, Source of Truth, state root, and `XDG_STATE_HOME`; metadata v2 also exercises legacy Installed Selection analysis.
  - Existing home-rooted tests remain green.
  - Plan tests reject relative/outside roots, absolute/traversing/dot targets, and symlink escapes.
  - `ResolveTarget` is unchanged and directly asserted to reject arbitrary relative targets.
  - The CLI test proves the read-only command does not create the XDG state subtree.
- Automated validation:
  - `gofmt -l .` — passed (no output).
  - `go vet ./...` — passed.
  - `go build ./...` — passed.
  - `go test ./...` — passed.
- Manual verification:
  - Built a real binary with `go build -o "$SANDBOX/dots" ./cmd/dots`.
  - Ran that binary as `dots installed --output json` with temporary explicit home/source/state roots and `XDG_STATE_HOME`.
  - Expected/observed: exit `0`, `status: ok`, `manifest_matched: true`, Profile `complete` with `1/1` coverage, and XDG state home absent before and after.
- Independent review:
  - Spec — 0 findings on `origin/main...be79d13`.
  - Standards — 0 findings on `origin/main...be79d13`.
- Delegation:
  - Native subagent performed a read-only impact/test exploration; recommendations were accepted after main-agent inspection.
  - Implementation stayed with the main agent because the change is one cohesive module path and installed custom delegation artifacts were absent.
  - Main agent verified all returned work through direct source inspection, focused tests, full CI-equivalent gates, and manual binary execution.
<!-- delivery-issue:evidence:end -->