### PR TITLE
refactor(plan): consume selected surface

### DIFF
--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -152,8 +153,7 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 	actionByTarget := map[string]int{}
 	readSourcesByTarget := map[string][]string{}
 	scheduledLegacyParents := map[string]struct{}{}
-	surface := selectedsurface.Evaluate(m, tags, opts.OS)
-	for _, selected := range surface.Entries {
+	for _, selected := range selectedEntries(m, tags, opts.OS) {
 		entry := selected.Entry
 		defaultSource := entry.Source
 		source := selected.Source
@@ -279,6 +279,29 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 	}
 
 	return plan, nil
+}
+
+type selectedManifestEntry struct {
+	Index int
+	selectedsurface.SelectedEntry
+}
+
+// selectedEntries projects the Selected Surface back onto manifest positions.
+// The projection preserves declaration multiplicity for existing duplicate-target
+// diagnostics while keeping Tag, OS, ordering, and source selection in the
+// Selected Surface module.
+func selectedEntries(m manifest.Manifest, tags []string, osName string) []selectedManifestEntry {
+	surface := selectedsurface.Evaluate(m, tags, osName)
+	selected := make([]selectedManifestEntry, 0, len(surface.Entries))
+	for index, entry := range m.Entries {
+		for _, surfaceEntry := range surface.Entries {
+			if reflect.DeepEqual(entry, surfaceEntry.Entry) {
+				selected = append(selected, selectedManifestEntry{Index: index, SelectedEntry: surfaceEntry})
+				break
+			}
+		}
+	}
+	return selected
 }
 
 func planLegacyMigration(entry manifest.Entry, currentSource string, migration LegacyMigration) (LegacyMigration, bool, error) {

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -12,6 +12,7 @@ import (
 	"github.com/yersonargotev/dots/internal/configsubset"
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/seededstate"
+	"github.com/yersonargotev/dots/internal/selectedsurface"
 	"github.com/yersonargotev/dots/internal/selection"
 	"github.com/yersonargotev/dots/internal/state"
 	"github.com/yersonargotev/dots/internal/textblock"
@@ -151,16 +152,11 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 	actionByTarget := map[string]int{}
 	readSourcesByTarget := map[string][]string{}
 	scheduledLegacyParents := map[string]struct{}{}
-	for _, entry := range m.Entries {
-		if !manifest.SharesTag(entry.Tags, tags) {
-			continue
-		}
-		if !manifest.MatchesOS(entry.OS, opts.OS) {
-			continue
-		}
-
+	surface := selectedsurface.Evaluate(m, tags, opts.OS)
+	for _, selected := range surface.Entries {
+		entry := selected.Entry
 		defaultSource := entry.Source
-		source := manifest.EntrySource(entry, tags)
+		source := selected.Source
 		target, err := ResolveEntryTarget(entry, opts.Home, opts.XDGStateHome)
 		if err != nil {
 			return Plan{}, err

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -1164,6 +1164,40 @@ func TestBuildUsesSourceOverrideForSelectedExtraTag(t *testing.T) {
 	}
 }
 
+func TestBuildProfileAndEquivalentExplicitTagsProduceSameActions(t *testing.T) {
+	sourceRoot := t.TempDir()
+	home := t.TempDir()
+	writeSource(t, sourceRoot, "core.conf", "core\n")
+	writeSource(t, sourceRoot, "desktop.conf", "desktop\n")
+	writeSource(t, sourceRoot, "linux.conf", "linux\n")
+
+	m := manifest.Manifest{
+		Version: 1,
+		Profiles: map[string]manifest.Profile{
+			"workstation": {Tags: []string{"core", "desktop"}},
+		},
+		Entries: []manifest.Entry{
+			{Source: "core.conf", Target: "~/.core", Strategy: "copy", Tags: []string{"core"}},
+			{Source: "desktop.conf", Target: "~/.desktop", Strategy: "copy", Tags: []string{"desktop"}, OS: []string{"darwin"}},
+			{Source: "linux.conf", Target: "~/.linux", Strategy: "copy", Tags: []string{"desktop"}, OS: []string{"linux"}},
+		},
+	}
+	profileSelection := manifest.Selection{Profile: "workstation", Profiles: []string{"workstation"}, Tags: []string{"core", "desktop"}}
+	explicitTagSelection := manifest.Selection{Tags: []string{"core", "desktop"}}
+
+	fromProfile, err := plan.Build(m, plan.Options{Selection: &profileSelection, OS: "darwin", SourceRoot: sourceRoot, Home: home})
+	if err != nil {
+		t.Fatalf("Build() from Profile error = %v", err)
+	}
+	fromTags, err := plan.Build(m, plan.Options{Selection: &explicitTagSelection, OS: "darwin", SourceRoot: sourceRoot, Home: home})
+	if err != nil {
+		t.Fatalf("Build() from explicit Tags error = %v", err)
+	}
+	if !reflect.DeepEqual(fromProfile.Actions, fromTags.Actions) {
+		t.Fatalf("Profile actions = %#v, explicit Tag actions = %#v", fromProfile.Actions, fromTags.Actions)
+	}
+}
+
 func TestBuildDiagnosesUnselectedSourceOverrides(t *testing.T) {
 	sourceRoot := t.TempDir()
 	home := t.TempDir()

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -1185,16 +1185,37 @@ func TestBuildProfileAndEquivalentExplicitTagsProduceSameActions(t *testing.T) {
 	profileSelection := manifest.Selection{Profile: "workstation", Profiles: []string{"workstation"}, Tags: []string{"core", "desktop"}}
 	explicitTagSelection := manifest.Selection{Tags: []string{"core", "desktop"}}
 
-	fromProfile, err := plan.Build(m, plan.Options{Selection: &profileSelection, OS: "darwin", SourceRoot: sourceRoot, Home: home})
-	if err != nil {
-		t.Fatalf("Build() from Profile error = %v", err)
+	for _, osName := range []string{"darwin", "linux"} {
+		t.Run(osName, func(t *testing.T) {
+			fromProfile, err := plan.Build(m, plan.Options{Selection: &profileSelection, OS: osName, SourceRoot: sourceRoot, Home: home})
+			if err != nil {
+				t.Fatalf("Build() from Profile error = %v", err)
+			}
+			fromTags, err := plan.Build(m, plan.Options{Selection: &explicitTagSelection, OS: osName, SourceRoot: sourceRoot, Home: home})
+			if err != nil {
+				t.Fatalf("Build() from explicit Tags error = %v", err)
+			}
+			if !reflect.DeepEqual(fromProfile.Actions, fromTags.Actions) {
+				t.Fatalf("Profile actions = %#v, explicit Tag actions = %#v", fromProfile.Actions, fromTags.Actions)
+			}
+		})
 	}
-	fromTags, err := plan.Build(m, plan.Options{Selection: &explicitTagSelection, OS: "darwin", SourceRoot: sourceRoot, Home: home})
-	if err != nil {
-		t.Fatalf("Build() from explicit Tags error = %v", err)
+}
+
+func TestBuildPreservesDuplicateTargetConflictFromSelectedSurface(t *testing.T) {
+	sourceRoot := t.TempDir()
+	home := t.TempDir()
+	writeSource(t, sourceRoot, "duplicate.conf", "content\n")
+	duplicate := manifest.Entry{Source: "duplicate.conf", Target: "~/.duplicate", Strategy: "copy", Tags: []string{"core"}}
+	m := manifest.Manifest{
+		Version:  1,
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}},
+		Entries:  []manifest.Entry{duplicate, duplicate},
 	}
-	if !reflect.DeepEqual(fromProfile.Actions, fromTags.Actions) {
-		t.Fatalf("Profile actions = %#v, explicit Tag actions = %#v", fromProfile.Actions, fromTags.Actions)
+
+	_, err := plan.Build(m, plan.Options{Profile: "default", OS: "linux", SourceRoot: sourceRoot, Home: home})
+	if err == nil || !strings.Contains(err.Error(), "duplicate target") {
+		t.Fatalf("Build() error = %v, want duplicate target conflict", err)
 	}
 }
 

--- a/internal/plan/skipped.go
+++ b/internal/plan/skipped.go
@@ -2,16 +2,16 @@ package plan
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/profilesel"
+	"github.com/yersonargotev/dots/internal/selectedsurface"
 )
 
-// selectedEntryIndices returns the set of m.Entries positions a profile would
-// select on the given OS. Working in index space lets SkippedEntries reason about
-// entry identity across profiles (which entry, not just how many) without
-// depending on struct equality, and keeps Build and SkippedEntries filtering
-// through one tag/OS rule. It mirrors provision.selectedIndices for provisioners.
+// selectedEntryIndices maps the Selected Surface back to manifest positions so
+// SkippedEntries can compare entry identity across Profiles without repeating
+// Tag or OS selection. It mirrors provision.selectedIndices for Provisioners.
 func selectedEntryIndices(m manifest.Manifest, profileName, os string) (map[int]bool, error) {
 	profile, ok := m.Profiles[profileName]
 	if !ok {
@@ -19,9 +19,12 @@ func selectedEntryIndices(m manifest.Manifest, profileName, os string) (map[int]
 	}
 
 	indices := make(map[int]bool)
-	for i, entry := range m.Entries {
-		if manifest.SharesTag(entry.Tags, profile.Tags) && manifest.MatchesOS(entry.OS, os) {
-			indices[i] = true
+	for _, selected := range selectedsurface.Evaluate(m, profile.Tags, os).Entries {
+		for i, entry := range m.Entries {
+			if !indices[i] && reflect.DeepEqual(entry, selected.Entry) {
+				indices[i] = true
+				break
+			}
 		}
 	}
 	return indices, nil

--- a/internal/plan/skipped.go
+++ b/internal/plan/skipped.go
@@ -2,11 +2,9 @@ package plan
 
 import (
 	"fmt"
-	"reflect"
 
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/profilesel"
-	"github.com/yersonargotev/dots/internal/selectedsurface"
 )
 
 // selectedEntryIndices maps the Selected Surface back to manifest positions so
@@ -19,13 +17,8 @@ func selectedEntryIndices(m manifest.Manifest, profileName, os string) (map[int]
 	}
 
 	indices := make(map[int]bool)
-	for _, selected := range selectedsurface.Evaluate(m, profile.Tags, os).Entries {
-		for i, entry := range m.Entries {
-			if !indices[i] && reflect.DeepEqual(entry, selected.Entry) {
-				indices[i] = true
-				break
-			}
-		}
+	for _, selected := range selectedEntries(m, profile.Tags, os) {
+		indices[selected.Index] = true
 	}
 	return indices, nil
 }

--- a/internal/provision/plan.go
+++ b/internal/provision/plan.go
@@ -47,11 +47,15 @@ func Select(m manifest.Manifest, opts Options) ([]manifest.Provisioner, error) {
 	if err != nil {
 		return nil, err
 	}
-	selected := selectedsurface.Evaluate(m, selection.Tags, opts.OS).Provisioners
+	selected := selectedProvisioners(m, selection.Tags, opts.OS)
 	if len(selected) == 0 {
 		return nil, nil
 	}
-	return selected, nil
+	provisioners := make([]manifest.Provisioner, 0, len(selected))
+	for _, item := range selected {
+		provisioners = append(provisioners, item.Provisioner)
+	}
+	return provisioners, nil
 }
 
 // selectedIndices maps the Selected Surface back to manifest positions so the
@@ -67,15 +71,32 @@ func selectedIndices(m manifest.Manifest, profileNames []string, os string, extr
 
 func selectedIndicesForSelection(m manifest.Manifest, selection manifest.Selection, os string) map[int]bool {
 	indices := make(map[int]bool)
-	for _, selected := range selectedsurface.Evaluate(m, selection.Tags, os).Provisioners {
-		for i, provisioner := range m.Provisioners {
-			if !indices[i] && reflect.DeepEqual(provisioner, selected) {
-				indices[i] = true
+	for _, selected := range selectedProvisioners(m, selection.Tags, os) {
+		indices[selected.Index] = true
+	}
+	return indices
+}
+
+type selectedManifestProvisioner struct {
+	Index       int
+	Provisioner manifest.Provisioner
+}
+
+// selectedProvisioners projects the Selected Surface back onto manifest
+// positions. The projection preserves declaration multiplicity while keeping
+// Tag, OS, and ordering rules in the Selected Surface module.
+func selectedProvisioners(m manifest.Manifest, tags []string, osName string) []selectedManifestProvisioner {
+	surface := selectedsurface.Evaluate(m, tags, osName)
+	selected := make([]selectedManifestProvisioner, 0, len(surface.Provisioners))
+	for index, provisioner := range m.Provisioners {
+		for _, surfaceProvisioner := range surface.Provisioners {
+			if reflect.DeepEqual(provisioner, surfaceProvisioner) {
+				selected = append(selected, selectedManifestProvisioner{Index: index, Provisioner: surfaceProvisioner})
 				break
 			}
 		}
 	}
-	return indices
+	return selected
 }
 
 // SkippedProvisioners reports whether the active profile omits provisioners that

--- a/internal/provision/plan.go
+++ b/internal/provision/plan.go
@@ -1,11 +1,13 @@
 package provision
 
 import (
+	"reflect"
 	"strings"
 
 	"github.com/yersonargotev/dots/internal/deps"
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/profilesel"
+	"github.com/yersonargotev/dots/internal/selectedsurface"
 )
 
 // Options carries the resolved inputs needed to select and plan Provisioners.
@@ -38,30 +40,23 @@ type Plan struct {
 	Steps    []Step   `json:"steps"`
 }
 
-// Select gathers the Provisioners that belong to the Profile (their tags
-// intersect the Profile's tags) and pass the OS filter, preserving manifest
-// order. It mirrors the Entry selection used by deps, plan, and status.
+// Select returns the Provisioners from the Selected Surface, preserving its
+// deterministic manifest order.
 func Select(m manifest.Manifest, opts Options) ([]manifest.Provisioner, error) {
 	selection, err := resolveOptionsSelection(m, opts)
 	if err != nil {
 		return nil, err
 	}
-	indices := selectedIndicesForSelection(m, selection, opts.OS)
-
-	var selected []manifest.Provisioner
-	for i, prov := range m.Provisioners {
-		if indices[i] {
-			selected = append(selected, prov)
-		}
+	selected := selectedsurface.Evaluate(m, selection.Tags, opts.OS).Provisioners
+	if len(selected) == 0 {
+		return nil, nil
 	}
 	return selected, nil
 }
 
-// selectedIndices returns the set of m.Provisioners positions a profile would
-// select on the given OS. Working in index space lets callers reason about
-// provisioner identity across profiles (which provisioner, not just how many)
-// without depending on struct equality, and keeps Select and SkippedProvisioners
-// filtering through one tag/OS rule.
+// selectedIndices maps the Selected Surface back to manifest positions so the
+// skipped-surface hint can compare Provisioner identity across Profiles without
+// repeating Tag or OS selection.
 func selectedIndices(m manifest.Manifest, profileNames []string, os string, extraTags []string) (map[int]bool, error) {
 	selection, err := manifest.ResolveSelection(m, profileNames, extraTags)
 	if err != nil {
@@ -72,9 +67,12 @@ func selectedIndices(m manifest.Manifest, profileNames []string, os string, extr
 
 func selectedIndicesForSelection(m manifest.Manifest, selection manifest.Selection, os string) map[int]bool {
 	indices := make(map[int]bool)
-	for i, prov := range m.Provisioners {
-		if manifest.SharesTag(prov.Tags, selection.Tags) && manifest.MatchesOS(prov.OS, os) {
-			indices[i] = true
+	for _, selected := range selectedsurface.Evaluate(m, selection.Tags, os).Provisioners {
+		for i, provisioner := range m.Provisioners {
+			if !indices[i] && reflect.DeepEqual(provisioner, selected) {
+				indices[i] = true
+				break
+			}
 		}
 	}
 	return indices
@@ -84,8 +82,7 @@ func selectedIndicesForSelection(m manifest.Manifest, selection manifest.Selecti
 // another profile would select on this OS, and which single profile best recovers
 // them. It is a thin adapter over profilesel.Skipped, injecting the provisioner
 // index selection; plan.SkippedEntries is its file-entry twin over the same
-// shared math. It is PURE: no I/O, safe in a dry-run, and mirrors the tag/OS
-// scoping used by Select.
+// shared math. It is PURE: no I/O and safe in a dry-run.
 func SkippedProvisioners(m manifest.Manifest, opts Options) (profilesel.Hint, bool, error) {
 	active := selectionLabel(opts.Profile, opts.Profiles)
 	if len(opts.Profiles) > 1 {

--- a/internal/provision/plan_test.go
+++ b/internal/provision/plan_test.go
@@ -134,16 +134,33 @@ func TestBuildProfileAndEquivalentExplicitTagsProduceSameSteps(t *testing.T) {
 	profileSelection := manifest.Selection{Profile: "workstation", Profiles: []string{"workstation"}, Tags: []string{"core", "desktop"}}
 	explicitTagSelection := manifest.Selection{Tags: []string{"core", "desktop"}}
 
-	fromProfile, err := provision.Build(m, provision.Options{Selection: &profileSelection, OS: "darwin"})
-	if err != nil {
-		t.Fatalf("Build() from Profile error = %v", err)
+	for _, osName := range []string{"darwin", "linux"} {
+		t.Run(osName, func(t *testing.T) {
+			fromProfile, err := provision.Build(m, provision.Options{Selection: &profileSelection, OS: osName})
+			if err != nil {
+				t.Fatalf("Build() from Profile error = %v", err)
+			}
+			fromTags, err := provision.Build(m, provision.Options{Selection: &explicitTagSelection, OS: osName})
+			if err != nil {
+				t.Fatalf("Build() from explicit Tags error = %v", err)
+			}
+			if !reflect.DeepEqual(fromProfile.Steps, fromTags.Steps) {
+				t.Fatalf("Profile steps = %#v, explicit Tag steps = %#v", fromProfile.Steps, fromTags.Steps)
+			}
+		})
 	}
-	fromTags, err := provision.Build(m, provision.Options{Selection: &explicitTagSelection, OS: "darwin"})
+}
+
+func TestSelectPreservesDuplicateProvisionerDeclarations(t *testing.T) {
+	duplicate := manifest.Provisioner{Tool: "zimfw", Tags: []string{"core"}, Spec: manifest.ProvisionerSpec{Yes: true}}
+	m := manifestWithProvisioners(duplicate, duplicate)
+
+	selected, err := provision.Select(m, provision.Options{Profile: "default", OS: "linux"})
 	if err != nil {
-		t.Fatalf("Build() from explicit Tags error = %v", err)
+		t.Fatalf("Select() error = %v", err)
 	}
-	if !reflect.DeepEqual(fromProfile.Steps, fromTags.Steps) {
-		t.Fatalf("Profile steps = %#v, explicit Tag steps = %#v", fromProfile.Steps, fromTags.Steps)
+	if len(selected) != 2 {
+		t.Fatalf("len(Select()) = %d, want 2 duplicate declarations preserved", len(selected))
 	}
 }
 

--- a/internal/provision/plan_test.go
+++ b/internal/provision/plan_test.go
@@ -125,6 +125,28 @@ func TestPlanResolvesSelectedProvisioners(t *testing.T) {
 	}
 }
 
+func TestBuildProfileAndEquivalentExplicitTagsProduceSameSteps(t *testing.T) {
+	core := manifest.Provisioner{Tool: "zimfw", Tags: []string{"core"}, Spec: manifest.ProvisionerSpec{Yes: true}}
+	desktop := manifest.Provisioner{Tool: "claude", Tags: []string{"desktop"}, OS: []string{"darwin"}, Spec: manifest.ProvisionerSpec{Marketplace: "example/tools"}}
+	linux := manifest.Provisioner{Tool: "codex", Tags: []string{"desktop"}, OS: []string{"linux"}, Spec: manifest.ProvisionerSpec{MCP: "example", Command: []string{"npx"}}}
+	m := manifestWithProvisioners(core, desktop, linux)
+	m.Profiles["workstation"] = manifest.Profile{Tags: []string{"core", "desktop"}}
+	profileSelection := manifest.Selection{Profile: "workstation", Profiles: []string{"workstation"}, Tags: []string{"core", "desktop"}}
+	explicitTagSelection := manifest.Selection{Tags: []string{"core", "desktop"}}
+
+	fromProfile, err := provision.Build(m, provision.Options{Selection: &profileSelection, OS: "darwin"})
+	if err != nil {
+		t.Fatalf("Build() from Profile error = %v", err)
+	}
+	fromTags, err := provision.Build(m, provision.Options{Selection: &explicitTagSelection, OS: "darwin"})
+	if err != nil {
+		t.Fatalf("Build() from explicit Tags error = %v", err)
+	}
+	if !reflect.DeepEqual(fromProfile.Steps, fromTags.Steps) {
+		t.Fatalf("Profile steps = %#v, explicit Tag steps = %#v", fromProfile.Steps, fromTags.Steps)
+	}
+}
+
 func TestPlanResolvesClaudeProvisioner(t *testing.T) {
 	market := manifest.Provisioner{
 		Tool: "claude", Tags: []string{"core"},


### PR DESCRIPTION
Closes #431

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [x] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Routes Install Plan Managed Entry and source-override selection through Selected Surface.
- Routes Provisioner Plan selection and skipped-surface hints through the same module.
- Preserves declaration multiplicity, duplicate-target diagnostics, output shape, and Profile/Tag parity on Darwin and Linux.

## Changes

| File | Change |
|------|--------|
| `internal/plan/*` | Builds actions from Selected Surface, preserves manifest-position compatibility, and verifies Profile/Tag parity plus duplicate-target behavior. |
| `internal/provision/*` | Builds Provisioner steps from Selected Surface, preserves declaration multiplicity, and verifies Darwin/Linux parity. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go build ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml` (validated with the built binary instead of `go run`)
- [x] Sandboxed plan: real binary, Profile/Tag JSON action comparison, and install dry-run with explicit home/source/state roots.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] CLI validation that targeted home/config paths used temporary directories and explicit `--home`, `--source-root`, and `--state-root` flags.

## Contributor Checklist

- [x] Linked one issue with an admitted Delivery Contract using `Closes #431`.
- [x] Added exactly one `type:*` label.
- [x] Delivery Evidence records the Contract Source snapshot, Acceptance coverage, and Independent review.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Docs or agent instructions were not needed because public workflow and domain behavior remain unchanged.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

### Contract Source snapshot

Kind: composed delivery ticket #431 with native parent specification #427.

| Source | Node ID | URL | `updatedAt` | SHA-256 of exact raw UTF-8 body |
|---|---|---|---|---|
| Ticket #431 | `I_kwDOSzLlmM8AAAABMEOvrA` | https://github.com/yersonargotev/dots/issues/431 | `2026-08-09T21:01:38Z` | `e5007e353185b902916ed0205be68d3b100499138548cd8266482c6b9d5a7b09` |
| Parent #427 | `I_kwDOSzLlmM8AAAABMEODWA` | https://github.com/yersonargotev/dots/issues/427 | `2026-08-09T20:58:54Z` | `294db5b0d8a1d718b2b5ae57f3a09dbe61720b13db334c248eac4eea7ade823c` |

Snapshotted labels for #431: category `enhancement`; readiness `ready-for-agent`; no other triage-state label.

Native relationships at admission/revalidation:

- Parent: #427 (`I_kwDOSzLlmM8AAAABMEODWA`), OPEN, updated `2026-08-09T20:58:54Z`.
- Sub-issues of #431: none.
- Blocked by: #429 (`I_kwDOSzLlmM8AAAABMEOtqA`), CLOSED, updated `2026-08-09T21:57:24Z`.
- Blocking: #432 (`I_kwDOSzLlmM8AAAABMEOw_w`), OPEN, updated `2026-08-09T21:01:43Z`.
- Parent #427 native sub-issues: #428 CLOSED (`I_kwDOSzLlmM8AAAABMEOsJg`, `2026-08-09T21:33:49Z`); #429 CLOSED (`I_kwDOSzLlmM8AAAABMEOtqA`, `2026-08-09T21:57:24Z`); #430 CLOSED (`I_kwDOSzLlmM8AAAABMEOvpQ`, `2026-08-09T22:22:37Z`); #431 OPEN (`I_kwDOSzLlmM8AAAABMEOvrA`, `2026-08-09T21:01:38Z`); #432 OPEN (`I_kwDOSzLlmM8AAAABMEOw_w`, `2026-08-09T21:01:43Z`); #433 OPEN (`I_kwDOSzLlmM8AAAABMEOyZg`, `2026-08-09T21:01:49Z`).

#### Exact ticket #431 body

~~~~markdown
### Pre-flight checks

- [x] I searched existing issues and this is not a duplicate.
- [x] The scope is small enough for one reviewable work unit.

### Desired outcome

Install Plan and Provisioner planning consume the same Selected Surface already used by selection evolution, Dependencies, and Install Catalog.

### Current-state gap

Managed Entry and Provisioner planning still perform their own Tag and operating-system filtering after the Selected Surface module exists. That keeps duplicate selection knowledge inside the mutation path and can make preview or application disagree with catalog and dependency reports.

### What to build

Migrate the installation-planning path and Provisioner-planning path to consume Selected Surface while preserving all filesystem planning, Conflict, source override, and command-rendering behavior behind their existing interfaces.

### Key interfaces

- Install Plan construction — receives selected Managed Entries and resolved source overrides from Selected Surface.
- Provisioner Plan construction — receives selected Provisioners from Selected Surface.
- Dry-run and machine-readable reports — continue exposing the same selected Profiles, Tags, actions, and Provisioner steps.

### Acceptance criteria

- [ ] Install Plan no longer independently selects Managed Entries by Tags and operating system.
- [ ] Provisioner planning no longer independently selects Provisioners by Tags and operating system.
- [ ] Source override precedence and deterministic ordering remain unchanged.
- [ ] Profile and equivalent explicit Tag selection produce the same Install Plan and Provisioner Plan.
- [ ] Skipped-surface hints remain truthful for composed Profiles.
- [ ] Conflict detection, Backup Set behavior, and application semantics remain unchanged.
- [ ] Dry-run and JSON output remain compatible.
- [ ] Tests assert observable plans and steps rather than Selected Surface internals.

### Non-goals

- Migrating status, doctor, or installed reporting.
- Removing every legacy selection helper before diagnostic callers migrate.
- Changing Provisioner command rendering or executing historical cleanup.

### Validation notes

- Run focused Install Plan and Provisioner tests followed by the full CI-equivalent suite.
- Exercise plan behavior only with temporary home, source, and state roots.
- Compare Profile and explicit Tag plans without applying configuration.
~~~~

#### Exact parent #427 body

~~~~markdown
### Pre-flight checks

- [x] I searched existing issues and this is not a duplicate.
- [x] The scope clearly identifies independently reviewable slices.

### Desired outcome

Profiles are removable, composable names for ordered Tag selections rather than a second owner of installation behavior. For the same effective Tags and operating system, dots produces one deterministic Selected Surface regardless of whether the operator selected those Tags through a Profile or explicit `--tag` flags. Historical migrations remain evidence-gated and separate from current Tag selection.

### Current-state gap

Profiles currently may own Dependencies directly in addition to selecting Tags. This makes equivalent selections diverge: the `desktop` Profile selects the Desktop Nerd Font while explicit `--tag desktop` does not, and the composite `workstation` Profile duplicates that Dependency to reproduce the desktop surface. Selection by Tags and operating system is also recalculated across several modules, while the `agents` Tag still activates a hidden Gentle AI cleanup action rather than selecting only declarative surface. These seams make adding or removing Profiles more transversal than the domain model promises.

## Problem Statement

As an operator maintaining several workstation roles, I cannot treat Profiles as lightweight, removable compositions of Tags because Profiles can carry installation behavior that their Tags do not. Equivalent intent can therefore produce different Dependencies, composite Profiles must duplicate declarations, and retiring a capability can require unrelated callers to understand hidden Tag behavior.

## Solution

Make Profile a pure named union of Tags. Define Selected Surface as the deterministic Managed Entries, resolved source overrides, Dependencies, and Provisioners applicable to effective Tags and the operating system. Move capability-wide Dependencies into Tag-scoped Dependency Sets, deepen Selected Surface evaluation behind one cohesive module, and migrate historical cleanup authority from current Tags to proven Installation Metadata. Preserve the existing explicit Installed Selection and reduction-safety contracts.

## User Stories

1. As a dots operator, I want a Profile to mean only a named set of Tags, so that I can understand it without inspecting hidden Dependencies.
2. As a dots operator, I want `--profile desktop` and `--tag desktop` to select the same surface, so that equivalent intent behaves consistently.
3. As a dots operator, I want composite Profiles to reuse Tag-owned capabilities, so that they do not duplicate dependency declarations.
4. As a dots operator, I want to add a new Profile by listing existing Tags, so that adding a workstation role does not require changes across the installer.
5. As a dots operator, I want to remove a Profile without removing its Tags, so that other Profiles and explicit Tag selections continue working.
6. As a dots operator, I want a removed recorded Profile to block before mutation, so that dots never guesses replacement intent.
7. As a dots operator, I want Profile retirement not to uninstall historical artifacts automatically, so that dots never deletes state without explicit authority.
8. As a dots operator, I want legacy Profiles to remain explicitly queryable while being hidden from normal discovery, so that staged retirement remains understandable.
9. As a user of an alternate Install Manifest, I want a precise validation error for retired Profile Dependencies, so that I know how to migrate them.
10. As a user updating an older Installed Repository, I want dots to read its historical Profile Dependencies for evolution comparison, so that the schema cleanup does not prevent a safe update.
11. As an automation author, I want deterministic Selected Surface ordering, so that machine-readable reports remain stable.
12. As an automation author, I want the existing catalog envelope to remain schema-compatible during this change, so that a removed concept does not cause an unrelated schema break.
13. As a maintainer, I want Dependencies owned by the narrowest declarative surface that requires them, so that ownership remains local.
14. As a maintainer, I want capability-wide Dependencies selected by Tags, so that every route to the same capability has the same prerequisites.
15. As a maintainer, I want one Selected Surface evaluation rule, so that selection changes are fixed and tested in one place.
16. As a maintainer, I want command modules to consume Selected Surface instead of recreating Tag and operating-system filters, so that callers receive leverage from a deeper module.
17. As a maintainer, I want Install Catalog, Dependency Plan, Install Plan, status, doctor, and installed reporting to agree on selection, so that diagnostics do not contradict installation.
18. As a maintainer, I want current Tags to select declarative surface only, so that selecting a capability does not trigger unrelated hidden cleanup.
19. As a maintainer, I want historical cleanup gated by Installation Metadata evidence, so that user-owned files are not changed merely because a current Tag was selected.
20. As a maintainer, I want Gentle AI retirement isolated from Profile schema cleanup, so that each risky change is independently reviewable.
21. As a contributor, I want the domain glossary and ADR for composable Profiles to state the same invariants as the code, so that future changes do not reintroduce Profile-owned behavior.
22. As a release maintainer, I want each delivery slice to remain green and demonstrable, so that the architectural change can ship incrementally.

## Implementation Decisions

- `Profile` is the sole canonical domain term. The duplicate `Install Profile` term is retired.
- A Profile contains descriptive metadata, lifecycle status, and an ordered list of Tags. Profiles do not contain other Profiles and do not own Dependencies, Managed Entries, or Provisioners.
- A Tag is the elemental declarative selection intent. Tags do not directly trigger built-in Go behavior.
- Selected Surface is the ordered, de-duplicated set of Managed Entries, resolved source overrides, Dependencies, and Provisioners selected by effective Tags and the operating system.
- Selected Surface excludes filesystem state, Drift, Conflicts, Install Plan actions, and historical migrations.
- Dependencies belong to the narrowest owning declaration: a Managed Entry, a Provisioner, or a Tag-scoped Dependency Set for capability-wide prerequisites.
- Equivalent effective Tags on the same operating system produce the same Selected Surface regardless of Profile or explicit Tag provenance. Provenance remains reportable but does not change selection.
- The repository manifest moves the Desktop Nerd Font to a `desktop` Dependency Set and Playwright CLI to a `web` Dependency Set. The composite `workstation` Profile no longer duplicates the font.
- Normal manifest loading rejects `profiles[].dependencies` with actionable migration guidance while retaining manifest version 1.
- Historical manifest loading may accept the retired field only to compare pre-refresh selection evolution. It does not make the field valid for a new install.
- A Profile may transition to `legacy` for discovery purposes. Removing it does not redirect intent; a recorded missing Profile blocks before mutation and requires a complete explicit replacement.
- Profile removal does not prune historical inventory or uninstall artifacts.
- The catalog JSON presentation adapter temporarily retains `profile_dependencies` as an empty array until a separately planned envelope-version change. The domain and human presentation no longer expose Profile Dependencies.
- Selected Surface evaluation is deepened as in-process computation. Cobra, YAML, Installation Metadata, filesystem mutation, and text/JSON presentation remain adapters rather than entering the selection interface.
- Interfaces are introduced only at demonstrated I/O substitution seams and live with their consumers. Pure selection accepts and returns concrete values.
- Gentle AI cleanup moves to an evidence-gated historical migration based on sufficiently specific Installation Metadata, preserving marker-based ownership checks and fail-closed behavior.
- The work is delivered in three ordered Delivery Units: pure Profiles, deep Selected Surface evaluation, and evidence-gated historical migrations.
- `CONTEXT.md` and manifest documentation are updated, and ADR-0013 receives an amendment rather than creating a separate architectural decision.

## Testing Decisions

- The primary test seam is existing machine-readable command behavior: manifest validation, Dependency Plan, Install Catalog, and selection-evolution output. Tests assert observable outcomes rather than internal helper calls.
- For Darwin and Linux, every repository Profile is compared with an explicit selection of its resolved Tags; both must expose the same Selected Surface.
- A focused regression proves that `--profile desktop` and `--tag desktop` both include the Desktop Nerd Font.
- A focused regression proves that `--profile web` and `--tag web` both include Playwright CLI.
- A manifest test proves that Profile Dependencies are rejected with migration guidance during normal loading.
- An update test proves that a previous manifest containing Profile Dependencies can still be read for selection-evolution comparison before refresh.
- Catalog tests prove that human output omits Profile Dependencies while schema-version-compatible JSON emits an empty compatibility field.
- Selected Surface tests exercise ordering, de-duplication, Tag/OS matching, source overrides, Profile equivalence, and absence of filesystem I/O through the module interface.
- Existing command tests remain the prior art for command-level JSON envelopes, and existing selection-evolution tests remain the prior art for historical manifest comparison.
- Historical migration tests distinguish positive metadata evidence, irrelevant current Tags, ambiguous or missing evidence, malformed markers, user-owned content, and partial filesystem failure.
- Full validation matches CI: formatting, vet, build, test, manifest validation, catalog generation checks, and sandboxed CLI commands that never target the real home.

### Key interfaces

- Install Manifest Profile declaration — Profile-owned Dependencies are retired; ordered Tags remain.
- Selected Surface evaluation — effective Tags plus operating system determine declarative selected surface independently of provenance.
- `dots deps plan` and Install Catalog machine-readable output — equivalent Profile and Tag selections agree.
- Selection evolution during `dots update` — historical manifests remain comparable without accepting retired schema for current installation.
- Installed Selection change handling — missing or reduced intent still blocks or requires explicit acknowledgement before mutation.
- Historical retirement workflow — Installation Metadata evidence authorizes cleanup; current Tag selection does not.

### Requirements

- The implementation must preserve explicit Profile and Tag intent and ordered Tag union semantics.
- The implementation must preserve the fail-before-mutation behavior for missing recorded Profiles.
- The implementation must not infer, redirect, merge, or silently replace Installed Selection.
- The implementation must keep the Install Manifest declarative and must not introduce dynamic Go plugins.
- The implementation must keep each Delivery Unit independently reviewable and green.
- The implementation must preserve JSON compatibility unless a separately authorized envelope-version change is required.

## Out of Scope

- Dynamic Go plugins or runtime code discovery for Profiles or Tags.
- Nested Profiles or recursive Profile inheritance.
- Automatic replacement of a removed Profile.
- Automatic uninstall or pruning caused by Profile removal.
- Changing the Installed Selection reduction acknowledgement contract.
- Reworking filesystem planning, Conflict resolution, Drift detection, or uninstall semantics.
- Performing all three Delivery Units in one pull request.
- Removing the temporary catalog JSON compatibility field as part of this specification.
- Generalizing every historical migration before the Gentle AI path demonstrates the seam.

### Acceptance criteria

- [ ] Profiles contain no Dependencies and compose only ordered Tags plus descriptive lifecycle metadata.
- [ ] Capability-wide Dependencies are Tag-scoped and composite Profiles contain no duplicated prerequisites.
- [ ] Equivalent Profile and explicit Tag selections produce the same Selected Surface on Darwin and Linux.
- [ ] Normal loading rejects retired Profile Dependencies with actionable guidance; update can still compare a historical manifest that contains them.
- [ ] Selected Surface selection is concentrated behind one cohesive in-process module and consumed consistently by its callers.
- [ ] Current Tags no longer trigger hidden cleanup behavior.
- [ ] Gentle AI cleanup runs only with sufficient historical Installation Metadata evidence and preserves user-owned content.
- [ ] Installed Selection blocking, reduction acknowledgement, and no-pruning behavior remain unchanged.
- [ ] Human and machine-readable contracts remain consistent, including the temporary empty catalog compatibility field.
- [ ] The glossary, manifest documentation, and ADR-0013 describe the final domain model.
- [ ] Each child Delivery Unit has a complete Delivery Contract, native parent relationship, and correct blocking edges.

### Validation notes

- `gofmt -l .`
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- `go generate ./internal/catalog`
- `go run ./cmd/dots manifest validate --file dots.yaml`
- Compare Profile and explicit Tag dependency/catalog output for both supported operating systems where the command permits an OS selector.
- Run any home/state behavior with temporary `--home`, `--source-root`, and `--state-root` paths; never use the real home.

## Further Notes

- This specification deepens ADR-0013 rather than replacing explicit composable Profiles.
- ADR-0014 continues to govern Installed Selection persistence, evolution, replacement, and reduction safety.
- The architecture deliberately applies ports and adapters only at real I/O seams. The pure selection core does not require interface indirection.
- The broad file count in the Codex delegation retirement was mostly required by safe compatibility and migration behavior; this specification targets the avoidable second sources of truth revealed by that change.
~~~~

### Reviewed head

- `e0abc746102e5d7775534f7c785ee78adb33c7aa` on base `6da78f00b97965a8649973f516dcc01930893898`.

### Acceptance coverage

- Install Plan consumes Selected Surface entries and resolved source overrides; it no longer performs Tag/OS selection.
- Provisioner selection and planning consume Selected Surface Provisioners; skipped-surface hints use the same selected declarations.
- Manifest-order projection preserves source precedence, declaration multiplicity, duplicate-target Conflict diagnostics, Backup Set inputs, and application semantics.
- Profile and equivalent explicit Tag selections produce equal actions and steps on Darwin and Linux.
- Existing composed-Profile skipped-surface tests remain green.
- Existing golden, dry-run, JSON, install, Conflict, and source-override tests remain green.
- New tests assert Plan actions and Provisioner steps rather than Selected Surface internals.

### Automated validation

- `gofmt -l .` — PASS (no output).
- `go vet ./...` — PASS.
- `go build ./...` — PASS.
- `go test ./...` — PASS.
- `go test ./internal/selectedsurface ./internal/plan ./internal/provision` — PASS.
- `go test ./internal/cli/... ./internal/install/... ./internal/plan/... ./internal/provision/...` — PASS.
- `go generate ./internal/catalog` — PASS; no generated diff.

### Manual verification

- Built one real binary with `go build -o <tmp>/dots ./cmd/dots`.
- `<tmp>/dots manifest validate --file dots.yaml` — exit 0, `manifest is valid`.
- Sandboxed `dots plan --output json` for `--profile web` and equivalent `--tag web` — both exit 0; projected actions were byte-for-byte equal.
- Sandboxed `dots install --dry-run --skip-deps --profile web --output json` — exit 0; one action, six Provisioner steps, `dry_run: true`.
- Temporary home and state roots remained empty after verification.

### Independent review

- Spec: PASS on `origin/main...e0abc746`; zero remaining findings after duplicate-target preservation and Darwin/Linux evidence fixes.
- Standards: PASS; no documented-standard violations or actionable findings.
- Observation: Managed Entry and Provisioner manifest-position projections share a similar shape. No follow-up is warranted now because they adapt distinct declaration types, there are only two uses, and a generic helper or wider Selected Surface interface would add speculative abstraction.
<!-- delivery-issue:evidence:end -->