### PR TITLE
refactor(selection): introduce selected surface module

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -128,6 +128,10 @@ _Avoid_: local script, custom install command, manual curl pipe
 A User-Local Provider for fast-moving tools that resolves the latest stable artifact from allowlisted official metadata when the Dependency is absent, verifies its published digest, and records the resolved release instead of pinning it in the Install Manifest.
 _Avoid_: latest installer, unpinned download, auto-updater
 
+**Selected Surface**:
+The deterministic, ordered, and de-duplicated Managed Entries, resolved source overrides, Dependencies, and Provisioners selected by effective Tags and the operating system. Equivalent effective Tags on the same operating system produce the same Selected Surface regardless of whether they came from a Profile or explicit Tag selection. It excludes filesystem state, Drift, Conflicts, Install Plan actions, and historical migrations.
+_Avoid_: install plan, status, installed selection, profile surface
+
 **Install Plan**:
 The preview of filesystem changes, conflicts, dependency findings, and backup requirements that the Dotfiles CLI computes before applying installation. It is shown during normal installation and is the output of dry-run mode.
 _Avoid_: preview, dry run output, change list

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/selectedsurface"
 	"github.com/yersonargotev/dots/internal/tagpolicy"
 )
 
@@ -271,60 +272,34 @@ func Tag(m manifest.Manifest, name string, opts Options) (Report, error) {
 
 func buildDetail(m manifest.Manifest, name, description, status, kind, replacedBy string, tags []string, osName string) *Detail {
 	d := &Detail{Name: name, Description: description, Status: status, Kind: kind, ReplacedBy: replacedBy, ResolvedTags: clone(tags), Dependencies: []Dependency{}, DependencySets: []DependencySet{}, ProfileDependencies: []Dependency{}, Entries: []Entry{}, SourceOverrides: []SourceOverride{}, Provisioners: []Provisioner{}, Behaviors: behaviors(tags), Excluded: []ExcludedSurface{}}
-	for _, set := range m.Dependencies {
-		if !manifest.SharesTag(set.Tags, tags) {
-			continue
-		}
-		if !matches(set.OS, osName) {
-			d.Excluded = append(d.Excluded, excluded("dependency_set", strings.Join(set.Tags, ","), set.OS, osName))
-			continue
-		}
+	surface := selectedSurface(m, tags, osName)
+	for _, set := range surface.DependencySets {
 		item := DependencySet{Tags: clone(set.Tags), OS: declaredOS(set.OS), Dependencies: []Dependency{}}
 		for _, dep := range set.Dependencies {
 			item.Dependencies = append(item.Dependencies, dependency(dep, Origin{Type: "dependency_set", Tags: clone(set.Tags)}))
-			d.Dependencies = append(d.Dependencies, dependency(dep, Origin{Type: "dependency_set", Tags: clone(set.Tags)}))
 		}
 		d.DependencySets = append(d.DependencySets, item)
 	}
-	for _, entry := range m.Entries {
-		for tag, source := range entry.SourceOverrides {
-			if contains(tags, tag) {
-				applicable := matches(entry.OS, osName)
-				d.SourceOverrides = append(d.SourceOverrides, SourceOverride{Tag: tag, Source: source, Entry: entry.Source, Target: entry.Target, OS: declaredOS(entry.OS), Applicable: applicable})
-				if !applicable {
-					d.Excluded = append(d.Excluded, excluded("source_override", entry.Target+" ("+tag+")", entry.OS, osName))
-				}
-			}
-		}
-		if !manifest.SharesTag(entry.Tags, tags) {
-			continue
-		}
-		if !matches(entry.OS, osName) {
-			d.Excluded = append(d.Excluded, excluded("entry", entry.Target, entry.OS, osName))
-			continue
-		}
-		selected := manifest.EntrySource(entry, tags)
-		item := Entry{Source: selected, Target: entry.Target, TargetRoot: entry.TargetRoot, Strategy: entry.Strategy, Ownership: entry.Ownership, Tags: clone(entry.Tags), OS: declaredOS(entry.OS), Dependencies: []Dependency{}}
+	for _, origin := range surface.DependencyOrigins {
+		d.Dependencies = append(d.Dependencies, dependency(origin.Dependency, catalogOrigin(origin.Origin)))
+	}
+	for _, selected := range surface.Entries {
+		entry := selected.Entry
+		item := Entry{Source: selected.Source, Target: entry.Target, TargetRoot: entry.TargetRoot, Strategy: entry.Strategy, Ownership: entry.Ownership, Tags: clone(entry.Tags), OS: declaredOS(entry.OS), Dependencies: []Dependency{}}
 		for _, dep := range entry.Dependencies {
-			x := dependency(dep, Origin{Type: "entry", Name: entry.Target, Tags: clone(entry.Tags)})
-			item.Dependencies = append(item.Dependencies, x)
-			d.Dependencies = append(d.Dependencies, x)
+			item.Dependencies = append(item.Dependencies, dependency(dep, Origin{Type: "entry", Name: entry.Target, Tags: clone(entry.Tags)}))
 		}
 		d.Entries = append(d.Entries, item)
 	}
-	for _, p := range m.Provisioners {
-		if !manifest.SharesTag(p.Tags, tags) {
-			continue
-		}
-		if !matches(p.OS, osName) {
-			d.Excluded = append(d.Excluded, excluded("provisioner", p.Tool, p.OS, osName))
-			continue
-		}
-		d.Provisioners = append(d.Provisioners, provisioner(p))
-		for _, dep := range p.Dependencies {
-			d.Dependencies = append(d.Dependencies, dependency(dep, Origin{Type: "provisioner", Name: p.Tool, Tags: clone(p.Tags)}))
-		}
+	for _, override := range surface.SourceOverrides {
+		entry := override.Entry
+		d.SourceOverrides = append(d.SourceOverrides, SourceOverride{Tag: override.Tag, Source: override.Source, Entry: entry.Source, Target: entry.Target, OS: declaredOS(entry.OS), Applicable: true})
 	}
+	d.SourceOverrides = append(d.SourceOverrides, inactiveSourceOverrides(m, tags, osName)...)
+	for _, p := range surface.Provisioners {
+		d.Provisioners = append(d.Provisioners, provisioner(p))
+	}
+	d.Excluded = excludedSurfaces(m, tags, osName)
 	sort.Slice(d.SourceOverrides, func(i, j int) bool {
 		if d.SourceOverrides[i].Tag == d.SourceOverrides[j].Tag {
 			return d.SourceOverrides[i].Target < d.SourceOverrides[j].Target
@@ -338,6 +313,74 @@ func buildDetail(m manifest.Manifest, name, description, status, kind, replacedB
 		return d.Excluded[i].Type < d.Excluded[j].Type
 	})
 	return d
+}
+
+func catalogOrigin(origin selectedsurface.Origin) Origin {
+	return Origin{Type: origin.Type, Name: origin.Name, Tags: clone(origin.Tags)}
+}
+
+func selectedSurface(m manifest.Manifest, tags []string, osName string) selectedsurface.Surface {
+	if osName == "all" {
+		return selectedsurface.EvaluateAll(m, tags)
+	}
+	return selectedsurface.Evaluate(m, tags, osName)
+}
+
+// inactiveSourceOverrides preserves the catalog explanation for selected tags
+// whose override is excluded by OS. Applicable overrides always come from the
+// selected surface above.
+func inactiveSourceOverrides(m manifest.Manifest, tags []string, osName string) []SourceOverride {
+	result := []SourceOverride{}
+	for _, entry := range m.Entries {
+		if matches(entry.OS, osName) {
+			continue
+		}
+		for tag, source := range entry.SourceOverrides {
+			if contains(tags, tag) {
+				result = append(result, SourceOverride{Tag: tag, Source: source, Entry: entry.Source, Target: entry.Target, OS: declaredOS(entry.OS), Applicable: false})
+			}
+		}
+	}
+	return result
+}
+
+// excludedSurfaces reports raw declarations that share the requested tags but
+// are not applicable to the requested operating system. They are deliberately
+// outside selectedsurface because that package exposes applicable declarations.
+func excludedSurfaces(m manifest.Manifest, tags []string, osName string) []ExcludedSurface {
+	result := []ExcludedSurface{}
+	for _, set := range m.Dependencies {
+		if !manifest.SharesTag(set.Tags, tags) {
+			continue
+		}
+		if !matches(set.OS, osName) {
+			result = append(result, excluded("dependency_set", strings.Join(set.Tags, ","), set.OS, osName))
+		}
+	}
+	for _, entry := range m.Entries {
+		for tag := range entry.SourceOverrides {
+			if contains(tags, tag) {
+				if !matches(entry.OS, osName) {
+					result = append(result, excluded("source_override", entry.Target+" ("+tag+")", entry.OS, osName))
+				}
+			}
+		}
+		if !manifest.SharesTag(entry.Tags, tags) {
+			continue
+		}
+		if !matches(entry.OS, osName) {
+			result = append(result, excluded("entry", entry.Target, entry.OS, osName))
+		}
+	}
+	for _, p := range m.Provisioners {
+		if !manifest.SharesTag(p.Tags, tags) {
+			continue
+		}
+		if !matches(p.OS, osName) {
+			result = append(result, excluded("provisioner", p.Tool, p.OS, osName))
+		}
+	}
+	return result
 }
 
 func comparisonSurface(detail *Detail) ComparisonSurface {

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -62,6 +62,64 @@ func TestTagDetailIsPortableSafeAndDescribesExclusions(t *testing.T) {
 	}
 }
 
+func TestDetailUsesSelectedSurfaceForResolvedEntriesAndActiveOverrides(t *testing.T) {
+	m := manifest.Manifest{
+		Profiles: map[string]manifest.Profile{
+			"theme": {Tags: []string{"core", "theme"}},
+		},
+		Dependencies: []manifest.DependencySet{{
+			Tags:         []string{"core"},
+			Dependencies: []manifest.Dependency{{Name: "set-tool"}},
+		}},
+		Entries: []manifest.Entry{
+			{Source: "base", Target: "selected", Strategy: "copy", Tags: []string{"core"}, SourceOverrides: map[string]string{"theme": "selected-theme"}, Dependencies: []manifest.Dependency{{Name: "entry-tool"}}},
+			{Source: "other", Target: "unselected", Strategy: "copy", Tags: []string{"other"}, SourceOverrides: map[string]string{"theme": "unselected-theme"}},
+		},
+		Provisioners: []manifest.Provisioner{{
+			Tool:         "theme-tool",
+			Tags:         []string{"theme"},
+			Dependencies: []manifest.Dependency{{Name: "provisioner-tool"}},
+		}},
+	}
+
+	got, err := Profile(m, "theme", Options{OS: "linux"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	detail := got.Profile
+	if detail == nil {
+		t.Fatal("Profile detail = nil")
+	}
+	if len(detail.Entries) != 1 || detail.Entries[0].Source != "selected-theme" {
+		t.Fatalf("Entries = %#v", detail.Entries)
+	}
+	if got := detail.Dependencies; !reflect.DeepEqual(dependencyNames(got), []string{"set-tool", "entry-tool", "provisioner-tool"}) {
+		t.Fatalf("Dependency origins = %#v", got)
+	}
+	if got := detail.SourceOverrides; !reflect.DeepEqual(overrideSources(got), []string{"selected-theme", "unselected-theme"}) || !allApplicable(got) {
+		t.Fatalf("active SourceOverrides = %#v", got)
+	}
+}
+
+func TestAllOSDetailCombinesSelectedSurfacesInManifestOrder(t *testing.T) {
+	m := manifest.Manifest{
+		Profiles: map[string]manifest.Profile{"core": {Tags: []string{"core"}}},
+		Entries: []manifest.Entry{
+			{Source: "linux", Target: "linux", Strategy: "copy", Tags: []string{"core"}, OS: []string{"linux"}},
+			{Source: "portable", Target: "portable", Strategy: "copy", Tags: []string{"core"}},
+			{Source: "darwin", Target: "darwin", Strategy: "copy", Tags: []string{"core"}, OS: []string{"darwin"}},
+		},
+	}
+
+	got, err := Profile(m, "core", Options{OS: "all"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if targets := entryTargets(got.Profile.Entries); !reflect.DeepEqual(targets, []string{"linux", "portable", "darwin"}) {
+		t.Fatalf("Entries = %#v", targets)
+	}
+}
+
 func TestRegistrylessCatalogDerivesSurfaceTags(t *testing.T) {
 	m := fixtureManifest()
 	m.Tags = nil
@@ -165,4 +223,37 @@ func tagNames(items []TagSummary) []string {
 		result = append(result, item.Name)
 	}
 	return result
+}
+
+func dependencyNames(items []Dependency) []string {
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		result = append(result, item.Name)
+	}
+	return result
+}
+
+func overrideSources(items []SourceOverride) []string {
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		result = append(result, item.Source)
+	}
+	return result
+}
+
+func entryTargets(items []Entry) []string {
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		result = append(result, item.Target)
+	}
+	return result
+}
+
+func allApplicable(items []SourceOverride) bool {
+	for _, item := range items {
+		if !item.Applicable {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/deps/deps.go
+++ b/internal/deps/deps.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/selectedsurface"
 	"github.com/yersonargotev/dots/internal/selection"
 )
 
@@ -242,68 +243,16 @@ func fontProbeLabel(matches []string) string {
 	return strings.Join(matches, ", ")
 }
 
-// selectDependencies gathers the Dependencies declared by tag-scoped Dependency
-// Sets, then every Managed Entry and Provisioner that belongs to the selected
-// Tags and passes the OS filter, deduplicated by name in first-declared order.
-
+// selectDependencies resolves Options before evaluating the selected manifest
+// surface. The surface owns dependency ordering, normalization, deduplication,
+// and required-dependency promotion.
 func selectDependencies(m manifest.Manifest, opts Options) ([]manifest.Dependency, error) {
 	selection, err := resolveOptionsSelection(m, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	var selected []manifest.Dependency
-	seen := make(map[string]bool)
-	addDependencies := func(deps []manifest.Dependency) {
-		for _, dep := range deps {
-			// Normalize the name so padded and unpadded declarations of the same
-			// dependency deduplicate and render consistently with Probe().
-			dep.Name = strings.TrimSpace(dep.Name)
-			if seen[dep.Name] {
-				if dep.IsRequired() {
-					for i := range selected {
-						if selected[i].Name == dep.Name && !selected[i].IsRequired() {
-							selected[i].Requirement = manifest.DependencyRequirementRequired
-							break
-						}
-					}
-				}
-				continue
-			}
-			seen[dep.Name] = true
-			selected = append(selected, dep)
-		}
-	}
-
-	tags := selection.Tags
-	for _, set := range m.Dependencies {
-		if !manifest.SharesTag(set.Tags, tags) {
-			continue
-		}
-		if !manifest.MatchesOS(set.OS, opts.OS) {
-			continue
-		}
-		addDependencies(set.Dependencies)
-	}
-	for _, entry := range m.Entries {
-		if !manifest.SharesTag(entry.Tags, tags) {
-			continue
-		}
-		if !manifest.MatchesOS(entry.OS, opts.OS) {
-			continue
-		}
-		addDependencies(entry.Dependencies)
-	}
-	for _, prov := range m.Provisioners {
-		if !manifest.SharesTag(prov.Tags, tags) {
-			continue
-		}
-		if !manifest.MatchesOS(prov.OS, opts.OS) {
-			continue
-		}
-		addDependencies(prov.Dependencies)
-	}
-	return selected, nil
+	return selectedsurface.Evaluate(m, selection.Tags, opts.OS).Dependencies, nil
 }
 
 func resolveOptionsSelection(m manifest.Manifest, opts Options) (manifest.Selection, error) {

--- a/internal/selectedsurface/selectedsurface.go
+++ b/internal/selectedsurface/selectedsurface.go
@@ -1,0 +1,254 @@
+// Package selectedsurface evaluates the declarative Install Manifest surface
+// selected by effective tags and an operating system. It is deliberately pure:
+// it does not resolve profiles, inspect state, or touch the filesystem.
+package selectedsurface
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/yersonargotev/dots/internal/manifest"
+)
+
+// Surface is the ordered, applicable declaration surface for a selection.
+// Dependencies is the execution-oriented, name-deduplicated view. DependencyOrigins
+// retains every declaration occurrence for callers that need to explain it.
+type Surface struct {
+	Tags              []string
+	DependencySets    []manifest.DependencySet
+	Entries           []SelectedEntry
+	Dependencies      []manifest.Dependency
+	DependencyOrigins []DependencyOrigin
+	Provisioners      []manifest.Provisioner
+	SourceOverrides   []SourceOverride
+}
+
+// SelectedEntry is an applicable Managed Entry with its selected Source of
+// Truth. OverrideTag is empty when the entry's base Source wins.
+type SelectedEntry struct {
+	Entry       manifest.Entry
+	Source      string
+	OverrideTag string
+}
+
+// DependencyOrigin records one dependency declaration and its manifest origin.
+type DependencyOrigin struct {
+	Dependency manifest.Dependency
+	Origin     Origin
+}
+
+// Origin identifies the manifest declaration that contributed a dependency.
+type Origin struct {
+	Type string
+	Name string
+	Tags []string
+}
+
+// SourceOverride is an active, OS-applicable entry source override. It remains
+// present even if the entry's own Tags are not selected.
+type SourceOverride struct {
+	Entry  manifest.Entry
+	Tag    string
+	Source string
+}
+
+// Evaluate returns the pure selected surface. Effective tags are normalized to
+// their first occurrence. All remaining collections retain manifest order.
+func Evaluate(m manifest.Manifest, effectiveTags []string, osName string) Surface {
+	return evaluate(m, effectiveTags, func(itemOS []string) bool {
+		return manifest.MatchesOS(itemOS, osName)
+	})
+}
+
+// EvaluateAll returns the portable selected surface across Darwin and Linux.
+// It evaluates each declaration once, preserving manifest order without
+// introducing an all-platform sentinel into the selected surface.
+func EvaluateAll(m manifest.Manifest, effectiveTags []string) Surface {
+	return evaluate(m, effectiveTags, func(itemOS []string) bool {
+		return manifest.MatchesOS(itemOS, "darwin") || manifest.MatchesOS(itemOS, "linux")
+	})
+}
+
+func evaluate(m manifest.Manifest, effectiveTags []string, matchesOS func([]string) bool) Surface {
+	tags := uniqueTags(effectiveTags)
+	result := Surface{
+		Tags:              tags,
+		DependencySets:    []manifest.DependencySet{},
+		Entries:           []SelectedEntry{},
+		Dependencies:      []manifest.Dependency{},
+		DependencyOrigins: []DependencyOrigin{},
+		Provisioners:      []manifest.Provisioner{},
+		SourceOverrides:   []SourceOverride{},
+	}
+
+	seenSets := make([]manifest.DependencySet, 0)
+	seenEntries := make([]manifest.Entry, 0)
+	seenProvisioners := make([]manifest.Provisioner, 0)
+	seenOverrides := make([]SourceOverride, 0)
+	seenDependencies := map[string]int{}
+
+	addDependencies := func(dependencies []manifest.Dependency, origin Origin) {
+		for _, dependency := range dependencies {
+			dependency.Name = strings.TrimSpace(dependency.Name)
+			result.DependencyOrigins = append(result.DependencyOrigins, DependencyOrigin{
+				Dependency: cloneDependency(dependency),
+				Origin:     cloneOrigin(origin),
+			})
+			if index, ok := seenDependencies[dependency.Name]; ok {
+				if dependency.IsRequired() && !result.Dependencies[index].IsRequired() {
+					result.Dependencies[index].Requirement = manifest.DependencyRequirementRequired
+				}
+				continue
+			}
+			seenDependencies[dependency.Name] = len(result.Dependencies)
+			result.Dependencies = append(result.Dependencies, cloneDependency(dependency))
+		}
+	}
+
+	for _, set := range m.Dependencies {
+		if !manifest.SharesTag(set.Tags, tags) || !matchesOS(set.OS) || containsExact(seenSets, set) {
+			continue
+		}
+		seenSets = append(seenSets, set)
+		selected := cloneDependencySet(set)
+		result.DependencySets = append(result.DependencySets, selected)
+		addDependencies(set.Dependencies, Origin{Type: "dependency_set", Tags: cloneStrings(set.Tags)})
+	}
+
+	for _, entry := range m.Entries {
+		if matchesOS(entry.OS) {
+			for _, tag := range tags {
+				source, ok := entry.SourceOverrides[tag]
+				if !ok {
+					continue
+				}
+				override := SourceOverride{Entry: cloneEntry(entry), Tag: tag, Source: source}
+				if !containsExact(seenOverrides, override) {
+					seenOverrides = append(seenOverrides, override)
+					result.SourceOverrides = append(result.SourceOverrides, override)
+				}
+			}
+		}
+		if !manifest.SharesTag(entry.Tags, tags) || !matchesOS(entry.OS) || containsExact(seenEntries, entry) {
+			continue
+		}
+		seenEntries = append(seenEntries, entry)
+		source, overrideTag := entrySource(entry, tags)
+		result.Entries = append(result.Entries, SelectedEntry{Entry: cloneEntry(entry), Source: source, OverrideTag: overrideTag})
+		addDependencies(entry.Dependencies, Origin{Type: "entry", Name: entry.Target, Tags: cloneStrings(entry.Tags)})
+	}
+
+	for _, provisioner := range m.Provisioners {
+		if !manifest.SharesTag(provisioner.Tags, tags) || !matchesOS(provisioner.OS) || containsExact(seenProvisioners, provisioner) {
+			continue
+		}
+		seenProvisioners = append(seenProvisioners, provisioner)
+		result.Provisioners = append(result.Provisioners, cloneProvisioner(provisioner))
+		addDependencies(provisioner.Dependencies, Origin{Type: "provisioner", Name: provisioner.Tool, Tags: cloneStrings(provisioner.Tags)})
+	}
+
+	return result
+}
+
+func entrySource(entry manifest.Entry, tags []string) (string, string) {
+	for index := len(tags) - 1; index >= 0; index-- {
+		if source, ok := entry.SourceOverrides[tags[index]]; ok {
+			return source, tags[index]
+		}
+	}
+	return entry.Source, ""
+}
+
+func uniqueTags(tags []string) []string {
+	result := make([]string, 0, len(tags))
+	seen := make(map[string]bool, len(tags))
+	for _, tag := range tags {
+		if seen[tag] {
+			continue
+		}
+		seen[tag] = true
+		result = append(result, tag)
+	}
+	return result
+}
+
+func containsExact[T any](values []T, candidate T) bool {
+	for _, value := range values {
+		if reflect.DeepEqual(value, candidate) {
+			return true
+		}
+	}
+	return false
+}
+
+func cloneStrings(values []string) []string { return append([]string(nil), values...) }
+
+func cloneDependency(dependency manifest.Dependency) manifest.Dependency {
+	dependency.FontFallbackMatches = cloneStrings(dependency.FontFallbackMatches)
+	dependency.Commands = cloneStrings(dependency.Commands)
+	if dependency.UserLocal != nil {
+		userLocal := *dependency.UserLocal
+		if userLocal.Checksums != nil {
+			userLocal.Checksums = make(map[string]string, len(userLocal.Checksums))
+			for key, value := range dependency.UserLocal.Checksums {
+				userLocal.Checksums[key] = value
+			}
+		}
+		dependency.UserLocal = &userLocal
+	}
+	if dependency.RollingUserLocal != nil {
+		rollingUserLocal := *dependency.RollingUserLocal
+		dependency.RollingUserLocal = &rollingUserLocal
+	}
+	return dependency
+}
+
+func cloneDependencySet(set manifest.DependencySet) manifest.DependencySet {
+	set.Tags = cloneStrings(set.Tags)
+	set.OS = cloneStrings(set.OS)
+	set.Dependencies = cloneDependencies(set.Dependencies)
+	return set
+}
+
+func cloneEntry(entry manifest.Entry) manifest.Entry {
+	entry.Tags = cloneStrings(entry.Tags)
+	entry.OS = cloneStrings(entry.OS)
+	entry.Dependencies = cloneDependencies(entry.Dependencies)
+	if entry.SourceOverrides != nil {
+		entry.SourceOverrides = make(map[string]string, len(entry.SourceOverrides))
+		for tag, source := range entry.SourceOverrides {
+			entry.SourceOverrides[tag] = source
+		}
+	}
+	return entry
+}
+
+func cloneProvisioner(provisioner manifest.Provisioner) manifest.Provisioner {
+	provisioner.Tags = cloneStrings(provisioner.Tags)
+	provisioner.OS = cloneStrings(provisioner.OS)
+	provisioner.Dependencies = cloneDependencies(provisioner.Dependencies)
+	provisioner.Spec.Agents = cloneStrings(provisioner.Spec.Agents)
+	provisioner.Spec.Skills = cloneStrings(provisioner.Spec.Skills)
+	provisioner.Spec.Command = cloneStrings(provisioner.Spec.Command)
+	if provisioner.Spec.Env != nil {
+		environment := provisioner.Spec.Env
+		provisioner.Spec.Env = make(map[string]string, len(environment))
+		for key, value := range environment {
+			provisioner.Spec.Env[key] = value
+		}
+	}
+	return provisioner
+}
+
+func cloneDependencies(dependencies []manifest.Dependency) []manifest.Dependency {
+	result := make([]manifest.Dependency, len(dependencies))
+	for index, dependency := range dependencies {
+		result[index] = cloneDependency(dependency)
+	}
+	return result
+}
+
+func cloneOrigin(origin Origin) Origin {
+	origin.Tags = cloneStrings(origin.Tags)
+	return origin
+}

--- a/internal/selectedsurface/selectedsurface_test.go
+++ b/internal/selectedsurface/selectedsurface_test.go
@@ -1,0 +1,151 @@
+package selectedsurface_test
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/selectedsurface"
+)
+
+func TestEvaluateFiltersByTagAndOSInManifestOrder(t *testing.T) {
+	m := manifest.Manifest{
+		Dependencies: []manifest.DependencySet{
+			{Tags: []string{"linux"}, OS: []string{"linux"}, Dependencies: []manifest.Dependency{{Name: "linux-set"}}},
+			{Tags: []string{"core"}, Dependencies: []manifest.Dependency{{Name: "core-set"}}},
+			{Tags: []string{"core"}, OS: []string{"darwin"}, Dependencies: []manifest.Dependency{{Name: "darwin-set"}}},
+		},
+		Entries: []manifest.Entry{
+			{Source: "skip", Target: "skip", Strategy: "copy", Tags: []string{"other"}},
+			{Source: "core", Target: "core", Strategy: "copy", Tags: []string{"core"}},
+			{Source: "linux", Target: "linux", Strategy: "copy", Tags: []string{"linux"}, OS: []string{"linux"}},
+		},
+		Provisioners: []manifest.Provisioner{
+			{Tool: "core-tool", Tags: []string{"core"}},
+			{Tool: "darwin-tool", Tags: []string{"core"}, OS: []string{"darwin"}},
+		},
+	}
+
+	got := selectedsurface.Evaluate(m, []string{"core", "linux", "core"}, "linux")
+	if want := []string{"core", "linux"}; !reflect.DeepEqual(got.Tags, want) {
+		t.Fatalf("Tags = %#v, want %#v", got.Tags, want)
+	}
+	if got.DependencySets[0].Dependencies[0].Name != "linux-set" || got.DependencySets[1].Dependencies[0].Name != "core-set" {
+		t.Fatalf("DependencySets order = %#v", got.DependencySets)
+	}
+	if got.Entries[0].Entry.Target != "core" || got.Entries[1].Entry.Target != "linux" {
+		t.Fatalf("Entries order = %#v", got.Entries)
+	}
+	if len(got.Provisioners) != 1 || got.Provisioners[0].Tool != "core-tool" {
+		t.Fatalf("Provisioners = %#v", got.Provisioners)
+	}
+}
+
+func TestEvaluateDeduplicatesOnlyExactSelectedDeclarations(t *testing.T) {
+	set := manifest.DependencySet{Tags: []string{"core"}, Dependencies: []manifest.Dependency{{Name: "set"}}}
+	entry := manifest.Entry{Source: "a", Target: "shared", Strategy: "copy", Tags: []string{"core"}}
+	provisioner := manifest.Provisioner{Tool: "tool", Tags: []string{"core"}}
+	m := manifest.Manifest{
+		Dependencies: []manifest.DependencySet{set, set, {Tags: []string{"core"}, Dependencies: []manifest.Dependency{{Name: "different"}}}},
+		Entries:      []manifest.Entry{entry, entry, {Source: "b", Target: "shared", Strategy: "copy", Tags: []string{"core"}}},
+		Provisioners: []manifest.Provisioner{provisioner, provisioner, {Tool: "tool", Tags: []string{"core"}, Spec: manifest.ProvisionerSpec{Scope: "user"}}},
+	}
+	got := selectedsurface.Evaluate(m, []string{"core"}, "linux")
+	if len(got.DependencySets) != 2 || len(got.Entries) != 2 || len(got.Provisioners) != 2 {
+		t.Fatalf("deduplicated surface = %#v", got)
+	}
+}
+
+func TestEvaluateDependenciesPreservesOccurrencesAndPromotesRequired(t *testing.T) {
+	m := manifest.Manifest{
+		Dependencies: []manifest.DependencySet{{Tags: []string{"core"}, Dependencies: []manifest.Dependency{{Name: " tool ", Requirement: "optional"}, {Name: "set-only"}}}},
+		Entries:      []manifest.Entry{{Source: "entry", Target: "target", Strategy: "copy", Tags: []string{"core"}, Dependencies: []manifest.Dependency{{Name: "tool", Requirement: "required"}, {Name: "entry-only"}}}},
+		Provisioners: []manifest.Provisioner{{Tool: "prov", Tags: []string{"core"}, Dependencies: []manifest.Dependency{{Name: "tool"}, {Name: "prov-only"}}}},
+	}
+	got := selectedsurface.Evaluate(m, []string{"core"}, "linux")
+	if want := []string{"tool", "set-only", "entry-only", "prov-only"}; dependencyNames(got.Dependencies) == nil || !reflect.DeepEqual(dependencyNames(got.Dependencies), want) {
+		t.Fatalf("Dependencies = %#v, want %#v", got.Dependencies, want)
+	}
+	if !got.Dependencies[0].IsRequired() {
+		t.Fatalf("first dependency = %#v, want required after promotion", got.Dependencies[0])
+	}
+	if want := []string{"dependency_set", "dependency_set", "entry", "entry", "provisioner", "provisioner"}; !reflect.DeepEqual(originTypes(got.DependencyOrigins), want) {
+		t.Fatalf("DependencyOrigins = %#v", got.DependencyOrigins)
+	}
+	if got.DependencyOrigins[0].Dependency.Name != "tool" || got.DependencyOrigins[2].Origin.Name != "target" || got.DependencyOrigins[4].Origin.Name != "prov" {
+		t.Fatalf("DependencyOrigins do not retain declaration and origin: %#v", got.DependencyOrigins)
+	}
+}
+
+func TestEvaluateResolvesLastTagOverrideAndKeepsActiveOverrides(t *testing.T) {
+	selected := manifest.Entry{Source: "base", Target: "selected", Strategy: "copy", Tags: []string{"core"}, SourceOverrides: map[string]string{"theme": "theme-source", "work": "work-source"}}
+	unselected := manifest.Entry{Source: "other", Target: "unselected", Strategy: "copy", Tags: []string{"other"}, SourceOverrides: map[string]string{"theme": "other-theme"}}
+	m := manifest.Manifest{Entries: []manifest.Entry{selected, unselected, {Source: "darwin", Target: "darwin", Strategy: "copy", Tags: []string{"core"}, OS: []string{"darwin"}, SourceOverrides: map[string]string{"theme": "skip"}}}}
+	got := selectedsurface.Evaluate(m, []string{"core", "theme", "work"}, "linux")
+	if len(got.Entries) != 1 || got.Entries[0].Source != "work-source" || got.Entries[0].OverrideTag != "work" {
+		t.Fatalf("Entries = %#v", got.Entries)
+	}
+	if want := []string{"theme-source", "work-source", "other-theme"}; !reflect.DeepEqual(overrideSources(got.SourceOverrides), want) {
+		t.Fatalf("SourceOverrides = %#v, want %#v", got.SourceOverrides, want)
+	}
+}
+
+func TestEvaluateSameTagsHaveNoProvenanceInputOrOutput(t *testing.T) {
+	m := manifest.Manifest{Entries: []manifest.Entry{{Source: "base", Target: "target", Strategy: "copy", Tags: []string{"core"}}}}
+	first := selectedsurface.Evaluate(m, []string{"core"}, "linux")
+	second := selectedsurface.Evaluate(m, []string{"core"}, "linux")
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("same effective tags must have the same pure surface: %#v != %#v", first, second)
+	}
+}
+
+func TestRepositoryProfilesMatchEquivalentExplicitTagsAcrossSupportedOS(t *testing.T) {
+	m, err := manifest.LoadFile(filepath.Join("..", "..", "dots.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, profile := range m.Profiles {
+		profileSelection, err := manifest.ResolveReadOnlySelection(*m, []string{name}, nil)
+		if err != nil {
+			t.Fatalf("resolve Profile %q: %v", name, err)
+		}
+		tagSelection, err := manifest.ResolveReadOnlySelection(*m, nil, profile.Tags)
+		if err != nil {
+			t.Fatalf("resolve explicit Tags for %q: %v", name, err)
+		}
+		for _, osName := range []string{"darwin", "linux"} {
+			t.Run(name+"/"+osName, func(t *testing.T) {
+				fromProfile := selectedsurface.Evaluate(*m, profileSelection.Tags, osName)
+				fromTags := selectedsurface.Evaluate(*m, tagSelection.Tags, osName)
+				if !reflect.DeepEqual(fromProfile, fromTags) {
+					t.Fatalf("Profile and explicit Tag surfaces differ\nProfile: %#v\nTags: %#v", fromProfile, fromTags)
+				}
+			})
+		}
+	}
+}
+
+func dependencyNames(dependencies []manifest.Dependency) []string {
+	names := make([]string, len(dependencies))
+	for i, dependency := range dependencies {
+		names[i] = dependency.Name
+	}
+	return names
+}
+
+func originTypes(origins []selectedsurface.DependencyOrigin) []string {
+	types := make([]string, len(origins))
+	for i, origin := range origins {
+		types[i] = origin.Origin.Type
+	}
+	return types
+}
+
+func overrideSources(overrides []selectedsurface.SourceOverride) []string {
+	sources := make([]string, len(overrides))
+	for i, override := range overrides {
+		sources[i] = override.Source
+	}
+	return sources
+}

--- a/internal/selection/selection.go
+++ b/internal/selection/selection.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/selectedsurface"
 	"github.com/yersonargotev/dots/internal/state"
 	"github.com/yersonargotev/dots/internal/tagpolicy"
 )
@@ -341,6 +342,7 @@ func staleExtraTags(m manifest.Manifest, extraTags []string) []string {
 }
 
 func selectedSurface(m manifest.Manifest, selected manifest.Selection, osName string) Changes {
+	surface := selectedsurface.Evaluate(m, selected.Tags, osName)
 	result := Changes{
 		Profiles:       make([]string, 0),
 		ExtraTags:      make([]string, 0),
@@ -360,30 +362,23 @@ func selectedSurface(m manifest.Manifest, selected manifest.Selection, osName st
 			}
 		}
 	}
+	// Profile dependencies existed only in previous manifest revisions. They
+	// are not part of selectedsurface's current declarative surface, but must
+	// remain visible to evolution while historical manifests are compared.
 	for _, profileName := range selected.Profiles {
 		addDependencies(m.LegacyProfileDependencies(profileName))
 	}
-	for _, set := range m.Dependencies {
-		if manifest.SharesTag(set.Tags, selected.Tags) && manifest.MatchesOS(set.OS, osName) {
-			addDependencies(set.Dependencies)
+	addDependencies(surface.Dependencies)
+	for _, entry := range surface.Entries {
+		if !seenEntries[entry.Entry.Target] {
+			seenEntries[entry.Entry.Target] = true
+			result.ManagedEntries = append(result.ManagedEntries, entry.Entry.Target)
 		}
 	}
-	for _, entry := range m.Entries {
-		if manifest.SharesTag(entry.Tags, selected.Tags) && manifest.MatchesOS(entry.OS, osName) {
-			if !seenEntries[entry.Target] {
-				seenEntries[entry.Target] = true
-				result.ManagedEntries = append(result.ManagedEntries, entry.Target)
-			}
-			addDependencies(entry.Dependencies)
-		}
-	}
-	for _, provisioner := range m.Provisioners {
-		if manifest.SharesTag(provisioner.Tags, selected.Tags) && manifest.MatchesOS(provisioner.OS, osName) {
-			if !seenProvisioners[provisioner.Tool] {
-				seenProvisioners[provisioner.Tool] = true
-				result.Provisioners = append(result.Provisioners, provisioner.Tool)
-			}
-			addDependencies(provisioner.Dependencies)
+	for _, provisioner := range surface.Provisioners {
+		if !seenProvisioners[provisioner.Tool] {
+			seenProvisioners[provisioner.Tool] = true
+			result.Provisioners = append(result.Provisioners, provisioner.Tool)
 		}
 	}
 	return result


### PR DESCRIPTION
Closes #429

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [x] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Introduces one pure `internal/selectedsurface` module for deterministic Tag/OS selection.
- Migrates selection evolution, Dependency Plan, and Install Catalog to the shared selected declarations.
- Preserves catalog envelopes, historical Profile Dependency comparison, and Profile/Tag parity.

## Changes

| File | Change |
|------|--------|
| `internal/selectedsurface/*` | Adds the pure Selected Surface interface and direct behavioral coverage. |
| `internal/selection/selection.go` | Projects evolution changes from Selected Surface while retaining legacy history outside it. |
| `internal/deps/deps.go` | Uses Selected Surface for Dependency selection and de-duplication. |
| `internal/catalog/*` | Projects portable catalog detail and origin data from Selected Surface. |
| `CONTEXT.md` | Defines Selected Surface in the domain glossary. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go build ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] `go generate ./internal/catalog` and catalog doc-sync test
- [x] Sandboxed real-binary catalog and Dependency Plan verification; no mutating install was applicable.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] CLI validation that targeted home/config paths used `/tmp/dots-issue-429-manual.BGFjWc/home` and an explicit source root.

## Contributor Checklist

- [x] Linked one issue with an admitted Delivery Contract using `Closes #429`.
- [x] Added exactly one `type:*` label.
- [x] Delivery Evidence records the Contract Source snapshot, Acceptance coverage, and Independent review.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated the glossary required by the Delivery Contract.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

### Contract Source snapshot

Kind: composed delivery ticket #429 with native parent specification #427.

| Source | Node ID | URL | `updatedAt` | SHA-256 of exact raw UTF-8 body |
|---|---|---|---|---|
| Ticket #429 | `I_kwDOSzLlmM8AAAABMEOtqA` | https://github.com/yersonargotev/dots/issues/429 | `2026-08-09T21:01:30Z` | `2c873d56525d6c02d0cfade6c5d58ed40799ed8c7052071b515e621d8196562c` |
| Parent #427 | `I_kwDOSzLlmM8AAAABMEODWA` | https://github.com/yersonargotev/dots/issues/427 | `2026-08-09T20:58:54Z` | `294db5b0d8a1d718b2b5ae57f3a09dbe61720b13db334c248eac4eea7ade823c` |

Snapshotted labels for #429: category `enhancement`; readiness `ready-for-agent`; no other triage-state label.

Native relationships at admission/revalidation:

- Parent: #427 (`I_kwDOSzLlmM8AAAABMEODWA`), OPEN, updated `2026-08-09T20:58:54Z`.
- Sub-issues of #429: none.
- Blocked by: #428 (`I_kwDOSzLlmM8AAAABMEOsJg`), CLOSED, updated `2026-08-09T21:33:49Z`.
- Blocking: #430 (`I_kwDOSzLlmM8AAAABMEOvpQ`), OPEN, updated `2026-08-09T21:01:38Z`; #431 (`I_kwDOSzLlmM8AAAABMEOvrA`), OPEN, updated `2026-08-09T21:01:38Z`.
- Parent #427 native sub-issues: #428 CLOSED (`I_kwDOSzLlmM8AAAABMEOsJg`, `2026-08-09T21:33:49Z`); #429 OPEN (`I_kwDOSzLlmM8AAAABMEOtqA`, `2026-08-09T21:01:30Z`); #430 OPEN (`I_kwDOSzLlmM8AAAABMEOvpQ`, `2026-08-09T21:01:38Z`); #431 OPEN (`I_kwDOSzLlmM8AAAABMEOvrA`, `2026-08-09T21:01:38Z`); #432 OPEN (`I_kwDOSzLlmM8AAAABMEOw_w`, `2026-08-09T21:01:43Z`); #433 OPEN (`I_kwDOSzLlmM8AAAABMEOyZg`, `2026-08-09T21:01:49Z`).

#### Exact ticket #429 body

~~~~markdown
### Pre-flight checks

- [x] I searched existing issues and this is not a duplicate.
- [x] The scope is small enough for one reviewable work unit.

### Desired outcome

Dots has one deep, pure module that evaluates the Selected Surface for effective Tags and an operating system, and the first high-leverage callers use it without changing user-visible behavior.

### Current-state gap

Selection evolution, dependency planning, and catalog reporting independently traverse manifest declarations and repeat Tag, operating-system, ordering, and de-duplication rules. The repeated implementation makes it possible for equivalent callers to disagree even after Profiles become pure.

### What to build

Introduce the in-process Selected Surface module and migrate selection evolution, Dependencies, and Install Catalog to consume it. The module receives concrete declarative values and returns deterministic selected declarations; it performs no filesystem, state, Cobra, YAML, or presentation work. Leave temporary legacy selection paths available only for callers assigned to later migration tickets.

### Key interfaces

- Selected Surface evaluation — effective Tags plus operating system produce deterministic Managed Entries, resolved source overrides, Dependencies, and Provisioners.
- Selection evolution — compares surfaces produced by the shared module.
- Dependency Plan and Install Catalog — project their reports from the shared selected declarations.

### Acceptance criteria

- [ ] Selected Surface has one cohesive in-process interface using concrete values rather than speculative adapter interfaces.
- [ ] Its result includes ordered and de-duplicated Managed Entries, resolved source overrides, Dependencies, and Provisioners applicable to Tags and operating system.
- [ ] It excludes filesystem state, Drift, Conflicts, Install Plan actions, and historical migrations.
- [ ] Selection provenance does not affect the returned surface.
- [ ] Selection evolution, Dependency Plan, and Install Catalog consume the new module.
- [ ] Existing machine-readable envelopes and human behavior remain compatible.
- [ ] Tests cover Tag and operating-system matching, ordering, de-duplication, dependency origin, and source overrides through the module interface.
- [ ] Profile-versus-explicit-Tag parity remains green for Darwin and Linux.
- [ ] Remaining legacy callers stay green and are explicitly left for the blocked migration tickets.
- [ ] The glossary defines Selected Surface consistently with the parent specification.

### Non-goals

- Migrating Install Plan, Provisioners, status, doctor, or installed reporting in this slice.
- Deleting all previous selection helpers before their callers migrate.
- Changing Installed Selection or historical migration semantics.
- Creating a generic ports, interfaces, types, or utility package.

### Validation notes

- Run focused module, selection, dependency, and catalog tests followed by the full CI-equivalent suite.
- Verify generated catalog documentation remains current.
- Prefer machine-readable command output as the highest observable test seam.

~~~~

#### Exact parent #427 body

~~~~markdown
### Pre-flight checks

- [x] I searched existing issues and this is not a duplicate.
- [x] The scope clearly identifies independently reviewable slices.

### Desired outcome

Profiles are removable, composable names for ordered Tag selections rather than a second owner of installation behavior. For the same effective Tags and operating system, dots produces one deterministic Selected Surface regardless of whether the operator selected those Tags through a Profile or explicit `--tag` flags. Historical migrations remain evidence-gated and separate from current Tag selection.

### Current-state gap

Profiles currently may own Dependencies directly in addition to selecting Tags. This makes equivalent selections diverge: the `desktop` Profile selects the Desktop Nerd Font while explicit `--tag desktop` does not, and the composite `workstation` Profile duplicates that Dependency to reproduce the desktop surface. Selection by Tags and operating system is also recalculated across several modules, while the `agents` Tag still activates a hidden Gentle AI cleanup action rather than selecting only declarative surface. These seams make adding or removing Profiles more transversal than the domain model promises.

## Problem Statement

As an operator maintaining several workstation roles, I cannot treat Profiles as lightweight, removable compositions of Tags because Profiles can carry installation behavior that their Tags do not. Equivalent intent can therefore produce different Dependencies, composite Profiles must duplicate declarations, and retiring a capability can require unrelated callers to understand hidden Tag behavior.

## Solution

Make Profile a pure named union of Tags. Define Selected Surface as the deterministic Managed Entries, resolved source overrides, Dependencies, and Provisioners applicable to effective Tags and the operating system. Move capability-wide Dependencies into Tag-scoped Dependency Sets, deepen Selected Surface evaluation behind one cohesive module, and migrate historical cleanup authority from current Tags to proven Installation Metadata. Preserve the existing explicit Installed Selection and reduction-safety contracts.

## User Stories

1. As a dots operator, I want a Profile to mean only a named set of Tags, so that I can understand it without inspecting hidden Dependencies.
2. As a dots operator, I want `--profile desktop` and `--tag desktop` to select the same surface, so that equivalent intent behaves consistently.
3. As a dots operator, I want composite Profiles to reuse Tag-owned capabilities, so that they do not duplicate dependency declarations.
4. As a dots operator, I want to add a new Profile by listing existing Tags, so that adding a workstation role does not require changes across the installer.
5. As a dots operator, I want to remove a Profile without removing its Tags, so that other Profiles and explicit Tag selections continue working.
6. As a dots operator, I want a removed recorded Profile to block before mutation, so that dots never guesses replacement intent.
7. As a dots operator, I want Profile retirement not to uninstall historical artifacts automatically, so that dots never deletes state without explicit authority.
8. As a dots operator, I want legacy Profiles to remain explicitly queryable while being hidden from normal discovery, so that staged retirement remains understandable.
9. As a user of an alternate Install Manifest, I want a precise validation error for retired Profile Dependencies, so that I know how to migrate them.
10. As a user updating an older Installed Repository, I want dots to read its historical Profile Dependencies for evolution comparison, so that the schema cleanup does not prevent a safe update.
11. As an automation author, I want deterministic Selected Surface ordering, so that machine-readable reports remain stable.
12. As an automation author, I want the existing catalog envelope to remain schema-compatible during this change, so that a removed concept does not cause an unrelated schema break.
13. As a maintainer, I want Dependencies owned by the narrowest declarative surface that requires them, so that ownership remains local.
14. As a maintainer, I want capability-wide Dependencies selected by Tags, so that every route to the same capability has the same prerequisites.
15. As a maintainer, I want one Selected Surface evaluation rule, so that selection changes are fixed and tested in one place.
16. As a maintainer, I want command modules to consume Selected Surface instead of recreating Tag and operating-system filters, so that callers receive leverage from a deeper module.
17. As a maintainer, I want Install Catalog, Dependency Plan, Install Plan, status, doctor, and installed reporting to agree on selection, so that diagnostics do not contradict installation.
18. As a maintainer, I want current Tags to select declarative surface only, so that selecting a capability does not trigger unrelated hidden cleanup.
19. As a maintainer, I want historical cleanup gated by Installation Metadata evidence, so that user-owned files are not changed merely because a current Tag was selected.
20. As a maintainer, I want Gentle AI retirement isolated from Profile schema cleanup, so that each risky change is independently reviewable.
21. As a contributor, I want the domain glossary and ADR for composable Profiles to state the same invariants as the code, so that future changes do not reintroduce Profile-owned behavior.
22. As a release maintainer, I want each delivery slice to remain green and demonstrable, so that the architectural change can ship incrementally.

## Implementation Decisions

- `Profile` is the sole canonical domain term. The duplicate `Install Profile` term is retired.
- A Profile contains descriptive metadata, lifecycle status, and an ordered list of Tags. Profiles do not contain other Profiles and do not own Dependencies, Managed Entries, or Provisioners.
- A Tag is the elemental declarative selection intent. Tags do not directly trigger built-in Go behavior.
- Selected Surface is the ordered, de-duplicated set of Managed Entries, resolved source overrides, Dependencies, and Provisioners selected by effective Tags and the operating system.
- Selected Surface excludes filesystem state, Drift, Conflicts, Install Plan actions, and historical migrations.
- Dependencies belong to the narrowest owning declaration: a Managed Entry, a Provisioner, or a Tag-scoped Dependency Set for capability-wide prerequisites.
- Equivalent effective Tags on the same operating system produce the same Selected Surface regardless of Profile or explicit Tag provenance. Provenance remains reportable but does not change selection.
- The repository manifest moves the Desktop Nerd Font to a `desktop` Dependency Set and Playwright CLI to a `web` Dependency Set. The composite `workstation` Profile no longer duplicates the font.
- Normal manifest loading rejects `profiles[].dependencies` with actionable migration guidance while retaining manifest version 1.
- Historical manifest loading may accept the retired field only to compare pre-refresh selection evolution. It does not make the field valid for a new install.
- A Profile may transition to `legacy` for discovery purposes. Removing it does not redirect intent; a recorded missing Profile blocks before mutation and requires a complete explicit replacement.
- Profile removal does not prune historical inventory or uninstall artifacts.
- The catalog JSON presentation adapter temporarily retains `profile_dependencies` as an empty array until a separately planned envelope-version change. The domain and human presentation no longer expose Profile Dependencies.
- Selected Surface evaluation is deepened as in-process computation. Cobra, YAML, Installation Metadata, filesystem mutation, and text/JSON presentation remain adapters rather than entering the selection interface.
- Interfaces are introduced only at demonstrated I/O substitution seams and live with their consumers. Pure selection accepts and returns concrete values.
- Gentle AI cleanup moves to an evidence-gated historical migration based on sufficiently specific Installation Metadata, preserving marker-based ownership checks and fail-closed behavior.
- The work is delivered in three ordered Delivery Units: pure Profiles, deep Selected Surface evaluation, and evidence-gated historical migrations.
- `CONTEXT.md` and manifest documentation are updated, and ADR-0013 receives an amendment rather than creating a separate architectural decision.

## Testing Decisions

- The primary test seam is existing machine-readable command behavior: manifest validation, Dependency Plan, Install Catalog, and selection-evolution output. Tests assert observable outcomes rather than internal helper calls.
- For Darwin and Linux, every repository Profile is compared with an explicit selection of its resolved Tags; both must expose the same Selected Surface.
- A focused regression proves that `--profile desktop` and `--tag desktop` both include the Desktop Nerd Font.
- A focused regression proves that `--profile web` and `--tag web` both include Playwright CLI.
- A manifest test proves that Profile Dependencies are rejected with migration guidance during normal loading.
- An update test proves that a previous manifest containing Profile Dependencies can still be read for selection-evolution comparison before refresh.
- Catalog tests prove that human output omits Profile Dependencies while schema-version-compatible JSON emits an empty compatibility field.
- Selected Surface tests exercise ordering, de-duplication, Tag/OS matching, source overrides, Profile equivalence, and absence of filesystem I/O through the module interface.
- Existing command tests remain the prior art for command-level JSON envelopes, and existing selection-evolution tests remain the prior art for historical manifest comparison.
- Historical migration tests distinguish positive metadata evidence, irrelevant current Tags, ambiguous or missing evidence, malformed markers, user-owned content, and partial filesystem failure.
- Full validation matches CI: formatting, vet, build, test, manifest validation, catalog generation checks, and sandboxed CLI commands that never target the real home.

### Key interfaces

- Install Manifest Profile declaration — Profile-owned Dependencies are retired; ordered Tags remain.
- Selected Surface evaluation — effective Tags plus operating system determine declarative selected surface independently of provenance.
- `dots deps plan` and Install Catalog machine-readable output — equivalent Profile and Tag selections agree.
- Selection evolution during `dots update` — historical manifests remain comparable without accepting retired schema for current installation.
- Installed Selection change handling — missing or reduced intent still blocks or requires explicit acknowledgement before mutation.
- Historical retirement workflow — Installation Metadata evidence authorizes cleanup; current Tag selection does not.

### Requirements

- The implementation must preserve explicit Profile and Tag intent and ordered Tag union semantics.
- The implementation must preserve the fail-before-mutation behavior for missing recorded Profiles.
- The implementation must not infer, redirect, merge, or silently replace Installed Selection.
- The implementation must keep the Install Manifest declarative and must not introduce dynamic Go plugins.
- The implementation must keep each Delivery Unit independently reviewable and green.
- The implementation must preserve JSON compatibility unless a separately authorized envelope-version change is required.

## Out of Scope

- Dynamic Go plugins or runtime code discovery for Profiles or Tags.
- Nested Profiles or recursive Profile inheritance.
- Automatic replacement of a removed Profile.
- Automatic uninstall or pruning caused by Profile removal.
- Changing the Installed Selection reduction acknowledgement contract.
- Reworking filesystem planning, Conflict resolution, Drift detection, or uninstall semantics.
- Performing all three Delivery Units in one pull request.
- Removing the temporary catalog JSON compatibility field as part of this specification.
- Generalizing every historical migration before the Gentle AI path demonstrates the seam.

### Acceptance criteria

- [ ] Profiles contain no Dependencies and compose only ordered Tags plus descriptive lifecycle metadata.
- [ ] Capability-wide Dependencies are Tag-scoped and composite Profiles contain no duplicated prerequisites.
- [ ] Equivalent Profile and explicit Tag selections produce the same Selected Surface on Darwin and Linux.
- [ ] Normal loading rejects retired Profile Dependencies with actionable guidance; update can still compare a historical manifest that contains them.
- [ ] Selected Surface selection is concentrated behind one cohesive in-process module and consumed consistently by its callers.
- [ ] Current Tags no longer trigger hidden cleanup behavior.
- [ ] Gentle AI cleanup runs only with sufficient historical Installation Metadata evidence and preserves user-owned content.
- [ ] Installed Selection blocking, reduction acknowledgement, and no-pruning behavior remain unchanged.
- [ ] Human and machine-readable contracts remain consistent, including the temporary empty catalog compatibility field.
- [ ] The glossary, manifest documentation, and ADR-0013 describe the final domain model.
- [ ] Each child Delivery Unit has a complete Delivery Contract, native parent relationship, and correct blocking edges.

### Validation notes

- `gofmt -l .`
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- `go generate ./internal/catalog`
- `go run ./cmd/dots manifest validate --file dots.yaml`
- Compare Profile and explicit Tag dependency/catalog output for both supported operating systems where the command permits an OS selector.
- Run any home/state behavior with temporary `--home`, `--source-root`, and `--state-root` paths; never use the real home.

## Further Notes

- This specification deepens ADR-0013 rather than replacing explicit composable Profiles.
- ADR-0014 continues to govern Installed Selection persistence, evolution, replacement, and reduction safety.
- The architecture deliberately applies ports and adapters only at real I/O seams. The pure selection core does not require interface indirection.
- The broad file count in the Codex delegation retirement was mostly required by safe compatibility and migration behavior; this specification targets the avoidable second sources of truth revealed by that change.
~~~~

### Reviewed head

`33fe32673ed93e9f6ee48ac15d69eab7cb96a318` against `origin/main` `740e9dd67c7912a408890d84b8339b6308fb00d9`.

### Acceptance coverage

- Pure concrete interface: `selectedsurface.Evaluate` / `EvaluateAll`; no filesystem, state, Cobra, YAML, presentation, Drift, Conflict, Install Plan action, or migration input.
- Deterministic surface: direct tests cover Tag/OS selection, manifest order, exact declaration de-duplication, Dependency origin and required promotion, source override precedence, multiple same-tool Provisioners, and provenance independence.
- Consumers: selection evolution, Dependency Plan/Check, and Install Catalog project from the module. Historical Profile Dependencies remain an explicit evolution-only compatibility path.
- Compatibility: existing package/CLI/golden tests pass; catalog generation produces no documentation delta.
- Parity: every repository Profile equals its explicit Tags through the module for Darwin and Linux.
- Glossary: `CONTEXT.md` defines Selected Surface consistently with #427.

### Automated validation

All passed for the reviewed head:

- `gofmt -l .` (no output)
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- `go test ./internal/selectedsurface ./internal/selection ./internal/deps ./internal/catalog`
- focused catalog/dependency CLI tests
- `go generate ./internal/catalog`
- catalog documentation sync test
- `go run ./cmd/dots manifest validate --file dots.yaml` → `manifest is valid`

### Manual verification

Built one real binary with `go build -o /tmp/dots-issue-429-manual.BGFjWc/dots ./cmd/dots` and used `/tmp/dots-issue-429-manual.BGFjWc/home` for Dependency inspection.

- Catalog Profile-versus-Tag surface equality: PASS on Darwin (6 entries, 5 dependency-origin rows) and Linux (6 entries, 7 dependency-origin rows).
- `deps plan --profile desktop` versus `--tag desktop`: identical actions/items/tier; both returned semantic exit 2 with one missing action.
- `catalog tag codegraph --os linux --output json`: active source override projection PASS.
- `catalog profile workstation --os all --output json`: portable all-OS projection PASS.

### Independent review

- Standards: PASS, 0 actionable findings, 0 observations.
- Spec: PASS, 0 missing/partial requirements, 0 scope-creep findings, 0 incorrect behaviors. The review's hash observation was resolved: `jq -j` reproduces the exact #429 digest above; `jq -r` adds one CLI newline and produces the alternate digest.
<!-- delivery-issue:evidence:end -->
