### PR TITLE
ci(release): migrate artifact actions to Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         run: scripts/build-release-artifacts.sh --version "${{ steps.release.outputs.tag }}" --out-dir dist
 
       - name: Preserve release checksums for Homebrew publication
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-checksums
           path: dist/checksums.txt
@@ -92,7 +92,7 @@ jobs:
           ref: ${{ needs.release.outputs.tag }}
 
       - name: Download release checksums
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: release-checksums
           path: dist

--- a/internal/release/release_automation_test.go
+++ b/internal/release/release_automation_test.go
@@ -111,7 +111,7 @@ func TestReleaseWorkflowGatesHomebrewPublishingBehindEnvironment(t *testing.T) {
 	})
 	uploadChecksumsIndex := workflowStepIndex(t, releaseSteps, "release checksum workflow artifact upload", func(step map[string]any) bool {
 		with := stepWith(step)
-		return stepUses(step) == "actions/upload-artifact@v4" &&
+		return stepUses(step) == "actions/upload-artifact@v7" &&
 			with["name"] == "release-checksums" &&
 			with["path"] == "dist/checksums.txt"
 	})
@@ -129,7 +129,7 @@ func TestReleaseWorkflowGatesHomebrewPublishingBehindEnvironment(t *testing.T) {
 
 	downloadChecksumsIndex := workflowStepIndex(t, homebrewSteps, "release checksum workflow artifact download", func(step map[string]any) bool {
 		with := stepWith(step)
-		return stepUses(step) == "actions/download-artifact@v4" &&
+		return stepUses(step) == "actions/download-artifact@v7" &&
 			with["name"] == "release-checksums" &&
 			with["path"] == "dist"
 	})


### PR DESCRIPTION
Closes #423

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [x] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Migrates the release checksum artifact upload and download Actions to Node.js 24-backed major versions.
- Preserves the artifact name, paths, failure behavior, and Homebrew publication handoff.
- Updates the structural release workflow test to prevent regression to the Node.js 20-backed versions.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Use `actions/upload-artifact@v7` and `actions/download-artifact@v7`. |
| `internal/release/release_automation_test.go` | Require the Node.js 24-backed Action majors in the release workflow contract test. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go build ./...`
- [ ] `go run ./cmd/dots manifest validate --file dots.yaml` — not applicable; the Install Manifest is unchanged.
- [ ] Sandboxed plan only when dotfiles behavior changes — not applicable; no dotfiles behavior changed.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] No CLI validation targeted home/config paths; this is a CI workflow dependency update.

## Contributor Checklist

- [x] Linked one issue with an admitted Delivery Contract using `Closes #423`.
- [x] Added exactly one `type:*` label.
- [x] Delivery Evidence records the Contract Source snapshot, Acceptance coverage, and Independent review.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Documentation and agent instructions do not require updates because their behavior is unchanged.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

### Contract Source snapshot

- Kind: standalone issue body
- Source: issue node `I_kwDOSzLlmM8AAAABMDd1rw`, https://github.com/yersonargotev/dots/issues/423
- `updatedAt`: `2026-08-09T17:54:13Z`
- SHA-256: `2fed63cbeac8be21860bd1395c2edfb8aa1ef2638cdc8b4d507511d96a47c904`
- Category: `enhancement`
- Readiness: `ready-for-agent`
- Native relationships: no parent, sub-issues, blockers, or blocked dependents

### Reviewed candidate

- Head: `912c78f3199ebc6d0795f6628d3e7da9fdb3f0a8`
- Base comparison: `origin/main...HEAD` from `9f6605ed526b0eb8791e07ffd665b3fbd0b02a26`

### Acceptance coverage

- Both artifact Actions use `@v7`; upstream `action.yml` for each declares `runs.using: node24`.
- `release-checksums`, `dist/checksums.txt`, `if-no-files-found: error`, and download destination `dist` are unchanged.
- No `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` or `actions/setup-node` override was added.
- The focused workflow contract test and complete CI-equivalent suite pass.

### Automated validation

- `go test ./internal/release -run TestReleaseWorkflowGatesHomebrewPublishingBehindEnvironment -count=1` — passed.
- `gofmt -l .` — passed with no output.
- `go vet ./...` — passed.
- `go build ./...` — passed.
- `go test ./...` — passed.
- `git diff --check` — passed.

### Manual verification

- CLI verification: not applicable. This changes only CI workflow dependencies and their structural test; it exposes no CLI behavior.
- Direct artifact evidence: upstream `actions/upload-artifact@v7` and `actions/download-artifact@v7` metadata both declare `runs.using: node24`; the focused YAML diff preserves every existing input.

### Independent review

- Spec review of `origin/main...HEAD`: passed with no actionable findings.
- Standards review of `origin/main...HEAD`: passed with no actionable findings or code smells.
- Non-blocking observation: exact Action-version assertions are intentional and consistent with the existing workflow contract test.

### Delegation

- Implementation delegation skipped because this is one small, coherent two-file change with coupled workflow/test ownership.
- Independent Spec and Standards reviews ran as separate read-only review slices; the main agent inspected and accepted both results.
<!-- delivery-issue:evidence:end -->
