### PR TITLE
docs(manifest): catalog current profiles and tags

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -64,6 +64,49 @@ Current Profiles:
 | `mobile` | `mobile` | Optional Dart and Flutter mobile development agent skills plus Dart/Flutter MCP integration for Claude, Codex, Antigravity, and GitHub Copilot in VS Code. | — |
 | `workstation` | `core`, `desktop`, `agents` | Opinionated composite when core, desktop integrations, and the native Agent CLI Baseline are desired; web and mobile remain explicit opt-ins. | Core Development Baseline, GitHub CLI, shared `jq`, the five Agent CLIs, and the Desktop Nerd Font |
 
+### Current Tags
+
+The table below is the canonical catalog of values accepted by repeated
+`--tag`. Ordinary Install Manifest surface Tags select matching Dependency
+Sets, Managed Entries, source overrides, or Provisioners. Behavior-only
+modifiers are accepted selection intent but perform cleanup instead of selecting
+one of those surfaces. Legacy compatibility aliases remain accepted only so an
+existing selection can converge safely; do not use them for new selections.
+
+| Tag | Classification | Status | Selection or cleanup effect |
+|-----|----------------|--------|-----------------------------|
+| `core` | Ordinary manifest surface | Current; prefer `--profile core` or `workstation` | Selects the Core Development Baseline and core shell, terminal, Git, editor, and CLI configuration. |
+| `desktop` | Ordinary manifest surface | Current; prefer `--profile desktop` or `workstation` | Selects desktop terminal/editor configuration and integrations plus the Profile's Nerd Font Dependency. |
+| `agents` | Ordinary manifest surface | Current; prefer `--profile agents` or `workstation` | Selects the native Agent CLI Baseline and dots-owned configuration for Codex, Claude Code, OpenCode, Antigravity, and Copilot CLI; it does not include delegation. |
+| `codex-delegation` | Ordinary manifest surface | Current; prefer `--profile codex-delegation` | Selects the Codex-only delegation skill Provisioner and converges the generic delegation overlay plus dots-owned explorer/worker agents. |
+| `web` | Ordinary manifest surface | Current; prefer `--profile web` | Selects the optional browser/frontend workbench, including web skills and Chrome DevTools integrations. |
+| `mobile` | Ordinary manifest surface | Current; prefer `--profile mobile` | Selects optional Dart, Flutter, and Android skills plus Dart/Flutter MCP integrations. |
+| `adaptive-theme` | Ordinary manifest surface | Current; opt-in Tag | Selects the adaptive-theme marker and supported app-specific sources or fragments; dark fallbacks remain when adaptive behavior is unavailable. |
+| `codegraph` | Ordinary manifest surface | Current; opt-in Tag | Selects the CodeGraph Provisioner and the Codex configuration override that adds its SessionStart hook. |
+| `without-codex-delegation` | Behavior-only cleanup modifier | Current; supported cleanup Tag | Removes the dots-owned generic delegation overlay and native Codex explorer/worker agents while preserving unrelated Codex configuration and user-owned agents. |
+| `codex-spark-delegation` | Legacy compatibility alias | Legacy-only; prefer `--profile codex-delegation` | Migrates the old Spark-specific marker and converges the current generic delegation overlay and native agents; it is not the current delegation Profile surface. |
+| `without-codex-spark-delegation` | Legacy compatibility alias | Legacy-only; prefer `without-codex-delegation` | Applies the supported delegation cleanup behavior for selections that still record the old Spark-named Tag. |
+
+Any explicit `--profile` or `--tag` flags describe the complete selection for
+that invocation; they are not merged with an Installed Selection. These
+examples therefore repeat every intended Profile and Tag:
+
+```bash
+# Compose core configuration with the optional web workbench.
+dots install --profile core --profile web
+
+# Add an optional capability to the complete workstation selection.
+dots install --profile workstation --tag adaptive-theme
+
+# Keep the delegation Profile intent while removing its dots-owned overlay and agents.
+dots install --profile codex-delegation --tag without-codex-delegation
+```
+
+See the [adaptive theme audit](adaptive-theme-audit.md), the
+[`codegraph` Provisioner specification](#codegraph-spec), and the
+[delegation inventory and cleanup contract](agents/delegation.md) for the
+detailed behavior behind those focused capabilities.
+
 ## Tag-scoped Dependency Sets
 
 Top-level `dependencies` declare shared toolchain baselines selected by tag,


### PR DESCRIPTION
Closes #416

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [x] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds one canonical catalog for every current Install Profile and accepted Tag.
- Distinguishes ordinary manifest surfaces, cleanup modifiers, and legacy aliases.
- Adds complete-selection examples and focused adaptive theme, CodeGraph, and delegation links.

## Changes

| File | Change |
|------|--------|
| `docs/manifest.md` | Add the canonical Profile and Tag catalog, classifications, effects, examples, and cross-links. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [ ] `go run ./cmd/dots manifest validate --file dots.yaml` — not applicable; the Install Manifest did not change.
- [ ] Sandboxed plan only when dotfiles behavior changes — not applicable; documentation-only change.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] CLI validation against home/config paths was not applicable because no CLI or dotfiles behavior changed.

## Contributor Checklist

- [x] Linked one issue with an admitted Delivery Contract using `Closes #416`.
- [x] Added exactly one `type:*` label.
- [x] Delivery Evidence records the Contract Source snapshot, Acceptance coverage, and Independent review.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated user documentation for the selection catalog.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

### Delivery Contract snapshot

- Contract Source: historical Agent Brief.
- Source body ID: `IC_kwDOSzLlmM8AAAABN9ppzg`.
- Source URL: https://github.com/yersonargotev/dots/issues/416#issuecomment-5232028110
- Source `updatedAt`: `2026-08-09T14:29:21Z`.
- Source SHA-256: `af230f577f768874fa8320e9e88520df5cc58ae9754b9dfaa1ea75743ca5308b`.
- Category: `enhancement`.
- Readiness: `ready-for-agent` is the only triage-state label.
- Native relationships: no parent, sub-issues, blocked-by issues, or blocking issues.

### Reviewed candidate

- Head commit: `a3979d23e895a54615d6934fef70e9191506db5e`.
- Range: `origin/main...HEAD`.

### Acceptance coverage

- Profile catalog: mechanically compared with the seven keys in the `dots.yaml` profile map; all matched.
- Tag catalog: mechanically compared with manifest tags, source override keys, and `supportedSelectionModifier`; all eleven matched.
- Classification and effect: reviewed against `dots.yaml`, `internal/selection/selection.go`, install cleanup behavior, and focused guides.
- Examples: cover composed Profiles, optional capability Tag, and supported delegation cleanup with complete explicit selections.
- Cross-links: adaptive theme audit, local CodeGraph specification, and delegation guide all resolve; README quickstart and update guidance remain consistent.
- Markdown: `git diff --check` passed and table/link structure was inspected.

### Automated validation

- `gofmt -l .`: passed with no output.
- `go vet ./...`: passed.
- `go build ./...`: passed.
- `go test ./...`: passed.
- Focused catalog comparison: 7 Profiles and 11 Tags matched their authoritative sources.
- Focused tests: `go test ./internal/manifest ./internal/selection ./internal/agentinstructions` passed.

### Manual verification

Not applicable: this change edits documentation only and does not alter CLI selection behavior, the Install Manifest, Managed Entries, Dependencies, Provisioners, or cleanup behavior.

### Independent review

- Standards: 0 actionable findings, 0 observations.
- Spec: 0 actionable findings, 0 observations.
- Reviewed head: `a3979d23e895a54615d6934fef70e9191506db5e`.

### Delegation

- Implementation delegation skipped: this is one small, coherent documentation change in a single file with no independent implementation slices.
- Independent review used separate Standards and Spec contexts; both returned clean reports.
- Main-agent verification: inspected the final diff, mechanically compared both catalogs with authoritative sources, and ran focused plus full CI-equivalent validation.
<!-- delivery-issue:evidence:end -->
