### PR TITLE
refactor(diagnostics): consume selected surface

### DIFF
--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/provision"
+	"github.com/yersonargotev/dots/internal/selectedsurface"
 	"github.com/yersonargotev/dots/internal/selection"
 	"github.com/yersonargotev/dots/internal/state"
 	"github.com/yersonargotev/dots/internal/status"
@@ -155,15 +156,12 @@ func ScanSecrets(m manifest.Manifest, opts Options) (SecretReport, error) {
 		}
 		resolved = &selection
 	}
-	tags := resolved.Tags
+	surface := selectedsurface.Evaluate(m, resolved.Tags, opts.OS)
 
 	var report SecretReport
 	seen := map[string]bool{}
-	for _, entry := range m.Entries {
-		if !manifest.SharesTag(entry.Tags, tags) || !manifest.MatchesOS(entry.OS, opts.OS) {
-			continue
-		}
-		source := manifest.EntrySource(entry, tags)
+	for _, selected := range surface.Entries {
+		source := selected.Source
 		if seen[source] {
 			continue
 		}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/yersonargotev/dots/internal/doctor"
@@ -88,6 +89,45 @@ func TestScanSecretsIgnoresPlaceholdersAndUnselectedSources(t *testing.T) {
 	}
 	if len(report.Findings) != 0 {
 		t.Fatalf("Findings = %#v, want placeholders and unselected sources ignored", report.Findings)
+	}
+}
+
+func TestScanSecretsProfileAndEquivalentTagsHaveSameDiagnosticScope(t *testing.T) {
+	sourceRoot := t.TempDir()
+	writeFile(t, sourceRoot, "configs/base", "safe = true\n")
+	writeFile(t, sourceRoot, "configs/theme", "api_key = realthemevalue\n")
+	writeFile(t, sourceRoot, "configs/darwin", "token = darwinsecret\n")
+	writeFile(t, sourceRoot, "configs/other", "password = othersecret\n")
+	m := manifest.Manifest{
+		Profiles: map[string]manifest.Profile{"work": {Tags: []string{"core", "theme"}}},
+		Entries: []manifest.Entry{
+			{Source: "configs/base", SourceOverrides: map[string]string{"theme": "configs/theme"}, Target: "~/.selected", Strategy: "copy", Tags: []string{"core"}, OS: []string{"linux"}},
+			{Source: "configs/darwin", Target: "~/.darwin", Strategy: "copy", Tags: []string{"core"}, OS: []string{"darwin"}},
+			{Source: "configs/other", Target: "~/.other", Strategy: "copy", Tags: []string{"other"}},
+		},
+	}
+	fromProfile, err := manifest.ResolveReadOnlySelection(m, []string{"work"}, nil)
+	if err != nil {
+		t.Fatalf("resolve Profile selection: %v", err)
+	}
+	fromTags, err := manifest.ResolveReadOnlySelection(m, nil, []string{"core", "theme"})
+	if err != nil {
+		t.Fatalf("resolve Tag selection: %v", err)
+	}
+	scan := func(selected manifest.Selection) doctor.SecretReport {
+		report, scanErr := doctor.ScanSecrets(m, doctor.Options{Selection: &selected, OS: "linux", SourceRoot: sourceRoot})
+		if scanErr != nil {
+			t.Fatalf("ScanSecrets() error = %v", scanErr)
+		}
+		return report
+	}
+	profileReport := scan(fromProfile)
+	tagReport := scan(fromTags)
+	if !reflect.DeepEqual(profileReport, tagReport) {
+		t.Fatalf("Secret Scan scope differs\nProfile: %+v\nTags: %+v", profileReport, tagReport)
+	}
+	if len(profileReport.Findings) != 1 || profileReport.Findings[0].Source != "configs/theme" {
+		t.Fatalf("Findings = %+v, want only selected override source", profileReport.Findings)
 	}
 }
 

--- a/internal/installed/installed.go
+++ b/internal/installed/installed.go
@@ -10,6 +10,7 @@ import (
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/provision"
+	"github.com/yersonargotev/dots/internal/selectedsurface"
 	"github.com/yersonargotev/dots/internal/state"
 )
 
@@ -313,6 +314,7 @@ func profileCoverage(m manifest.Manifest, opts Options, representedTags map[stri
 	out := []ProfileCoverage{}
 	for _, name := range profileNames {
 		profile := m.Profiles[name]
+		surface := selectedsurface.Evaluate(m, profile.Tags, opts.OS)
 		coveredTags, missingTags := splitTags(profile.Tags, representedTags)
 		if len(coveredTags) == 0 && !explicitProfiles[name] {
 			continue
@@ -326,8 +328,8 @@ func profileCoverage(m manifest.Manifest, opts Options, representedTags map[stri
 			coverage.Source = "recorded"
 		}
 
-		coverage.TotalEntries, coverage.CoveredEntries = entryCoverageForProfile(m, name, opts, matchedEntryKeys)
-		coverage.TotalProvisioners, coverage.RecordedProvisioners, coverage.ProvisionedProvisioners = provisionerCoverageForProfile(m, name, opts.OS, recordedProvisioners)
+		coverage.TotalEntries, coverage.CoveredEntries = entryCoverageForProfile(surface.Entries, opts, matchedEntryKeys)
+		coverage.TotalProvisioners, coverage.RecordedProvisioners, coverage.ProvisionedProvisioners = provisionerCoverageForProfile(surface.Provisioners, recordedProvisioners)
 		coverage.State = CoverageComplete
 		if len(missingTags) > 0 || coverage.CoveredEntries < coverage.TotalEntries || coverage.RecordedProvisioners < coverage.TotalProvisioners {
 			coverage.State = CoveragePartial
@@ -337,13 +339,10 @@ func profileCoverage(m manifest.Manifest, opts Options, representedTags map[stri
 	return out
 }
 
-func entryCoverageForProfile(m manifest.Manifest, profileName string, opts Options, matchedEntryKeys map[string]bool) (int, int) {
-	profile := m.Profiles[profileName]
+func entryCoverageForProfile(entries []selectedsurface.SelectedEntry, opts Options, matchedEntryKeys map[string]bool) (int, int) {
 	total, covered := 0, 0
-	for _, entry := range m.Entries {
-		if !manifest.SharesTag(entry.Tags, profile.Tags) || !manifest.MatchesOS(entry.OS, opts.OS) {
-			continue
-		}
+	for _, selected := range entries {
+		entry := selected.Entry
 		total++
 		if matchedEntryKeys[entryKey(entry, opts)] {
 			covered++
@@ -352,14 +351,10 @@ func entryCoverageForProfile(m manifest.Manifest, profileName string, opts Optio
 	return total, covered
 }
 
-func provisionerCoverageForProfile(m manifest.Manifest, profileName, osName string, records map[string]state.ProvisionerRecord) (int, int, int) {
-	profile := m.Profiles[profileName]
+func provisionerCoverageForProfile(provisioners []manifest.Provisioner, records map[string]state.ProvisionerRecord) (int, int, int) {
 	total, recorded, provisioned := 0, 0, 0
 	seen := map[string]bool{}
-	for _, prov := range m.Provisioners {
-		if !manifest.SharesTag(prov.Tags, profile.Tags) || !manifest.MatchesOS(prov.OS, osName) {
-			continue
-		}
+	for _, prov := range provisioners {
 		executable, args := provision.RenderCommand(prov)
 		key := provisionerKey(prov.Tool, executable, args)
 		if seen[key] {

--- a/internal/installed/installed_test.go
+++ b/internal/installed/installed_test.go
@@ -223,6 +223,29 @@ func TestBuildDoesNotPromoteLegacyInventoryToInstalledSelection(t *testing.T) {
 	}
 }
 
+func TestBuildUsesSelectedSurfaceForCurrentProfileCoverageWithoutPromotingInventory(t *testing.T) {
+	home := t.TempDir()
+	entry := manifest.Entry{Source: "configs/zsh/zshrc", Target: "~/.zshrc", Strategy: "symlink", Tags: []string{"core"}, OS: []string{"linux"}}
+	m := manifest.Manifest{
+		Profiles: map[string]manifest.Profile{"core": {Tags: []string{"core"}}},
+		Entries:  []manifest.Entry{entry, entry},
+	}
+	meta := state.Metadata{Version: 2, Entries: []state.Record{{
+		Target: filepath.Join(home, ".zshrc"), Source: entry.Source, Strategy: entry.Strategy, Tags: []string{"core"},
+	}}}
+	report, err := inst.Build(m, meta, inst.Options{StatePath: filepath.Join(home, "installed.json"), Home: home, OS: "linux"})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	coverage := findProfile(t, report.Profiles, "core")
+	if coverage.TotalEntries != 1 || coverage.CoveredEntries != 1 || coverage.State != inst.CoverageComplete {
+		t.Fatalf("core coverage = %+v, want de-duplicated current Selected Surface coverage", coverage)
+	}
+	if report.InstalledSelection != nil || !sameStrings(report.Tags, []string{"core"}) {
+		t.Fatalf("historical inventory was promoted: selection=%+v tags=%v", report.InstalledSelection, report.Tags)
+	}
+}
+
 func TestBuildReturnsEmptyListsForEmptyMetadata(t *testing.T) {
 	home := t.TempDir()
 	report, err := inst.Build(inventoryManifest(), state.Metadata{}, inst.Options{StatePath: filepath.Join(home, "installed.json"), Home: home, OS: "linux"})

--- a/internal/selectedsurface/selectedsurface.go
+++ b/internal/selectedsurface/selectedsurface.go
@@ -181,7 +181,12 @@ func containsExact[T any](values []T, candidate T) bool {
 	return false
 }
 
-func cloneStrings(values []string) []string { return append([]string(nil), values...) }
+func cloneStrings(values []string) []string {
+	if values == nil {
+		return nil
+	}
+	return append([]string(nil), values...)
+}
 
 func cloneDependency(dependency manifest.Dependency) manifest.Dependency {
 	dependency.FontFallbackMatches = cloneStrings(dependency.FontFallbackMatches)
@@ -215,8 +220,9 @@ func cloneEntry(entry manifest.Entry) manifest.Entry {
 	entry.OS = cloneStrings(entry.OS)
 	entry.Dependencies = cloneDependencies(entry.Dependencies)
 	if entry.SourceOverrides != nil {
-		entry.SourceOverrides = make(map[string]string, len(entry.SourceOverrides))
-		for tag, source := range entry.SourceOverrides {
+		sourceOverrides := entry.SourceOverrides
+		entry.SourceOverrides = make(map[string]string, len(sourceOverrides))
+		for tag, source := range sourceOverrides {
 			entry.SourceOverrides[tag] = source
 		}
 	}
@@ -241,6 +247,9 @@ func cloneProvisioner(provisioner manifest.Provisioner) manifest.Provisioner {
 }
 
 func cloneDependencies(dependencies []manifest.Dependency) []manifest.Dependency {
+	if dependencies == nil {
+		return nil
+	}
 	result := make([]manifest.Dependency, len(dependencies))
 	for index, dependency := range dependencies {
 		result[index] = cloneDependency(dependency)

--- a/internal/selectedsurface/selectedsurface.go
+++ b/internal/selectedsurface/selectedsurface.go
@@ -31,6 +31,15 @@ type SelectedEntry struct {
 	OverrideTag string
 }
 
+// EntryEvaluation is the ordered, de-duplicated diagnostic view of a
+// tag-selected Managed Entry. Applicable reports whether its OS Filter admits
+// the requested operating system; non-applicable entries let diagnostics
+// preserve the public skipped state without recreating selection rules.
+type EntryEvaluation struct {
+	SelectedEntry
+	Applicable bool
+}
+
 // DependencyOrigin records one dependency declaration and its manifest origin.
 type DependencyOrigin struct {
 	Dependency manifest.Dependency
@@ -60,6 +69,15 @@ func Evaluate(m manifest.Manifest, effectiveTags []string, osName string) Surfac
 	})
 }
 
+// EvaluateEntries returns the diagnostic Managed Entry scope for effective
+// tags and an operating system. It uses the same selection implementation as
+// Evaluate while retaining OS-excluded entries as non-applicable.
+func EvaluateEntries(m manifest.Manifest, effectiveTags []string, osName string) []EntryEvaluation {
+	return evaluateEntries(m, uniqueTags(effectiveTags), func(itemOS []string) bool {
+		return manifest.MatchesOS(itemOS, osName)
+	})
+}
+
 // EvaluateAll returns the portable selected surface across Darwin and Linux.
 // It evaluates each declaration once, preserving manifest order without
 // introducing an all-platform sentinel into the selected surface.
@@ -82,7 +100,6 @@ func evaluate(m manifest.Manifest, effectiveTags []string, matchesOS func([]stri
 	}
 
 	seenSets := make([]manifest.DependencySet, 0)
-	seenEntries := make([]manifest.Entry, 0)
 	seenProvisioners := make([]manifest.Provisioner, 0)
 	seenOverrides := make([]SourceOverride, 0)
 	seenDependencies := map[string]int{}
@@ -129,12 +146,14 @@ func evaluate(m manifest.Manifest, effectiveTags []string, matchesOS func([]stri
 				}
 			}
 		}
-		if !manifest.SharesTag(entry.Tags, tags) || !matchesOS(entry.OS) || containsExact(seenEntries, entry) {
+	}
+
+	for _, evaluated := range evaluateEntries(m, tags, matchesOS) {
+		if !evaluated.Applicable {
 			continue
 		}
-		seenEntries = append(seenEntries, entry)
-		source, overrideTag := entrySource(entry, tags)
-		result.Entries = append(result.Entries, SelectedEntry{Entry: cloneEntry(entry), Source: source, OverrideTag: overrideTag})
+		entry := evaluated.Entry
+		result.Entries = append(result.Entries, evaluated.SelectedEntry)
 		addDependencies(entry.Dependencies, Origin{Type: "entry", Name: entry.Target, Tags: cloneStrings(entry.Tags)})
 	}
 
@@ -147,6 +166,23 @@ func evaluate(m manifest.Manifest, effectiveTags []string, matchesOS func([]stri
 		addDependencies(provisioner.Dependencies, Origin{Type: "provisioner", Name: provisioner.Tool, Tags: cloneStrings(provisioner.Tags)})
 	}
 
+	return result
+}
+
+func evaluateEntries(m manifest.Manifest, tags []string, matchesOS func([]string) bool) []EntryEvaluation {
+	result := []EntryEvaluation{}
+	seenEntries := make([]manifest.Entry, 0)
+	for _, entry := range m.Entries {
+		if !manifest.SharesTag(entry.Tags, tags) || containsExact(seenEntries, entry) {
+			continue
+		}
+		seenEntries = append(seenEntries, entry)
+		source, overrideTag := entrySource(entry, tags)
+		result = append(result, EntryEvaluation{
+			SelectedEntry: SelectedEntry{Entry: cloneEntry(entry), Source: source, OverrideTag: overrideTag},
+			Applicable:    matchesOS(entry.OS),
+		})
+	}
 	return result
 }
 

--- a/internal/selectedsurface/selectedsurface_test.go
+++ b/internal/selectedsurface/selectedsurface_test.go
@@ -105,6 +105,16 @@ func TestEvaluatePreservesAndCopiesEntrySourceOverrides(t *testing.T) {
 	}
 }
 
+func TestEvaluateEntriesPreservesSkippedScopeAndResolvedSource(t *testing.T) {
+	selected := manifest.Entry{Source: "base", SourceOverrides: map[string]string{"theme": "theme-source"}, Target: "selected", Strategy: "copy", Tags: []string{"core"}}
+	skipped := manifest.Entry{Source: "darwin", SourceOverrides: map[string]string{"theme": "darwin-theme"}, Target: "skipped", Strategy: "copy", Tags: []string{"core"}, OS: []string{"darwin"}}
+	m := manifest.Manifest{Entries: []manifest.Entry{selected, selected, skipped, {Source: "other", Target: "other", Strategy: "copy", Tags: []string{"other"}}}}
+	got := selectedsurface.EvaluateEntries(m, []string{"core", "theme"}, "linux")
+	if len(got) != 2 || !got[0].Applicable || got[0].Source != "theme-source" || got[1].Applicable || got[1].Source != "darwin-theme" {
+		t.Fatalf("Entry scope = %#v, want de-duplicated selected and OS-skipped entries with resolved sources", got)
+	}
+}
+
 func TestEvaluateSameTagsHaveNoProvenanceInputOrOutput(t *testing.T) {
 	m := manifest.Manifest{Entries: []manifest.Entry{{Source: "base", Target: "target", Strategy: "copy", Tags: []string{"core"}}}}
 	first := selectedsurface.Evaluate(m, []string{"core"}, "linux")

--- a/internal/selectedsurface/selectedsurface_test.go
+++ b/internal/selectedsurface/selectedsurface_test.go
@@ -91,6 +91,20 @@ func TestEvaluateResolvesLastTagOverrideAndKeepsActiveOverrides(t *testing.T) {
 	}
 }
 
+func TestEvaluatePreservesAndCopiesEntrySourceOverrides(t *testing.T) {
+	m := manifest.Manifest{Entries: []manifest.Entry{{
+		Source: "base", SourceOverrides: map[string]string{"theme": "theme-source"}, Target: "target", Strategy: "copy", Tags: []string{"core"},
+	}}}
+	got := selectedsurface.Evaluate(m, []string{"core", "theme"}, "linux")
+	if len(got.Entries) != 1 || got.Entries[0].Entry.SourceOverrides["theme"] != "theme-source" {
+		t.Fatalf("Entries = %#v, want preserved source override declaration", got.Entries)
+	}
+	got.Entries[0].Entry.SourceOverrides["theme"] = "changed"
+	if m.Entries[0].SourceOverrides["theme"] != "theme-source" {
+		t.Fatalf("Evaluate result mutated manifest source overrides: %#v", m.Entries[0].SourceOverrides)
+	}
+}
+
 func TestEvaluateSameTagsHaveNoProvenanceInputOrOutput(t *testing.T) {
 	m := manifest.Manifest{Entries: []manifest.Entry{{Source: "base", Target: "target", Strategy: "copy", Tags: []string{"core"}}}}
 	first := selectedsurface.Evaluate(m, []string{"core"}, "linux")

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"reflect"
 
 	"github.com/yersonargotev/dots/internal/configsubset"
 	"github.com/yersonargotev/dots/internal/manifest"
@@ -102,24 +101,19 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options) (Report, erro
 	}
 	tags := resolved.Tags
 	surface := selectedsurface.Evaluate(m, tags, opts.OS)
-	jsonContentByTarget, jsonSourcesByTarget, err := selectedJSONContributions(m, surface, opts)
+	entryScope := selectedsurface.EvaluateEntries(m, tags, opts.OS)
+	jsonContentByTarget, jsonSourcesByTarget, err := selectedJSONContributions(surface.Entries, opts)
 	if err != nil {
 		return Report{}, err
 	}
 
 	report := Report{Profile: resolved.Profile, Profiles: resolved.Profiles, Tags: resolved.Tags}
-	for _, entry := range m.Entries {
-		selected, applicable := selectedSurfaceEntry(surface, entry)
-		if !applicable && !manifest.SharesTag(entry.Tags, tags) {
-			continue
-		}
-
-		source := entry.Source
-		if applicable {
-			source = selected.Source
-		}
+	for _, scoped := range entryScope {
+		selected := scoped.SelectedEntry
+		entry := selected.Entry
+		source := selected.Source
 		evaluated := Entry{Source: source, Target: entry.Target, Strategy: entry.Strategy}
-		if !applicable {
+		if !scoped.Applicable {
 			evaluated.State = StateSkipped
 			report.Entries = append(report.Entries, evaluated)
 			continue
@@ -165,12 +159,12 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options) (Report, erro
 	return report, nil
 }
 
-func selectedJSONContributions(m manifest.Manifest, surface selectedsurface.Surface, opts Options) (map[string][]byte, map[string][]string, error) {
+func selectedJSONContributions(entries []selectedsurface.SelectedEntry, opts Options) (map[string][]byte, map[string][]string, error) {
 	pathsByTarget := map[string][]string{}
 	sourcesByTarget := map[string][]string{}
-	for _, entry := range m.Entries {
-		selected, applicable := selectedSurfaceEntry(surface, entry)
-		if !applicable || entry.Strategy != "copy" || entry.Ownership != "json-subset" {
+	for _, selected := range entries {
+		entry := selected.Entry
+		if entry.Strategy != "copy" || entry.Ownership != "json-subset" {
 			continue
 		}
 		source := selected.Source
@@ -207,15 +201,6 @@ func selectedJSONContributions(m manifest.Manifest, surface selectedsurface.Surf
 		contentByTarget[target] = content
 	}
 	return contentByTarget, sourcesByTarget, nil
-}
-
-func selectedSurfaceEntry(surface selectedsurface.Surface, entry manifest.Entry) (selectedsurface.SelectedEntry, bool) {
-	for _, selected := range surface.Entries {
-		if reflect.DeepEqual(selected.Entry, entry) {
-			return selected, true
-		}
-	}
-	return selectedsurface.SelectedEntry{}, false
 }
 
 func evaluate(entry manifest.Entry, target string, meta state.Metadata, sourceRoot string, defaultSource string, currentJSON []byte, currentSources []string) (State, error) {

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -10,11 +10,13 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"reflect"
 
 	"github.com/yersonargotev/dots/internal/configsubset"
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/seededstate"
+	"github.com/yersonargotev/dots/internal/selectedsurface"
 	"github.com/yersonargotev/dots/internal/selection"
 	"github.com/yersonargotev/dots/internal/state"
 	"github.com/yersonargotev/dots/internal/textblock"
@@ -99,21 +101,25 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options) (Report, erro
 		resolved = &selection
 	}
 	tags := resolved.Tags
-	jsonContentByTarget, jsonSourcesByTarget, err := selectedJSONContributions(m, tags, opts)
+	surface := selectedsurface.Evaluate(m, tags, opts.OS)
+	jsonContentByTarget, jsonSourcesByTarget, err := selectedJSONContributions(m, surface, opts)
 	if err != nil {
 		return Report{}, err
 	}
 
 	report := Report{Profile: resolved.Profile, Profiles: resolved.Profiles, Tags: resolved.Tags}
 	for _, entry := range m.Entries {
-		if !manifest.SharesTag(entry.Tags, tags) {
+		selected, applicable := selectedSurfaceEntry(surface, entry)
+		if !applicable && !manifest.SharesTag(entry.Tags, tags) {
 			continue
 		}
 
-		defaultSource := entry.Source
-		source := manifest.EntrySource(entry, tags)
+		source := entry.Source
+		if applicable {
+			source = selected.Source
+		}
 		evaluated := Entry{Source: source, Target: entry.Target, Strategy: entry.Strategy}
-		if !manifest.MatchesOS(entry.OS, opts.OS) {
+		if !applicable {
 			evaluated.State = StateSkipped
 			report.Entries = append(report.Entries, evaluated)
 			continue
@@ -129,7 +135,7 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options) (Report, erro
 		}
 
 		entry.Source = source
-		st, err := evaluate(entry, target, meta, opts.SourceRoot, defaultSource, jsonContentByTarget[target], jsonSourcesByTarget[target])
+		st, err := evaluate(entry, target, meta, opts.SourceRoot, selected.Entry.Source, jsonContentByTarget[target], jsonSourcesByTarget[target])
 		if err != nil {
 			return Report{}, err
 		}
@@ -159,14 +165,15 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options) (Report, erro
 	return report, nil
 }
 
-func selectedJSONContributions(m manifest.Manifest, tags []string, opts Options) (map[string][]byte, map[string][]string, error) {
+func selectedJSONContributions(m manifest.Manifest, surface selectedsurface.Surface, opts Options) (map[string][]byte, map[string][]string, error) {
 	pathsByTarget := map[string][]string{}
 	sourcesByTarget := map[string][]string{}
 	for _, entry := range m.Entries {
-		if entry.Strategy != "copy" || entry.Ownership != "json-subset" || !manifest.SharesTag(entry.Tags, tags) || !manifest.MatchesOS(entry.OS, opts.OS) {
+		selected, applicable := selectedSurfaceEntry(surface, entry)
+		if !applicable || entry.Strategy != "copy" || entry.Ownership != "json-subset" {
 			continue
 		}
-		source := manifest.EntrySource(entry, tags)
+		source := selected.Source
 		target, err := plan.ResolveEntryTarget(entry, opts.Home, opts.XDGStateHome)
 		if err != nil {
 			return nil, nil, err
@@ -200,6 +207,15 @@ func selectedJSONContributions(m manifest.Manifest, tags []string, opts Options)
 		contentByTarget[target] = content
 	}
 	return contentByTarget, sourcesByTarget, nil
+}
+
+func selectedSurfaceEntry(surface selectedsurface.Surface, entry manifest.Entry) (selectedsurface.SelectedEntry, bool) {
+	for _, selected := range surface.Entries {
+		if reflect.DeepEqual(selected.Entry, entry) {
+			return selected, true
+		}
+	}
+	return selectedsurface.SelectedEntry{}, false
 }
 
 func evaluate(entry manifest.Entry, target string, meta state.Metadata, sourceRoot string, defaultSource string, currentJSON []byte, currentSources []string) (State, error) {

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -3,6 +3,7 @@ package status_test
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/yersonargotev/dots/internal/manifest"
@@ -726,6 +727,42 @@ func TestBuildExcludesEntriesOutsideProfileTags(t *testing.T) {
 	}
 	if report.Entries[0].Source != "configs/zsh/zshrc" {
 		t.Fatalf("unexpected entry %q in report", report.Entries[0].Source)
+	}
+}
+
+func TestBuildProfileAndEquivalentTagsHaveSameDiagnosticScope(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	m := manifest.Manifest{
+		Profiles: map[string]manifest.Profile{"work": {Tags: []string{"core", "theme"}}},
+		Entries: []manifest.Entry{
+			{Source: "configs/base", SourceOverrides: map[string]string{"theme": "configs/theme"}, Target: "~/.selected", Strategy: "copy", Tags: []string{"core"}, OS: []string{"linux"}},
+			{Source: "configs/darwin", Target: "~/.darwin", Strategy: "copy", Tags: []string{"core"}, OS: []string{"darwin"}},
+			{Source: "configs/other", Target: "~/.other", Strategy: "copy", Tags: []string{"other"}},
+		},
+	}
+	fromProfile, err := manifest.ResolveReadOnlySelection(m, []string{"work"}, nil)
+	if err != nil {
+		t.Fatalf("resolve Profile selection: %v", err)
+	}
+	fromTags, err := manifest.ResolveReadOnlySelection(m, nil, []string{"core", "theme"})
+	if err != nil {
+		t.Fatalf("resolve Tag selection: %v", err)
+	}
+	build := func(selected manifest.Selection) status.Report {
+		report, buildErr := status.Build(m, state.Metadata{}, status.Options{Selection: &selected, OS: "linux", SourceRoot: sourceRoot, Home: home})
+		if buildErr != nil {
+			t.Fatalf("Build() error = %v", buildErr)
+		}
+		return report
+	}
+	profileReport := build(fromProfile)
+	tagReport := build(fromTags)
+	if !reflect.DeepEqual(profileReport.Entries, tagReport.Entries) {
+		t.Fatalf("diagnostic scope differs\nProfile: %+v\nTags: %+v", profileReport.Entries, tagReport.Entries)
+	}
+	if len(profileReport.Entries) != 2 || profileReport.Entries[0].Source != "configs/theme" || profileReport.Entries[0].State != status.StateMissing || profileReport.Entries[1].State != status.StateSkipped {
+		t.Fatalf("diagnostic entries = %+v, want selected override plus OS-skipped entry", profileReport.Entries)
 	}
 }
 

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -737,7 +737,8 @@ func TestBuildProfileAndEquivalentTagsHaveSameDiagnosticScope(t *testing.T) {
 		Profiles: map[string]manifest.Profile{"work": {Tags: []string{"core", "theme"}}},
 		Entries: []manifest.Entry{
 			{Source: "configs/base", SourceOverrides: map[string]string{"theme": "configs/theme"}, Target: "~/.selected", Strategy: "copy", Tags: []string{"core"}, OS: []string{"linux"}},
-			{Source: "configs/darwin", Target: "~/.darwin", Strategy: "copy", Tags: []string{"core"}, OS: []string{"darwin"}},
+			{Source: "configs/base", SourceOverrides: map[string]string{"theme": "configs/theme"}, Target: "~/.selected", Strategy: "copy", Tags: []string{"core"}, OS: []string{"linux"}},
+			{Source: "configs/darwin", SourceOverrides: map[string]string{"theme": "configs/darwin-theme"}, Target: "~/.darwin", Strategy: "copy", Tags: []string{"core"}, OS: []string{"darwin"}},
 			{Source: "configs/other", Target: "~/.other", Strategy: "copy", Tags: []string{"other"}},
 		},
 	}
@@ -761,7 +762,7 @@ func TestBuildProfileAndEquivalentTagsHaveSameDiagnosticScope(t *testing.T) {
 	if !reflect.DeepEqual(profileReport.Entries, tagReport.Entries) {
 		t.Fatalf("diagnostic scope differs\nProfile: %+v\nTags: %+v", profileReport.Entries, tagReport.Entries)
 	}
-	if len(profileReport.Entries) != 2 || profileReport.Entries[0].Source != "configs/theme" || profileReport.Entries[0].State != status.StateMissing || profileReport.Entries[1].State != status.StateSkipped {
+	if len(profileReport.Entries) != 2 || profileReport.Entries[0].Source != "configs/theme" || profileReport.Entries[0].State != status.StateMissing || profileReport.Entries[1].Source != "configs/darwin-theme" || profileReport.Entries[1].State != status.StateSkipped {
 		t.Fatalf("diagnostic entries = %+v, want selected override plus OS-skipped entry", profileReport.Entries)
 	}
 }


### PR DESCRIPTION
Closes #430

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [x] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Routes Status and doctor Managed Entry applicability through the Selected Surface module while preserving skipped-entry reporting.
- Uses Selected Surface for current Profile coverage in installed reporting without promoting historical inventory into Installed Selection.
- Preserves report fields, ordering, semantic exit codes, Drift, Conflict, absent-selection, and Selection Migration Candidate behavior.

## Changes

| File | Change |
|------|--------|
| `internal/selectedsurface/` | Adds an ordered, de-duplicated diagnostic entry evaluation that retains OS-skipped entries and fixes defensive source-override copying. |
| `internal/status/` | Consumes Selected Surface entries for workstation evaluation and JSON-subset composition. |
| `internal/doctor/` | Scans only Selected Surface sources through the public Secret Scan report interface. |
| `internal/installed/` | Computes current declarative Profile entry/provisioner coverage from Selected Surface while retaining historical inventory semantics. |
| Tests | Covers Profile/Tag scope parity, skipped source overrides, de-duplication, and inventory-versus-selection separation. |

## Test Plan

- [x] `go test ./... -count=1`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go build ./...`
- [x] `go generate ./internal/catalog`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed real-binary status, doctor, and installed diagnostics with explicit temporary home and state roots; Install Plan is not applicable because installation behavior did not change.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked one issue with an admitted Delivery Contract using `Closes #430`.
- [x] Added exactly one `type:*` label.
- [x] Delivery Evidence records the Contract Source snapshot, Acceptance coverage, and Independent review.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed (not applicable; public behavior and documentation contracts are unchanged).
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

### Contract Source snapshot

- Kind: composed delivery ticket (child #430 plus native parent specification #427).
- Child body: node `I_kwDOSzLlmM8AAAABMEOvpQ`; https://github.com/yersonargotev/dots/issues/430#issue-5104709541; updated `2026-08-09T21:01:38Z`; SHA-256 `2b36b0f69ddc1bf700cf66b4b4d827ba35a316e57ab38c1b4a70cfe67a4b5ab3`.
- Parent body: node `I_kwDOSzLlmM8AAAABMEODWA`; https://github.com/yersonargotev/dots/issues/427#issue-5104698200; updated `2026-08-09T20:58:54Z`; SHA-256 `294db5b0d8a1d718b2b5ae57f3a09dbe61720b13db334c248eac4eea7ade823c`.
- Category/readiness: `enhancement`; `ready-for-agent` is the only triage-state label.
- Native relationships: parent #427 (OPEN, updated `2026-08-09T20:58:54Z`); no sub-issues; blocked by #429 (CLOSED, updated `2026-08-09T21:57:24Z`); blocking #432 (OPEN, updated `2026-08-09T21:01:43Z`).
- Comments at snapshot: none.
- Reviewed head: `05a1497d3bfeb0c1374a18a2b6fe351b39f2bc14` against `origin/main` at `0610283c653d23e36ae7e95fb9f9e3da343dbeaa`.

### Acceptance coverage

- Status: ordered and de-duplicated Managed Entry applicability, source overrides, JSON-subset contributions, and OS-skipped entries come from the Selected Surface module.
- Doctor: Secret Scan consumes Selected Surface entries; configuration diagnostics inherit the same Status scope.
- Installed: current Profile coverage uses Selected Surface entries and Provisioners; historical records, represented Tags, Installed Selection, and Selection Migration Candidate remain separate.
- Stability: existing CLI, golden-envelope, Drift, Conflict, absent-selection, and migration suites pass without report schema changes.
- Equivalence: public Status and Secret Scan tests compare Profile selection with equivalent explicit Tags; manual JSON scopes match for repository Profile `core` and Tag `core`.

### Automated validation

All passed for reviewed head `05a1497`:

- `gofmt -l .` (no output)
- `go vet ./...`
- `go build ./...`
- `go test ./... -count=1`
- focused status, doctor, installed, selected-surface, CLI, selection, and selection-migration tests
- `go generate ./internal/catalog` (no generated diff)
- `go run ./cmd/dots manifest validate --file dots.yaml` → `manifest is valid`

### Manual verification

Built one real binary with `go build -o <tmp>/dots ./cmd/dots` and used `<tmp>/home` plus `<tmp>/state` for every command.

- `status --profile core --output json` and `status --tag core --output json`: both exited 2 for findings; 18 entry records; entry scopes identical.
- `doctor --profile core --output json` and `doctor --tag core --output json`: both exited 2 for findings; 18 configuration entries, 0 Secret Scan findings; configuration and Secret Scan scopes identical.
- `installed --output json` with empty sandbox metadata: exited 0; `installed_selection` null, 0 historical entries, and 0 Profile coverage rows.

### Independent review

- Standards: PASS at `05a1497`; 0 actionable findings. Confirmed Selected Surface de-duplication, skipped-source resolution, module ownership, and Installed Selection separation.
- Spec: PASS at `05a1497`; 0 missing/partial requirements, scope-creep findings, or incorrect behaviors.
- One initial review finding about Status de-duplication and skipped source resolution was fixed in `05a1497`; all automated/manual gates and both review axes were then rerun.
<!-- delivery-issue:evidence:end -->