### PR TITLE
refactor(selection): contract duplicated selection paths

### DIFF
--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -4,6 +4,7 @@ package catalog
 
 import (
 	"fmt"
+	"reflect"
 	"runtime"
 	"sort"
 	"strings"
@@ -272,7 +273,7 @@ func Tag(m manifest.Manifest, name string, opts Options) (Report, error) {
 
 func buildDetail(m manifest.Manifest, name, description, status, kind, replacedBy string, tags []string, osName string) *Detail {
 	d := &Detail{Name: name, Description: description, Status: status, Kind: kind, ReplacedBy: replacedBy, ResolvedTags: clone(tags), Dependencies: []Dependency{}, DependencySets: []DependencySet{}, ProfileDependencies: []Dependency{}, Entries: []Entry{}, SourceOverrides: []SourceOverride{}, Provisioners: []Provisioner{}, Behaviors: behaviors(tags), Excluded: []ExcludedSurface{}}
-	surface := selectedSurface(m, tags, osName)
+	surface, excludedSurface := selectedSurfaces(m, tags, osName)
 	for _, set := range surface.DependencySets {
 		item := DependencySet{Tags: clone(set.Tags), OS: declaredOS(set.OS), Dependencies: []Dependency{}}
 		for _, dep := range set.Dependencies {
@@ -295,11 +296,11 @@ func buildDetail(m manifest.Manifest, name, description, status, kind, replacedB
 		entry := override.Entry
 		d.SourceOverrides = append(d.SourceOverrides, SourceOverride{Tag: override.Tag, Source: override.Source, Entry: entry.Source, Target: entry.Target, OS: declaredOS(entry.OS), Applicable: true})
 	}
-	d.SourceOverrides = append(d.SourceOverrides, inactiveSourceOverrides(m, tags, osName)...)
+	d.SourceOverrides = append(d.SourceOverrides, inactiveSourceOverrides(excludedSurface)...)
 	for _, p := range surface.Provisioners {
 		d.Provisioners = append(d.Provisioners, provisioner(p))
 	}
-	d.Excluded = excludedSurfaces(m, tags, osName)
+	d.Excluded = excludedSurfaces(excludedSurface, osName)
 	sort.Slice(d.SourceOverrides, func(i, j int) bool {
 		if d.SourceOverrides[i].Tag == d.SourceOverrides[j].Tag {
 			return d.SourceOverrides[i].Target < d.SourceOverrides[j].Target
@@ -319,68 +320,75 @@ func catalogOrigin(origin selectedsurface.Origin) Origin {
 	return Origin{Type: origin.Type, Name: origin.Name, Tags: clone(origin.Tags)}
 }
 
-func selectedSurface(m manifest.Manifest, tags []string, osName string) selectedsurface.Surface {
+func selectedSurfaces(m manifest.Manifest, tags []string, osName string) (selectedsurface.Surface, selectedsurface.Surface) {
 	if osName == "all" {
-		return selectedsurface.EvaluateAll(m, tags)
+		return selectedsurface.EvaluateAll(m, tags), selectedsurface.Surface{}
 	}
-	return selectedsurface.Evaluate(m, tags, osName)
+	selected := selectedsurface.Evaluate(m, tags, osName)
+	otherOS := "darwin"
+	if osName == "darwin" {
+		otherOS = "linux"
+	}
+	other := selectedsurface.Evaluate(m, tags, otherOS)
+	return selected, subtractSurface(other, selected)
 }
 
 // inactiveSourceOverrides preserves the catalog explanation for selected tags
 // whose override is excluded by OS. Applicable overrides always come from the
 // selected surface above.
-func inactiveSourceOverrides(m manifest.Manifest, tags []string, osName string) []SourceOverride {
-	result := []SourceOverride{}
-	for _, entry := range m.Entries {
-		if matches(entry.OS, osName) {
-			continue
-		}
-		for tag, source := range entry.SourceOverrides {
-			if contains(tags, tag) {
-				result = append(result, SourceOverride{Tag: tag, Source: source, Entry: entry.Source, Target: entry.Target, OS: declaredOS(entry.OS), Applicable: false})
-			}
+func inactiveSourceOverrides(surface selectedsurface.Surface) []SourceOverride {
+	result := make([]SourceOverride, 0, len(surface.SourceOverrides))
+	for _, override := range surface.SourceOverrides {
+		entry := override.Entry
+		result = append(result, SourceOverride{Tag: override.Tag, Source: override.Source, Entry: entry.Source, Target: entry.Target, OS: declaredOS(entry.OS), Applicable: false})
+	}
+	return result
+}
+
+// excludedSurfaces projects declarations selected only on the other Supported
+// Platform. Tag and OS traversal remains owned by selectedsurface.
+func excludedSurfaces(surface selectedsurface.Surface, osName string) []ExcludedSurface {
+	result := []ExcludedSurface{}
+	for _, set := range surface.DependencySets {
+		result = append(result, excluded("dependency_set", strings.Join(set.Tags, ","), set.OS, osName))
+	}
+	for _, override := range surface.SourceOverrides {
+		result = append(result, excluded("source_override", override.Entry.Target+" ("+override.Tag+")", override.Entry.OS, osName))
+	}
+	for _, entry := range surface.Entries {
+		result = append(result, excluded("entry", entry.Entry.Target, entry.Entry.OS, osName))
+	}
+	for _, provisioner := range surface.Provisioners {
+		result = append(result, excluded("provisioner", provisioner.Tool, provisioner.OS, osName))
+	}
+	return result
+}
+
+func subtractSurface(surface, selected selectedsurface.Surface) selectedsurface.Surface {
+	surface.DependencySets = subtractExact(surface.DependencySets, selected.DependencySets)
+	surface.Entries = subtractExact(surface.Entries, selected.Entries)
+	surface.Provisioners = subtractExact(surface.Provisioners, selected.Provisioners)
+	surface.SourceOverrides = subtractExact(surface.SourceOverrides, selected.SourceOverrides)
+	return surface
+}
+
+func subtractExact[T any](values, excludedValues []T) []T {
+	result := make([]T, 0, len(values))
+	for _, value := range values {
+		if !containsExact(excludedValues, value) {
+			result = append(result, value)
 		}
 	}
 	return result
 }
 
-// excludedSurfaces reports raw declarations that share the requested tags but
-// are not applicable to the requested operating system. They are deliberately
-// outside selectedsurface because that package exposes applicable declarations.
-func excludedSurfaces(m manifest.Manifest, tags []string, osName string) []ExcludedSurface {
-	result := []ExcludedSurface{}
-	for _, set := range m.Dependencies {
-		if !manifest.SharesTag(set.Tags, tags) {
-			continue
-		}
-		if !matches(set.OS, osName) {
-			result = append(result, excluded("dependency_set", strings.Join(set.Tags, ","), set.OS, osName))
+func containsExact[T any](values []T, candidate T) bool {
+	for _, value := range values {
+		if reflect.DeepEqual(value, candidate) {
+			return true
 		}
 	}
-	for _, entry := range m.Entries {
-		for tag := range entry.SourceOverrides {
-			if contains(tags, tag) {
-				if !matches(entry.OS, osName) {
-					result = append(result, excluded("source_override", entry.Target+" ("+tag+")", entry.OS, osName))
-				}
-			}
-		}
-		if !manifest.SharesTag(entry.Tags, tags) {
-			continue
-		}
-		if !matches(entry.OS, osName) {
-			result = append(result, excluded("entry", entry.Target, entry.OS, osName))
-		}
-	}
-	for _, p := range m.Provisioners {
-		if !manifest.SharesTag(p.Tags, tags) {
-			continue
-		}
-		if !matches(p.OS, osName) {
-			result = append(result, excluded("provisioner", p.Tool, p.OS, osName))
-		}
-	}
-	return result
+	return false
 }
 
 func comparisonSurface(detail *Detail) ComparisonSurface {
@@ -594,7 +602,6 @@ func resolveOS(value string) (string, error) {
 		return "", fmt.Errorf("catalog OS %q is invalid: choose darwin, linux, or all", value)
 	}
 }
-func matches(os []string, value string) bool { return value == "all" || manifest.MatchesOS(os, value) }
 func declaredOS(os []string) []string {
 	if len(os) == 0 {
 		return []string{"darwin", "linux"}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/yersonargotev/dots/internal/cli"
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/plan"
+	"github.com/yersonargotev/dots/internal/selectedsurface"
 )
 
 func TestRootHelpIdentifiesDotsCLI(t *testing.T) {
@@ -1101,8 +1102,8 @@ func TestRepositoryGitConfigInstallsAndReportsAlignedInSandbox(t *testing.T) {
 		t.Fatalf("no managed entries apply to profile \"default\" on %s; derived plan is empty", runtime.GOOS)
 	}
 	wantSkipped := 0
-	for _, entry := range loaded.Entries {
-		if manifest.SharesTag(entry.Tags, coreProfile.Tags) && !manifest.MatchesOS(entry.OS, runtime.GOOS) {
+	for _, entry := range selectedsurface.EvaluateEntries(*loaded, coreProfile.Tags, runtime.GOOS) {
+		if !entry.Applicable {
 			wantSkipped++
 		}
 	}

--- a/internal/cli/ghostty_config_test.go
+++ b/internal/cli/ghostty_config_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 
@@ -89,12 +90,12 @@ func TestGhosttyDesktopProfileInstallsAndReportsAlignedInSandbox(t *testing.T) {
 	if ghosttyEntry == nil {
 		t.Fatal("dots manifest missing Ghostty managed entry")
 	}
-	if !manifest.SharesTag(ghosttyEntry.Tags, []string{"desktop"}) {
+	if !slices.Contains(ghosttyEntry.Tags, "desktop") {
 		t.Fatalf("Ghostty managed entry tags = %#v, want desktop", ghosttyEntry.Tags)
 	}
 	foundDesktopFontDependency := false
 	for _, set := range manifestFile.Dependencies {
-		if !manifest.SharesTag(set.Tags, []string{"desktop"}) {
+		if !slices.Contains(set.Tags, "desktop") {
 			continue
 		}
 		for _, dep := range set.Dependencies {

--- a/internal/cli/warp_config_test.go
+++ b/internal/cli/warp_config_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 
@@ -115,7 +116,7 @@ func TestWarpDesktopProfileInstallsAndReportsAlignedInSandbox(t *testing.T) {
 		if entry.Strategy != "copy" {
 			t.Fatalf("Warp entry %s -> %s strategy = %q, want copy", entry.Source, entry.Target, entry.Strategy)
 		}
-		if !manifest.SharesTag(entry.Tags, []string{"desktop"}) {
+		if !slices.Contains(entry.Tags, "desktop") {
 			t.Fatalf("Warp entry %s -> %s tags = %#v, want desktop", entry.Source, entry.Target, entry.Tags)
 		}
 		wantOS := "linux"

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -1116,57 +1116,12 @@ func resolveSelection(m Manifest, profileNames []string, extraTags []string, all
 	return Selection{Profile: strings.Join(profiles, ","), Profiles: profiles, Tags: tags}, nil
 }
 
-// SelectionTags returns the effective tag set for a profile plus any
-// explicit tags requested by the caller. The profile tags stay first so selected
-// entries and provisioners preserve the manifest's role-oriented baseline while
-// --tag can opt into one-off capabilities without creating feature profiles.
-func SelectionTags(profile Profile, extraTags []string) []string {
-	tags := append([]string(nil), profile.Tags...)
-	seen := make(map[string]bool, len(tags)+len(extraTags))
-	for _, tag := range tags {
-		seen[tag] = true
-	}
-	for _, tag := range extraTags {
-		if seen[tag] {
-			continue
-		}
-		seen[tag] = true
-		tags = append(tags, tag)
-	}
-	return tags
-}
-
-func EntrySource(entry Entry, selectionTags []string) string {
-	for i := len(selectionTags) - 1; i >= 0; i-- {
-		if source, ok := entry.SourceOverrides[selectionTags[i]]; ok {
-			return source
-		}
-	}
-	return entry.Source
-}
-
-// SharesTag reports whether an item's tags intersect a profile's tags. It is
-// half the profile-scoping rule entries and provisioners share: an item belongs
-// to a profile when at least one of its tags matches one of the profile's tags.
-// Centralizing it here keeps plan, status, deps, doctor, and provision filtering
-// through one rule instead of each carrying its own copy.
-func SharesTag(itemTags, profileTags []string) bool {
-	for _, it := range itemTags {
-		for _, pt := range profileTags {
-			if it == pt {
-				return true
-			}
-		}
-	}
-	return false
-}
-
 // MatchesOS reports whether an item's OS filter admits the current OS. An empty
 // filter matches every OS. The comparison is case-insensitive so a manifest that
 // declared an OS in mixed case still matches runtime.GOOS, which is always
 // lowercase; validation already constrains OS values to lowercase darwin/linux,
-// so this is defensive rather than load-bearing. It is the other half of the
-// profile-scoping rule SharesTag begins.
+// so this is defensive rather than load-bearing. Current declarative selection
+// belongs to selectedsurface; this helper remains for historical record matching.
 func MatchesOS(itemOS []string, currentOS string) bool {
 	if len(itemOS) == 0 {
 		return true

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/provision"
+	"github.com/yersonargotev/dots/internal/selectedsurface"
 )
 
 func TestLoadFileAcceptsMinimalValidManifest(t *testing.T) {
@@ -3144,21 +3145,13 @@ func TestRepositoryManifestPlansMVPConfigurationSetSafely(t *testing.T) {
 		t.Fatalf("Build() error = %v", err)
 	}
 
-	// Derive the expected action count from the loaded manifest instead of a
-	// hardcoded literal: every managed entry whose tags intersect the profile
-	// and that passes the OS filter must produce exactly one action. This is the
-	// same selection plan.Build applies, so adding or removing a dots.yaml entry
-	// never forces a magic-number bump here.
+	// Derive the expected action count from the Selected Surface instead of
+	// repeating its Tag and OS traversal in this command-level plan test.
 	profile, ok := got.Profiles["core"]
 	if !ok {
 		t.Fatal("manifest missing profile \"default\"")
 	}
-	wantActions := 0
-	for _, entry := range got.Entries {
-		if manifest.SharesTag(entry.Tags, profile.Tags) && manifest.MatchesOS(entry.OS, "darwin") {
-			wantActions++
-		}
-	}
+	wantActions := len(selectedsurface.Evaluate(*got, profile.Tags, "darwin").Entries)
 	if wantActions == 0 {
 		t.Fatal("no managed entries apply to profile \"default\" on darwin; derived plan is empty")
 	}

--- a/internal/selectedsurface/report_parity_test.go
+++ b/internal/selectedsurface/report_parity_test.go
@@ -1,0 +1,179 @@
+package selectedsurface_test
+
+import (
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/catalog"
+	"github.com/yersonargotev/dots/internal/deps"
+	"github.com/yersonargotev/dots/internal/doctor"
+	"github.com/yersonargotev/dots/internal/installed"
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/plan"
+	"github.com/yersonargotev/dots/internal/provision"
+	"github.com/yersonargotev/dots/internal/selectedsurface"
+	"github.com/yersonargotev/dots/internal/state"
+	"github.com/yersonargotev/dots/internal/status"
+)
+
+func TestRepositoryReportsAgreeWithSelectedSurface(t *testing.T) {
+	repositoryRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := manifest.LoadFile(filepath.Join(repositoryRoot, "dots.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	profileNames := make([]string, 0, len(m.Profiles))
+	for name := range m.Profiles {
+		profileNames = append(profileNames, name)
+	}
+	sort.Strings(profileNames)
+
+	for _, profileName := range profileNames {
+		profile := m.Profiles[profileName]
+		profileSelection, err := manifest.ResolveReadOnlySelection(*m, []string{profileName}, nil)
+		if err != nil {
+			t.Fatalf("resolve Profile %q: %v", profileName, err)
+		}
+		tagSelection, err := manifest.ResolveReadOnlySelection(*m, nil, profile.Tags)
+		if err != nil {
+			t.Fatalf("resolve Tags for Profile %q: %v", profileName, err)
+		}
+
+		for _, osName := range []string{"darwin", "linux"} {
+			t.Run(profileName+"/"+osName, func(t *testing.T) {
+				home := t.TempDir()
+				xdgStateHome := filepath.Join(home, ".local", "state")
+				profileSurface := selectedsurface.Evaluate(*m, profileSelection.Tags, osName)
+				tagSurface := selectedsurface.Evaluate(*m, tagSelection.Tags, osName)
+				if !reflect.DeepEqual(profileSurface, tagSurface) {
+					t.Fatal("Profile and equivalent explicit Tags produced different Selected Surfaces")
+				}
+
+				profileDeps, err := deps.Check(*m, deps.Options{Selection: &profileSelection, OS: osName}, absent, absent)
+				if err != nil {
+					t.Fatal(err)
+				}
+				tagDeps, err := deps.Check(*m, deps.Options{Selection: &tagSelection, OS: osName}, absent, absent)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !reflect.DeepEqual(profileDeps.Results, tagDeps.Results) || len(profileDeps.Results) != len(profileSurface.Dependencies) {
+					t.Fatalf("Dependency report disagrees with Selected Surface: results=%d dependencies=%d", len(profileDeps.Results), len(profileSurface.Dependencies))
+				}
+
+				profilePlan := buildPlan(t, *m, profileSelection, osName, repositoryRoot, home, xdgStateHome)
+				tagPlan := buildPlan(t, *m, tagSelection, osName, repositoryRoot, home, xdgStateHome)
+				if !reflect.DeepEqual(profilePlan.Actions, tagPlan.Actions) {
+					t.Fatal("Install Plan differs for Profile and equivalent explicit Tags")
+				}
+
+				profileProvisioners, err := provision.Build(*m, provision.Options{Selection: &profileSelection, OS: osName})
+				if err != nil {
+					t.Fatal(err)
+				}
+				tagProvisioners, err := provision.Build(*m, provision.Options{Selection: &tagSelection, OS: osName})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !reflect.DeepEqual(profileProvisioners.Steps, tagProvisioners.Steps) || len(profileProvisioners.Steps) != len(profileSurface.Provisioners) {
+					t.Fatalf("Provisioner Plan disagrees with Selected Surface: steps=%d provisioners=%d", len(profileProvisioners.Steps), len(profileSurface.Provisioners))
+				}
+
+				profileStatus := buildStatus(t, *m, profileSelection, osName, repositoryRoot, home, xdgStateHome)
+				tagStatus := buildStatus(t, *m, tagSelection, osName, repositoryRoot, home, xdgStateHome)
+				if !reflect.DeepEqual(profileStatus.Entries, tagStatus.Entries) {
+					t.Fatal("status differs for Profile and equivalent explicit Tags")
+				}
+
+				profileDoctor := buildDoctor(t, *m, profileSelection, osName, repositoryRoot, home, xdgStateHome)
+				tagDoctor := buildDoctor(t, *m, tagSelection, osName, repositoryRoot, home, xdgStateHome)
+				if !reflect.DeepEqual(profileDoctor.Dependencies.Results, tagDoctor.Dependencies.Results) ||
+					!reflect.DeepEqual(profileDoctor.Configuration.Entries, tagDoctor.Configuration.Entries) ||
+					!reflect.DeepEqual(profileDoctor.Provisioners.Items, tagDoctor.Provisioners.Items) ||
+					!reflect.DeepEqual(profileDoctor.SecretScan, tagDoctor.SecretScan) {
+					t.Fatal("doctor differs for Profile and equivalent explicit Tags")
+				}
+
+				assertCatalogSurface(t, *m, profileName, osName, profileSurface)
+				assertInstalledCoverage(t, *m, profileName, profile.Tags, osName, repositoryRoot, home, xdgStateHome, profileSurface)
+			})
+		}
+	}
+}
+
+func absent(string) bool { return false }
+
+func buildPlan(t *testing.T, m manifest.Manifest, selected manifest.Selection, osName, sourceRoot, home, xdgStateHome string) plan.Plan {
+	t.Helper()
+	result, err := plan.Build(m, plan.Options{Selection: &selected, OS: osName, SourceRoot: sourceRoot, Home: home, XDGStateHome: xdgStateHome})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+func buildStatus(t *testing.T, m manifest.Manifest, selected manifest.Selection, osName, sourceRoot, home, xdgStateHome string) status.Report {
+	t.Helper()
+	result, err := status.Build(m, state.Metadata{}, status.Options{Selection: &selected, OS: osName, SourceRoot: sourceRoot, Home: home, XDGStateHome: xdgStateHome})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+func buildDoctor(t *testing.T, m manifest.Manifest, selected manifest.Selection, osName, sourceRoot, home, xdgStateHome string) doctor.Report {
+	t.Helper()
+	result, err := doctor.Build(m, state.Metadata{}, doctor.Options{Selection: &selected, OS: osName, SourceRoot: sourceRoot, Home: home, XDGStateHome: xdgStateHome}, absent, absent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+func assertCatalogSurface(t *testing.T, m manifest.Manifest, profileName, osName string, surface selectedsurface.Surface) {
+	t.Helper()
+	report, err := catalog.Profile(m, profileName, catalog.Options{OS: osName})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Profile == nil {
+		t.Fatal("catalog Profile detail is nil")
+	}
+	applicableOverrides := 0
+	for _, override := range report.Profile.SourceOverrides {
+		if override.Applicable {
+			applicableOverrides++
+		}
+	}
+	if len(report.Profile.Entries) != len(surface.Entries) ||
+		len(report.Profile.Dependencies) != len(surface.DependencyOrigins) ||
+		len(report.Profile.DependencySets) != len(surface.DependencySets) ||
+		len(report.Profile.Provisioners) != len(surface.Provisioners) ||
+		applicableOverrides != len(surface.SourceOverrides) {
+		t.Fatalf("Install Catalog disagrees with Selected Surface: detail=%+v surface=%+v", report.Profile, surface)
+	}
+}
+
+func assertInstalledCoverage(t *testing.T, m manifest.Manifest, profileName string, tags []string, osName, sourceRoot, home, xdgStateHome string, surface selectedsurface.Surface) {
+	t.Helper()
+	meta := state.Metadata{Entries: []state.Record{{Source: "not-in-manifest", Target: "~/.not-in-manifest", Strategy: "copy", Profiles: []string{profileName}, Tags: append([]string(nil), tags...)}}}
+	report, err := installed.Build(m, meta, installed.Options{SourceRoot: sourceRoot, Home: home, XDGStateHome: xdgStateHome, OS: osName})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, coverage := range report.Profiles {
+		if coverage.Name != profileName {
+			continue
+		}
+		if coverage.TotalEntries != len(surface.Entries) || coverage.TotalProvisioners != len(surface.Provisioners) {
+			t.Fatalf("installed coverage disagrees with Selected Surface: coverage=%+v entries=%d provisioners=%d", coverage, len(surface.Entries), len(surface.Provisioners))
+		}
+		return
+	}
+	t.Fatalf("installed report omitted Profile %q coverage", profileName)
+}

--- a/internal/selectedsurface/selectedsurface.go
+++ b/internal/selectedsurface/selectedsurface.go
@@ -123,7 +123,7 @@ func evaluate(m manifest.Manifest, effectiveTags []string, matchesOS func([]stri
 	}
 
 	for _, set := range m.Dependencies {
-		if !manifest.SharesTag(set.Tags, tags) || !matchesOS(set.OS) || containsExact(seenSets, set) {
+		if !sharesTag(set.Tags, tags) || !matchesOS(set.OS) || containsExact(seenSets, set) {
 			continue
 		}
 		seenSets = append(seenSets, set)
@@ -158,7 +158,7 @@ func evaluate(m manifest.Manifest, effectiveTags []string, matchesOS func([]stri
 	}
 
 	for _, provisioner := range m.Provisioners {
-		if !manifest.SharesTag(provisioner.Tags, tags) || !matchesOS(provisioner.OS) || containsExact(seenProvisioners, provisioner) {
+		if !sharesTag(provisioner.Tags, tags) || !matchesOS(provisioner.OS) || containsExact(seenProvisioners, provisioner) {
 			continue
 		}
 		seenProvisioners = append(seenProvisioners, provisioner)
@@ -173,7 +173,7 @@ func evaluateEntries(m manifest.Manifest, tags []string, matchesOS func([]string
 	result := []EntryEvaluation{}
 	seenEntries := make([]manifest.Entry, 0)
 	for _, entry := range m.Entries {
-		if !manifest.SharesTag(entry.Tags, tags) || containsExact(seenEntries, entry) {
+		if !sharesTag(entry.Tags, tags) || containsExact(seenEntries, entry) {
 			continue
 		}
 		seenEntries = append(seenEntries, entry)
@@ -206,6 +206,17 @@ func uniqueTags(tags []string) []string {
 		result = append(result, tag)
 	}
 	return result
+}
+
+func sharesTag(itemTags, selectedTags []string) bool {
+	for _, itemTag := range itemTags {
+		for _, selectedTag := range selectedTags {
+			if itemTag == selectedTag {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func containsExact[T any](values []T, candidate T) bool {


### PR DESCRIPTION
Closes #432

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [x] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Makes Selected Surface the sole owner of current Tag traversal across migrated callers.
- Derives Install Catalog applicable and excluded scope from Selected Surface on both Supported Platforms.
- Removes obsolete manifest selection helpers and adds cross-report Profile/Tag parity coverage.

## Changes

| File | Change |
|------|--------|
| `internal/selectedsurface/*` | Owns Tag intersection and verifies every repository Profile across report seams on Darwin and Linux. |
| `internal/catalog/catalog.go` | Projects applicable and excluded catalog scope from Selected Surface without raw Tag/OS traversal. |
| `internal/manifest/manifest.go` | Removes obsolete `SelectionTags`, `EntrySource`, and `SharesTag` exports. |
| `internal/cli/*_test.go`, `internal/manifest/manifest_test.go` | Replaces helper-coupled assertions with observable selection behavior or direct declaration membership. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go build ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] `go generate ./internal/catalog` with no generated diff
- [x] Sandboxed real-binary Profile/Tag parity for catalog, deps check, plan, status, and doctor

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] CLI validation used `/tmp/dots-issue-432-manual.MOI82M/home`, explicit `--source-root`, and `/tmp/dots-issue-432-manual.MOI82M/state`.

## Contributor Checklist

- [x] Linked one issue with an admitted Delivery Contract using `Closes #432`.
- [x] Added exactly one `type:*` label.
- [x] Delivery Evidence records the Contract Source snapshot, Acceptance coverage, and Independent review.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Existing domain documentation already describes the unchanged Selected Surface invariant.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

### Contract Source snapshot

Kind: composed delivery ticket #432 with native parent specification #427.

| Source | Node ID | URL | `updatedAt` | SHA-256 of exact raw UTF-8 body |
|---|---|---|---|---|
| Ticket #432 | `I_kwDOSzLlmM8AAAABMEOw_w` | https://github.com/yersonargotev/dots/issues/432 | `2026-08-09T21:01:43Z` | `fee6bce3b3514d5a9fd50c308075446f44a18db0b6d9f42a995dde3a973040b5` |
| Parent #427 | `I_kwDOSzLlmM8AAAABMEODWA` | https://github.com/yersonargotev/dots/issues/427 | `2026-08-09T20:58:54Z` | `294db5b0d8a1d718b2b5ae57f3a09dbe61720b13db334c248eac4eea7ade823c` |

Snapshotted labels for #432: category `enhancement`; readiness `ready-for-agent`; no other triage-state label.

Native relationships at admission/revalidation:

- Parent: #427 (`I_kwDOSzLlmM8AAAABMEODWA`), OPEN, updated `2026-08-09T20:58:54Z`.
- Sub-issues of #432: none.
- Blocked by: #430 (`I_kwDOSzLlmM8AAAABMEOvpQ`), CLOSED, updated `2026-08-09T22:22:37Z`; #431 (`I_kwDOSzLlmM8AAAABMEOvrA`), CLOSED, updated `2026-08-09T22:40:54Z`.
- Blocking: #433 (`I_kwDOSzLlmM8AAAABMEOyZg`), OPEN, updated `2026-08-09T21:01:49Z`.
- Parent #427 native sub-issues: #428 CLOSED (`I_kwDOSzLlmM8AAAABMEOsJg`, `2026-08-09T21:33:49Z`); #429 CLOSED (`I_kwDOSzLlmM8AAAABMEOtqA`, `2026-08-09T21:57:24Z`); #430 CLOSED (`I_kwDOSzLlmM8AAAABMEOvpQ`, `2026-08-09T22:22:37Z`); #431 CLOSED (`I_kwDOSzLlmM8AAAABMEOvrA`, `2026-08-09T22:40:54Z`); #432 OPEN (`I_kwDOSzLlmM8AAAABMEOw_w`, `2026-08-09T21:01:43Z`); #433 OPEN (`I_kwDOSzLlmM8AAAABMEOyZg`, `2026-08-09T21:01:49Z`).

#### Exact ticket #432 body

~~~~markdown
### Pre-flight checks

- [x] I searched existing issues and this is not a duplicate.
- [x] The scope is small enough for one reviewable work unit.

### Desired outcome

Selected Surface is the single implementation of current Tag and operating-system selection across all migrated callers, with obsolete paths removed and parity protected at the highest observable seams.

### Current-state gap

The expand-and-migrate sequence intentionally keeps old selection helpers while callers move in independent green batches. Once planning and diagnostics have migrated, retaining those helpers would preserve the same architectural ambiguity the sequence is meant to remove.

### What to build

Contract the migration by deleting obsolete Tag/OS traversal and pass-through selection modules, narrowing exported interfaces, and replacing internal-detail tests with Selected Surface and command-level behavior tests. Apply the deletion test: retain a module only when removing it would spread complexity back into callers.

### Key interfaces

- Selected Surface — remains the sole current declarative selection interface.
- Machine-readable Dependency Plan, Install Catalog, Install Plan, Provisioner Plan, status, doctor, and installed reports — remain the observable compatibility seams.

### Acceptance criteria

- [ ] No migrated caller independently reimplements current Tag and operating-system selection.
- [ ] Obsolete pass-through helpers and their implementation-coupled tests are removed.
- [ ] Exported selection interfaces are no wider than their remaining callers require.
- [ ] Profile and equivalent explicit Tag selections produce the same Selected Surface for every repository Profile on Darwin and Linux.
- [ ] Dependency Plan, Install Catalog, Install Plan, Provisioner Plan, status, doctor, and installed reporting agree on selected scope.
- [ ] Source override, ordering, de-duplication, semantic exit code, and JSON compatibility tests remain green.
- [ ] The full CI-equivalent suite and generated documentation checks pass.

### Non-goals

- Changing Profiles, Tags, or Selected Surface semantics established by preceding tickets.
- Introducing new adapters without two demonstrated implementations.
- Migrating historical cleanup or removing hidden Tag behavior.

### Validation notes

- Run focused parity and command report tests before the full suite.
- Use code search to prove obsolete current-selection paths are gone, but treat observable tests as the acceptance authority.
- Run generated catalog and manifest validation checks.

~~~~

#### Exact parent #427 body

~~~~markdown
### Pre-flight checks

- [x] I searched existing issues and this is not a duplicate.
- [x] The scope clearly identifies independently reviewable slices.

### Desired outcome

Profiles are removable, composable names for ordered Tag selections rather than a second owner of installation behavior. For the same effective Tags and operating system, dots produces one deterministic Selected Surface regardless of whether the operator selected those Tags through a Profile or explicit `--tag` flags. Historical migrations remain evidence-gated and separate from current Tag selection.

### Current-state gap

Profiles currently may own Dependencies directly in addition to selecting Tags. This makes equivalent selections diverge: the `desktop` Profile selects the Desktop Nerd Font while explicit `--tag desktop` does not, and the composite `workstation` Profile duplicates that Dependency to reproduce the desktop surface. Selection by Tags and operating system is also recalculated across several modules, while the `agents` Tag still activates a hidden Gentle AI cleanup action rather than selecting only declarative surface. These seams make adding or removing Profiles more transversal than the domain model promises.

## Problem Statement

As an operator maintaining several workstation roles, I cannot treat Profiles as lightweight, removable compositions of Tags because Profiles can carry installation behavior that their Tags do not. Equivalent intent can therefore produce different Dependencies, composite Profiles must duplicate declarations, and retiring a capability can require unrelated callers to understand hidden Tag behavior.

## Solution

Make Profile a pure named union of Tags. Define Selected Surface as the deterministic Managed Entries, resolved source overrides, Dependencies, and Provisioners applicable to effective Tags and the operating system. Move capability-wide Dependencies into Tag-scoped Dependency Sets, deepen Selected Surface evaluation behind one cohesive module, and migrate historical cleanup authority from current Tags to proven Installation Metadata. Preserve the existing explicit Installed Selection and reduction-safety contracts.

## User Stories

1. As a dots operator, I want a Profile to mean only a named set of Tags, so that I can understand it without inspecting hidden Dependencies.
2. As a dots operator, I want `--profile desktop` and `--tag desktop` to select the same surface, so that equivalent intent behaves consistently.
3. As a dots operator, I want composite Profiles to reuse Tag-owned capabilities, so that they do not duplicate dependency declarations.
4. As a dots operator, I want to add a new Profile by listing existing Tags, so that adding a workstation role does not require changes across the installer.
5. As a dots operator, I want to remove a Profile without removing its Tags, so that other Profiles and explicit Tag selections continue working.
6. As a dots operator, I want a removed recorded Profile to block before mutation, so that dots never guesses replacement intent.
7. As a dots operator, I want Profile retirement not to uninstall historical artifacts automatically, so that dots never deletes state without explicit authority.
8. As a dots operator, I want legacy Profiles to remain explicitly queryable while being hidden from normal discovery, so that staged retirement remains understandable.
9. As a user of an alternate Install Manifest, I want a precise validation error for retired Profile Dependencies, so that I know how to migrate them.
10. As a user updating an older Installed Repository, I want dots to read its historical Profile Dependencies for evolution comparison, so that the schema cleanup does not prevent a safe update.
11. As an automation author, I want deterministic Selected Surface ordering, so that machine-readable reports remain stable.
12. As an automation author, I want the existing catalog envelope to remain schema-compatible during this change, so that a removed concept does not cause an unrelated schema break.
13. As a maintainer, I want Dependencies owned by the narrowest declarative surface that requires them, so that ownership remains local.
14. As a maintainer, I want capability-wide Dependencies selected by Tags, so that every route to the same capability has the same prerequisites.
15. As a maintainer, I want one Selected Surface evaluation rule, so that selection changes are fixed and tested in one place.
16. As a maintainer, I want command modules to consume Selected Surface instead of recreating Tag and operating-system filters, so that callers receive leverage from a deeper module.
17. As a maintainer, I want Install Catalog, Dependency Plan, Install Plan, status, doctor, and installed reporting to agree on selection, so that diagnostics do not contradict installation.
18. As a maintainer, I want current Tags to select declarative surface only, so that selecting a capability does not trigger unrelated hidden cleanup.
19. As a maintainer, I want historical cleanup gated by Installation Metadata evidence, so that user-owned files are not changed merely because a current Tag was selected.
20. As a maintainer, I want Gentle AI retirement isolated from Profile schema cleanup, so that each risky change is independently reviewable.
21. As a contributor, I want the domain glossary and ADR for composable Profiles to state the same invariants as the code, so that future changes do not reintroduce Profile-owned behavior.
22. As a release maintainer, I want each delivery slice to remain green and demonstrable, so that the architectural change can ship incrementally.

## Implementation Decisions

- `Profile` is the sole canonical domain term. The duplicate `Install Profile` term is retired.
- A Profile contains descriptive metadata, lifecycle status, and an ordered list of Tags. Profiles do not contain other Profiles and do not own Dependencies, Managed Entries, or Provisioners.
- A Tag is the elemental declarative selection intent. Tags do not directly trigger built-in Go behavior.
- Selected Surface is the ordered, de-duplicated set of Managed Entries, resolved source overrides, Dependencies, and Provisioners selected by effective Tags and the operating system.
- Selected Surface excludes filesystem state, Drift, Conflicts, Install Plan actions, and historical migrations.
- Dependencies belong to the narrowest owning declaration: a Managed Entry, a Provisioner, or a Tag-scoped Dependency Set for capability-wide prerequisites.
- Equivalent effective Tags on the same operating system produce the same Selected Surface regardless of Profile or explicit Tag provenance. Provenance remains reportable but does not change selection.
- The repository manifest moves the Desktop Nerd Font to a `desktop` Dependency Set and Playwright CLI to a `web` Dependency Set. The composite `workstation` Profile no longer duplicates the font.
- Normal manifest loading rejects `profiles[].dependencies` with actionable migration guidance while retaining manifest version 1.
- Historical manifest loading may accept the retired field only to compare pre-refresh selection evolution. It does not make the field valid for a new install.
- A Profile may transition to `legacy` for discovery purposes. Removing it does not redirect intent; a recorded missing Profile blocks before mutation and requires a complete explicit replacement.
- Profile removal does not prune historical inventory or uninstall artifacts.
- The catalog JSON presentation adapter temporarily retains `profile_dependencies` as an empty array until a separately planned envelope-version change. The domain and human presentation no longer expose Profile Dependencies.
- Selected Surface evaluation is deepened as in-process computation. Cobra, YAML, Installation Metadata, filesystem mutation, and text/JSON presentation remain adapters rather than entering the selection interface.
- Interfaces are introduced only at demonstrated I/O substitution seams and live with their consumers. Pure selection accepts and returns concrete values.
- Gentle AI cleanup moves to an evidence-gated historical migration based on sufficiently specific Installation Metadata, preserving marker-based ownership checks and fail-closed behavior.
- The work is delivered in three ordered Delivery Units: pure Profiles, deep Selected Surface evaluation, and evidence-gated historical migrations.
- `CONTEXT.md` and manifest documentation are updated, and ADR-0013 receives an amendment rather than creating a separate architectural decision.

## Testing Decisions

- The primary test seam is existing machine-readable command behavior: manifest validation, Dependency Plan, Install Catalog, and selection-evolution output. Tests assert observable outcomes rather than internal helper calls.
- For Darwin and Linux, every repository Profile is compared with an explicit selection of its resolved Tags; both must expose the same Selected Surface.
- A focused regression proves that `--profile desktop` and `--tag desktop` both include the Desktop Nerd Font.
- A focused regression proves that `--profile web` and `--tag web` both include Playwright CLI.
- A manifest test proves that Profile Dependencies are rejected with migration guidance during normal loading.
- An update test proves that a previous manifest containing Profile Dependencies can still be read for selection-evolution comparison before refresh.
- Catalog tests prove that human output omits Profile Dependencies while schema-version-compatible JSON emits an empty compatibility field.
- Selected Surface tests exercise ordering, de-duplication, Tag/OS matching, source overrides, Profile equivalence, and absence of filesystem I/O through the module interface.
- Existing command tests remain the prior art for command-level JSON envelopes, and existing selection-evolution tests remain the prior art for historical manifest comparison.
- Historical migration tests distinguish positive metadata evidence, irrelevant current Tags, ambiguous or missing evidence, malformed markers, user-owned content, and partial filesystem failure.
- Full validation matches CI: formatting, vet, build, test, manifest validation, catalog generation checks, and sandboxed CLI commands that never target the real home.

### Key interfaces

- Install Manifest Profile declaration — Profile-owned Dependencies are retired; ordered Tags remain.
- Selected Surface evaluation — effective Tags plus operating system determine declarative selected surface independently of provenance.
- `dots deps plan` and Install Catalog machine-readable output — equivalent Profile and Tag selections agree.
- Selection evolution during `dots update` — historical manifests remain comparable without accepting retired schema for current installation.
- Installed Selection change handling — missing or reduced intent still blocks or requires explicit acknowledgement before mutation.
- Historical retirement workflow — Installation Metadata evidence authorizes cleanup; current Tag selection does not.

### Requirements

- The implementation must preserve explicit Profile and Tag intent and ordered Tag union semantics.
- The implementation must preserve the fail-before-mutation behavior for missing recorded Profiles.
- The implementation must not infer, redirect, merge, or silently replace Installed Selection.
- The implementation must keep the Install Manifest declarative and must not introduce dynamic Go plugins.
- The implementation must keep each Delivery Unit independently reviewable and green.
- The implementation must preserve JSON compatibility unless a separately authorized envelope-version change is required.

## Out of Scope

- Dynamic Go plugins or runtime code discovery for Profiles or Tags.
- Nested Profiles or recursive Profile inheritance.
- Automatic replacement of a removed Profile.
- Automatic uninstall or pruning caused by Profile removal.
- Changing the Installed Selection reduction acknowledgement contract.
- Reworking filesystem planning, Conflict resolution, Drift detection, or uninstall semantics.
- Performing all three Delivery Units in one pull request.
- Removing the temporary catalog JSON compatibility field as part of this specification.
- Generalizing every historical migration before the Gentle AI path demonstrates the seam.

### Acceptance criteria

- [ ] Profiles contain no Dependencies and compose only ordered Tags plus descriptive lifecycle metadata.
- [ ] Capability-wide Dependencies are Tag-scoped and composite Profiles contain no duplicated prerequisites.
- [ ] Equivalent Profile and explicit Tag selections produce the same Selected Surface on Darwin and Linux.
- [ ] Normal loading rejects retired Profile Dependencies with actionable guidance; update can still compare a historical manifest that contains them.
- [ ] Selected Surface selection is concentrated behind one cohesive in-process module and consumed consistently by its callers.
- [ ] Current Tags no longer trigger hidden cleanup behavior.
- [ ] Gentle AI cleanup runs only with sufficient historical Installation Metadata evidence and preserves user-owned content.
- [ ] Installed Selection blocking, reduction acknowledgement, and no-pruning behavior remain unchanged.
- [ ] Human and machine-readable contracts remain consistent, including the temporary empty catalog compatibility field.
- [ ] The glossary, manifest documentation, and ADR-0013 describe the final domain model.
- [ ] Each child Delivery Unit has a complete Delivery Contract, native parent relationship, and correct blocking edges.

### Validation notes

- `gofmt -l .`
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- `go generate ./internal/catalog`
- `go run ./cmd/dots manifest validate --file dots.yaml`
- Compare Profile and explicit Tag dependency/catalog output for both supported operating systems where the command permits an OS selector.
- Run any home/state behavior with temporary `--home`, `--source-root`, and `--state-root` paths; never use the real home.

## Further Notes

- This specification deepens ADR-0013 rather than replacing explicit composable Profiles.
- ADR-0014 continues to govern Installed Selection persistence, evolution, replacement, and reduction safety.
- The architecture deliberately applies ports and adapters only at real I/O seams. The pure selection core does not require interface indirection.
- The broad file count in the Codex delegation retirement was mostly required by safe compatibility and migration behavior; this specification targets the avoidable second sources of truth revealed by that change.
~~~~

### Reviewed head

`39d498254bd263f61c9853fca1b1022bffbbb762` against `origin/main` `b295309d7386761aa9755f154d79679947df58f3`.

### Acceptance coverage

- Single selection implementation: `selectedsurface` now owns Tag intersection; migrated catalog scope is produced only through `Evaluate`/`EvaluateAll`.
- Contracted interface: removed unused `SelectionTags` and `EntrySource`, plus the cross-package `SharesTag` traversal helper. `MatchesOS` remains only where current Selected Surface evaluation or historical record matching requires it.
- Cross-report parity: one repository-level test covers every Profile and equivalent explicit Tags on Darwin/Linux across Dependencies, Install Catalog, Install Plan, Provisioner Plan, status, doctor, and installed coverage.
- Compatibility: existing source override, ordering, exact declaration de-duplication, semantic exit-code, JSON golden, manifest, and generated catalog tests remain green.
- Scope boundaries: no Profile/Tag semantics, historical migrations, Installed Selection, output schema, or hidden Tag behavior changed.

### Automated validation

All passed for reviewed head `39d498254bd263f61c9853fca1b1022bffbbb762`:

- `gofmt -l .` (no output)
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- `go generate ./internal/catalog` (no generated diff)
- catalog documentation sync test
- `go run ./cmd/dots manifest validate --file dots.yaml` → `manifest is valid`
- code search: no `SelectionTags`, `manifest.EntrySource`, `manifest.SharesTag`, or exported `SharesTag` remains

### Manual verification

Built one real binary at `/tmp/dots-issue-432-manual.MOI82M/dots`; all home/state inspection used the sibling temporary sandbox.

- Install Catalog Profile-versus-Tag selected scope: PASS on Darwin and Linux, exit 0.
- `deps check --profile desktop` versus `--tag desktop`: identical results, semantic exit 2/2.
- `plan --profile desktop` versus `--tag desktop`: identical actions, semantic exit 0/0.
- `status --profile desktop` versus `--tag desktop`: identical entries, semantic exit 2/2.
- `doctor --profile desktop` versus `--tag desktop`: identical Dependency, configuration, Provisioner, and Secret Scan scope, semantic exit 2/2.

### Independent review

- Standards: PASS, 0 documented-standard violations and 0 actionable findings.
- Spec: PASS, 0 missing/partial requirements, scope-creep findings, or incorrect behaviors.
- Observation: the repository-level parity test repeats sandbox parameters across private helpers. This does not merit later triage; a fixture abstraction would add indirection without improving the production seam.
<!-- delivery-issue:evidence:end -->
