### PR TITLE
feat(catalog): expose profiles and tags

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -132,6 +132,10 @@ _Avoid_: latest installer, unpinned download, auto-updater
 The preview of filesystem changes, conflicts, dependency findings, and backup requirements that the Dotfiles CLI computes before applying installation. It is shown during normal installation and is the output of dry-run mode.
 _Avoid_: preview, dry run output, change list
 
+**Install Catalog**:
+The read-only, Source of Truth-derived description of available Profiles, Tags, and their portable selected surfaces. It explains what the current Install Manifest offers without reading Installation Metadata, historical inventory, workstation alignment, or an Install Plan, and it never implies or changes an Installed Selection.
+_Avoid_: installed catalog, status report, selection preview
+
 **Uninstall Plan**:
 The preview of removals the Dotfiles CLI computes from the Installation Metadata before reversing an install, classifying each recorded target as remove, retain, skip, modified, or not-owned. It is the mirror of the Install Plan and is the output of `dots uninstall --dry-run`.
 _Avoid_: removal preview, deletion list, reverse plan

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -52,40 +52,41 @@ may instead offer an unambiguous candidate for confirmation.
 | `tags` | Yes | Non-empty strings. Entries and Provisioners are selected when at least one tag matches. Optional CLI `--tag` values join this set at runtime. |
 | `dependencies` | No | Profile-level Dependencies, using the same dependency fields as entries. |
 
-Current Profiles:
+The following compact catalog is generated from the Install Manifest. It lists
+current and legacy declarations; the `dots catalog` command hides legacy items
+from compact discovery unless `--all` is supplied.
 
-| Profile | Tags | Intent | Profile Dependencies |
-|---------|------|--------|----------------------|
-| `core` | `core` | Core dotfiles and general developer tooling without agent/web/mobile provisioners. | Core Development Baseline plus GitHub CLI and `jq` via the `core` tag-scoped Dependency Set |
-| `desktop` | `desktop` | Desktop-only configuration and integrations; compose with `--profile core` when core dotfiles are desired too. | `Desktop Nerd Font` via Homebrew cask `font-cascadia-code-nf`, detected with `CascadiaCodeNF*` or `CaskaydiaCoveNerdFont*` |
-| `agents` | `agents` | Native configuration for Codex, Claude Code, OpenCode, Antigravity, and Copilot CLI. Add `--profile core` separately for core dotfiles. | The five Agent CLIs through Rolling User-Local Providers plus shared `jq` |
-| `codex-delegation` | `codex-delegation` | Codex-only delegation skill, generic delegation overlay, and dots-owned native explorer/worker agents without the broader agent baseline. | `npx` via the selected Provisioner Dependency |
-| `web` | `web` | Optional frontend/browser workbench: web design skills plus Chrome DevTools integrations. | `Playwright CLI` via Homebrew formula `playwright-cli` |
-| `mobile` | `mobile` | Optional Dart and Flutter mobile development agent skills plus Dart/Flutter MCP integration for Claude, Codex, Antigravity, and GitHub Copilot in VS Code. | — |
-| `workstation` | `core`, `desktop`, `agents` | Opinionated composite when core, desktop integrations, and the native Agent CLI Baseline are desired; web and mobile remain explicit opt-ins. | Core Development Baseline, GitHub CLI, shared `jq`, the five Agent CLIs, and the Desktop Nerd Font |
+<!-- dots:catalog:start -->
 
-### Current Tags
+### Profiles
 
-The table below is the canonical catalog of values accepted by repeated
-`--tag`. Ordinary Install Manifest surface Tags select matching Dependency
-Sets, Managed Entries, source overrides, or Provisioners. Behavior-only
-modifiers are accepted selection intent but perform cleanup instead of selecting
-one of those surfaces. Legacy compatibility aliases remain accepted only so an
-existing selection can converge safely; do not use them for new selections.
+| Profile | Status | Tags | Description |
+|---------|--------|------|-------------|
+| `agents` | current | `agents` | Native configuration for Codex, Claude Code, OpenCode, Antigravity, and Copilot CLI. |
+| `codex-delegation` | current | `codex-delegation` | Codex-only delegation capability without the broader Agent CLI Baseline. |
+| `core` | current | `core` | Core dotfiles and general developer tooling without agent, web, or mobile provisioners. |
+| `desktop` | current | `desktop` | Desktop-only configuration and integrations; compose with core when core dotfiles are desired too. |
+| `mobile` | current | `mobile` | Optional Dart and Flutter mobile development capabilities. |
+| `web` | current | `web` | Optional frontend and browser workbench. |
+| `workstation` | current | `core`, `desktop`, `agents` | Composite core, desktop, and Agent CLI Baseline selection; web and mobile stay opt-in. |
 
-| Tag | Classification | Status | Selection or cleanup effect |
-|-----|----------------|--------|-----------------------------|
-| `core` | Ordinary manifest surface | Current; prefer `--profile core` or `workstation` | Selects the Core Development Baseline and core shell, terminal, Git, editor, and CLI configuration. |
-| `desktop` | Ordinary manifest surface | Current; prefer `--profile desktop` or `workstation` | Selects desktop terminal/editor configuration and integrations plus the Profile's Nerd Font Dependency. |
-| `agents` | Ordinary manifest surface | Current; prefer `--profile agents` or `workstation` | Selects the native Agent CLI Baseline and dots-owned configuration for Codex, Claude Code, OpenCode, Antigravity, and Copilot CLI; it does not include delegation. |
-| `codex-delegation` | Ordinary manifest surface | Current; prefer `--profile codex-delegation` | Selects the Codex-only delegation skill Provisioner and converges the generic delegation overlay plus dots-owned explorer/worker agents. |
-| `web` | Ordinary manifest surface | Current; prefer `--profile web` | Selects the optional browser/frontend workbench, including web skills and Chrome DevTools integrations. |
-| `mobile` | Ordinary manifest surface | Current; prefer `--profile mobile` | Selects optional Dart, Flutter, and Android skills plus Dart/Flutter MCP integrations. |
-| `adaptive-theme` | Ordinary manifest surface | Current; opt-in Tag | Selects the adaptive-theme marker and supported app-specific sources or fragments; dark fallbacks remain when adaptive behavior is unavailable. |
-| `codegraph` | Ordinary manifest surface | Current; opt-in Tag | Selects the CodeGraph Provisioner and the Codex configuration override that adds its SessionStart hook. |
-| `without-codex-delegation` | Behavior-only cleanup modifier | Current; supported cleanup Tag | Removes the dots-owned generic delegation overlay and native Codex explorer/worker agents while preserving unrelated Codex configuration and user-owned agents. |
-| `codex-spark-delegation` | Legacy compatibility alias | Legacy-only; prefer `--profile codex-delegation` | Migrates the old Spark-specific marker and converges the current generic delegation overlay and native agents; it is not the current delegation Profile surface. |
-| `without-codex-spark-delegation` | Legacy compatibility alias | Legacy-only; prefer `without-codex-delegation` | Applies the supported delegation cleanup behavior for selections that still record the old Spark-named Tag. |
+### Tags
+
+| Tag | Kind | Status | Description | Replacement |
+|-----|------|--------|-------------|-------------|
+| `adaptive-theme` | surface | current | Opt-in adaptive-theme marker and supported app-specific sources or fragments. |  |
+| `agents` | surface | current | Native Agent CLI Baseline for Codex, Claude Code, OpenCode, Antigravity, and Copilot CLI. |  |
+| `codegraph` | surface | current | Opt-in CodeGraph provisioner and Codex SessionStart hook source override. |  |
+| `codex-delegation` | surface | current | Codex-only delegation skill, generic delegation overlay, and native explorer/worker agents. |  |
+| `codex-spark-delegation` | compatibility | legacy | Legacy Spark-specific delegation alias that converges the current generic delegation overlay and native agents. | `codex-delegation` |
+| `core` | surface | current | Core Development Baseline: shell, terminal, Git, editor, and common developer tooling. |  |
+| `desktop` | surface | current | Desktop terminal/editor configuration and integrations. |  |
+| `mobile` | surface | current | Optional Dart, Flutter, and Android development skills and MCP integrations. |  |
+| `web` | surface | current | Optional frontend/browser workbench with web skills and Chrome DevTools integrations. |  |
+| `without-codex-delegation` | cleanup | current | Remove the dots-owned generic delegation overlay and native Codex explorer/worker agents. |  |
+| `without-codex-spark-delegation` | compatibility | legacy | Legacy Spark-specific cleanup alias for the supported delegation cleanup behavior. | `without-codex-delegation` |
+
+<!-- dots:catalog:end -->
 
 Any explicit `--profile` or `--tag` flags describe the complete selection for
 that invocation; they are not merged with an Installed Selection. These

--- a/dots.yaml
+++ b/dots.yaml
@@ -1,9 +1,60 @@
 version: 1
+tags:
+  core:
+    description: "Core Development Baseline: shell, terminal, Git, editor, and common developer tooling."
+    kind: surface
+    status: current
+  desktop:
+    description: Desktop terminal/editor configuration and integrations.
+    kind: surface
+    status: current
+  agents:
+    description: Native Agent CLI Baseline for Codex, Claude Code, OpenCode, Antigravity, and Copilot CLI.
+    kind: surface
+    status: current
+  codex-delegation:
+    description: Codex-only delegation skill, generic delegation overlay, and native explorer/worker agents.
+    kind: surface
+    status: current
+  web:
+    description: Optional frontend/browser workbench with web skills and Chrome DevTools integrations.
+    kind: surface
+    status: current
+  mobile:
+    description: Optional Dart, Flutter, and Android development skills and MCP integrations.
+    kind: surface
+    status: current
+  adaptive-theme:
+    description: Opt-in adaptive-theme marker and supported app-specific sources or fragments.
+    kind: surface
+    status: current
+  codegraph:
+    description: Opt-in CodeGraph provisioner and Codex SessionStart hook source override.
+    kind: surface
+    status: current
+  without-codex-delegation:
+    description: Remove the dots-owned generic delegation overlay and native Codex explorer/worker agents.
+    kind: cleanup
+    status: current
+  codex-spark-delegation:
+    description: Legacy Spark-specific delegation alias that converges the current generic delegation overlay and native agents.
+    kind: compatibility
+    status: legacy
+    replaced_by: codex-delegation
+  without-codex-spark-delegation:
+    description: Legacy Spark-specific cleanup alias for the supported delegation cleanup behavior.
+    kind: compatibility
+    status: legacy
+    replaced_by: without-codex-delegation
 profiles:
   core:
+    description: Core dotfiles and general developer tooling without agent, web, or mobile provisioners.
+    status: current
     tags:
       - core
   desktop:
+    description: Desktop-only configuration and integrations; compose with core when core dotfiles are desired too.
+    status: current
     tags:
       - desktop
     dependencies:
@@ -13,12 +64,18 @@ profiles:
         font_fallback_matches:
           - "CaskaydiaCoveNerdFont*"
   agents:
+    description: Native configuration for Codex, Claude Code, OpenCode, Antigravity, and Copilot CLI.
+    status: current
     tags:
       - agents
   codex-delegation:
+    description: Codex-only delegation capability without the broader Agent CLI Baseline.
+    status: current
     tags:
       - codex-delegation
   web:
+    description: Optional frontend and browser workbench.
+    status: current
     tags:
       - web
     dependencies:
@@ -27,9 +84,13 @@ profiles:
         brew: playwright-cli
         linux_homebrew: true
   mobile:
+    description: Optional Dart and Flutter mobile development capabilities.
+    status: current
     tags:
       - mobile
   workstation:
+    description: Composite core, desktop, and Agent CLI Baseline selection; web and mobile stay opt-in.
+    status: current
     tags:
       - core
       - desktop

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -1,0 +1,446 @@
+// Package catalog builds a portable, read-only description of an Install
+// Manifest. It deliberately does not inspect a workstation or installed state.
+package catalog
+
+import (
+	"fmt"
+	"runtime"
+	"sort"
+	"strings"
+
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/tagpolicy"
+)
+
+const (
+	MetadataDeclared = "declared"
+	MetadataDerived  = "derived"
+)
+
+// Options controls a portable catalog view. OS is darwin, linux, or all; an
+// empty value uses the host OS. IncludeLegacy only affects list views: explicit
+// Profile and Tag queries always return their named item.
+type Options struct {
+	OS            string
+	IncludeLegacy bool
+}
+
+// Report is the stable shared data model for text, JSON, Markdown, and future
+// presentation adapters.
+type Report struct {
+	OS             string           `json:"os"`
+	MetadataOrigin string           `json:"metadata_origin"`
+	Profiles       []ProfileSummary `json:"profiles"`
+	Tags           []TagSummary     `json:"tags"`
+	Hidden         Hidden           `json:"hidden"`
+	Profile        *Detail          `json:"profile,omitempty"`
+	Tag            *Detail          `json:"tag,omitempty"`
+}
+
+// Hidden records items deliberately omitted from a compact current-only list.
+type Hidden struct {
+	Profiles int `json:"profiles"`
+	Tags     int `json:"tags"`
+}
+
+// ProfileSummary is a compact Profile summary.
+type ProfileSummary struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Status      string   `json:"status"`
+	Tags        []string `json:"tags"`
+}
+
+// TagSummary is a compact Tag summary.
+type TagSummary struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Kind        string `json:"kind"`
+	Status      string `json:"status"`
+	ReplacedBy  string `json:"replaced_by,omitempty"`
+	Origin      string `json:"origin"`
+}
+
+// Detail explains exactly one Profile or Tag selection without composing it
+// with Installed Selection or reading machine state.
+type Detail struct {
+	Name                string            `json:"name"`
+	Description         string            `json:"description"`
+	Status              string            `json:"status"`
+	Kind                string            `json:"kind,omitempty"`
+	ReplacedBy          string            `json:"replaced_by,omitempty"`
+	ResolvedTags        []string          `json:"resolved_tags"`
+	Dependencies        []Dependency      `json:"dependencies"`
+	DependencySets      []DependencySet   `json:"dependency_sets"`
+	ProfileDependencies []Dependency      `json:"profile_dependencies"`
+	Entries             []Entry           `json:"entries"`
+	SourceOverrides     []SourceOverride  `json:"source_overrides"`
+	Provisioners        []Provisioner     `json:"provisioners"`
+	Behaviors           []Behavior        `json:"behaviors"`
+	Excluded            []ExcludedSurface `json:"excluded"`
+}
+
+// Dependency identifies a declared dependency and why the selected surface
+// includes it. It contains declaration data only; no probe result is present.
+type Dependency struct {
+	Name        string   `json:"name"`
+	Requirement string   `json:"requirement"`
+	Probes      []string `json:"probes"`
+	Origin      Origin   `json:"origin"`
+}
+
+// Origin pinpoints the manifest surface that selected a dependency.
+type Origin struct {
+	Type string   `json:"type"`
+	Name string   `json:"name,omitempty"`
+	Tags []string `json:"tags,omitempty"`
+}
+
+type DependencySet struct {
+	Tags         []string     `json:"tags"`
+	OS           []string     `json:"os"`
+	Dependencies []Dependency `json:"dependencies"`
+}
+
+// Entry describes one portable Managed Entry selected by the queried intent.
+type Entry struct {
+	Source       string       `json:"source"`
+	Target       string       `json:"target"`
+	TargetRoot   string       `json:"target_root,omitempty"`
+	Strategy     string       `json:"strategy"`
+	Ownership    string       `json:"ownership,omitempty"`
+	Tags         []string     `json:"tags"`
+	OS           []string     `json:"os"`
+	Dependencies []Dependency `json:"dependencies"`
+}
+
+// SourceOverride records a source change activated by a selected Tag. It is
+// retained separately when the override's base Entry is not itself selected.
+type SourceOverride struct {
+	Tag        string   `json:"tag"`
+	Source     string   `json:"source"`
+	Entry      string   `json:"entry"`
+	Target     string   `json:"target"`
+	OS         []string `json:"os"`
+	Applicable bool     `json:"applicable"`
+}
+
+// Provisioner is a safe declarative description. EnvironmentValues are never
+// represented; only declared variable names may appear in EnvironmentNames.
+type Provisioner struct {
+	Tool             string       `json:"tool"`
+	Operation        string       `json:"operation"`
+	Identity         string       `json:"identity,omitempty"`
+	Scope            string       `json:"scope,omitempty"`
+	Agents           []string     `json:"agents"`
+	Skills           []string     `json:"skills"`
+	Command          []string     `json:"command,omitempty"`
+	EnvironmentNames []string     `json:"environment_names"`
+	Tags             []string     `json:"tags"`
+	OS               []string     `json:"os"`
+	Dependencies     []Dependency `json:"dependencies"`
+}
+
+type Behavior struct {
+	Action      string `json:"action"`
+	Description string `json:"description"`
+}
+
+type ExcludedSurface struct {
+	Type   string   `json:"type"`
+	Name   string   `json:"name"`
+	OS     []string `json:"os"`
+	Reason string   `json:"reason"`
+}
+
+// Build returns deterministic Profile and Tag summaries. The manifest must
+// already have passed manifest validation.
+func Build(m manifest.Manifest, opts Options) (Report, error) {
+	osName, err := resolveOS(opts.OS)
+	if err != nil {
+		return Report{}, err
+	}
+	r := Report{OS: osName, MetadataOrigin: metadataOrigin(m), Profiles: []ProfileSummary{}, Tags: []TagSummary{}}
+	for _, name := range sortedProfileNames(m) {
+		profile := summaryProfile(name, m.Profiles[name])
+		if profile.Status == "legacy" && !opts.IncludeLegacy {
+			r.Hidden.Profiles++
+			continue
+		}
+		r.Profiles = append(r.Profiles, profile)
+	}
+	for _, tag := range allTags(m) {
+		summary := summaryTag(m, tag)
+		if summary.Status == "legacy" && !opts.IncludeLegacy {
+			r.Hidden.Tags++
+			continue
+		}
+		r.Tags = append(r.Tags, summary)
+	}
+	return r, nil
+}
+
+// Profile returns a detailed, exact Profile view. Legacy details are always
+// available so prior declared intent remains inspectable.
+func Profile(m manifest.Manifest, name string, opts Options) (Report, error) {
+	base, err := Build(m, Options{OS: opts.OS, IncludeLegacy: true})
+	if err != nil {
+		return Report{}, err
+	}
+	p, ok := m.Profiles[name]
+	if !ok {
+		return Report{}, fmt.Errorf("profile %q not found", name)
+	}
+	summary := summaryProfile(name, p)
+	base.Profile = buildDetail(m, name, summary.Description, summary.Status, "", "", unique(p.Tags), base.OS, p.Dependencies)
+	return base, nil
+}
+
+// Tag returns a detailed, exact Tag view. Registryless manifests derive a
+// current surface Tag mechanically from all manifest references.
+func Tag(m manifest.Manifest, name string, opts Options) (Report, error) {
+	base, err := Build(m, Options{OS: opts.OS, IncludeLegacy: true})
+	if err != nil {
+		return Report{}, err
+	}
+	if !contains(allTags(m), name) {
+		return Report{}, fmt.Errorf("tag %q not found", name)
+	}
+	t := summaryTag(m, name)
+	base.Tag = buildDetail(m, name, t.Description, t.Status, t.Kind, t.ReplacedBy, []string{name}, base.OS, nil)
+	return base, nil
+}
+
+func buildDetail(m manifest.Manifest, name, description, status, kind, replacedBy string, tags []string, osName string, profileDeps []manifest.Dependency) *Detail {
+	d := &Detail{Name: name, Description: description, Status: status, Kind: kind, ReplacedBy: replacedBy, ResolvedTags: clone(tags), Dependencies: []Dependency{}, DependencySets: []DependencySet{}, ProfileDependencies: []Dependency{}, Entries: []Entry{}, SourceOverrides: []SourceOverride{}, Provisioners: []Provisioner{}, Behaviors: behaviors(tags), Excluded: []ExcludedSurface{}}
+	for _, dep := range profileDeps {
+		d.ProfileDependencies = append(d.ProfileDependencies, dependency(dep, Origin{Type: "profile", Name: name}))
+	}
+	for _, set := range m.Dependencies {
+		if !manifest.SharesTag(set.Tags, tags) {
+			continue
+		}
+		if !matches(set.OS, osName) {
+			d.Excluded = append(d.Excluded, excluded("dependency_set", strings.Join(set.Tags, ","), set.OS, osName))
+			continue
+		}
+		item := DependencySet{Tags: clone(set.Tags), OS: declaredOS(set.OS), Dependencies: []Dependency{}}
+		for _, dep := range set.Dependencies {
+			item.Dependencies = append(item.Dependencies, dependency(dep, Origin{Type: "dependency_set", Tags: clone(set.Tags)}))
+			d.Dependencies = append(d.Dependencies, dependency(dep, Origin{Type: "dependency_set", Tags: clone(set.Tags)}))
+		}
+		d.DependencySets = append(d.DependencySets, item)
+	}
+	for _, entry := range m.Entries {
+		for tag, source := range entry.SourceOverrides {
+			if contains(tags, tag) {
+				applicable := matches(entry.OS, osName)
+				d.SourceOverrides = append(d.SourceOverrides, SourceOverride{Tag: tag, Source: source, Entry: entry.Source, Target: entry.Target, OS: declaredOS(entry.OS), Applicable: applicable})
+				if !applicable {
+					d.Excluded = append(d.Excluded, excluded("source_override", entry.Target+" ("+tag+")", entry.OS, osName))
+				}
+			}
+		}
+		if !manifest.SharesTag(entry.Tags, tags) {
+			continue
+		}
+		if !matches(entry.OS, osName) {
+			d.Excluded = append(d.Excluded, excluded("entry", entry.Target, entry.OS, osName))
+			continue
+		}
+		selected := manifest.EntrySource(entry, tags)
+		item := Entry{Source: selected, Target: entry.Target, TargetRoot: entry.TargetRoot, Strategy: entry.Strategy, Ownership: entry.Ownership, Tags: clone(entry.Tags), OS: declaredOS(entry.OS), Dependencies: []Dependency{}}
+		for _, dep := range entry.Dependencies {
+			x := dependency(dep, Origin{Type: "entry", Name: entry.Target, Tags: clone(entry.Tags)})
+			item.Dependencies = append(item.Dependencies, x)
+			d.Dependencies = append(d.Dependencies, x)
+		}
+		d.Entries = append(d.Entries, item)
+	}
+	for _, p := range m.Provisioners {
+		if !manifest.SharesTag(p.Tags, tags) {
+			continue
+		}
+		if !matches(p.OS, osName) {
+			d.Excluded = append(d.Excluded, excluded("provisioner", p.Tool, p.OS, osName))
+			continue
+		}
+		d.Provisioners = append(d.Provisioners, provisioner(p))
+		for _, dep := range p.Dependencies {
+			d.Dependencies = append(d.Dependencies, dependency(dep, Origin{Type: "provisioner", Name: p.Tool, Tags: clone(p.Tags)}))
+		}
+	}
+	sort.Slice(d.SourceOverrides, func(i, j int) bool {
+		if d.SourceOverrides[i].Tag == d.SourceOverrides[j].Tag {
+			return d.SourceOverrides[i].Target < d.SourceOverrides[j].Target
+		}
+		return d.SourceOverrides[i].Tag < d.SourceOverrides[j].Tag
+	})
+	sort.Slice(d.Excluded, func(i, j int) bool {
+		if d.Excluded[i].Type == d.Excluded[j].Type {
+			return d.Excluded[i].Name < d.Excluded[j].Name
+		}
+		return d.Excluded[i].Type < d.Excluded[j].Type
+	})
+	return d
+}
+
+func provisioner(p manifest.Provisioner) Provisioner {
+	s := p.Spec
+	result := Provisioner{Tool: p.Tool, Scope: s.Scope, Agents: clone(s.Agents), Skills: clone(s.Skills), Tags: clone(p.Tags), OS: declaredOS(p.OS), Dependencies: []Dependency{}, EnvironmentNames: []string{}}
+	switch {
+	case s.Marketplace != "":
+		result.Operation, result.Identity = "marketplace", s.Marketplace
+	case s.Plugin != "":
+		result.Operation, result.Identity = "plugin", s.Plugin+"@"+s.From
+	case s.MCP != "":
+		result.Operation, result.Identity, result.Command = "mcp", s.MCP, clone(s.Command)
+	case s.Package != "":
+		result.Operation, result.Identity = "skills", s.Package
+	case p.Tool == "codegraph":
+		result.Operation = "install"
+	case p.Tool == "zimfw":
+		result.Operation = "initialize"
+	default:
+		result.Operation = "declared"
+	}
+	for key := range s.Env {
+		result.EnvironmentNames = append(result.EnvironmentNames, key)
+	}
+	sort.Strings(result.EnvironmentNames)
+	for _, dep := range p.Dependencies {
+		result.Dependencies = append(result.Dependencies, dependency(dep, Origin{Type: "provisioner", Name: p.Tool, Tags: clone(p.Tags)}))
+	}
+	return result
+}
+
+func dependency(dep manifest.Dependency, origin Origin) Dependency {
+	return Dependency{Name: dep.Name, Requirement: dep.RequirementValue(), Probes: dep.Probes(), Origin: origin}
+}
+
+func behaviors(tags []string) []Behavior {
+	result := []Behavior{}
+	for _, action := range tagpolicy.Actions(tags) {
+		result = append(result, Behavior{Action: string(action), Description: behaviorDescription(action)})
+	}
+	return result
+}
+
+func behaviorDescription(action tagpolicy.Action) string {
+	switch action {
+	case tagpolicy.ActionRetireGentleAIState:
+		return "Retire dots-owned Gentle AI state."
+	case tagpolicy.ActionRemoveCodexDelegation:
+		return "Remove the dots-owned Codex delegation overlay and native agents."
+	case tagpolicy.ActionConvergeCodexDelegation:
+		return "Converge the dots-owned Codex delegation overlay and native agents."
+	default:
+		return "Allowlisted selection behavior."
+	}
+}
+
+func summaryProfile(name string, p manifest.Profile) ProfileSummary {
+	status := p.Status
+	if status == "" {
+		status = "current"
+	}
+	return ProfileSummary{Name: name, Description: p.Description, Status: status, Tags: clone(p.Tags)}
+}
+func summaryTag(m manifest.Manifest, name string) TagSummary {
+	if t, ok := m.Tags[name]; ok {
+		return TagSummary{Name: name, Description: t.Description, Kind: t.Kind, Status: t.Status, ReplacedBy: t.ReplacedBy, Origin: MetadataDeclared}
+	}
+	return TagSummary{Name: name, Kind: "surface", Status: "current", Origin: MetadataDerived}
+}
+func metadataOrigin(m manifest.Manifest) string {
+	if len(m.Tags) == 0 {
+		return MetadataDerived
+	}
+	return MetadataDeclared
+}
+
+func allTags(m manifest.Manifest) []string {
+	seen := map[string]bool{}
+	add := func(tags []string) {
+		for _, tag := range tags {
+			seen[tag] = true
+		}
+	}
+	for name := range m.Tags {
+		seen[name] = true
+	}
+	for _, p := range m.Profiles {
+		add(p.Tags)
+	}
+	for _, s := range m.Dependencies {
+		add(s.Tags)
+	}
+	for _, e := range m.Entries {
+		add(e.Tags)
+		for tag := range e.SourceOverrides {
+			seen[tag] = true
+		}
+	}
+	for _, p := range m.Provisioners {
+		add(p.Tags)
+	}
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+func sortedProfileNames(m manifest.Manifest) []string {
+	names := make([]string, 0, len(m.Profiles))
+	for name := range m.Profiles {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+func resolveOS(value string) (string, error) {
+	if value == "" {
+		value = runtime.GOOS
+	}
+	value = strings.ToLower(strings.TrimSpace(value))
+	switch value {
+	case "darwin", "linux", "all":
+		return value, nil
+	default:
+		return "", fmt.Errorf("catalog OS %q is invalid: choose darwin, linux, or all", value)
+	}
+}
+func matches(os []string, value string) bool { return value == "all" || manifest.MatchesOS(os, value) }
+func declaredOS(os []string) []string {
+	if len(os) == 0 {
+		return []string{"darwin", "linux"}
+	}
+	return clone(os)
+}
+func excluded(kind, name string, os []string, requested string) ExcludedSurface {
+	return ExcludedSurface{Type: kind, Name: name, OS: declaredOS(os), Reason: "not applicable to " + requested}
+}
+func clone(values []string) []string {
+	if len(values) == 0 {
+		return []string{}
+	}
+	return append([]string{}, values...)
+}
+func contains(values []string, wanted string) bool {
+	for _, value := range values {
+		if value == wanted {
+			return true
+		}
+	}
+	return false
+}
+func unique(values []string) []string {
+	result := []string{}
+	for _, value := range values {
+		if !contains(result, value) {
+			result = append(result, value)
+		}
+	}
+	return result
+}

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -1,0 +1,131 @@
+package catalog
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/manifest"
+)
+
+func TestBuildHidesLegacyAndSortsDeclaredCatalog(t *testing.T) {
+	m := fixtureManifest()
+	got, err := Build(m, Options{OS: "linux"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.MetadataOrigin != MetadataDeclared {
+		t.Fatalf("MetadataOrigin = %q", got.MetadataOrigin)
+	}
+	if got.Hidden != (Hidden{Profiles: 1, Tags: 1}) {
+		t.Fatalf("Hidden = %#v", got.Hidden)
+	}
+	if names := profileNames(got.Profiles); !reflect.DeepEqual(names, []string{"core"}) {
+		t.Fatalf("profiles = %#v", names)
+	}
+	if names := tagNames(got.Tags); !reflect.DeepEqual(names, []string{"agents", "cleanup", "core", "theme"}) {
+		t.Fatalf("tags = %#v", names)
+	}
+}
+
+func TestTagDetailIsPortableSafeAndDescribesExclusions(t *testing.T) {
+	m := fixtureManifest()
+	got, err := Tag(m, "theme", Options{OS: "linux"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	detail := got.Tag
+	if detail == nil {
+		t.Fatal("Tag detail = nil")
+	}
+	if len(detail.SourceOverrides) != 1 || detail.SourceOverrides[0].Source != "adaptive" || detail.SourceOverrides[0].Applicable {
+		t.Fatalf("SourceOverrides = %#v", detail.SourceOverrides)
+	}
+	if len(detail.Excluded) != 3 {
+		t.Fatalf("Excluded = %#v", detail.Excluded)
+	}
+	all, err := Tag(m, "theme", Options{OS: "all"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all.Tag.Provisioners) != 1 {
+		t.Fatalf("Provisioners = %#v", all.Tag.Provisioners)
+	}
+	p := all.Tag.Provisioners[0]
+	if !reflect.DeepEqual(p.EnvironmentNames, []string{"PUBLIC", "SECRET"}) {
+		t.Fatalf("EnvironmentNames = %#v", p.EnvironmentNames)
+	}
+	if reflect.DeepEqual(p.Command, []string{"hidden"}) {
+		t.Fatal("unexpected command")
+	}
+	if p.Identity != "demo" || p.Operation != "mcp" {
+		t.Fatalf("Provisioner = %#v", p)
+	}
+}
+
+func TestRegistrylessCatalogDerivesSurfaceTags(t *testing.T) {
+	m := fixtureManifest()
+	m.Tags = nil
+	got, err := Build(m, Options{OS: "all", IncludeLegacy: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.MetadataOrigin != MetadataDerived {
+		t.Fatalf("MetadataOrigin = %q", got.MetadataOrigin)
+	}
+	for _, tag := range got.Tags {
+		if tag.Origin != MetadataDerived || tag.Kind != "surface" || tag.Status != "current" {
+			t.Fatalf("derived tag = %#v", tag)
+		}
+	}
+}
+
+func TestProfileDetailIncludesOriginAndBehavior(t *testing.T) {
+	got, err := Profile(fixtureManifest(), "core", Options{OS: "all"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	detail := got.Profile
+	if detail == nil || !reflect.DeepEqual(detail.ResolvedTags, []string{"core", "agents"}) {
+		t.Fatalf("Detail = %#v", detail)
+	}
+	if len(detail.ProfileDependencies) != 1 || detail.ProfileDependencies[0].Origin.Type != "profile" {
+		t.Fatalf("profile dependencies = %#v", detail.ProfileDependencies)
+	}
+	if len(detail.Behaviors) != 1 || detail.Behaviors[0].Action != "retire-gentle-ai-state" {
+		t.Fatalf("behaviors = %#v", detail.Behaviors)
+	}
+}
+
+func fixtureManifest() manifest.Manifest {
+	return manifest.Manifest{
+		Tags: map[string]manifest.Tag{
+			"core":    {Description: "Core", Kind: "surface", Status: "current"},
+			"agents":  {Description: "Agents", Kind: "surface", Status: "current"},
+			"theme":   {Description: "Theme", Kind: "surface", Status: "current"},
+			"cleanup": {Description: "Cleanup", Kind: "cleanup", Status: "current"},
+			"old":     {Description: "Old", Kind: "compatibility", Status: "legacy", ReplacedBy: "core"},
+		},
+		Profiles: map[string]manifest.Profile{
+			"core": {Description: "Core profile", Tags: []string{"core", "agents"}, Dependencies: []manifest.Dependency{{Name: "profile-tool"}}},
+			"old":  {Description: "Old profile", Status: "legacy", Tags: []string{"old"}},
+		},
+		Dependencies: []manifest.DependencySet{{Tags: []string{"core"}, Dependencies: []manifest.Dependency{{Name: "set-tool"}}}},
+		Entries:      []manifest.Entry{{Source: "base", SourceOverrides: map[string]string{"theme": "adaptive"}, Target: "~/.example", Strategy: "copy", Tags: []string{"theme"}, OS: []string{"darwin"}, Dependencies: []manifest.Dependency{{Name: "entry-tool"}}}},
+		Provisioners: []manifest.Provisioner{{Tool: "codex", Tags: []string{"theme"}, OS: []string{"darwin"}, Spec: manifest.ProvisionerSpec{MCP: "demo", Command: []string{"demo", "serve"}, Env: map[string]string{"SECRET": "must-not-leak", "PUBLIC": "1"}}, Dependencies: []manifest.Dependency{{Name: "provisioner-tool"}}}},
+	}
+}
+
+func profileNames(items []ProfileSummary) []string {
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		result = append(result, item.Name)
+	}
+	return result
+}
+func tagNames(items []TagSummary) []string {
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		result = append(result, item.Name)
+	}
+	return result
+}

--- a/internal/catalog/cmd/docgen/main.go
+++ b/internal/catalog/cmd/docgen/main.go
@@ -1,0 +1,40 @@
+// catalogdoc refreshes only the marked catalog block in the manifest guide.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/yersonargotev/dots/internal/catalog"
+	"github.com/yersonargotev/dots/internal/manifest"
+)
+
+func main() {
+	manifestPath := flag.String("manifest", "dots.yaml", "Install Manifest")
+	docPath := flag.String("doc", "docs/manifest.md", "manifest documentation")
+	flag.Parse()
+	m, err := manifest.LoadFile(*manifestPath)
+	if err != nil {
+		fail(err)
+	}
+	fragment, err := catalog.Markdown(*m)
+	if err != nil {
+		fail(err)
+	}
+	document, err := os.ReadFile(*docPath)
+	if err != nil {
+		fail(err)
+	}
+	updated, err := catalog.ReplaceDocumentationBlock(string(document), fragment)
+	if err != nil {
+		fail(err)
+	}
+	if updated != string(document) {
+		if err := os.WriteFile(*docPath, []byte(updated), 0o644); err != nil {
+			fail(err)
+		}
+	}
+}
+
+func fail(err error) { fmt.Fprintln(os.Stderr, "catalogdoc:", err); os.Exit(1) }

--- a/internal/catalog/doc.go
+++ b/internal/catalog/doc.go
@@ -1,0 +1,4 @@
+// Package catalog builds the portable Install Catalog report.
+package catalog
+
+//go:generate go run ./cmd/docgen -manifest ../../dots.yaml -doc ../../docs/manifest.md

--- a/internal/catalog/docsync.go
+++ b/internal/catalog/docsync.go
@@ -1,0 +1,27 @@
+package catalog
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	DocumentationStartMarker = "<!-- dots:catalog:start -->"
+	DocumentationEndMarker   = "<!-- dots:catalog:end -->"
+)
+
+// ReplaceDocumentationBlock changes only the one generated catalog block. It
+// rejects missing, duplicate, and malformed markers so generation cannot alter
+// an unintended portion of the narrative guide.
+func ReplaceDocumentationBlock(document, fragment string) (string, error) {
+	if strings.Count(document, DocumentationStartMarker) != 1 || strings.Count(document, DocumentationEndMarker) != 1 {
+		return "", fmt.Errorf("catalog documentation must contain exactly one start and end marker")
+	}
+	from := strings.Index(document, DocumentationStartMarker)
+	to := strings.Index(document, DocumentationEndMarker)
+	if to < from {
+		return "", fmt.Errorf("catalog documentation markers are malformed")
+	}
+	contentStart := from + len(DocumentationStartMarker)
+	return document[:contentStart] + "\n\n" + strings.TrimSuffix(fragment, "\n") + "\n\n" + document[to:], nil
+}

--- a/internal/catalog/docsync_test.go
+++ b/internal/catalog/docsync_test.go
@@ -1,0 +1,50 @@
+package catalog
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/manifest"
+)
+
+func TestRepositoryManifestDocumentationCatalogIsCurrent(t *testing.T) {
+	m, err := manifest.LoadFile("../../dots.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fragment, err := Markdown(*m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	document, err := os.ReadFile("../../docs/manifest.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated, err := ReplaceDocumentationBlock(string(document), fragment)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated != string(document) {
+		t.Fatal("docs/manifest.md catalog block is stale; run go generate ./internal/catalog")
+	}
+}
+
+func TestReplaceDocumentationBlockRequiresOneOrderedMarkerPair(t *testing.T) {
+	valid := DocumentationStartMarker + "\nold\n" + DocumentationEndMarker
+	updated, err := ReplaceDocumentationBlock(valid, "new\n")
+	if err != nil || updated != DocumentationStartMarker+"\n\nnew\n\n"+DocumentationEndMarker {
+		t.Fatalf("ReplaceDocumentationBlock() = %q, %v", updated, err)
+	}
+	for _, document := range []string{
+		DocumentationStartMarker,
+		DocumentationEndMarker,
+		DocumentationEndMarker + DocumentationStartMarker,
+		DocumentationStartMarker + DocumentationStartMarker + DocumentationEndMarker,
+		DocumentationStartMarker + DocumentationEndMarker + DocumentationEndMarker,
+	} {
+		if _, err := ReplaceDocumentationBlock(document, "new"); err == nil {
+			t.Fatalf("ReplaceDocumentationBlock(%q) succeeded", strings.ReplaceAll(document, "\n", "\\n"))
+		}
+	}
+}

--- a/internal/catalog/markdown.go
+++ b/internal/catalog/markdown.go
@@ -1,0 +1,48 @@
+package catalog
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/yersonargotev/dots/internal/manifest"
+)
+
+// Markdown returns the deterministic documentation fragment shared with the
+// catalog report. Narrative documentation deliberately remains outside this
+// generated fragment.
+func Markdown(m manifest.Manifest) (string, error) {
+	report, err := Build(m, Options{OS: "all", IncludeLegacy: true})
+	if err != nil {
+		return "", err
+	}
+	var out strings.Builder
+	out.WriteString("### Profiles\n\n")
+	out.WriteString("| Profile | Status | Tags | Description |\n")
+	out.WriteString("|---------|--------|------|-------------|\n")
+	for _, profile := range report.Profiles {
+		fmt.Fprintf(&out, "| `%s` | %s | %s | %s |\n", profile.Name, profile.Status, codeList(profile.Tags), markdownCell(profile.Description))
+	}
+	out.WriteString("\n### Tags\n\n")
+	out.WriteString("| Tag | Kind | Status | Description | Replacement |\n")
+	out.WriteString("|-----|------|--------|-------------|-------------|\n")
+	for _, tag := range report.Tags {
+		replacement := ""
+		if tag.ReplacedBy != "" {
+			replacement = "`" + tag.ReplacedBy + "`"
+		}
+		fmt.Fprintf(&out, "| `%s` | %s | %s | %s | %s |\n", tag.Name, tag.Kind, tag.Status, markdownCell(tag.Description), replacement)
+	}
+	return out.String(), nil
+}
+
+func codeList(items []string) string {
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		result = append(result, "`"+item+"`")
+	}
+	return strings.Join(result, ", ")
+}
+
+func markdownCell(value string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(value, "|", "\\|"), "\n", " ")
+}

--- a/internal/cli/catalog.go
+++ b/internal/cli/catalog.go
@@ -1,0 +1,256 @@
+package cli
+
+import (
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/yersonargotev/dots/internal/catalog"
+	"github.com/yersonargotev/dots/internal/manifest"
+)
+
+// newCatalogCommand exposes the portable, manifest-declared configuration
+// catalog. It deliberately has no home or state flags: catalog data does not
+// describe the current workstation or an Installed Selection.
+func newCatalogCommand() *cobra.Command {
+	var (
+		file       string
+		sourceRoot string
+		osName     string
+		includeAll bool
+	)
+
+	load := func(cmd *cobra.Command) (*catalog.Report, error) {
+		m, err := loadCatalogManifest(cmd, file, sourceRoot)
+		if err != nil {
+			return nil, err
+		}
+		report, err := catalog.Build(*m, catalog.Options{OS: osName, IncludeLegacy: includeAll})
+		if err != nil {
+			return nil, err
+		}
+		return &report, nil
+	}
+
+	cmd := &cobra.Command{
+		Use:          "catalog",
+		Short:        "Inspect the portable configuration catalog",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			report, err := load(cmd)
+			if err != nil {
+				return err
+			}
+			return renderOrEmitCatalog(cmd, *report, renderCatalogSummary)
+		},
+	}
+
+	cmd.PersistentFlags().StringVarP(&file, "file", "f", "dots.yaml", "manifest file to inspect")
+	cmd.PersistentFlags().StringVar(&sourceRoot, "source-root", "", "installed repository root (default ~/.local/share/dots)")
+	cmd.PersistentFlags().StringVar(&osName, "os", "", "catalog OS: darwin, linux, or all (default: host OS)")
+	cmd.PersistentFlags().BoolVar(&includeAll, "all", false, "include legacy profiles and tags in list views")
+	_ = cmd.RegisterFlagCompletionFunc("os", completeCatalogOS)
+
+	cmd.AddCommand(newCatalogProfilesCommand(load))
+	cmd.AddCommand(newCatalogProfileCommand())
+	cmd.AddCommand(newCatalogTagsCommand(load))
+	cmd.AddCommand(newCatalogTagCommand())
+	return cmd
+}
+
+type catalogLoader func(*cobra.Command) (*catalog.Report, error)
+
+func newCatalogProfilesCommand(load catalogLoader) *cobra.Command {
+	return &cobra.Command{
+		Use:          "profiles",
+		Short:        "List manifest profiles",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			report, err := load(cmd)
+			if err != nil {
+				return err
+			}
+			return renderOrEmitCatalog(cmd, *report, renderCatalogProfiles)
+		},
+	}
+}
+
+func newCatalogProfileCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "profile NAME",
+		Short:        "Show a manifest profile in detail",
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			report, err := loadCatalogProfile(cmd, args[0])
+			if err != nil {
+				return err
+			}
+			return renderOrEmitCatalog(cmd, report, renderCatalogProfileDetail)
+		},
+	}
+	cmd.ValidArgsFunction = completeCatalogProfiles
+	return cmd
+}
+
+func newCatalogTagsCommand(load catalogLoader) *cobra.Command {
+	return &cobra.Command{
+		Use:          "tags",
+		Short:        "List manifest tags",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			report, err := load(cmd)
+			if err != nil {
+				return err
+			}
+			return renderOrEmitCatalog(cmd, *report, renderCatalogTags)
+		},
+	}
+}
+
+func newCatalogTagCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "tag NAME",
+		Short:        "Show a manifest tag in detail",
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			report, err := loadCatalogTag(cmd, args[0])
+			if err != nil {
+				return err
+			}
+			return renderOrEmitCatalog(cmd, report, renderCatalogTagDetail)
+		},
+	}
+	cmd.ValidArgsFunction = completeCatalogTags
+	return cmd
+}
+
+func loadCatalogProfile(cmd *cobra.Command, name string) (catalog.Report, error) {
+	file, sourceRoot, osName, err := catalogCommandOptions(cmd)
+	if err != nil {
+		return catalog.Report{}, err
+	}
+	m, err := loadCatalogManifest(cmd, file, sourceRoot)
+	if err != nil {
+		return catalog.Report{}, err
+	}
+	return catalog.Profile(*m, name, catalog.Options{OS: osName})
+}
+
+func loadCatalogTag(cmd *cobra.Command, name string) (catalog.Report, error) {
+	file, sourceRoot, osName, err := catalogCommandOptions(cmd)
+	if err != nil {
+		return catalog.Report{}, err
+	}
+	m, err := loadCatalogManifest(cmd, file, sourceRoot)
+	if err != nil {
+		return catalog.Report{}, err
+	}
+	return catalog.Tag(*m, name, catalog.Options{OS: osName})
+}
+
+func renderOrEmitCatalog(cmd *cobra.Command, report catalog.Report, render func(*cobra.Command, catalog.Report)) error {
+	if wantsJSON(cmd) {
+		return emitOK(cmd, report)
+	}
+	render(cmd, report)
+	return nil
+}
+
+func completeCatalogOS(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return matchingCatalogValues([]string{"darwin", "linux", "all"}, toComplete), cobra.ShellCompDirectiveNoFileComp
+}
+
+func completeCatalogProfiles(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	report, err := loadCatalogCompletionReport(cmd)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	values := make([]string, 0, len(report.Profiles))
+	for _, profile := range report.Profiles {
+		values = append(values, profile.Name)
+	}
+	return matchingCatalogValues(values, toComplete), cobra.ShellCompDirectiveNoFileComp
+}
+
+func completeCatalogTags(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	report, err := loadCatalogCompletionReport(cmd)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	values := make([]string, 0, len(report.Tags))
+	for _, tag := range report.Tags {
+		values = append(values, tag.Name)
+	}
+	return matchingCatalogValues(values, toComplete), cobra.ShellCompDirectiveNoFileComp
+}
+
+func loadCatalogCompletionReport(cmd *cobra.Command) (catalog.Report, error) {
+	file, sourceRoot, osName, err := catalogCommandOptions(cmd)
+	if err != nil {
+		return catalog.Report{}, err
+	}
+	m, err := loadCatalogManifest(cmd, file, sourceRoot)
+	if err != nil {
+		return catalog.Report{}, err
+	}
+	return catalog.Build(*m, catalog.Options{OS: osName, IncludeLegacy: true})
+}
+
+func catalogCommandOptions(cmd *cobra.Command) (file, sourceRoot, osName string, err error) {
+	if file, err = cmd.Flags().GetString("file"); err != nil {
+		return "", "", "", err
+	}
+	if sourceRoot, err = cmd.Flags().GetString("source-root"); err != nil {
+		return "", "", "", err
+	}
+	if osName, err = cmd.Flags().GetString("os"); err != nil {
+		return "", "", "", err
+	}
+	return file, sourceRoot, osName, nil
+}
+
+// resolveCatalogSourceRoot keeps Catalog independent from the target home and
+// Installation Metadata. An explicit source root is already sufficient; only
+// the default Installed Repository convention needs the user's home directory.
+func resolveCatalogSourceRoot(sourceRoot string) (string, error) {
+	if sourceRoot != "" {
+		return sourceRoot, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return defaultSourceRoot(home), nil
+}
+
+func loadCatalogManifest(cmd *cobra.Command, file, sourceRoot string) (*manifest.Manifest, error) {
+	if cmd.Flags().Changed("file") {
+		return loadManifestForCommand(cmd, file, "")
+	}
+	resolvedSourceRoot, err := resolveCatalogSourceRoot(sourceRoot)
+	if err != nil {
+		return nil, err
+	}
+	return loadManifestForCommand(cmd, file, resolvedSourceRoot)
+}
+
+func matchingCatalogValues(values []string, toComplete string) []string {
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if strings.HasPrefix(value, toComplete) {
+			result = append(result, value)
+		}
+	}
+	return result
+}

--- a/internal/cli/catalog_golden_test.go
+++ b/internal/cli/catalog_golden_test.go
@@ -1,0 +1,29 @@
+package cli
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestCatalogTextGolden(t *testing.T) {
+	manifestPath := writeCatalogManifest(t)
+	cmd := NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"catalog", "tag", "theme", "--file", manifestPath, "--os", "all"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	assertGolden(t, "catalog_tag.golden", out.Bytes())
+}
+
+func TestCatalogJSONGolden(t *testing.T) {
+	manifestPath := writeCatalogManifest(t)
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"catalog", "tag", "theme", "--file", manifestPath, "--os", "all", "--output", "json"}, &stdout, &stderr)
+	if code != ExitOK {
+		t.Fatalf("Run() exit code = %d\nstderr:\n%s\nstdout:\n%s", code, stderr.String(), stdout.String())
+	}
+	assertGolden(t, "envelope_catalog_tag.golden", stdout.Bytes())
+}

--- a/internal/cli/catalog_test.go
+++ b/internal/cli/catalog_test.go
@@ -1,0 +1,273 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestCatalogCommandsRenderManifestOnlyViews(t *testing.T) {
+	manifestPath := writeCatalogManifest(t)
+
+	tests := []struct {
+		name  string
+		args  []string
+		want  []string
+		avoid []string
+	}{
+		{
+			name:  "compact summary hides legacy",
+			args:  []string{"catalog", "--file", manifestPath, "--os", "all"},
+			want:  []string{"Catalog (OS: all; metadata: declared)", "- core (current)", "- theme (surface, current, declared)", "Hidden legacy items:"},
+			avoid: []string{"- old (legacy)"},
+		},
+		{
+			name:  "profile list focuses profiles and includes legacy on request",
+			args:  []string{"catalog", "profiles", "--file", manifestPath, "--os", "all", "--all"},
+			want:  []string{"Profiles (OS: all; metadata: declared)", "- core (current)", "- old (legacy)"},
+			avoid: []string{"Tags:"},
+		},
+		{
+			name:  "tag list focuses current tags",
+			args:  []string{"catalog", "tags", "--file", manifestPath, "--os", "all"},
+			want:  []string{"Tags (OS: all; metadata: declared)", "- theme (surface, current, declared)", "Hidden legacy tags: 1"},
+			avoid: []string{"Profiles:", "- old (surface, legacy, declared)"},
+		},
+		{
+			name: "legacy tag detail remains directly addressable",
+			args: []string{"catalog", "tag", "old", "--file", manifestPath, "--os", "all"},
+			want: []string{"Tag \"old\"", "Status: legacy", "Replaced by: core"},
+		},
+		{
+			name:  "tag detail renders surfaces and exclusions",
+			args:  []string{"catalog", "tag", "theme", "--file", manifestPath, "--os", "linux"},
+			want:  []string{"Tag \"theme\"", "Dependency sets:", "Entries:", "Source overrides:", "Provisioners:", "Behaviors:", "Excluded surfaces:", "not applicable to linux"},
+			avoid: []string{"must-not-leak"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := NewRootCommand()
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs(tt.args)
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(out.String(), want) {
+					t.Fatalf("output missing %q:\n%s", want, out.String())
+				}
+			}
+			for _, avoid := range tt.avoid {
+				if strings.Contains(out.String(), avoid) {
+					t.Fatalf("output unexpectedly contains %q:\n%s", avoid, out.String())
+				}
+			}
+		})
+	}
+}
+
+func TestCatalogDetailCompletionUsesManifestNames(t *testing.T) {
+	manifestPath := writeCatalogManifest(t)
+	root := NewRootCommand()
+	profileCmd, _, err := root.Find([]string{"catalog", "profile"})
+	if err != nil {
+		t.Fatalf("find profile: %v", err)
+	}
+	if err := profileCmd.InheritedFlags().Set("file", manifestPath); err != nil {
+		t.Fatalf("set profile file: %v", err)
+	}
+	if err := profileCmd.InheritedFlags().Set("os", "all"); err != nil {
+		t.Fatalf("set profile os: %v", err)
+	}
+	profiles, directive := profileCmd.ValidArgsFunction(profileCmd, nil, "")
+	if !reflect.DeepEqual(profiles, []string{"core", "old"}) {
+		t.Fatalf("profile completion = %#v", profiles)
+	}
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Fatalf("profile completion directive = %v", directive)
+	}
+
+	tagCmd, _, err := root.Find([]string{"catalog", "tag"})
+	if err != nil {
+		t.Fatalf("find tag: %v", err)
+	}
+	if err := tagCmd.InheritedFlags().Set("file", manifestPath); err != nil {
+		t.Fatalf("set tag file: %v", err)
+	}
+	if err := tagCmd.InheritedFlags().Set("os", "all"); err != nil {
+		t.Fatalf("set tag os: %v", err)
+	}
+	tags, directive := tagCmd.ValidArgsFunction(tagCmd, nil, "t")
+	if !reflect.DeepEqual(tags, []string{"theme"}) {
+		t.Fatalf("tag completion = %#v", tags)
+	}
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Fatalf("tag completion directive = %v", directive)
+	}
+}
+
+func TestCatalogJSONAndErrorsUseTheOutputContract(t *testing.T) {
+	manifestPath := writeCatalogManifest(t)
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"catalog", "profile", "core", "--file", manifestPath, "--os", "all", "--output", "json"}, &stdout, &stderr); code != ExitOK {
+		t.Fatalf("Run() exit code = %d, stderr = %s", code, stderr.String())
+	}
+	var result envelope
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("decode JSON: %v\n%s", err, stdout.String())
+	}
+	if result.SchemaVersion != schemaVersion || result.Command != "catalog profile" || result.Status != statusOK {
+		t.Fatalf("envelope = %#v", result)
+	}
+	data, ok := result.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("data = %#v", result.Data)
+	}
+	if _, ok := data["profile"].(map[string]any); !ok {
+		t.Fatalf("profile detail missing from data: %#v", data)
+	}
+	if strings.Contains(stdout.String(), "must-not-leak") {
+		t.Fatalf("JSON leaked provisioner environment value: %s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"catalog", "--file", manifestPath, "--os", "windows", "--output", "json"}, &stdout, &stderr); code != ExitError {
+		t.Fatalf("invalid OS exit code = %d", code)
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("decode error JSON: %v\n%s", err, stdout.String())
+	}
+	if result.Command != "catalog" || result.Status != statusError || !strings.Contains(result.Error, "catalog OS \"windows\" is invalid") {
+		t.Fatalf("error envelope = %#v", result)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"catalog", "profile", "missing", "--file", manifestPath, "--output", "json"}, &stdout, &stderr); code != ExitError {
+		t.Fatalf("unknown profile exit code = %d", code)
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("decode unknown-profile JSON: %v\n%s", err, stdout.String())
+	}
+	if result.Command != "catalog profile" || result.Status != statusError || result.Error != `profile "missing" not found` {
+		t.Fatalf("unknown-profile envelope = %#v", result)
+	}
+}
+
+func TestCatalogDetailsRequireExactlyOneName(t *testing.T) {
+	cmd := NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"catalog", "profile"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "accepts 1 arg(s), received 0") {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestCatalogUsesAnExplicitSourceRootWithoutHomeOrStateFlags(t *testing.T) {
+	sourceRoot := t.TempDir()
+	manifestPath := filepath.Join(sourceRoot, "dots.yaml")
+	writeCatalogManifestAt(t, manifestPath)
+
+	cmd := NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"catalog", "--source-root", sourceRoot, "--os", "all"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Catalog (OS: all; metadata: declared)") {
+		t.Fatalf("catalog did not load default manifest from explicit source root:\n%s", out.String())
+	}
+}
+
+func TestCatalogUsesTheDefaultInstalledRepositoryConvention(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	sourceRoot := filepath.Join(home, ".local", "share", "dots")
+	manifestPath := filepath.Join(sourceRoot, "dots.yaml")
+	if err := os.MkdirAll(sourceRoot, 0o755); err != nil {
+		t.Fatalf("mkdir source root: %v", err)
+	}
+	writeCatalogManifestAt(t, manifestPath)
+
+	var out, errOut bytes.Buffer
+	if code := Run([]string{"catalog", "--os", "all"}, &out, &errOut); code != ExitOK {
+		t.Fatalf("Run() exit code = %d\nstderr:\n%s\nstdout:\n%s", code, errOut.String(), out.String())
+	}
+	if !strings.Contains(out.String(), "Catalog (OS: all; metadata: declared)") {
+		t.Fatalf("catalog did not load the default Installed Repository:\n%s", out.String())
+	}
+}
+
+func writeCatalogManifest(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "dots.yaml")
+	writeCatalogManifestAt(t, path)
+	return path
+}
+
+func writeCatalogManifestAt(t *testing.T, path string) {
+	t.Helper()
+	contents := `version: 1
+tags:
+  core:
+    description: Core configuration
+    kind: surface
+    status: current
+  theme:
+    description: Theme configuration
+    kind: surface
+    status: current
+  old:
+    description: Compatibility profile
+    kind: surface
+    status: legacy
+    replaced_by: core
+profiles:
+  core:
+    description: Core profile
+    tags: [core]
+  old:
+    status: legacy
+    tags: [old]
+dependencies:
+  - tags: [theme]
+    dependencies:
+      - name: theme-tool
+entries:
+  - source: base
+    source_overrides:
+      theme: adaptive
+    target: ~/.example
+    strategy: copy
+    tags: [theme]
+    os: [darwin]
+provisioners:
+  - tool: codex
+    tags: [theme]
+    os: [darwin]
+    spec:
+      mcp: demo
+      command: [demo, serve]
+      env:
+        SECRET: must-not-leak
+`
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+}

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -25,6 +25,7 @@ import (
 	"github.com/yersonargotev/dots/internal/provision"
 	"github.com/yersonargotev/dots/internal/selection"
 	"github.com/yersonargotev/dots/internal/state"
+	"github.com/yersonargotev/dots/internal/tagpolicy"
 	"github.com/yersonargotev/dots/internal/tui"
 	"github.com/yersonargotev/dots/internal/version"
 )
@@ -512,18 +513,17 @@ func runProvisionersWithOptionsAndEnvironment(cmd *cobra.Command, m manifest.Man
 	if recordErr := recordProvisionerMetadata(stateRoot, sourceRoot, report); recordErr != nil {
 		return report, recordErr
 	}
-	selectedTags := report.Tags
-	if containsString(selectedTags, "agents") {
-		if cleanupErr := agentinstructions.RetireGentleAIState(home); cleanupErr != nil {
-			return report, errors.Join(err, cleanupErr)
+	for _, action := range tagpolicy.Actions(report.Tags) {
+		var cleanupErr error
+		switch action {
+		case tagpolicy.ActionRetireGentleAIState:
+			cleanupErr = agentinstructions.RetireGentleAIState(home)
+		case tagpolicy.ActionRemoveCodexDelegation:
+			cleanupErr = agentinstructions.RemoveCodexDelegation(home)
+		case tagpolicy.ActionConvergeCodexDelegation:
+			cleanupErr = agentinstructions.ConvergeCodexDelegation(home)
 		}
-	}
-	if containsString(selectedTags, "without-codex-delegation") || containsString(selectedTags, "without-codex-spark-delegation") {
-		if cleanupErr := agentinstructions.RemoveCodexDelegation(home); cleanupErr != nil {
-			return report, errors.Join(err, cleanupErr)
-		}
-	} else if containsString(selectedTags, "codex-delegation") || containsString(selectedTags, "codex-spark-delegation") {
-		if cleanupErr := agentinstructions.ConvergeCodexDelegation(home); cleanupErr != nil {
+		if cleanupErr != nil {
 			return report, errors.Join(err, cleanupErr)
 		}
 	}
@@ -534,15 +534,6 @@ func runProvisionersWithOptionsAndEnvironment(cmd *cobra.Command, m manifest.Man
 		return report, codexconfig.EnsureCodeGraphMode(home, agents...)
 	}
 	return report, nil
-}
-
-func containsString(values []string, want string) bool {
-	for _, value := range values {
-		if value == want {
-			return true
-		}
-	}
-	return false
 }
 
 func selectedCodeGraphAgents(selected []manifest.Provisioner) []string {

--- a/internal/cli/render_catalog.go
+++ b/internal/cli/render_catalog.go
@@ -1,0 +1,256 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/yersonargotev/dots/internal/catalog"
+)
+
+func renderCatalogSummary(cmd *cobra.Command, report catalog.Report) {
+	w := cmd.OutOrStdout()
+	fmt.Fprintf(w, "Catalog (OS: %s; metadata: %s)\n", report.OS, report.MetadataOrigin)
+	renderCatalogProfilesTo(w, report.Profiles)
+	renderCatalogTagsTo(w, report.Tags)
+	renderCatalogHidden(w, report.Hidden)
+}
+
+func renderCatalogProfiles(cmd *cobra.Command, report catalog.Report) {
+	w := cmd.OutOrStdout()
+	fmt.Fprintf(w, "Profiles (OS: %s; metadata: %s)\n", report.OS, report.MetadataOrigin)
+	renderCatalogProfilesTo(w, report.Profiles)
+	if report.Hidden.Profiles > 0 {
+		fmt.Fprintf(w, "Hidden legacy profiles: %d (use --all to include)\n", report.Hidden.Profiles)
+	}
+}
+
+func renderCatalogTags(cmd *cobra.Command, report catalog.Report) {
+	w := cmd.OutOrStdout()
+	fmt.Fprintf(w, "Tags (OS: %s; metadata: %s)\n", report.OS, report.MetadataOrigin)
+	renderCatalogTagsTo(w, report.Tags)
+	if report.Hidden.Tags > 0 {
+		fmt.Fprintf(w, "Hidden legacy tags: %d (use --all to include)\n", report.Hidden.Tags)
+	}
+}
+
+func renderCatalogProfilesTo(w io.Writer, profiles []catalog.ProfileSummary) {
+	fmt.Fprintln(w, "Profiles:")
+	if len(profiles) == 0 {
+		fmt.Fprintln(w, "  none")
+		return
+	}
+	for _, profile := range profiles {
+		fmt.Fprintf(w, "  - %s (%s)", profile.Name, profile.Status)
+		if profile.Description != "" {
+			fmt.Fprintf(w, ": %s", profile.Description)
+		}
+		fmt.Fprintf(w, " [tags: %s]\n", catalogList(profile.Tags))
+	}
+}
+
+func renderCatalogTagsTo(w io.Writer, tags []catalog.TagSummary) {
+	fmt.Fprintln(w, "Tags:")
+	if len(tags) == 0 {
+		fmt.Fprintln(w, "  none")
+		return
+	}
+	for _, tag := range tags {
+		fmt.Fprintf(w, "  - %s (%s, %s, %s)", tag.Name, tag.Kind, tag.Status, tag.Origin)
+		if tag.Description != "" {
+			fmt.Fprintf(w, ": %s", tag.Description)
+		}
+		if tag.ReplacedBy != "" {
+			fmt.Fprintf(w, " [replaced by: %s]", tag.ReplacedBy)
+		}
+		fmt.Fprintln(w)
+	}
+}
+
+func renderCatalogHidden(w io.Writer, hidden catalog.Hidden) {
+	if hidden.Profiles == 0 && hidden.Tags == 0 {
+		return
+	}
+	fmt.Fprintln(w, "Hidden legacy items:")
+	if hidden.Profiles > 0 {
+		fmt.Fprintf(w, "  profiles: %d\n", hidden.Profiles)
+	}
+	if hidden.Tags > 0 {
+		fmt.Fprintf(w, "  tags: %d\n", hidden.Tags)
+	}
+	fmt.Fprintln(w, "  use --all to include")
+}
+
+func renderCatalogProfileDetail(cmd *cobra.Command, report catalog.Report) {
+	renderCatalogDetail(cmd.OutOrStdout(), "Profile", report, report.Profile)
+}
+
+func renderCatalogTagDetail(cmd *cobra.Command, report catalog.Report) {
+	renderCatalogDetail(cmd.OutOrStdout(), "Tag", report, report.Tag)
+}
+
+func renderCatalogDetail(w io.Writer, label string, report catalog.Report, detail *catalog.Detail) {
+	if detail == nil {
+		return
+	}
+	fmt.Fprintf(w, "%s %q\n", label, detail.Name)
+	fmt.Fprintf(w, "OS: %s\n", report.OS)
+	fmt.Fprintf(w, "Metadata origin: %s\n", report.MetadataOrigin)
+	if detail.Description != "" {
+		fmt.Fprintf(w, "Description: %s\n", detail.Description)
+	}
+	fmt.Fprintf(w, "Status: %s\n", detail.Status)
+	if detail.Kind != "" {
+		fmt.Fprintf(w, "Kind: %s\n", detail.Kind)
+	}
+	if detail.ReplacedBy != "" {
+		fmt.Fprintf(w, "Replaced by: %s\n", detail.ReplacedBy)
+	}
+	fmt.Fprintf(w, "Resolved tags: %s\n", catalogList(detail.ResolvedTags))
+	renderCatalogDependencies(w, "Profile dependencies", detail.ProfileDependencies)
+	renderCatalogDependencySets(w, detail.DependencySets)
+	renderCatalogDependencies(w, "Dependencies", detail.Dependencies)
+	renderCatalogEntries(w, detail.Entries)
+	renderCatalogSourceOverrides(w, detail.SourceOverrides)
+	renderCatalogProvisioners(w, detail.Provisioners)
+	renderCatalogBehaviors(w, detail.Behaviors)
+	renderCatalogExcluded(w, detail.Excluded)
+}
+
+func renderCatalogDependencies(w io.Writer, heading string, dependencies []catalog.Dependency) {
+	fmt.Fprintf(w, "%s:\n", heading)
+	if len(dependencies) == 0 {
+		fmt.Fprintln(w, "  none")
+		return
+	}
+	for _, dep := range dependencies {
+		fmt.Fprintf(w, "  - %s (%s; origin: %s)\n", dep.Name, dep.Requirement, renderCatalogOrigin(dep.Origin))
+		if len(dep.Probes) > 0 {
+			fmt.Fprintf(w, "    probes: %s\n", catalogList(dep.Probes))
+		}
+	}
+}
+
+func renderCatalogDependencySets(w io.Writer, sets []catalog.DependencySet) {
+	fmt.Fprintln(w, "Dependency sets:")
+	if len(sets) == 0 {
+		fmt.Fprintln(w, "  none")
+		return
+	}
+	for _, set := range sets {
+		fmt.Fprintf(w, "  - tags: %s; OS: %s\n", catalogList(set.Tags), catalogList(set.OS))
+		for _, dep := range set.Dependencies {
+			fmt.Fprintf(w, "    - %s (%s)\n", dep.Name, dep.Requirement)
+		}
+	}
+}
+
+func renderCatalogEntries(w io.Writer, entries []catalog.Entry) {
+	fmt.Fprintln(w, "Entries:")
+	if len(entries) == 0 {
+		fmt.Fprintln(w, "  none")
+		return
+	}
+	for _, entry := range entries {
+		fmt.Fprintf(w, "  - %s -> %s (%s; tags: %s; OS: %s)", entry.Source, entry.Target, entry.Strategy, catalogList(entry.Tags), catalogList(entry.OS))
+		if entry.TargetRoot != "" {
+			fmt.Fprintf(w, " [target root: %s]", entry.TargetRoot)
+		}
+		if entry.Ownership != "" {
+			fmt.Fprintf(w, " [ownership: %s]", entry.Ownership)
+		}
+		fmt.Fprintln(w)
+		for _, dep := range entry.Dependencies {
+			fmt.Fprintf(w, "    dependency: %s (%s)\n", dep.Name, dep.Requirement)
+		}
+	}
+}
+
+func renderCatalogSourceOverrides(w io.Writer, overrides []catalog.SourceOverride) {
+	fmt.Fprintln(w, "Source overrides:")
+	if len(overrides) == 0 {
+		fmt.Fprintln(w, "  none")
+		return
+	}
+	for _, override := range overrides {
+		state := "not applicable"
+		if override.Applicable {
+			state = "applicable"
+		}
+		fmt.Fprintf(w, "  - %s: %s -> %s (entry: %s; OS: %s; %s)\n", override.Tag, override.Source, override.Target, override.Entry, catalogList(override.OS), state)
+	}
+}
+
+func renderCatalogProvisioners(w io.Writer, provisioners []catalog.Provisioner) {
+	fmt.Fprintln(w, "Provisioners:")
+	if len(provisioners) == 0 {
+		fmt.Fprintln(w, "  none")
+		return
+	}
+	for _, provisioner := range provisioners {
+		fmt.Fprintf(w, "  - %s (%s", provisioner.Tool, provisioner.Operation)
+		if provisioner.Identity != "" {
+			fmt.Fprintf(w, ": %s", provisioner.Identity)
+		}
+		fmt.Fprintf(w, "; tags: %s; OS: %s)\n", catalogList(provisioner.Tags), catalogList(provisioner.OS))
+		if provisioner.Scope != "" {
+			fmt.Fprintf(w, "    scope: %s\n", provisioner.Scope)
+		}
+		if len(provisioner.Agents) > 0 {
+			fmt.Fprintf(w, "    agents: %s\n", catalogList(provisioner.Agents))
+		}
+		if len(provisioner.Skills) > 0 {
+			fmt.Fprintf(w, "    skills: %s\n", catalogList(provisioner.Skills))
+		}
+		if len(provisioner.Command) > 0 {
+			fmt.Fprintf(w, "    command: %s\n", strings.Join(provisioner.Command, " "))
+		}
+		if len(provisioner.EnvironmentNames) > 0 {
+			fmt.Fprintf(w, "    environment names: %s\n", catalogList(provisioner.EnvironmentNames))
+		}
+		for _, dep := range provisioner.Dependencies {
+			fmt.Fprintf(w, "    dependency: %s (%s)\n", dep.Name, dep.Requirement)
+		}
+	}
+}
+
+func renderCatalogBehaviors(w io.Writer, behaviors []catalog.Behavior) {
+	fmt.Fprintln(w, "Behaviors:")
+	if len(behaviors) == 0 {
+		fmt.Fprintln(w, "  none")
+		return
+	}
+	for _, behavior := range behaviors {
+		fmt.Fprintf(w, "  - %s: %s\n", behavior.Action, behavior.Description)
+	}
+}
+
+func renderCatalogExcluded(w io.Writer, excluded []catalog.ExcludedSurface) {
+	fmt.Fprintln(w, "Excluded surfaces:")
+	if len(excluded) == 0 {
+		fmt.Fprintln(w, "  none")
+		return
+	}
+	for _, item := range excluded {
+		fmt.Fprintf(w, "  - %s %s (OS: %s): %s\n", item.Type, item.Name, catalogList(item.OS), item.Reason)
+	}
+}
+
+func renderCatalogOrigin(origin catalog.Origin) string {
+	parts := []string{origin.Type}
+	if origin.Name != "" {
+		parts = append(parts, origin.Name)
+	}
+	if len(origin.Tags) > 0 {
+		parts = append(parts, "tags="+catalogList(origin.Tags))
+	}
+	return strings.Join(parts, " ")
+}
+
+func catalogList(values []string) string {
+	if len(values) == 0 {
+		return "none"
+	}
+	return strings.Join(values, ", ")
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -63,6 +63,7 @@ func NewRootCommand() *cobra.Command {
 	root.AddCommand(newBackupsCommand())
 	root.AddCommand(newDepsCommand())
 	root.AddCommand(newDoctorCommand())
+	root.AddCommand(newCatalogCommand())
 	return root
 }
 

--- a/internal/cli/testdata/catalog_tag.golden
+++ b/internal/cli/testdata/catalog_tag.golden
@@ -1,0 +1,27 @@
+Tag "theme"
+OS: all
+Metadata origin: declared
+Description: Theme configuration
+Status: current
+Kind: surface
+Resolved tags: theme
+Profile dependencies:
+  none
+Dependency sets:
+  - tags: theme; OS: darwin, linux
+    - theme-tool (required)
+Dependencies:
+  - theme-tool (required; origin: dependency_set tags=theme)
+    probes: theme-tool
+Entries:
+  - adaptive -> ~/.example (copy; tags: theme; OS: darwin)
+Source overrides:
+  - theme: adaptive -> ~/.example (entry: base; OS: darwin; applicable)
+Provisioners:
+  - codex (mcp: demo; tags: theme; OS: darwin)
+    command: demo serve
+    environment names: SECRET
+Behaviors:
+  none
+Excluded surfaces:
+  none

--- a/internal/cli/testdata/envelope_catalog_tag.golden
+++ b/internal/cli/testdata/envelope_catalog_tag.golden
@@ -1,0 +1,157 @@
+{
+  "schema_version": "7",
+  "command": "catalog tag",
+  "status": "ok",
+  "data": {
+    "os": "all",
+    "metadata_origin": "declared",
+    "profiles": [
+      {
+        "name": "core",
+        "description": "Core profile",
+        "status": "current",
+        "tags": [
+          "core"
+        ]
+      },
+      {
+        "name": "old",
+        "description": "",
+        "status": "legacy",
+        "tags": [
+          "old"
+        ]
+      }
+    ],
+    "tags": [
+      {
+        "name": "core",
+        "description": "Core configuration",
+        "kind": "surface",
+        "status": "current",
+        "origin": "declared"
+      },
+      {
+        "name": "old",
+        "description": "Compatibility profile",
+        "kind": "surface",
+        "status": "legacy",
+        "replaced_by": "core",
+        "origin": "declared"
+      },
+      {
+        "name": "theme",
+        "description": "Theme configuration",
+        "kind": "surface",
+        "status": "current",
+        "origin": "declared"
+      }
+    ],
+    "hidden": {
+      "profiles": 0,
+      "tags": 0
+    },
+    "tag": {
+      "name": "theme",
+      "description": "Theme configuration",
+      "status": "current",
+      "kind": "surface",
+      "resolved_tags": [
+        "theme"
+      ],
+      "dependencies": [
+        {
+          "name": "theme-tool",
+          "requirement": "required",
+          "probes": [
+            "theme-tool"
+          ],
+          "origin": {
+            "type": "dependency_set",
+            "tags": [
+              "theme"
+            ]
+          }
+        }
+      ],
+      "dependency_sets": [
+        {
+          "tags": [
+            "theme"
+          ],
+          "os": [
+            "darwin",
+            "linux"
+          ],
+          "dependencies": [
+            {
+              "name": "theme-tool",
+              "requirement": "required",
+              "probes": [
+                "theme-tool"
+              ],
+              "origin": {
+                "type": "dependency_set",
+                "tags": [
+                  "theme"
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "profile_dependencies": [],
+      "entries": [
+        {
+          "source": "adaptive",
+          "target": "~/.example",
+          "strategy": "copy",
+          "tags": [
+            "theme"
+          ],
+          "os": [
+            "darwin"
+          ],
+          "dependencies": []
+        }
+      ],
+      "source_overrides": [
+        {
+          "tag": "theme",
+          "source": "adaptive",
+          "entry": "base",
+          "target": "~/.example",
+          "os": [
+            "darwin"
+          ],
+          "applicable": true
+        }
+      ],
+      "provisioners": [
+        {
+          "tool": "codex",
+          "operation": "mcp",
+          "identity": "demo",
+          "agents": [],
+          "skills": [],
+          "command": [
+            "demo",
+            "serve"
+          ],
+          "environment_names": [
+            "SECRET"
+          ],
+          "tags": [
+            "theme"
+          ],
+          "os": [
+            "darwin"
+          ],
+          "dependencies": []
+        }
+      ],
+      "behaviors": [],
+      "excluded": []
+    }
+  }
+}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/yersonargotev/dots/internal/tagpolicy"
 	"gopkg.in/yaml.v3"
 )
 
@@ -20,6 +21,7 @@ var (
 
 type Manifest struct {
 	Version      int                `yaml:"version"`
+	Tags         map[string]Tag     `yaml:"tags,omitempty"`
 	Profiles     map[string]Profile `yaml:"profiles"`
 	Dependencies []DependencySet    `yaml:"dependencies,omitempty"`
 	Entries      []Entry            `yaml:"entries"`
@@ -27,8 +29,20 @@ type Manifest struct {
 }
 
 type Profile struct {
+	Description  string       `yaml:"description,omitempty"`
+	Status       string       `yaml:"status,omitempty"`
 	Tags         []string     `yaml:"tags"`
 	Dependencies []Dependency `yaml:"dependencies,omitempty"`
+}
+
+// Tag describes a declared selection tag. The registry is optional for v1
+// compatibility; when present, every tag referenced by the manifest must be
+// declared here.
+type Tag struct {
+	Description string `yaml:"description,omitempty"`
+	Kind        string `yaml:"kind"`
+	Status      string `yaml:"status"`
+	ReplacedBy  string `yaml:"replaced_by,omitempty"`
 }
 
 type Entry struct {
@@ -387,6 +401,9 @@ func (m Manifest) Validate() error {
 	if len(m.Entries) == 0 {
 		return fmt.Errorf("entries is required")
 	}
+	if err := m.validateTagRegistry(); err != nil {
+		return err
+	}
 
 	names := make([]string, 0, len(m.Profiles))
 	for name := range m.Profiles {
@@ -395,12 +412,21 @@ func (m Manifest) Validate() error {
 	sort.Strings(names)
 	for _, name := range names {
 		profile := m.Profiles[name]
+		if profile.Description != "" && strings.TrimSpace(profile.Description) == "" {
+			return fmt.Errorf("profiles[%q].description must not be empty", name)
+		}
+		if profile.Status != "" && !tagpolicy.IsAllowedStatus(profile.Status) {
+			return fmt.Errorf("profiles[%q].status must be one of current, legacy", name)
+		}
 		tags := profile.Tags
 		if len(tags) == 0 {
 			return fmt.Errorf("profiles[%q].tags is required", name)
 		}
 		if i, ok := indexOfEmptyTag(tags); ok {
 			return fmt.Errorf("profiles[%q].tags[%d] must not be empty", name, i)
+		}
+		if err := m.validateDeclaredTags(tags, fmt.Sprintf("profiles[%q].tags", name)); err != nil {
+			return err
 		}
 		for j, dep := range profile.Dependencies {
 			if err := validateDependency(dep, fmt.Sprintf("profiles[%q].dependencies[%d]", name, j)); err != nil {
@@ -415,6 +441,9 @@ func (m Manifest) Validate() error {
 		}
 		if j, ok := indexOfEmptyTag(set.Tags); ok {
 			return fmt.Errorf("dependencies[%d].tags[%d] must not be empty", i, j)
+		}
+		if err := m.validateDeclaredTags(set.Tags, fmt.Sprintf("dependencies[%d].tags", i)); err != nil {
+			return err
 		}
 		for j, osName := range set.OS {
 			if !allowedOS(osName) {
@@ -450,6 +479,9 @@ func (m Manifest) Validate() error {
 			if strings.TrimSpace(entry.SourceOverrides[tag]) == "" {
 				return fmt.Errorf("entries[%d].source_overrides[%q] must not be empty", i, tag)
 			}
+			if err := m.validateDeclaredTags([]string{tag}, fmt.Sprintf("entries[%d].source_overrides", i)); err != nil {
+				return err
+			}
 		}
 		if !allowedStrategy(entry.Strategy) {
 			return fmt.Errorf("entries[%d].strategy must be one of copy, symlink, template", i)
@@ -477,6 +509,9 @@ func (m Manifest) Validate() error {
 		if j, ok := indexOfEmptyTag(entry.Tags); ok {
 			return fmt.Errorf("entries[%d].tags[%d] must not be empty", i, j)
 		}
+		if err := m.validateDeclaredTags(entry.Tags, fmt.Sprintf("entries[%d].tags", i)); err != nil {
+			return err
+		}
 		for j, osName := range entry.OS {
 			if !allowedOS(osName) {
 				return fmt.Errorf("entries[%d].os[%d] must be one of darwin, linux", i, j)
@@ -501,6 +536,9 @@ func (m Manifest) Validate() error {
 		}
 		if j, ok := indexOfEmptyTag(prov.Tags); ok {
 			return fmt.Errorf("provisioners[%d].tags[%d] must not be empty", i, j)
+		}
+		if err := m.validateDeclaredTags(prov.Tags, fmt.Sprintf("provisioners[%d].tags", i)); err != nil {
+			return err
 		}
 		for j, osName := range prov.OS {
 			if !allowedOS(osName) {
@@ -539,6 +577,64 @@ func (m Manifest) Validate() error {
 		}
 	}
 
+	return nil
+}
+
+func (m Manifest) validateTagRegistry() error {
+	if m.Tags == nil {
+		return nil
+	}
+	names := make([]string, 0, len(m.Tags))
+	for name := range m.Tags {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		if strings.TrimSpace(name) == "" {
+			return fmt.Errorf("tags contains an empty tag name")
+		}
+		tag := m.Tags[name]
+		if tag.Description != "" && strings.TrimSpace(tag.Description) == "" {
+			return fmt.Errorf("tags[%q].description must not be empty", name)
+		}
+		if !tagpolicy.IsAllowedKind(tag.Kind) {
+			return fmt.Errorf("tags[%q].kind must be one of surface, cleanup, compatibility", name)
+		}
+		if expectedKind, isBehaviorTag := tagpolicy.ExpectedKind(name); isBehaviorTag && tag.Kind != expectedKind {
+			return fmt.Errorf("tags[%q].kind must be %q", name, expectedKind)
+		}
+		if (tag.Kind == "cleanup" || tag.Kind == "compatibility") && !tagpolicy.IsBehaviorTag(name) {
+			return fmt.Errorf("tags[%q].kind %q requires a supported behavior tag", name, tag.Kind)
+		}
+		if !tagpolicy.IsAllowedStatus(tag.Status) {
+			return fmt.Errorf("tags[%q].status must be one of current, legacy", name)
+		}
+		if tag.ReplacedBy == "" {
+			continue
+		}
+		if tag.Status != "legacy" {
+			return fmt.Errorf("tags[%q].replaced_by requires status legacy", name)
+		}
+		replacement, ok := m.Tags[tag.ReplacedBy]
+		if !ok {
+			return fmt.Errorf("tags[%q].replaced_by %q is not declared", name, tag.ReplacedBy)
+		}
+		if replacement.Status != "current" {
+			return fmt.Errorf("tags[%q].replaced_by %q must reference a current tag", name, tag.ReplacedBy)
+		}
+	}
+	return nil
+}
+
+func (m Manifest) validateDeclaredTags(tags []string, path string) error {
+	if m.Tags == nil {
+		return nil
+	}
+	for i, tag := range tags {
+		if _, ok := m.Tags[tag]; !ok {
+			return fmt.Errorf("%s[%d] tag %q is not declared", path, i, tag)
+		}
+	}
 	return nil
 }
 

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -51,6 +51,87 @@ entries:
 	}
 }
 
+func TestParseValidatesOptionalTagRegistry(t *testing.T) {
+	valid := `version: 1
+tags:
+  core:
+    description: shared baseline
+    kind: surface
+    status: current
+  legacy-core:
+    description: old baseline selector
+    kind: surface
+    status: legacy
+    replaced_by: core
+  codex-delegation:
+    description: install Codex delegation guidance
+    kind: surface
+    status: current
+  codex-spark-delegation:
+    description: old Codex delegation selector
+    kind: compatibility
+    status: legacy
+    replaced_by: codex-delegation
+  agents:
+    description: retire Gentle AI state
+    kind: surface
+    status: current
+profiles:
+  default:
+    description: default workstation
+    status: current
+    tags: [core]
+dependencies:
+  - tags: [core]
+    dependencies: [{name: git}]
+entries:
+  - source: configs/zsh/zshrc
+    source_overrides: {legacy-core: configs/zsh/legacy-zshrc}
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+provisioners:
+  - tool: claude
+    tags: [agents]
+    spec: {marketplace: example/tools}
+`
+	got, err := manifest.Parse([]byte(valid))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if got.Profiles["default"].Description != "default workstation" || got.Profiles["default"].Status != "current" {
+		t.Fatalf("Profile = %#v, want description and status", got.Profiles["default"])
+	}
+	if got.Tags["legacy-core"].ReplacedBy != "core" {
+		t.Fatalf("legacy tag = %#v, want replacement", got.Tags["legacy-core"])
+	}
+
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{"profile reference", strings.Replace(valid, "tags: [core]\ndependencies:", "tags: [missing]\ndependencies:", 1), `profiles["default"].tags[0] tag "missing" is not declared`},
+		{"dependency reference", strings.Replace(valid, "  - tags: [core]\n    dependencies", "  - tags: [missing]\n    dependencies", 1), `dependencies[0].tags[0] tag "missing" is not declared`},
+		{"entry reference", strings.Replace(valid, "    tags: [core]\nprovisioners:", "    tags: [missing]\nprovisioners:", 1), `entries[0].tags[0] tag "missing" is not declared`},
+		{"override key", strings.Replace(valid, "source_overrides: {legacy-core:", "source_overrides: {missing:", 1), `entries[0].source_overrides[0] tag "missing" is not declared`},
+		{"provisioner reference", strings.Replace(valid, "    tags: [agents]\n    spec:", "    tags: [missing]\n    spec:", 1), `provisioners[0].tags[0] tag "missing" is not declared`},
+		{"invalid kind", strings.Replace(valid, "kind: compatibility", "kind: command", 1), `tags["codex-spark-delegation"].kind must be one of surface, cleanup, compatibility`},
+		{"behavior kind mismatch", strings.Replace(valid, "  codex-delegation:\n    description: install Codex delegation guidance\n    kind: surface", "  codex-delegation:\n    description: install Codex delegation guidance\n    kind: cleanup", 1), `tags["codex-delegation"].kind must be "surface"`},
+		{"unallowlisted behavior tag", strings.Replace(valid, "  legacy-core:\n    description: old baseline selector\n    kind: surface", "  legacy-core:\n    description: old baseline selector\n    kind: cleanup", 1), `tags["legacy-core"].kind "cleanup" requires a supported behavior tag`},
+		{"replacement source current", strings.Replace(valid, "status: legacy\n    replaced_by", "status: current\n    replaced_by", 1), `tags["legacy-core"].replaced_by requires status legacy`},
+		{"replacement target legacy", strings.Replace(valid, "status: current", "status: legacy", 1), `tags["legacy-core"].replaced_by "core" must reference a current tag`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := manifest.Parse([]byte(tt.content))
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Parse() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
 func TestLoadPreviousFileProjectsRetiredProvisionerInventoryWithoutAcceptingItsDialect(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "dots.yaml")
 	content := []byte(`version: 1

--- a/internal/selection/selection.go
+++ b/internal/selection/selection.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/state"
+	"github.com/yersonargotev/dots/internal/tagpolicy"
 )
 
 // Source identifies where a selection-aware command obtained its intent.
@@ -304,6 +305,16 @@ func missingProfiles(m manifest.Manifest, profiles []string) []string {
 }
 
 func staleExtraTags(m manifest.Manifest, extraTags []string) []string {
+	if m.Tags != nil {
+		var stale []string
+		for _, tag := range orderedUnique(extraTags) {
+			if _, declared := m.Tags[tag]; !declared && !tagpolicy.IsBehaviorTag(tag) {
+				stale = append(stale, tag)
+			}
+		}
+		return cloneStrings(stale)
+	}
+
 	declared := make(map[string]bool)
 	for _, entry := range m.Entries {
 		for _, tag := range entry.Tags {
@@ -322,21 +333,11 @@ func staleExtraTags(m manifest.Manifest, extraTags []string) []string {
 	}
 	var stale []string
 	for _, tag := range orderedUnique(extraTags) {
-		if !declared[tag] && !supportedSelectionModifier(tag) {
+		if !declared[tag] && !tagpolicy.IsBehaviorTag(tag) {
 			stale = append(stale, tag)
 		}
 	}
 	return cloneStrings(stale)
-}
-
-func supportedSelectionModifier(tag string) bool {
-	switch tag {
-	case "codex-delegation", "without-codex-delegation",
-		"codex-spark-delegation", "without-codex-spark-delegation":
-		return true
-	default:
-		return false
-	}
 }
 
 func selectedSurface(m manifest.Manifest, selected manifest.Selection, osName string) Changes {

--- a/internal/selection/selection_test.go
+++ b/internal/selection/selection_test.go
@@ -370,6 +370,36 @@ func TestCompareEvolutionPreservesSupportedSelectionModifiers(t *testing.T) {
 	}
 }
 
+func TestCompareEvolutionUsesTagRegistryForStaleExtraTags(t *testing.T) {
+	m := manifest.Manifest{
+		Tags: map[string]manifest.Tag{
+			"core":          {Kind: "surface", Status: "current"},
+			"legacy-option": {Kind: "compatibility", Status: "legacy", ReplacedBy: "core"},
+		},
+		Profiles: map[string]manifest.Profile{"core": {Tags: []string{"core"}}},
+		Entries:  []manifest.Entry{{Target: ".core", Tags: []string{"core"}}},
+	}
+	previous, err := selection.ResolveIntent(m, selection.Intent{
+		Source: selection.SourceExplicit, Profiles: []string{"core"}, ExtraTags: []string{"legacy-option"},
+	})
+	if err != nil {
+		t.Fatalf("ResolveIntent() error = %v", err)
+	}
+	if _, err := selection.CompareEvolution(m, m, previous, "linux"); err != nil {
+		t.Fatalf("CompareEvolution() error = %v, want declared legacy tag to remain selectable", err)
+	}
+
+	previous, err = selection.ResolveIntent(m, selection.Intent{
+		Source: selection.SourceExplicit, Profiles: []string{"core"}, ExtraTags: []string{"unknown"},
+	})
+	if err != nil {
+		t.Fatalf("ResolveIntent() error = %v", err)
+	}
+	if _, err := selection.CompareEvolution(m, m, previous, "linux"); err == nil {
+		t.Fatal("CompareEvolution() error = nil, want undeclared registry tag rejection")
+	}
+}
+
 func TestCompareEvolutionDeltaJSONUsesDeterministicEmptyArrays(t *testing.T) {
 	m := manifest.Manifest{
 		Profiles: map[string]manifest.Profile{"core": {Tags: []string{"core"}}},

--- a/internal/tagpolicy/tagpolicy.go
+++ b/internal/tagpolicy/tagpolicy.go
@@ -1,0 +1,81 @@
+// Package tagpolicy owns the closed set of tag-triggered behavior. Install
+// Manifests may select these tags, but they cannot define shell commands or
+// other executable behavior.
+package tagpolicy
+
+// Action is a reviewed, built-in behavior that may be selected by one or more
+// behavior tags.
+type Action string
+
+const (
+	ActionRetireGentleAIState     Action = "retire-gentle-ai-state"
+	ActionRemoveCodexDelegation   Action = "remove-codex-delegation"
+	ActionConvergeCodexDelegation Action = "converge-codex-delegation"
+)
+
+type behaviorPolicy struct {
+	kind   string
+	action Action
+}
+
+var behaviorByTag = map[string]behaviorPolicy{
+	"agents":                         {kind: "surface", action: ActionRetireGentleAIState},
+	"codex-delegation":               {kind: "surface", action: ActionConvergeCodexDelegation},
+	"without-codex-delegation":       {kind: "cleanup", action: ActionRemoveCodexDelegation},
+	"codex-spark-delegation":         {kind: "compatibility", action: ActionConvergeCodexDelegation},
+	"without-codex-spark-delegation": {kind: "compatibility", action: ActionRemoveCodexDelegation},
+}
+
+// IsBehaviorTag reports whether tag has an allowlisted effect beyond ordinary
+// manifest surface selection.
+func IsBehaviorTag(tag string) bool {
+	_, ok := behaviorByTag[tag]
+	return ok
+}
+
+// ExpectedKind returns the only registry kind permitted for a behavior tag.
+func ExpectedKind(tag string) (string, bool) {
+	policy, ok := behaviorByTag[tag]
+	return policy.kind, ok
+}
+
+// IsAllowedKind reports whether kind is a supported registry classification.
+func IsAllowedKind(kind string) bool {
+	switch kind {
+	case "surface", "cleanup", "compatibility":
+		return true
+	default:
+		return false
+	}
+}
+
+// IsAllowedStatus reports whether status is a supported lifecycle state.
+func IsAllowedStatus(status string) bool {
+	switch status {
+	case "current", "legacy":
+		return true
+	default:
+		return false
+	}
+}
+
+// Actions returns the deterministic set of built-in actions selected by tags.
+// Removal wins over convergence when both delegation modes are selected.
+func Actions(tags []string) []Action {
+	present := make(map[Action]bool)
+	for _, tag := range tags {
+		if policy, ok := behaviorByTag[tag]; ok {
+			present[policy.action] = true
+		}
+	}
+	actions := make([]Action, 0, 2)
+	if present[ActionRetireGentleAIState] {
+		actions = append(actions, ActionRetireGentleAIState)
+	}
+	if present[ActionRemoveCodexDelegation] {
+		actions = append(actions, ActionRemoveCodexDelegation)
+	} else if present[ActionConvergeCodexDelegation] {
+		actions = append(actions, ActionConvergeCodexDelegation)
+	}
+	return actions
+}

--- a/internal/tagpolicy/tagpolicy_test.go
+++ b/internal/tagpolicy/tagpolicy_test.go
@@ -1,0 +1,51 @@
+package tagpolicy
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestActionsUsesClosedPolicyAndRemovalPrecedence(t *testing.T) {
+	got := Actions([]string{"agents", "codex-delegation", "without-codex-spark-delegation", "unrelated"})
+	want := []Action{ActionRetireGentleAIState, ActionRemoveCodexDelegation}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Actions() = %#v, want %#v", got, want)
+	}
+}
+
+func TestRegistryValuesAreAllowlisted(t *testing.T) {
+	for _, kind := range []string{"surface", "cleanup", "compatibility"} {
+		if !IsAllowedKind(kind) {
+			t.Errorf("IsAllowedKind(%q) = false, want true", kind)
+		}
+	}
+	if IsAllowedKind("command") {
+		t.Error("IsAllowedKind(command) = true, want false")
+	}
+	for _, status := range []string{"current", "legacy"} {
+		if !IsAllowedStatus(status) {
+			t.Errorf("IsAllowedStatus(%q) = false, want true", status)
+		}
+	}
+	if IsAllowedStatus("retired") {
+		t.Error("IsAllowedStatus(retired) = true, want false")
+	}
+}
+
+func TestExpectedKindMatchesEachBehaviorTag(t *testing.T) {
+	for tag, want := range map[string]string{
+		"agents":                         "surface",
+		"codex-delegation":               "surface",
+		"without-codex-delegation":       "cleanup",
+		"codex-spark-delegation":         "compatibility",
+		"without-codex-spark-delegation": "compatibility",
+	} {
+		got, ok := ExpectedKind(tag)
+		if !ok || got != want {
+			t.Errorf("ExpectedKind(%q) = %q, %t; want %q, true", tag, got, ok, want)
+		}
+	}
+	if _, ok := ExpectedKind("unrelated"); ok {
+		t.Fatal("ExpectedKind(unrelated) reports a behavior policy")
+	}
+}


### PR DESCRIPTION
Closes #421

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Add a Source of Truth-derived Install Catalog for Profiles, Tags, and their portable selected surfaces.
- Extend Install Manifest v1 with optional descriptive Profile/Tag metadata while preserving registryless compatibility.
- Expose deterministic text and schema-7 JSON through the complete `dots catalog` command tree.

## Changes

| File | Change |
|------|--------|
| `internal/catalog/` | Deep, pure Catalog report module, Markdown renderer, generator, and synchronization tests. |
| `internal/manifest/`, `internal/tagpolicy/`, `internal/selection/` | Optional registry validation and one Go-owned behavior/classification allowlist. |
| `internal/cli/` | Cobra tree, completions, text renderer, schema-7 JSON, goldens, and focused tests. |
| `dots.yaml`, `CONTEXT.md`, `docs/manifest.md` | Declared catalog metadata, domain term, and generated documentation block. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan not applicable: Catalog is manifest-only and never evaluates targets or Installation Metadata.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] CLI verification used a temporary HOME and explicit `--source-root`; the sandbox home remained empty.

## Contributor Checklist

- [x] Linked one issue with an admitted Delivery Contract using `Closes #421`.
- [x] Added exactly one `type:*` label.
- [x] Delivery Evidence records the Contract Source snapshot, Acceptance coverage, and Independent review.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs and domain instructions for the new behavior.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

### Contract Source snapshot

- Kind: standalone issue body
- Body node ID: `I_kwDOSzLlmM8AAAABMDH2tQ`
- URL: https://github.com/yersonargotev/dots/issues/421
- `updatedAt`: `2026-08-09T16:25:48Z`
- SHA-256 (exact raw UTF-8 body, including terminal newline): `1fbf419c1751226b1fff8d35aaaf6acd63f0edeb3008399473e15df44fad3a5d`
- Category: `enhancement`
- Readiness: `ready-for-agent` (only triage-state label)
- Native relationships: parent none; sub-issues none; blocked-by none; blocking none.

<details><summary>Exact Contract Source body (base64 of raw UTF-8)</summary>

```text
IyMjIFByZS1mbGlnaHQgY2hlY2tzCi0gW3hdIEkgc2VhcmNoZWQgZXhpc3RpbmcgaXNzdWVzIGFuZCB0aGlzIGlzIG5vdCBhIGR1cGxpY2F0ZS4KLSBbeF0gVGhlIHNjb3BlIGlzIHNtYWxsIGVub3VnaCBmb3Igb25lIHJldmlld2FibGUgd29yayB1bml0IG9yIGNsZWFybHkgaWRlbnRpZmllcyBzbGljZXMuCgojIyMgRGVzaXJlZCBvdXRjb21lCgpPcGVyYXRvcnMgYW5kIGFnZW50cyBjYW4gZGlzY292ZXIgdGhlIFByb2ZpbGVzIGFuZCBUYWdzIGF2YWlsYWJsZSBmcm9tIHRoZSBpbnN0YWxsZWQgU291cmNlIG9mIFRydXRoLCB1bmRlcnN0YW5kIHRoZSBpbnRlbnQgYW5kIHN0YXR1cyBvZiBlYWNoIHNlbGVjdGlvbiwgYW5kIGluc3BlY3QgdGhlIGV4YWN0IHBvcnRhYmxlIHN1cmZhY2VzIHNlbGVjdGVkIGJ5IG9uZSBQcm9maWxlIG9yIFRhZyB3aXRob3V0IHByb2JpbmcgdGhlIHdvcmtzdGF0aW9uIG9yIG11dGF0aW5nIEluc3RhbGxhdGlvbiBNZXRhZGF0YS4KClRoZSBEb3RmaWxlcyBDTEkgZXhwb3NlcyBhIGRldGVybWluaXN0aWMgKipJbnN0YWxsIENhdGFsb2cqKiB0aHJvdWdoIGh1bWFuLXJlYWRhYmxlIGFuZCBBZ2VudCBPdXRwdXQgQ29udHJhY3Qgc3VyZmFjZXMuIGBkb3RzIGluc3RhbGxlZGAgcmVtYWlucyB0aGUgYXV0aG9yaXR5IGZvciBJbnN0YWxsZWQgU2VsZWN0aW9uIGFuZCBoaXN0b3JpY2FsIGludmVudG9yeSwgd2hpbGUgYGRvdHMgc3RhdHVzYCByZW1haW5zIHRoZSBhdXRob3JpdHkgZm9yIGFsaWdubWVudCBhbmQgRHJpZnQuCgojIyMgQ3VycmVudC1zdGF0ZSBnYXAKCmBkb3RzIGluc3RhbGxlZGAgYWxyZWFkeSByZXBvcnRzIGF1dGhvcml0YXRpdmUgSW5zdGFsbGVkIFNlbGVjdGlvbiBwbHVzIGhpc3RvcmljYWwgTWFuYWdlZCBFbnRyeSBhbmQgUHJvdmlzaW9uZXIgZXZpZGVuY2UsIGJ1dCBubyBjb21tYW5kIGxpc3RzIHRoZSBQcm9maWxlcyBhbmQgVGFncyBjdXJyZW50bHkgYXZhaWxhYmxlIGZyb20gdGhlIEluc3RhbGwgTWFuaWZlc3Qgb3IgZXhwbGFpbnMgd2hhdCBlYWNoIHNlbGVjdHMuIFRoZSBjdXJyZW50IGNhdGFsb2cgaXMgbWFpbnRhaW5lZCBtYW51YWxseSBpbiBgZG9jcy9tYW5pZmVzdC5tZGA7IGBtYW5pZmVzdC5Qcm9maWxlYCBjb250YWlucyBvbmx5IFRhZ3MgYW5kIERlcGVuZGVuY2llcywgVGFncyBhcmUgZGlzY292ZXJlZCBhY3Jvc3Mgc2V2ZXJhbCBtYW5pZmVzdCBzdXJmYWNlcywgYW5kIHN1cHBvcnRlZCBiZWhhdmlvci1vbmx5IG1vZGlmaWVycyBhcmUgY2xhc3NpZmllZCBpbiBHby4gQW4gb3BlcmF0b3IgbXVzdCByZWFkIE1hcmtkb3duIGFuZCBjb21iaW5lIGBpbnN0YWxsIC0tZHJ5LXJ1bmAsIGBkZXBzYCwgYW5kIG1hbmlmZXN0IGluc3BlY3Rpb24gdG8gYW5zd2VyIGEgYmFzaWMgZGlzY292ZXJ5IHF1ZXN0aW9uLgoKQnViYmxlIFRlYSBpcyBhbHJlYWR5IHVzZWQgZm9yIENvbmZsaWN0IFJlc29sdXRpb24sIGJ1dCB0aGF0IFRVSSBoYXMgYSBkZWxpYmVyYXRlIHNhZmV0eSBzZWFtIGFuZCBpcyBub3QgYSBzZWxlY3Rpb24gY2F0YWxvZy4gQWRkaW5nIGRpc2NvdmVyeSBkaXJlY3RseSB0byBpdCB3b3VsZCBkdXBsaWNhdGUgc2VsZWN0aW9uIGtub3dsZWRnZSBiZWZvcmUgYSByZXVzYWJsZSBDYXRhbG9nIG1vZHVsZSBleGlzdHMuCgojIyMgUmVxdWlyZW1lbnRzCgotIEFkZCB0aGUgZG9tYWluIHRlcm0gKipJbnN0YWxsIENhdGFsb2cqKiB0byBgQ09OVEVYVC5tZGA6IHRoZSBTb3VyY2Ugb2YgVHJ1dGgtZGVyaXZlZCwgcmVhZC1vbmx5IGRlc2NyaXB0aW9uIG9mIGF2YWlsYWJsZSBQcm9maWxlcywgVGFncywgYW5kIHRoZWlyIHNlbGVjdGVkIHBvcnRhYmxlIHN1cmZhY2VzLiBJdCBtdXN0IHJlbWFpbiBkaXN0aW5jdCBmcm9tIEluc3RhbGxlZCBTZWxlY3Rpb24sIGhpc3RvcmljYWwgaW52ZW50b3J5LCBEb3RmaWxlcyBTdGF0dXMsIGFuZCBhbiBJbnN0YWxsIFBsYW4uCi0gRXh0ZW5kIEluc3RhbGwgTWFuaWZlc3QgdjEgY29tcGF0aWJseToKICAtIFByb2ZpbGVzIG1heSBkZWNsYXJlIGBkZXNjcmlwdGlvbmAgYW5kIGBzdGF0dXNgLgogIC0gQWRkIGFuIG9wdGlvbmFsIHRvcC1sZXZlbCBgdGFnc2AgcmVnaXN0cnkuCiAgLSBBIFRhZyBkZWNsYXJhdGlvbiBtYXkgY29udGFpbiBgZGVzY3JpcHRpb25gLCBga2luZGAsIGBzdGF0dXNgLCBhbmQgYHJlcGxhY2VkX2J5YC4KICAtIFN1cHBvcnRlZCBUYWcga2luZHMgYXJlIGBzdXJmYWNlYCwgYGNsZWFudXBgLCBhbmQgYGNvbXBhdGliaWxpdHlgLgogIC0gU3VwcG9ydGVkIHN0YXR1c2VzIGFyZSBgY3VycmVudGAgYW5kIGBsZWdhY3lgLgogIC0gYHJlcGxhY2VkX2J5YCBpcyB2YWxpZCBvbmx5IGZvciBhIGxlZ2FjeSBUYWcgYW5kIG11c3QgbmFtZSBhIGRlY2xhcmVkIGN1cnJlbnQgVGFnIHdoZW4gdGhlIHJlZ2lzdHJ5IGlzIHByZXNlbnQuCiAgLSBFeGlzdGluZyBtYW5pZmVzdHMgd2l0aG91dCB0aGUgcmVnaXN0cnkgcmVtYWluIHZhbGlkLiBDYXRhbG9nIGRlcml2ZXMgdGhlaXIgc3VyZmFjZSBUYWdzIG1lY2hhbmljYWxseSwgbWFya3MgdGhlIG1ldGFkYXRhIHNvdXJjZSBhcyBkZXJpdmVkLCB0cmVhdHMgZGVyaXZlZCBzdXJmYWNlIGl0ZW1zIGFzIGN1cnJlbnQgZm9yIHZpc2liaWxpdHksIGFuZCBsZWF2ZXMgdW5hdmFpbGFibGUgZGVzY3JpcHRpdmUgbWV0YWRhdGEgZW1wdHkuCiAgLSBXaGVuIGEgVGFnIHJlZ2lzdHJ5IGlzIHByZXNlbnQsIGV2ZXJ5IFRhZyByZWZlcmVuY2VkIGJ5IFByb2ZpbGVzLCBEZXBlbmRlbmN5IFNldHMsIE1hbmFnZWQgRW50cmllcywgc291cmNlIG92ZXJyaWRlIGtleXMsIGFuZCBQcm92aXNpb25lcnMgbXVzdCBiZSBkZWNsYXJlZC4KLSBLZWVwIGJlaGF2aW9yIGF1dGhvcml0eSBhbGxvd2xpc3RlZCBpbiBHbzoKICAtIEEgbWFuaWZlc3QgbWF5IGRlc2NyaWJlIGFuZCBjbGFzc2lmeSBzdXBwb3J0ZWQgY2xlYW51cCBvciBjb21wYXRpYmlsaXR5IFRhZ3MgYnV0IG1heSBub3QgZGVmaW5lIGNvbW1hbmRzIG9yIGFyYml0cmFyeSBiZWhhdmlvci4KICAtIEV2ZXJ5IGRlY2xhcmVkIGBjbGVhbnVwYCBvciBgY29tcGF0aWJpbGl0eWAgVGFnIG11c3QgY29ycmVzcG9uZCB0byBhIHN1cHBvcnRlZCBzZWxlY3Rpb24gbW9kaWZpZXIuCiAgLSBDb25zb2xpZGF0ZSB0aGUgY3VycmVudCBtb2RpZmllciBjbGFzc2lmaWNhdGlvbiBzbyB2YWxpZGF0aW9uLCBzZWxlY3Rpb24gZXZvbHV0aW9uLCBDYXRhbG9nLCBhbmQgaW5zdGFsbCBjbGVhbnVwIGRvIG5vdCBtYWludGFpbiBjb250cmFkaWN0b3J5IGxpc3RzLgotIEFkZCBhIGRlZXAgYGludGVybmFsL2NhdGFsb2dgIG1vZHVsZS4gSXRzIHNtYWxsIGludGVyZmFjZSBhY2NlcHRzIGEgdmFsaWRhdGVkIEluc3RhbGwgTWFuaWZlc3QgcGx1cyBjYXRhbG9nIG9wdGlvbnMgYW5kIHJldHVybnMgYSBwb3J0YWJsZSByZXBvcnQuIEl0cyBpbXBsZW1lbnRhdGlvbiBvd25zIFByb2ZpbGUvVGFnIHJlc29sdXRpb24sIE9TIGFwcGxpY2FiaWxpdHksIGdyb3VwaW5nLCBvcmlnaW4gdHJhY2tpbmcsIG1vZGlmaWVyIG1ldGFkYXRhLCBhbmQgc2VsZWN0ZWQtc3VyZmFjZSBkZXNjcmlwdGlvbi4gQ29icmEgdGV4dCwgSlNPTiwgZ2VuZXJhdGVkIE1hcmtkb3duLCBhbmQgYSBwb3NzaWJsZSBsYXRlciBUVUkgY29uc3VtZSB0aGUgc2FtZSByZXBvcnQgcmF0aGVyIHRoYW4gcmVpbXBsZW1lbnRpbmcgc2VsZWN0aW9uIHJ1bGVzLgotIFRoZSByZXBvcnQgZm9yIGEgUHJvZmlsZSBvciBUYWcgbXVzdCBkaXN0aW5ndWlzaDoKICAtIHJlc29sdmVkIFRhZ3M7CiAgLSBEZXBlbmRlbmN5IFNldHMgYW5kIFByb2ZpbGUgRGVwZW5kZW5jaWVzOwogIC0gTWFuYWdlZCBFbnRyaWVzIHdpdGggcmVwb3NpdG9yeS1yZWxhdGl2ZSBzb3VyY2UsIHBvcnRhYmxlIHRhcmdldCwgc3RyYXRlZ3ksIG93bmVyc2hpcCwgYW5kIGRlY2xhcmVkIE9TIGFwcGxpY2FiaWxpdHk7CiAgLSBFbnRyeSBEZXBlbmRlbmNpZXM7CiAgLSBzb3VyY2Ugb3ZlcnJpZGVzIGFjdGl2YXRlZCBieSB0aGUgcXVlcmllZCBUYWc7CiAgLSBQcm92aXNpb25lcnMgYW5kIHRoZWlyIERlcGVuZGVuY2llczsKICAtIGFsbG93bGlzdGVkIGNsZWFudXAgYmVoYXZpb3I7CiAgLSBsZWdhY3kgcmVwbGFjZW1lbnQgcmVsYXRpb25zaGlwczsKICAtIGl0ZW1zIGV4Y2x1ZGVkIGJ5IHRoZSByZXF1ZXN0ZWQgT1MsIGluY2x1ZGluZyB0aGUgZXhjbHVzaW9uIHJlYXNvbjsKICAtIHRoZSBvcmlnaW4gb2YgZWFjaCBEZXBlbmRlbmN5IHNvIHVzZXJzIGNhbiB1bmRlcnN0YW5kIHdoeSBpdCBpcyBzZWxlY3RlZC4KLSBDYXRhbG9nIG11c3Qgbm90IHJlYWQgSW5zdGFsbGF0aW9uIE1ldGFkYXRhLCBpbnNwZWN0IG1hbmFnZWQgdGFyZ2V0cywgcHJvYmUgRGVwZW5kZW5jaWVzLCBleHBhbmQgcHJvY2VzcyBlbnZpcm9ubWVudCB2YWx1ZXMsIG9yIG90aGVyd2lzZSBldmFsdWF0ZSB3b3Jrc3RhdGlvbiBzdGF0ZS4KLSBQcm92aXNpb25lciBvdXRwdXQgbXVzdCBiZSBzdHJ1Y3R1cmVkIGFuZCBzYWZlOgogIC0gZXhwb3NlIHRoZSB0b29sLCBkZWNsYXJhdGl2ZSBvcGVyYXRpb24sIHBhY2thZ2UvcGx1Z2luL01DUCBpZGVudGl0eSwgc2NvcGUsIGFuZCBkZWNsYXJlZCBhZ2VudC9za2lsbCBuYW1lczsKICAtIGV4cG9zZSBleGVjdXRhYmxlL2FyZ3VtZW50IGRhdGEgb25seSB3aGVyZSBuZWVkZWQgdG8gZXhwbGFpbiB0aGUgZGVjbGFyZWQgZWZmZWN0OwogIC0gZXhwb3NlIGVudmlyb25tZW50IHZhcmlhYmxlIG5hbWVzIGJ1dCBuZXZlciB2YWx1ZXM7CiAgLSBuZXZlciByZXNvbHZlIHZhbHVlcyBmcm9tIHRoZSBwcm9jZXNzIGVudmlyb25tZW50LgotIEFkZCB0aGlzIENvYnJhIGNvbW1hbmQgdHJlZToKICAtIGBkb3RzIGNhdGFsb2dgIOKAlCBjb21wYWN0IGN1cnJlbnQgUHJvZmlsZSBhbmQgVGFnIHN1bW1hcnk7CiAgLSBgZG90cyBjYXRhbG9nIHByb2ZpbGVzYCDigJQgY3VycmVudCBQcm9maWxlczsKICAtIGBkb3RzIGNhdGFsb2cgcHJvZmlsZSBOQU1FYCDigJQgZGV0YWlsZWQgc2luZ2xlLVByb2ZpbGUgcmVwb3J0OwogIC0gYGRvdHMgY2F0YWxvZyB0YWdzYCDigJQgY3VycmVudCBUYWdzOwogIC0gYGRvdHMgY2F0YWxvZyB0YWcgTkFNRWAg4oCUIGRldGFpbGVkIHNpbmdsZS1UYWcgcmVwb3J0LgotIGBwcm9maWxlIE5BTUVgIGFuZCBgdGFnIE5BTUVgIHVzZSBwb3NpdGlvbmFsIGFyZ3VtZW50cywgYGNvYnJhLkV4YWN0QXJncygxKWAsIGFuZCBtYW5pZmVzdC1iYWNrZWQgc2hlbGwgY29tcGxldGlvbi4gRG8gbm90IG92ZXJsb2FkIHRoZSBleGlzdGluZyBzZWxlY3Rpb24gc2VtYW50aWNzIG9mIGAtLXByb2ZpbGVgIGFuZCBgLS10YWdgLgotIEdlbmVyYWwvbGlzdCBvdXRwdXQgaGlkZXMgbGVnYWN5IGl0ZW1zIGJ5IGRlZmF1bHQsIHJlcG9ydHMgdGhlIGhpZGRlbiBjb3VudCwgYW5kIHBvaW50cyB0byBgLS1hbGxgLiBgLS1hbGxgIGluY2x1ZGVzIGxlZ2FjeSBQcm9maWxlcyBhbmQgVGFncy4gQW4gZXhwbGljaXQgZGV0YWlsIHF1ZXJ5IGZvciBhIGxlZ2FjeSBuYW1lIGFsd2F5cyBzdWNjZWVkcyB3aGVuIGRlY2xhcmVkIG9yIGNvbXBhdGlibHkgZGVyaXZlZC4KLSBTdXBwb3J0IGAtLW9zIGRhcndpbnxsaW51eHxhbGxgOyB0aGUgZGVmYXVsdCBpcyB0aGUgY3VycmVudCBob3N0IE9TLiBEZXRhaWxlZCByZXBvcnRzIHJldGFpbiBkZWNsYXJlZCBhcHBsaWNhYmlsaXR5IGFuZCBpZGVudGlmeSBleGNsdWRlZCBpdGVtcy4gYC0tb3MgYWxsYCByZXR1cm5zIHRoZSBjb21wbGV0ZSBwb3J0YWJsZSB2aWV3LgotIEJ5IGRlZmF1bHQsIGxvYWQgYGRvdHMueWFtbGAgZnJvbSB0aGUgSW5zdGFsbGVkIFJlcG9zaXRvcnkgdXNpbmcgdGhlIHJlcG9zaXRvcnkncyBleGlzdGluZyBTb3VyY2Ugb2YgVHJ1dGggcGF0aCBjb252ZW50aW9ucy4gU3VwcG9ydCBgLS1zb3VyY2Utcm9vdGAgYW5kIGAtLWZpbGVgIGZvciBkZXZlbG9wbWVudCBjaGVja291dHMgYW5kIGFsdGVybmF0ZSBtYW5pZmVzdHMsIHdpdGggdGhlIHNhbWUgcGF0aC1yZXNvbHV0aW9uIGJlaGF2aW9yIGFzIGV4aXN0aW5nIG1hbmlmZXN0LWF3YXJlIGNvbW1hbmRzLiBDYXRhbG9nIHJlcXVpcmVzIG5vIGAtLWhvbWVgIG9yIGAtLXN0YXRlLXJvb3RgLgotIEFsbCBDYXRhbG9nIGNvbW1hbmRzIHN1cHBvcnQgYC0tb3V0cHV0IHRleHR8anNvbmAuIEpTT04gdXNlcyB0aGUgZXhpc3Rpbmcgc2NoZW1hLTcgZW52ZWxvcGUgYW5kIGEgc3RhYmxlIHBvcnRhYmxlIENhdGFsb2cgcmVwb3J0LiBTdWNjZXNzZnVsIENhdGFsb2cgY29tbWFuZHMgcmV0dXJuIGV4aXQgYDBgOyBpbnZhbGlkIG1hbmlmZXN0cywgaW52YWxpZCBmbGFncywgdW5rbm93biBuYW1lcywgYW5kIGV4ZWN1dGlvbiBlcnJvcnMgcmV0dXJuIGV4aXQgYDFgLiBDYXRhbG9nIG5ldmVyIHJldHVybnMgZmluZGluZ3MgZXhpdCBgMmAuCi0gVXBkYXRlIHRoaXMgcmVwb3NpdG9yeSdzIGBkb3RzLnlhbWxgIHdpdGggZGVzY3JpcHRpb25zIGFuZCBjb21wbGV0ZSBkZWNsYXJhdGlvbnMgZm9yIGFsbCBjdXJyZW50LCBjbGVhbnVwLCBhbmQgY29tcGF0aWJpbGl0eSBUYWdzIGFuZCBhbGwgUHJvZmlsZXMuIFByZXNlcnZlIHRoZSBhZ3JlZWQgaW50ZW50IGRvY3VtZW50ZWQgdG9kYXkgaW4gYGRvY3MvbWFuaWZlc3QubWRgLgotIEtlZXAgbmFycmF0aXZlIG1hbmlmZXN0IGRvY3VtZW50YXRpb24gaGFuZC1hdXRob3JlZCwgYnV0IGdlbmVyYXRlIGl0cyBQcm9maWxlL1RhZyBjYXRhbG9nIHNlY3Rpb24gZGV0ZXJtaW5pc3RpY2FsbHkgZnJvbSB0aGUgQ2F0YWxvZyByZXBvcnQgYmV0d2VlbiBgPCEtLSBkb3RzOmNhdGFsb2c6c3RhcnQgLS0+YCBhbmQgYDwhLS0gZG90czpjYXRhbG9nOmVuZCAtLT5gLiBQcm92aWRlIGEgcmVwb3NpdG9yeSBjb21tYW5kIGJhc2VkIG9uIGBnbyBnZW5lcmF0ZWAgdG8gcmVmcmVzaCB0aGUgYmxvY2sgYW5kIGEgdGVzdCB0aGF0IGZhaWxzIHdoZW4gaXQgaXMgc3RhbGUuCi0gUHJlc2VydmUgdGhlIGV4cGxpY2l0LXNlbGVjdGlvbiBydWxlcyBmcm9tIEFEUiAwMDEzIGFuZCB0aGUgSW5zdGFsbGVkIFNlbGVjdGlvbiBhdXRob3JpdHkgc3BsaXQgZnJvbSBBRFIgMDAxNC4gQ2F0YWxvZyBkaXNjb3ZlcnkgbXVzdCBub3QgaW1wbHksIHBlcnNpc3QsIG1lcmdlLCBvciBtdXRhdGUgYSBzZWxlY3Rpb24uCgojIyMgS2V5IGludGVyZmFjZXMKCi0gYGRvdHMgY2F0YWxvZyBbcHJvZmlsZXN8dGFnc10gWy0tYWxsXSBbLS1vcyBkYXJ3aW58bGludXh8YWxsXSBbLS1vdXRwdXQgdGV4dHxqc29uXWAg4oCUIGxpc3Qvc3VtbWFyeSBkaXNjb3Zlcnkgc3VyZmFjZS4KLSBgZG90cyBjYXRhbG9nIHByb2ZpbGUgTkFNRSBbLS1vcyBkYXJ3aW58bGludXh8YWxsXSBbLS1vdXRwdXQgdGV4dHxqc29uXWAg4oCUIGV4YWN0IFByb2ZpbGUgZGVzY3JpcHRpb24uCi0gYGRvdHMgY2F0YWxvZyB0YWcgTkFNRSBbLS1vcyBkYXJ3aW58bGludXh8YWxsXSBbLS1vdXRwdXQgdGV4dHxqc29uXWAg4oCUIGV4YWN0IFRhZyBkZXNjcmlwdGlvbi4KLSBJbnN0YWxsIE1hbmlmZXN0IGBwcm9maWxlcy5OQU1FLmRlc2NyaXB0aW9uL3N0YXR1c2AgYW5kIHRvcC1sZXZlbCBgdGFncy5OQU1FLmRlc2NyaXB0aW9uL2tpbmQvc3RhdHVzL3JlcGxhY2VkX2J5YCDigJQgc3RydWN0dXJlZCBkZXNjcmlwdGl2ZSBTb3VyY2Ugb2YgVHJ1dGguCi0gYGludGVybmFsL2NhdGFsb2dgIHJlcG9ydCDigJQgdGhlIHNoYXJlZCB0ZXN0IHN1cmZhY2UgZm9yIHRleHQsIEpTT04sIE1hcmtkb3duIGdlbmVyYXRpb24sIGFuZCBmdXR1cmUgYWRhcHRlcnMuCi0gRXhpc3RpbmcgYGRvdHMgaW5zdGFsbGVkYCBhbmQgYGRvdHMgc3RhdHVzYCBpbnRlcmZhY2VzIHJlbWFpbiB1bmNoYW5nZWQgYW5kIHNlcGFyYXRlLgoKIyMjIE5vbi1nb2FscwoKLSBBZGRpbmcgb3IgZXhwYW5kaW5nIGEgQnViYmxlIFRlYSBzZWxlY3Rpb24gVFVJLgotIENoYW5naW5nIHRoZSBleGlzdGluZyBDb25mbGljdCBSZXNvbHV0aW9uIFRVSS4KLSBJbnN0YWxsaW5nLCB1cGRhdGluZywgcmVtb3ZpbmcsIG9yIHNlbGVjdGluZyBQcm9maWxlcy9UYWdzIGZyb20gQ2F0YWxvZy4KLSBSZXBvcnRpbmcgd2hpY2ggUHJvZmlsZXMgb3IgVGFncyBhcmUgaW5zdGFsbGVkLCBhbGlnbmVkLCBtaXNzaW5nLCBvciBkcmlmdGluZy4KLSBQcm9iaW5nIERlcGVuZGVuY3kgcHJlc2VuY2Ugb3IgcGFja2FnZS1tYW5hZ2VyIGF2YWlsYWJpbGl0eS4KLSBQcmV2aWV3aW5nIGFyYml0cmFyeSBjb21wb3NlZCBzZWxlY3Rpb25zOyBgZG90cyBpbnN0YWxsIC4uLiAtLWRyeS1ydW5gIHJlbWFpbnMgdGhlIGV4aXN0aW5nIGNvbXBvc2l0aW9uIHByZXZpZXcuCi0gQWxsb3dpbmcgbWFuaWZlc3RzIHRvIGRlZmluZSBleGVjdXRhYmxlIGNsZWFudXAgYmVoYXZpb3IsIGFyYml0cmFyeSBjb21tYW5kcywgb3IgbmV3IG1vZGlmaWVyIHNlbWFudGljcy4KLSBNYWtpbmcgdGhlIFRhZyByZWdpc3RyeSBtYW5kYXRvcnkgZm9yIGFsbCB2MSBtYW5pZmVzdHMgb3IgaW50cm9kdWNpbmcgbWFuaWZlc3Qgc2NoZW1hIHYyLgotIEdlbmVyYXRpbmcgdGhlIG5hcnJhdGl2ZSBwb3J0aW9ucyBvZiBgZG9jcy9tYW5pZmVzdC5tZGAuCi0gQWRkaW5nIGEgc2VwYXJhdGUgQURSOyBBRFIgMDAwMSwgQURSIDAwMTMsIEFEUiAwMDE0LCB0aGUgaXNzdWUgQ29udHJhY3QgU291cmNlLCBhbmQgdGhlIHVwZGF0ZWQgZG9tYWluIGdsb3NzYXJ5IHByb3ZpZGUgdGhlIHJlcXVpcmVkIGNvbnRleHQuCgojIyMgQWNjZXB0YW5jZSBjcml0ZXJpYQoKLSBbIF0gYGdvIHJ1biAuL2NtZC9kb3RzIGNhdGFsb2cgLS1zb3VyY2Utcm9vdCAiJFBXRCJgIGxpc3RzIGN1cnJlbnQgUHJvZmlsZXMgYW5kIFRhZ3MgZGV0ZXJtaW5pc3RpY2FsbHksIGhpZGVzIGxlZ2FjeSBlbnRyaWVzLCByZXBvcnRzIHRoZSBoaWRkZW4gY291bnQsIGFuZCBkb2VzIG5vdCByZXF1aXJlIEluc3RhbGxhdGlvbiBNZXRhZGF0YS4KLSBbIF0gYGNhdGFsb2cgcHJvZmlsZXNgLCBgY2F0YWxvZyBwcm9maWxlIE5BTUVgLCBgY2F0YWxvZyB0YWdzYCwgYW5kIGBjYXRhbG9nIHRhZyBOQU1FYCBpbXBsZW1lbnQgdGhlIHNwZWNpZmllZCBhcmd1bWVudCB2YWxpZGF0aW9uLCBjb21wbGV0aW9ucywgbGVnYWN5IHZpc2liaWxpdHksIE9TIGZpbHRlcmluZywgYW5kIHVua25vd24tbmFtZSBlcnJvcnMuCi0gWyBdIFByb2ZpbGUgYW5kIFRhZyBkZXRhaWwgcmVwb3J0cyBpbmNsdWRlIGV2ZXJ5IGFwcGxpY2FibGUgRGVwZW5kZW5jeSwgTWFuYWdlZCBFbnRyeSwgc291cmNlIG92ZXJyaWRlLCBQcm92aXNpb25lciwgYWxsb3dsaXN0ZWQgYmVoYXZpb3IsIGxlZ2FjeSByZWxhdGlvbnNoaXAsIE9TIGV4Y2x1c2lvbiwgYW5kIG9yaWdpbiByZXF1aXJlZCBhYm92ZSB3aXRob3V0IGFic29sdXRlIGhvbWUgcGF0aHMgb3IgZW52aXJvbm1lbnQgdmFsdWVzLgotIFsgXSBgLS1vdXRwdXQganNvbmAgcHJvZHVjZXMgc2NoZW1hLTcgYG9rYCBlbnZlbG9wZXMgd2l0aCBzdGFibGUgQ2F0YWxvZyBkYXRhIGZvciBldmVyeSBzdWNjZXNzZnVsIGNvbW1hbmQsIGFuZCBlcnJvciBlbnZlbG9wZXMvZXhpdCBgMWAgZm9yIGludmFsaWQgaW5wdXQ7IENhdGFsb2cgbmV2ZXIgZXhpdHMgYDJgLgotIFsgXSBBIGxlZ2FjeSBtYW5pZmVzdCB3aXRob3V0IHRvcC1sZXZlbCBgdGFnc2Agc3RpbGwgdmFsaWRhdGVzIGFuZCBwcm9kdWNlcyBhIGRlcml2ZWQgQ2F0YWxvZyB3aXRob3V0IGRlc2NyaXB0aW9uczsgYSBtYW5pZmVzdCB3aXRoIGB0YWdzYCByZWplY3RzIHVuZGVjbGFyZWQgcmVmZXJlbmNlcywgaW52YWxpZCBraW5kL3N0YXR1cyBjb21iaW5hdGlvbnMsIGludmFsaWQgcmVwbGFjZW1lbnRzLCBhbmQgdW5zdXBwb3J0ZWQgYmVoYXZpb3IgY2xhc3NpZmljYXRpb25zLgotIFsgXSBUaGUgcmVwb3NpdG9yeSBJbnN0YWxsIE1hbmlmZXN0IGRlY2xhcmVzIGV2ZXJ5IFByb2ZpbGUgYW5kIFRhZyBjdXJyZW50bHkgZG9jdW1lbnRlZCwgaW5jbHVkaW5nIGN1cnJlbnQgc3VyZmFjZSBUYWdzLCBjbGVhbnVwIG1vZGlmaWVycywgYW5kIGNvbXBhdGliaWxpdHkgYWxpYXNlcywgd2l0aCBkZXNjcmlwdGlvbnMgdGhhdCBwcmVzZXJ2ZSB0aGVpciBleGlzdGluZyBpbnRlbnQuCi0gWyBdIENhdGFsb2cgb3V0cHV0IG5ldmVyIHJlYWRzIEluc3RhbGxhdGlvbiBNZXRhZGF0YSwgcHJvYmVzIERlcGVuZGVuY2llcyBvciB0YXJnZXRzLCByZXZlYWxzIFByb3Zpc2lvbmVyIGVudmlyb25tZW50IHZhbHVlcywgb3IgbXV0YXRlcyB0aGUgZmlsZXN5c3RlbSBleGNlcHQgd2hlbiB0aGUgZXhwbGljaXQgZG9jdW1lbnRhdGlvbiBnZW5lcmF0b3IgaXMgaW52b2tlZC4KLSBbIF0gYGRvY3MvbWFuaWZlc3QubWRgIGNvbnRhaW5zIGEgZ2VuZXJhdGVkIGNhdGFsb2cgYmxvY2sgc291cmNlZCBmcm9tIHRoZSBzYW1lIHJlcG9ydCwgYW5kIGl0cyBzeW5jaHJvbml6YXRpb24gdGVzdCBkZXRlY3RzIHN0YWxlIGdlbmVyYXRlZCBjb250ZW50LgotIFsgXSBgQ09OVEVYVC5tZGAgZGVmaW5lcyBJbnN0YWxsIENhdGFsb2cgd2l0aG91dCBpbXBsZW1lbnRhdGlvbiBkZXRhaWxzIGFuZCBkaXN0aW5ndWlzaGVzIGl0IGZyb20gSW5zdGFsbGVkIFNlbGVjdGlvbiwgaGlzdG9yaWNhbCBpbnZlbnRvcnksIERvdGZpbGVzIFN0YXR1cywgYW5kIEluc3RhbGwgUGxhbi4KLSBbIF0gRXhpc3RpbmcgYGRvdHMgaW5zdGFsbGVkYCwgc2VsZWN0aW9uIHJlc29sdXRpb24sIHNlbGVjdGlvbiBldm9sdXRpb24sIGNsZWFudXAsIGluc3RhbGwvdXBkYXRlL3VwZ3JhZGUsIGFuZCBDb25mbGljdCBSZXNvbHV0aW9uIFRVSSB0ZXN0cyByZW1haW4gZ3JlZW4uCi0gWyBdIEZvY3VzZWQgbWFuaWZlc3QsIENhdGFsb2cgbW9kdWxlLCBDb2JyYSBjb21tYW5kLCBjb21wbGV0aW9uLCB0ZXh0IGdvbGRlbiwgSlNPTiBnb2xkZW4sIHNlY3VyaXR5L3JlZGFjdGlvbiwgYW5kIGRvY3VtZW50YXRpb24tZ2VuZXJhdGlvbiB0ZXN0cyBjb3ZlciB0aGUgbmV3IGJlaGF2aW9yLgoKIyMjIFZhbGlkYXRpb24gbm90ZXMKCi0gSXRlcmF0ZSB3aXRoIGZvY3VzZWQgdGVzdHMgc3VjaCBhcyBgZ28gdGVzdCAuL2ludGVybmFsL21hbmlmZXN0Ly4uLiAuL2ludGVybmFsL2NhdGFsb2cvLi4uIC4vaW50ZXJuYWwvY2xpLy4uLmAuCi0gVmFsaWRhdGUgdGhlIHJlcG9zaXRvcnkgbWFuaWZlc3Qgd2l0aCBgZ28gcnVuIC4vY21kL2RvdHMgbWFuaWZlc3QgdmFsaWRhdGUgLS1maWxlIGRvdHMueWFtbGAuCi0gRXhlcmNpc2Ugc291cmNlIHJlc29sdXRpb24gb25seSB3aXRoIGV4cGxpY2l0IHJlcG9zaXRvcnkgcGF0aHMgYW5kIHRlbXBvcmFyeSBkaXJlY3RvcmllczsgZG8gbm90IHJlYWQgb3Igd3JpdGUgdGhlIG9wZXJhdG9yJ3MgcmVhbCBob21lIGNvbmZpZ3VyYXRpb24gb3Igc3RhdGUuCi0gVmVyaWZ5IGdlbmVyYXRlZCBkb2N1bWVudGF0aW9uIGlzIGNsZWFuIGFmdGVyIGl0cyBkb2N1bWVudGVkIGBnbyBnZW5lcmF0ZWAgY29tbWFuZC4KLSBSdW4gdGhlIENJLWVxdWl2YWxlbnQgc3VpdGUgYmVmb3JlIGRlbGl2ZXJ5OgoKYGBgYmFzaApnb2ZtdCAtbCAuCmdvIHZldCAuLy4uLgpnbyBidWlsZCAuLy4uLgpnbyB0ZXN0IC4vLi4uCmBgYAo=
```
</details>

### Reviewed candidate

- Head: `c97be238ab4a8f0b8290320c2833d69e99acfd3c`
- Base: `e33d3a7362fdffe6e62b9c1edadbbf1c269aa107` (`origin/main`)
- Commit: `feat(catalog): expose profiles and tags`

### Acceptance coverage

- Command tree, ExactArgs, manifest completions, legacy visibility, `--all`, and `--os`: Cobra tests plus manual binary scenarios.
- Portable detail surfaces, dependency origins, overrides, provisioners, behavior, replacements, and OS exclusions: `internal/catalog` tests and JSON/text goldens.
- Schema-7 success/error envelopes and exit 0/1 only: CLI tests, JSON golden, and manual invalid-input scenarios.
- Registryless derivation and strict declared-registry validation: Catalog and Manifest tests.
- Complete repository Profile/Tag declarations: `dots.yaml` plus `manifest validate`.
- No metadata/target probes or environment-value disclosure: pure module seam, redaction tests/golden, and empty temporary HOME after manual scenarios.
- Generated docs and stale detection: `go generate ./internal/catalog` and sync/marker tests.
- Domain distinction: `CONTEXT.md` defines Install Catalog separately from Installed Selection, inventory, Status, and Install Plan.
- Existing installed/selection/evolution/install/update/upgrade/TUI behavior: full `go test ./...`.

### Automated validation

- `gofmt -l .` — pass (no output)
- `go vet ./...` — pass
- `go build ./...` — pass
- `go test ./...` — pass
- `go test -race ./internal/catalog ./internal/cli -run Catalog -count=1` — pass
- `go run ./cmd/dots manifest validate --file dots.yaml` — pass
- `go generate ./internal/catalog` followed by clean synchronization test — pass
- `git diff --check` — pass

### Manual verification

- Built one temporary real binary with `go build -o <tmp>/dots ./cmd/dots`.
- `HOME=<tmp>/home <tmp>/dots catalog --source-root "$PWD" --os all` — exit 0; deterministic current Profiles/Tags; two legacy Tags hidden with `--all` guidance.
- `catalog profiles --file "$PWD/dots.yaml" --all --os all` and `catalog tags --source-root "$PWD" --os linux` — exit 0.
- `catalog profile workstation --source-root "$PWD" --os linux --output json` — schema 7/ok; tags `[core, desktop, agents]`; 2 Dependency Sets, 30 Entries, 1 Provisioner, 3 OS exclusions.
- `catalog tag web --source-root "$PWD" --os all --output json` — environment names present; values absent.
- `catalog tag codex-spark-delegation --source-root "$PWD" --os all` — exit 0 with legacy replacement.
- Unknown Profile and invalid OS — structured error envelopes, exit 1; no Catalog scenario returned 2.
- Temporary HOME contained zero entries after all Catalog commands; sandbox removed.

### Independent review

- Spec: PASS at `c97be23`; no actionable gaps, scope creep, or incorrect behavior.
- Standards: PASS at `c97be23`; no actionable documented-standard violations or code smells; security/redaction and dotfiles safety checked.
- Observations: detail JSON intentionally retains complete summaries; future provisioner argv literals must remain credential-free. Neither blocks this contract.

### Delegation

- Read-only scouts: manifest/modifier architecture, Cobra/output/path integration, and docs/generator patterns; findings accepted.
- Implementation slices: manifest/tag policy, Catalog/docs, and CLI adapter with non-overlapping ownership; returned work inspected and integrated.
- Main-agent corrections: exact Go-owned Tag classification, source-only path resolution, strict marker handling, OS override exclusions, and text/JSON goldens.
- Native subagent capability was used under the explicit Delivery workflow; optional dots custom explorer/worker files were absent. Main agent retained requirements decisions, GitHub mutations, integration, complete validation, and final verification.

<!-- delivery-issue:evidence:end -->