### PR TITLE
refactor(profiles): make profiles pure tag compositions

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -184,10 +184,6 @@ _Avoid_: dotfiles, config files, installed files
 A terminal preference that can follow the user across machines without encoding host-specific ergonomics, such as theme, intentional keybindings, cursor behavior, scrollback, copy/paste behavior, or close confirmations.
 _Avoid_: terminal setup, my terminal config, machine terminal preference
 
-**Install Profile**:
-A named selection in `dots.yaml` (such as `core`, `desktop`, or `workstation`) that resolves to a set of tags and decides which Managed Entries are installed on a given machine. Install Profiles are explicit and can be composed by repeating `--profile`; there is no repository-owned implicit `default` install baseline. It is about machine scope, not editor behavior.
-_Avoid_: profile, machine profile, install set
-
 **Project Name**:
 The public repository name for the dotfiles project. The canonical repository name is `dotfiles`, while the command-line binary remains `dots`.
 _Avoid_: repo name, product name, tool name
@@ -197,8 +193,8 @@ The executable name users run to manage installation, status, diagnostics, backu
 _Avoid_: binary name, CLI name, app name
 
 **Profile**:
-A named installation selection that represents an intended workstation role, such as `core`, `desktop`, `agents`, `workstation`, `personal`, `work`, or `minimal`. Profiles select Managed Entries through tags rather than duplicating manifests per machine, and repeated Profiles compose by ordered tag union.
-_Avoid_: machine config, host config, preset
+A named installation selection that represents an intended workstation role, such as `core`, `desktop`, `agents`, or `workstation`. A Profile contains descriptive lifecycle metadata and an ordered list of Tags only; it does not own Dependencies, Managed Entries, Provisioners, or other Profiles. Repeated Profiles compose by ordered Tag union.
+_Avoid_: install profile, machine config, host config, preset
 
 **Tag**:
 A label assigned to a Managed Entry so Profiles can include related configuration by intent, such as `core`, `agents`, `web`, `mobile`, or `desktop`. Tags from repeated Profiles and explicit `--tag` flags are de-duplicated while preserving order.

--- a/docs/adr/0013-explicit-composable-install-profiles.md
+++ b/docs/adr/0013-explicit-composable-install-profiles.md
@@ -26,3 +26,15 @@ mutation. Users run commands such as `dots install --profile core`,
 `dots install --profile core --profile agents --profile web` to state exactly
 what they want. Legacy test fixtures may still define a `default` Profile, but
 that name is no longer part of the repository manifest or public examples.
+
+## Amendment: pure Profile invariant
+
+A Profile is a removable name for an ordered Tag selection. Its declaration
+contains descriptive metadata, lifecycle status, and Tags only; Dependencies,
+Managed Entries, and Provisioners belong to their narrowest declarative owner.
+Capability-wide Dependencies therefore use Tag-scoped Dependency Sets. The same
+effective Tags on an operating system select the same declarative surface
+whether supplied by Profiles or explicit `--tag` values. Historical manifests
+may be read only for update-evolution inventory when they contain retired
+Profile Dependencies; current manifest loading rejects that field with migration
+guidance.

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -50,7 +50,6 @@ may instead offer an unambiguous candidate for confirmation.
 | Field | Required | Supported values |
 |-------|----------|------------------|
 | `tags` | Yes | Non-empty strings. Entries and Provisioners are selected when at least one tag matches. Optional CLI `--tag` values join this set at runtime. |
-| `dependencies` | No | Profile-level Dependencies, using the same dependency fields as entries. |
 
 The following compact catalog is generated from the Install Manifest. It lists
 current and legacy declarations; the `dots catalog` command hides legacy items
@@ -273,8 +272,8 @@ Current Managed Entries:
 
 ## Dependencies
 
-Dependencies can be declared in tag-scoped Dependency Sets, Profiles, Managed
-Entries, and Provisioners. They are detection and installation guidance, not
+Dependencies can be declared in tag-scoped Dependency Sets, Managed Entries,
+and Provisioners. They are detection and installation guidance, not
 arbitrary shell hooks.
 
 Tag-scoped Dependency Sets use:

--- a/dots.yaml
+++ b/dots.yaml
@@ -39,12 +39,6 @@ profiles:
     status: current
     tags:
       - desktop
-    dependencies:
-      - name: Desktop Nerd Font
-        brew_cask: font-cascadia-code-nf
-        font_match: "CascadiaCodeNF*"
-        font_fallback_matches:
-          - "CaskaydiaCoveNerdFont*"
   agents:
     description: Native configuration for Codex, Claude Code, OpenCode, Antigravity, and Copilot CLI.
     status: current
@@ -55,11 +49,6 @@ profiles:
     status: current
     tags:
       - web
-    dependencies:
-      - name: Playwright CLI
-        command: playwright-cli
-        brew: playwright-cli
-        linux_homebrew: true
   mobile:
     description: Optional Dart and Flutter mobile development capabilities.
     status: current
@@ -72,13 +61,28 @@ profiles:
       - core
       - desktop
       - agents
+dependencies:
+  - tags:
+      - desktop
+    os:
+      - darwin
+      - linux
     dependencies:
       - name: Desktop Nerd Font
         brew_cask: font-cascadia-code-nf
         font_match: "CascadiaCodeNF*"
         font_fallback_matches:
           - "CaskaydiaCoveNerdFont*"
-dependencies:
+  - tags:
+      - web
+    os:
+      - darwin
+      - linux
+    dependencies:
+      - name: Playwright CLI
+        command: playwright-cli
+        brew: playwright-cli
+        linux_homebrew: true
   - tags:
       - core
     os:

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -225,7 +225,7 @@ func Profile(m manifest.Manifest, name string, opts Options) (Report, error) {
 		return Report{}, fmt.Errorf("profile %q not found", name)
 	}
 	summary := summaryProfile(name, p)
-	base.Profile = buildDetail(m, name, summary.Description, summary.Status, "", "", unique(p.Tags), base.OS, p.Dependencies)
+	base.Profile = buildDetail(m, name, summary.Description, summary.Status, "", "", unique(p.Tags), base.OS)
 	return base, nil
 }
 
@@ -265,15 +265,12 @@ func Tag(m manifest.Manifest, name string, opts Options) (Report, error) {
 		return Report{}, fmt.Errorf("tag %q not found", name)
 	}
 	t := summaryTag(m, name)
-	base.Tag = buildDetail(m, name, t.Description, t.Status, t.Kind, t.ReplacedBy, []string{name}, base.OS, nil)
+	base.Tag = buildDetail(m, name, t.Description, t.Status, t.Kind, t.ReplacedBy, []string{name}, base.OS)
 	return base, nil
 }
 
-func buildDetail(m manifest.Manifest, name, description, status, kind, replacedBy string, tags []string, osName string, profileDeps []manifest.Dependency) *Detail {
+func buildDetail(m manifest.Manifest, name, description, status, kind, replacedBy string, tags []string, osName string) *Detail {
 	d := &Detail{Name: name, Description: description, Status: status, Kind: kind, ReplacedBy: replacedBy, ResolvedTags: clone(tags), Dependencies: []Dependency{}, DependencySets: []DependencySet{}, ProfileDependencies: []Dependency{}, Entries: []Entry{}, SourceOverrides: []SourceOverride{}, Provisioners: []Provisioner{}, Behaviors: behaviors(tags), Excluded: []ExcludedSurface{}}
-	for _, dep := range profileDeps {
-		d.ProfileDependencies = append(d.ProfileDependencies, dependency(dep, Origin{Type: "profile", Name: name}))
-	}
 	for _, set := range m.Dependencies {
 		if !manifest.SharesTag(set.Tags, tags) {
 			continue
@@ -347,9 +344,7 @@ func comparisonSurface(detail *Detail) ComparisonSurface {
 	if detail == nil {
 		return ComparisonSurface{ResolvedTags: []string{}, Dependencies: []Dependency{}, Entries: []Entry{}, SourceOverrides: []SourceOverride{}, Provisioners: []Provisioner{}, Behaviors: []Behavior{}}
 	}
-	dependencies := make([]Dependency, 0, len(detail.ProfileDependencies)+len(detail.Dependencies))
-	dependencies = append(dependencies, detail.ProfileDependencies...)
-	dependencies = append(dependencies, detail.Dependencies...)
+	dependencies := append([]Dependency{}, detail.Dependencies...)
 	return ComparisonSurface{
 		ResolvedTags:    clone(detail.ResolvedTags),
 		Dependencies:    deduplicate(dependencies, dependencyKey),

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -88,8 +88,8 @@ func TestProfileDetailIncludesOriginAndBehavior(t *testing.T) {
 	if detail == nil || !reflect.DeepEqual(detail.ResolvedTags, []string{"core", "agents"}) {
 		t.Fatalf("Detail = %#v", detail)
 	}
-	if len(detail.ProfileDependencies) != 1 || detail.ProfileDependencies[0].Origin.Type != "profile" {
-		t.Fatalf("profile dependencies = %#v", detail.ProfileDependencies)
+	if len(detail.ProfileDependencies) != 0 {
+		t.Fatalf("profile dependencies = %#v, want empty compatibility field", detail.ProfileDependencies)
 	}
 	if len(detail.Behaviors) != 1 || detail.Behaviors[0].Action != "retire-gentle-ai-state" {
 		t.Fatalf("behaviors = %#v", detail.Behaviors)
@@ -117,8 +117,8 @@ func TestCompareProfilesDescribesPortableSurfaceDelta(t *testing.T) {
 	if len(comparison.Removed.ResolvedTags) != 0 || comparison.Shared.ResolvedTags != 2 {
 		t.Fatalf("comparison tags = added %#v removed %#v shared %d", comparison.Added.ResolvedTags, comparison.Removed.ResolvedTags, comparison.Shared.ResolvedTags)
 	}
-	if comparison.Shared.Dependencies != 2 {
-		t.Fatalf("shared dependencies = %d, want profile-tool and set-tool", comparison.Shared.Dependencies)
+	if comparison.Shared.Dependencies != 1 {
+		t.Fatalf("shared dependencies = %d, want set-tool", comparison.Shared.Dependencies)
 	}
 	if got.Profile != nil {
 		t.Fatalf("Profile = %#v, want nil in comparison report", got.Profile)
@@ -142,8 +142,8 @@ func fixtureManifest() manifest.Manifest {
 			"old":     {Description: "Old", Kind: "compatibility", Status: "legacy", ReplacedBy: "core"},
 		},
 		Profiles: map[string]manifest.Profile{
-			"core":    {Description: "Core profile", Tags: []string{"core", "agents"}, Dependencies: []manifest.Dependency{{Name: "profile-tool"}}},
-			"desktop": {Description: "Desktop profile", Tags: []string{"core", "agents", "theme"}, Dependencies: []manifest.Dependency{{Name: "profile-tool"}}},
+			"core":    {Description: "Core profile", Tags: []string{"core", "agents"}},
+			"desktop": {Description: "Desktop profile", Tags: []string{"core", "agents", "theme"}},
 			"old":     {Description: "Old profile", Status: "legacy", Tags: []string{"old"}},
 		},
 		Dependencies: []manifest.DependencySet{{Tags: []string{"core"}, Dependencies: []manifest.Dependency{{Name: "set-tool"}}}},

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -362,6 +362,8 @@ func TestDoctorCommandReportsProfileFontDependencyPresentThroughFallbackFile(t *
 profiles:
   desktop:
     tags: [desktop]
+dependencies:
+  - tags: [desktop]
     dependencies:
       - name: Desktop Nerd Font
         brew_cask: font-cascadia-code-nf

--- a/internal/cli/deps_home_test.go
+++ b/internal/cli/deps_home_test.go
@@ -19,6 +19,8 @@ const fontManifest = `version: 1
 profiles:
   default:
     tags: [core]
+dependencies:
+  - tags: [core]
     dependencies:
       - name: Dots Home Flag Probe Font
         brew_cask: font-dots-home-flag-probe
@@ -34,6 +36,8 @@ const darwinAppManifest = `version: 1
 profiles:
   default:
     tags: [desktop]
+dependencies:
+  - tags: [desktop]
     dependencies:
       - name: Dots Sandbox App
         command: dots-sandbox-app

--- a/internal/cli/ghostty_config_test.go
+++ b/internal/cli/ghostty_config_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"slices"
 	"strings"
 	"testing"
 
@@ -93,21 +92,20 @@ func TestGhosttyDesktopProfileInstallsAndReportsAlignedInSandbox(t *testing.T) {
 	if !manifest.SharesTag(ghosttyEntry.Tags, []string{"desktop"}) {
 		t.Fatalf("Ghostty managed entry tags = %#v, want desktop", ghosttyEntry.Tags)
 	}
-	desktopProfile, ok := manifestFile.Profiles["desktop"]
-	if !ok {
-		t.Fatal("dots manifest missing desktop profile")
-	}
 	foundDesktopFontDependency := false
-	for _, dep := range desktopProfile.Dependencies {
-		if dep.BrewCask == "font-cascadia-code-nf" &&
-			dep.FontMatch == "CascadiaCodeNF*" &&
-			slices.Equal(dep.FontFallbackMatches, []string{"CaskaydiaCoveNerdFont*"}) {
-			foundDesktopFontDependency = true
-			break
+	for _, set := range manifestFile.Dependencies {
+		if !manifest.SharesTag(set.Tags, []string{"desktop"}) {
+			continue
+		}
+		for _, dep := range set.Dependencies {
+			if dep.BrewCask == "font-cascadia-code-nf" && dep.FontMatch == "CascadiaCodeNF*" && len(dep.FontFallbackMatches) == 1 && dep.FontFallbackMatches[0] == "CaskaydiaCoveNerdFont*" {
+				foundDesktopFontDependency = true
+				break
+			}
 		}
 	}
 	if !foundDesktopFontDependency {
-		t.Fatalf("desktop profile dependencies = %#v, want font-cascadia-code-nf with CascadiaCodeNF* and Caskaydia fallback", desktopProfile.Dependencies)
+		t.Fatalf("desktop dependency set is missing font-cascadia-code-nf with CascadiaCodeNF* and Caskaydia fallback")
 	}
 
 	localExample := filepath.Join(repoRoot, "configs", "ghostty", "config.local.ghostty.example")

--- a/internal/cli/render_catalog.go
+++ b/internal/cli/render_catalog.go
@@ -161,7 +161,6 @@ func renderCatalogDetail(w io.Writer, label string, report catalog.Report, detai
 		fmt.Fprintf(w, "Replaced by: %s\n", detail.ReplacedBy)
 	}
 	fmt.Fprintf(w, "Resolved tags: %s\n", catalogList(detail.ResolvedTags))
-	renderCatalogDependencies(w, "Profile dependencies", detail.ProfileDependencies)
 	renderCatalogDependencySets(w, detail.DependencySets)
 	renderCatalogDependencies(w, "Dependencies", detail.Dependencies)
 	renderCatalogEntries(w, detail.Entries)

--- a/internal/cli/testdata/catalog_tag.golden
+++ b/internal/cli/testdata/catalog_tag.golden
@@ -5,8 +5,6 @@ Description: Theme configuration
 Status: current
 Kind: surface
 Resolved tags: theme
-Profile dependencies:
-  none
 Dependency sets:
   - tags: theme; OS: darwin, linux
     - theme-tool (required)

--- a/internal/deps/deps.go
+++ b/internal/deps/deps.go
@@ -242,10 +242,9 @@ func fontProbeLabel(matches []string) string {
 	return strings.Join(matches, ", ")
 }
 
-// selectDependencies gathers the Dependencies declared directly by the Profile,
-// tag-scoped Dependency Sets, then every Managed Entry and Provisioner that
-// belongs to the Profile and passes the OS filter, deduplicated by name in
-// first-declared order.
+// selectDependencies gathers the Dependencies declared by tag-scoped Dependency
+// Sets, then every Managed Entry and Provisioner that belongs to the selected
+// Tags and passes the OS filter, deduplicated by name in first-declared order.
 
 func selectDependencies(m manifest.Manifest, opts Options) ([]manifest.Dependency, error) {
 	selection, err := resolveOptionsSelection(m, opts)
@@ -276,9 +275,6 @@ func selectDependencies(m manifest.Manifest, opts Options) ([]manifest.Dependenc
 		}
 	}
 
-	for _, profileName := range selection.Profiles {
-		addDependencies(m.Profiles[profileName].Dependencies)
-	}
 	tags := selection.Tags
 	for _, set := range m.Dependencies {
 		if !manifest.SharesTag(set.Tags, tags) {
@@ -314,5 +310,9 @@ func resolveOptionsSelection(m manifest.Manifest, opts Options) (manifest.Select
 	if opts.Selection != nil {
 		return *opts.Selection, nil
 	}
-	return manifest.ResolveSelection(m, manifest.SelectedProfileNames(opts.Profile, opts.Profiles), opts.ExtraTags)
+	profiles := manifest.SelectedProfileNames(opts.Profile, opts.Profiles)
+	if len(profiles) == 0 && len(opts.ExtraTags) == 0 {
+		return manifest.ResolveSelection(m, profiles, nil)
+	}
+	return manifest.ResolveReadOnlySelection(m, profiles, opts.ExtraTags)
 }

--- a/internal/deps/deps_test.go
+++ b/internal/deps/deps_test.go
@@ -2,12 +2,47 @@ package deps_test
 
 import (
 	"errors"
+	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/yersonargotev/dots/internal/deps"
 	"github.com/yersonargotev/dots/internal/manifest"
 )
+
+func TestRepositoryProfilesMatchEquivalentExplicitTagsAcrossSupportedOS(t *testing.T) {
+	m, err := manifest.LoadFile(filepath.Join("..", "..", "dots.yaml"))
+	if err != nil {
+		t.Fatalf("load repository manifest: %v", err)
+	}
+
+	for _, osName := range []string{"darwin", "linux"} {
+		for profileName, profile := range m.Profiles {
+			t.Run(osName+"/"+profileName, func(t *testing.T) {
+				byProfile, err := deps.Check(*m, deps.Options{Profile: profileName, OS: osName}, lookupSet(), fontLookupSet())
+				if err != nil {
+					t.Fatalf("profile dependency check: %v", err)
+				}
+				byTags, err := deps.Check(*m, deps.Options{ExtraTags: profile.Tags, OS: osName}, lookupSet(), fontLookupSet())
+				if err != nil {
+					t.Fatalf("explicit tag dependency check: %v", err)
+				}
+				if got, want := dependencyNames(byProfile.Results), dependencyNames(byTags.Results); !reflect.DeepEqual(got, want) {
+					t.Fatalf("profile dependencies = %#v, explicit tags = %#v", got, want)
+				}
+			})
+		}
+	}
+}
+
+func dependencyNames(results []deps.Result) []string {
+	names := make([]string, 0, len(results))
+	for _, result := range results {
+		names = append(names, result.Name)
+	}
+	return names
+}
 
 func lookupSet(present ...string) deps.Lookup {
 	defaultPresent := []string{"brew", "sudo", "apt-get", "dnf", "pacman"}
@@ -159,17 +194,13 @@ func TestRepositoryManifestDesktopFontAcceptsCurrentCaskaydiaName(t *testing.T) 
 	}
 }
 
-func TestCheckIncludesProfileDependenciesBeforeEntryDependencies(t *testing.T) {
+func TestCheckIncludesTagDependencySetsBeforeEntryDependencies(t *testing.T) {
 	m := manifest.Manifest{
-		Version: 1,
-		Profiles: map[string]manifest.Profile{
-			"default": {
-				Tags: []string{"desktop"},
-				Dependencies: []manifest.Dependency{
-					{Name: "Desktop Nerd Font", BrewCask: "font-cascadia-code-nf", FontMatch: "CascadiaCodeNF*"},
-				},
-			},
-		},
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"desktop"}}},
+		Dependencies: []manifest.DependencySet{{Tags: []string{"desktop"}, Dependencies: []manifest.Dependency{
+			{Name: "Desktop Nerd Font", BrewCask: "font-cascadia-code-nf", FontMatch: "CascadiaCodeNF*"},
+		}}},
 		Entries: []manifest.Entry{
 			{
 				Source: "configs/ghostty/config.ghostty", Target: "~/.config/ghostty/config.ghostty", Strategy: "symlink", Tags: []string{"desktop"},
@@ -233,15 +264,11 @@ func TestCheckReportsPresentAndMissingForProfile(t *testing.T) {
 
 func TestCheckReportsOptionalRequirementAndRequiredDominatesDuplicates(t *testing.T) {
 	m := manifest.Manifest{
-		Version: 1,
-		Profiles: map[string]manifest.Profile{
-			"default": {
-				Tags: []string{"core"},
-				Dependencies: []manifest.Dependency{
-					{Name: "starship", Requirement: manifest.DependencyRequirementOptional, Brew: "starship"},
-				},
-			},
-		},
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}},
+		Dependencies: []manifest.DependencySet{{Tags: []string{"core"}, Dependencies: []manifest.Dependency{
+			{Name: "starship", Requirement: manifest.DependencyRequirementOptional, Brew: "starship"},
+		}}},
 		Entries: []manifest.Entry{{
 			Source: "configs/zsh/zshrc", Target: "~/.zshrc", Strategy: "symlink", Tags: []string{"core"},
 			Dependencies: []manifest.Dependency{{Name: "starship", Brew: "starship"}},

--- a/internal/deps/plan_test.go
+++ b/internal/deps/plan_test.go
@@ -156,16 +156,12 @@ func TestPlanUsesAtuinUserLocalProviderOnLinuxWhenDistroProviderUnavailable(t *t
 
 func TestPlanReportsDependencyRequirement(t *testing.T) {
 	m := manifest.Manifest{
-		Version: 1,
-		Profiles: map[string]manifest.Profile{
-			"default": {
-				Tags: []string{"core"},
-				Dependencies: []manifest.Dependency{
-					{Name: "required-tool", Brew: "required-tool"},
-					{Name: "optional-tool", Requirement: manifest.DependencyRequirementOptional, Brew: "optional-tool"},
-				},
-			},
-		},
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}},
+		Dependencies: []manifest.DependencySet{{Tags: []string{"core"}, Dependencies: []manifest.Dependency{
+			{Name: "required-tool", Brew: "required-tool"},
+			{Name: "optional-tool", Requirement: manifest.DependencyRequirementOptional, Brew: "optional-tool"},
+		}}},
 		Entries: []manifest.Entry{{Source: "configs/x", Target: "~/.x", Strategy: "symlink", Tags: []string{"core"}}},
 	}
 

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -20,19 +20,19 @@ var (
 )
 
 type Manifest struct {
-	Version      int                `yaml:"version"`
-	Tags         map[string]Tag     `yaml:"tags,omitempty"`
-	Profiles     map[string]Profile `yaml:"profiles"`
-	Dependencies []DependencySet    `yaml:"dependencies,omitempty"`
-	Entries      []Entry            `yaml:"entries"`
-	Provisioners []Provisioner      `yaml:"provisioners,omitempty"`
+	Version                   int                `yaml:"version"`
+	Tags                      map[string]Tag     `yaml:"tags,omitempty"`
+	Profiles                  map[string]Profile `yaml:"profiles"`
+	Dependencies              []DependencySet    `yaml:"dependencies,omitempty"`
+	Entries                   []Entry            `yaml:"entries"`
+	Provisioners              []Provisioner      `yaml:"provisioners,omitempty"`
+	legacyProfileDependencies map[string][]Dependency
 }
 
 type Profile struct {
-	Description  string       `yaml:"description,omitempty"`
-	Status       string       `yaml:"status,omitempty"`
-	Tags         []string     `yaml:"tags"`
-	Dependencies []Dependency `yaml:"dependencies,omitempty"`
+	Description string   `yaml:"description,omitempty"`
+	Status      string   `yaml:"status,omitempty"`
+	Tags        []string `yaml:"tags"`
 }
 
 // Tag describes a declared selection tag. The registry is optional for v1
@@ -285,6 +285,9 @@ func LoadFile(path string) (*Manifest, error) {
 
 // Parse strictly decodes and validates a current Install Manifest.
 func Parse(data []byte) (*Manifest, error) {
+	if profileName, ok := profileDependenciesDeclaration(data); ok {
+		return nil, fmt.Errorf("profiles[%q].dependencies is retired; move the dependencies to a tag-scoped dependency set under dependencies using the profile's tags", profileName)
+	}
 	var manifest Manifest
 	decoder := yaml.NewDecoder(bytes.NewReader(data))
 	decoder.KnownFields(true)
@@ -314,6 +317,10 @@ func LoadPreviousFile(path string) (*Manifest, error) {
 	if err := yaml.Unmarshal(data, &document); err != nil {
 		return nil, fmt.Errorf("parse previous manifest: %w", err)
 	}
+	legacyProfileDependencies, err := discardPreviousProfileDependencies(&document)
+	if err != nil {
+		return nil, err
+	}
 	discardPreviousProvisionerSpecs(&document)
 	projected, err := yaml.Marshal(&document)
 	if err != nil {
@@ -329,7 +336,101 @@ func LoadPreviousFile(path string) (*Manifest, error) {
 	if err := previous.validateEvolutionInventory(); err != nil {
 		return nil, err
 	}
+	for name, dependencies := range legacyProfileDependencies {
+		if _, ok := previous.Profiles[name]; !ok {
+			return nil, fmt.Errorf("previous manifest profiles[%q] is not declared", name)
+		}
+		for i, dependency := range dependencies {
+			if err := validateDependency(dependency, fmt.Sprintf("profiles[%q].dependencies[%d]", name, i)); err != nil {
+				return nil, err
+			}
+		}
+	}
+	previous.legacyProfileDependencies = legacyProfileDependencies
 	return &previous, nil
+}
+
+// LegacyProfileDependencies returns inventory retained exclusively from a
+// previous Install Manifest for selection evolution. Current Install Manifests
+// never populate this retired declaration.
+func (m Manifest) LegacyProfileDependencies(profile string) []Dependency {
+	return append([]Dependency(nil), m.legacyProfileDependencies[profile]...)
+}
+
+func profileDependenciesDeclaration(data []byte) (string, bool) {
+	var document yaml.Node
+	if yaml.Unmarshal(data, &document) != nil {
+		return "", false
+	}
+	if document.Kind != yaml.DocumentNode || len(document.Content) == 0 {
+		return "", false
+	}
+	root := document.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return "", false
+	}
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		if root.Content[i].Value != "profiles" || root.Content[i+1].Kind != yaml.MappingNode {
+			continue
+		}
+		profiles := root.Content[i+1]
+		for j := 0; j+1 < len(profiles.Content); j += 2 {
+			profile := profiles.Content[j+1]
+			if profile.Kind != yaml.MappingNode {
+				continue
+			}
+			for k := 0; k+1 < len(profile.Content); k += 2 {
+				if profile.Content[k].Value == "dependencies" {
+					return profiles.Content[j].Value, true
+				}
+			}
+		}
+	}
+	return "", false
+}
+
+func discardPreviousProfileDependencies(document *yaml.Node) (map[string][]Dependency, error) {
+	legacy := make(map[string][]Dependency)
+	if document == nil || document.Kind != yaml.DocumentNode || len(document.Content) == 0 {
+		return legacy, nil
+	}
+	root := document.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return legacy, nil
+	}
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		if root.Content[i].Value != "profiles" || root.Content[i+1].Kind != yaml.MappingNode {
+			continue
+		}
+		profiles := root.Content[i+1]
+		for j := 0; j+1 < len(profiles.Content); j += 2 {
+			profileName := profiles.Content[j].Value
+			profile := profiles.Content[j+1]
+			if profile.Kind != yaml.MappingNode {
+				continue
+			}
+			for k := 0; k+1 < len(profile.Content); k += 2 {
+				if profile.Content[k].Value != "dependencies" {
+					continue
+				}
+				data, err := yaml.Marshal(profile.Content[k+1])
+				if err != nil {
+					return nil, fmt.Errorf("project previous manifest profiles[%q].dependencies: %w", profileName, err)
+				}
+				var dependencies []Dependency
+				decoder := yaml.NewDecoder(bytes.NewReader(data))
+				decoder.KnownFields(true)
+				if err := decoder.Decode(&dependencies); err != nil {
+					return nil, fmt.Errorf("parse previous manifest profiles[%q].dependencies: %w", profileName, err)
+				}
+				legacy[profileName] = dependencies
+				profile.Content = append(profile.Content[:k], profile.Content[k+2:]...)
+				break
+			}
+		}
+		return legacy, nil
+	}
+	return legacy, nil
 }
 
 func discardPreviousProvisionerSpecs(document *yaml.Node) {
@@ -427,11 +528,6 @@ func (m Manifest) Validate() error {
 		}
 		if err := m.validateDeclaredTags(tags, fmt.Sprintf("profiles[%q].tags", name)); err != nil {
 			return err
-		}
-		for j, dep := range profile.Dependencies {
-			if err := validateDependency(dep, fmt.Sprintf("profiles[%q].dependencies[%d]", name, j)); err != nil {
-				return err
-			}
 		}
 	}
 

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -318,7 +318,7 @@ entries:
 	}
 }
 
-func TestLoadFileParsesProfileDependencies(t *testing.T) {
+func TestLoadFileRejectsProfileDependenciesWithMigrationGuidance(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "dots.yaml")
 	content := []byte(`version: 1
@@ -342,17 +342,18 @@ entries:
 		t.Fatalf("write manifest: %v", err)
 	}
 
-	got, err := manifest.LoadFile(path)
-	if err != nil {
-		t.Fatalf("LoadFile() error = %v", err)
+	_, err := manifest.LoadFile(path)
+	if err == nil || !strings.Contains(err.Error(), "profiles[\"desktop\"].dependencies is retired") || !strings.Contains(err.Error(), "tag-scoped dependency set") {
+		t.Fatalf("LoadFile() error = %v, want actionable retired profile dependency guidance", err)
 	}
 
-	deps := got.Profiles["desktop"].Dependencies
-	if len(deps) != 1 {
-		t.Fatalf("Profile dependencies len = %d, want 1 (%#v)", len(deps), deps)
+	got, err := manifest.LoadPreviousFile(path)
+	if err != nil {
+		t.Fatalf("LoadPreviousFile() error = %v", err)
 	}
-	if deps[0].Name != "Desktop Nerd Font" || deps[0].Requirement != "optional" || deps[0].BrewCask != "font-cascadia-code-nf" || deps[0].FontMatch != "CascadiaCodeNF*" || !sameStrings(deps[0].FontFallbackMatches, []string{"CaskaydiaCoveNerdFont*"}) {
-		t.Fatalf("Profile dependency = %#v, want desktop font dependency with fallback match", deps[0])
+	deps := got.LegacyProfileDependencies("desktop")
+	if len(deps) != 1 || deps[0].Name != "Desktop Nerd Font" || deps[0].Requirement != "optional" || deps[0].BrewCask != "font-cascadia-code-nf" || deps[0].FontMatch != "CascadiaCodeNF*" || !sameStrings(deps[0].FontFallbackMatches, []string{"CaskaydiaCoveNerdFont*"}) {
+		t.Fatalf("legacy Profile dependencies = %#v, want desktop font dependency with fallback match", deps)
 	}
 }
 
@@ -761,7 +762,7 @@ func TestRepositoryManifestIncludesMobileAgentMCPConfigEntries(t *testing.T) {
 	}
 }
 
-func TestRepositoryManifestWebProfileIncludesPlaywrightCLI(t *testing.T) {
+func TestRepositoryManifestWebDependencySetIncludesPlaywrightCLI(t *testing.T) {
 	root := filepath.Clean(filepath.Join("..", ".."))
 	manifestPath := filepath.Join(root, "dots.yaml")
 
@@ -770,16 +771,15 @@ func TestRepositoryManifestWebProfileIncludesPlaywrightCLI(t *testing.T) {
 		t.Fatalf("LoadFile(%q) error = %v", manifestPath, err)
 	}
 
-	web := got.Profiles["web"]
-	if !hasDependency(web.Dependencies, "Playwright CLI") {
-		t.Fatalf("web profile dependencies = %#v, want Playwright CLI dependency", web.Dependencies)
-	}
-
 	var dep manifest.Dependency
-	for _, candidate := range web.Dependencies {
-		if candidate.Name == "Playwright CLI" {
-			dep = candidate
-			break
+	for _, set := range got.Dependencies {
+		if !hasString(set.Tags, "web") {
+			continue
+		}
+		for _, candidate := range set.Dependencies {
+			if candidate.Name == "Playwright CLI" {
+				dep = candidate
+			}
 		}
 	}
 	if dep.Command != "playwright-cli" || dep.Brew != "playwright-cli" || !dep.LinuxHomebrew {
@@ -891,11 +891,6 @@ func TestRepositoryManifestLinuxHomebrewReviewBoundary(t *testing.T) {
 	}
 
 	dependencies := make(map[string][]manifest.Dependency)
-	for _, profile := range got.Profiles {
-		for _, dep := range profile.Dependencies {
-			dependencies[dep.Name] = append(dependencies[dep.Name], dep)
-		}
-	}
 	for _, depSet := range got.Dependencies {
 		for _, dep := range depSet.Dependencies {
 			dependencies[dep.Name] = append(dependencies[dep.Name], dep)
@@ -1456,7 +1451,7 @@ entries:
     strategy: symlink
     tags: [core]
 `,
-			want: `profiles["default"].dependencies[0].name is required`,
+			want: `profiles["default"].dependencies is retired; move the dependencies to a tag-scoped dependency set under dependencies using the profile's tags`,
 		},
 		{
 			name: "unsupported strategy",

--- a/internal/selection/selection.go
+++ b/internal/selection/selection.go
@@ -361,7 +361,7 @@ func selectedSurface(m manifest.Manifest, selected manifest.Selection, osName st
 		}
 	}
 	for _, profileName := range selected.Profiles {
-		addDependencies(m.Profiles[profileName].Dependencies)
+		addDependencies(m.LegacyProfileDependencies(profileName))
 	}
 	for _, set := range m.Dependencies {
 		if manifest.SharesTag(set.Tags, selected.Tags) && manifest.MatchesOS(set.OS, osName) {

--- a/internal/selection/selection_test.go
+++ b/internal/selection/selection_test.go
@@ -3,6 +3,7 @@ package selection_test
 import (
 	"encoding/json"
 	"errors"
+	"os"
 	"path/filepath"
 	"reflect"
 	"slices"
@@ -14,13 +15,53 @@ import (
 	"github.com/yersonargotev/dots/internal/state"
 )
 
+func TestCompareEvolutionRetainsHistoricalProfileDependenciesForComparison(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "dots.yaml")
+	previousSource := []byte(`version: 1
+profiles:
+  desktop:
+    tags: [desktop]
+    dependencies:
+      - name: Desktop Nerd Font
+        brew_cask: font-cascadia-code-nf
+        font_match: "CascadiaCodeNF*"
+entries:
+  - source: configs/ghostty/config
+    target: ~/.config/ghostty/config
+    strategy: copy
+    tags: [desktop]
+`)
+	if err := os.WriteFile(path, previousSource, 0o600); err != nil {
+		t.Fatalf("write previous manifest: %v", err)
+	}
+	previousManifest, err := manifest.LoadPreviousFile(path)
+	if err != nil {
+		t.Fatalf("load previous manifest: %v", err)
+	}
+	currentManifest := manifest.Manifest{
+		Profiles: map[string]manifest.Profile{"desktop": {Tags: []string{"desktop"}}},
+		Dependencies: []manifest.DependencySet{{Tags: []string{"desktop"}, Dependencies: []manifest.Dependency{{
+			Name: "Desktop Nerd Font", BrewCask: "font-cascadia-code-nf", FontMatch: "CascadiaCodeNF*",
+		}}}},
+		Entries: []manifest.Entry{{Source: "configs/ghostty/config", Target: "~/.config/ghostty/config", Strategy: "copy", Tags: []string{"desktop"}}},
+	}
+	previous, err := selection.ResolveIntent(*previousManifest, selection.Intent{Source: selection.SourceRecorded, Profiles: []string{"desktop"}})
+	if err != nil {
+		t.Fatalf("resolve previous selection: %v", err)
+	}
+	evolved, err := selection.CompareEvolution(*previousManifest, currentManifest, previous, "darwin")
+	if err != nil {
+		t.Fatalf("compare evolution: %v", err)
+	}
+	if delta := evolved.Report.Delta; delta == nil || len(delta.Added.Dependencies) != 0 || len(delta.Removed.Dependencies) != 0 {
+		t.Fatalf("dependency evolution = %#v, want unchanged historical font selection", delta)
+	}
+}
+
 func TestCompareEvolutionReportsSelectedSurfaceChangesInManifestOrder(t *testing.T) {
 	oldManifest := manifest.Manifest{
 		Profiles: map[string]manifest.Profile{
-			"core": {
-				Tags:         []string{"core"},
-				Dependencies: []manifest.Dependency{{Name: "profile-old"}, {Name: "shared"}},
-			},
+			"core": {Tags: []string{"core"}},
 		},
 		Entries: []manifest.Entry{
 			{Target: ".old", Tags: []string{"core"}, Dependencies: []manifest.Dependency{{Name: "entry-old"}}},
@@ -30,10 +71,7 @@ func TestCompareEvolutionReportsSelectedSurfaceChangesInManifestOrder(t *testing
 	}
 	newManifest := manifest.Manifest{
 		Profiles: map[string]manifest.Profile{
-			"core": {
-				Tags:         []string{"core", "new"},
-				Dependencies: []manifest.Dependency{{Name: "shared"}, {Name: "profile-new"}},
-			},
+			"core": {Tags: []string{"core", "new"}},
 		},
 		Dependencies: []manifest.DependencySet{{
 			Tags: []string{"new"}, Dependencies: []manifest.Dependency{{Name: "set-new"}, {Name: "shared"}},
@@ -67,7 +105,7 @@ func TestCompareEvolutionReportsSelectedSurfaceChangesInManifestOrder(t *testing
 	if want := []string{".new"}; !reflect.DeepEqual(delta.Added.ManagedEntries, want) {
 		t.Fatalf("added Managed Entries = %#v, want %#v", delta.Added.ManagedEntries, want)
 	}
-	if want := []string{"profile-new", "set-new", "entry-new", "provisioner-new"}; !reflect.DeepEqual(delta.Added.Dependencies, want) {
+	if want := []string{"set-new", "entry-new", "provisioner-new"}; !reflect.DeepEqual(delta.Added.Dependencies, want) {
 		t.Fatalf("added Dependencies = %#v, want %#v", delta.Added.Dependencies, want)
 	}
 	if want := []string{"new-tool"}; !reflect.DeepEqual(delta.Added.Provisioners, want) {
@@ -76,7 +114,7 @@ func TestCompareEvolutionReportsSelectedSurfaceChangesInManifestOrder(t *testing
 	if want := []string{".old"}; !reflect.DeepEqual(delta.Removed.ManagedEntries, want) {
 		t.Fatalf("removed Managed Entries = %#v, want %#v", delta.Removed.ManagedEntries, want)
 	}
-	if want := []string{"profile-old", "entry-old"}; !reflect.DeepEqual(delta.Removed.Dependencies, want) {
+	if want := []string{"entry-old"}; !reflect.DeepEqual(delta.Removed.Dependencies, want) {
 		t.Fatalf("removed Dependencies = %#v, want %#v", delta.Removed.Dependencies, want)
 	}
 	if want := []string{"old-tool"}; !reflect.DeepEqual(delta.Removed.Provisioners, want) {


### PR DESCRIPTION
Closes #428

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [x] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Makes Profiles pure declarations of descriptive metadata, lifecycle status, and ordered Tags.
- Moves the Desktop Nerd Font and Playwright CLI into Tag-scoped Dependency Sets while preserving historical update comparison.
- Removes Profile Dependencies from human catalog output while retaining the empty JSON compatibility field at schema version 7.

## Changes

| File | Change |
|------|--------|
| `internal/manifest/manifest.go` | Reject current Profile Dependencies with migration guidance and retain them privately only for historical evolution. |
| `internal/deps/deps.go`, `internal/selection/selection.go` | Select current Dependencies from Tags and preserve historical comparison inventory. |
| `internal/catalog/`, `internal/cli/render_catalog.go` | Remove the retired concept from domain comparison and human output while retaining the empty JSON adapter field. |
| `dots.yaml` | Move desktop and web capability Dependencies to Tag-scoped Dependency Sets. |
| `CONTEXT.md`, `docs/manifest.md`, `docs/adr/0013-explicit-composable-install-profiles.md` | Record the sole Profile term and pure-Profile invariant. |
| Tests | Cover migration rejection, historical comparison, catalog compatibility, and Profile/Tag dependency parity on Darwin and Linux. |

## Test Plan

- [x] `go test ./... -count=1`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go build ./...`
- [x] `go generate ./internal/catalog`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed CLI verification with a temporary binary and home; no real configuration was read or written.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked one issue with an admitted Delivery Contract using `Closes #428`.
- [x] Added exactly one `type:*` label.
- [x] Delivery Evidence records the Contract Source snapshot, Acceptance coverage, and Independent review.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

### Contract Source snapshot

- Kind: composed delivery ticket (child #428 plus native parent specification #427).
- Child body: node `I_kwDOSzLlmM8AAAABMEOsJg`; https://github.com/yersonargotev/dots/issues/428; updated `2026-08-09T21:01:25Z`; SHA-256 `ff3c5dc8fa3e00ee2b5ae6954291f9a1462a9998945a811d1a02e9b24158d20f`.
- Parent body: node `I_kwDOSzLlmM8AAAABMEODWA`; https://github.com/yersonargotev/dots/issues/427; updated `2026-08-09T20:58:54Z`; SHA-256 `294db5b0d8a1d718b2b5ae57f3a09dbe61720b13db334c248eac4eea7ade823c`.
- Category/readiness: `enhancement`; `ready-for-agent` is the only triage-state label.
- Native relationships: parent #427 (OPEN, updated `2026-08-09T20:58:54Z`); no sub-issues; no `blockedBy`; blocking #429 (OPEN, updated `2026-08-09T21:01:30Z`).
- Comments at snapshot: none.
- Reviewed head: `a45540da754b5a90a94c3cea22d3bff86548fde3` against `origin/main` at `b7d8b79c19b9f097d904e9549738440087a4989f`.

### Acceptance coverage

- Pure, non-nested Profiles: `manifest.Profile` contains only description, status, and Tags; strict current parsing rejects retired/nested fields.
- Desktop font and Playwright: Tag-scoped `desktop` and `web` Dependency Sets in `dots.yaml`; `workstation` has no duplicate.
- Migration behavior: current loading returns actionable Tag-scoped guidance; `LoadPreviousFile` retains private historical inventory for selection evolution.
- Profile/Tag parity: repository-wide test compares every Profile with its explicit Tags on Darwin and Linux.
- Catalog compatibility: human output omits Profile Dependencies; JSON keeps `profile_dependencies: []` with schema version 7.
- Installed Selection safety: the full regression suite covers blocking, replacement, reduction acknowledgement, and no-pruning behavior unchanged.
- Domain documentation: the duplicate Install Profile glossary term is removed and ADR 0013 records the pure-Profile invariant.

### Automated validation

- PASS: `gofmt -l .` (no output).
- PASS: `go vet ./...`.
- PASS: `go build ./...`.
- PASS: `go test ./... -count=1` (all packages, including the temporary-home lifecycle E2E).
- PASS: `go generate ./internal/catalog` (generated catalog remains synchronized).
- PASS: manifest validation.

### Manual verification

- Built one temporary real binary with `go build -o <tmp>/dots ./cmd/dots`.
- PASS: `<tmp>/dots manifest validate --file dots.yaml` returned `manifest is valid`.
- PASS: `catalog profile` and `catalog tag` exposed identical dependency name arrays for `desktop` and `web` on both `--os darwin` and `--os linux`.
- PASS: catalog JSON reported `profile_dependencies: []` and `schema_version: "7"`; human profile catalog omitted `Profile dependencies`.
- PASS: sandboxed `deps check --tag desktop --output json --home <tmp>/home` exited 2 for findings and included `Desktop Nerd Font` with an explicit tag-only selection.

### Independent review

- Standards: PASS at `a45540d`; no actionable findings and no follow-up observations.
- Spec: PASS at `a45540d`; all child acceptance criteria satisfied, no scope creep, and no incorrect behavior identified.
<!-- delivery-issue:evidence:end -->
