### PR TITLE
refactor(agents): gate retirement on historical evidence

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -202,6 +202,7 @@ _Avoid_: install profile, machine config, host config, preset
 
 **Tag**:
 A label assigned to a Managed Entry so Profiles can include related configuration by intent, such as `core`, `agents`, `web`, `mobile`, or `desktop`. Tags from repeated Profiles and explicit `--tag` flags are de-duplicated while preserving order.
+Tags are declarative selection only: they do not authorize built-in cleanup or historical migrations.
 _Avoid_: category, group, label
 
 **Core Development Baseline**:

--- a/docs/adr/0013-explicit-composable-install-profiles.md
+++ b/docs/adr/0013-explicit-composable-install-profiles.md
@@ -38,3 +38,15 @@ whether supplied by Profiles or explicit `--tag` values. Historical manifests
 may be read only for update-evolution inventory when they contain retired
 Profile Dependencies; current manifest loading rejects that field with migration
 guidance.
+
+## Amendment: evidence-gated historical retirement
+
+Tags select declarative surface only and do not trigger built-in Go cleanup.
+Gentle AI retirement runs in the terminal historical-retirement workflow after
+successful application and before Installed Selection recording. Its authority
+is a successful historical `gentle-ai install` Provisioner receipt in
+Installation Metadata; Profile fields, Provisioner Tag fields, and Installed
+Selection containing `agents` are insufficient by themselves. The filesystem
+adapter continues to remove only recognized marker-owned blocks, preserves
+regular-file modes and unrelated bytes, reports non-regular targets for manual
+cleanup, and fails closed before terminal Installed Selection recording.

--- a/docs/agents/output-contract.md
+++ b/docs/agents/output-contract.md
@@ -171,12 +171,16 @@ prose the text surface prints:
   `selection-change-acknowledgement-required`; error `data` contains `code` and
   the complete `selection_change`. This acknowledgement is independent from
   Conflict Resolution and `--backup-and-replace`.
-- After a successful `install`, `update`, or `upgrade` finds historical evidence
-  of the retired Codex delegation capability, `data.retirement` records portable
-  `removed` and `manual_cleanup` arrays. The migration removes only proven
-  dots-owned markers and byte-exact native agent files; copied skills and
-  ambiguous files remain in `manual_cleanup`. The optional field is omitted
-  when no historical evidence exists and is never emitted by a dry run.
+- After a successful `install`, `update`, or `upgrade` finds sufficiently
+  specific historical Installation Metadata evidence for retired Gentle AI or
+  Codex delegation capabilities, `data.retirement` records portable `removed`
+  and `manual_cleanup` arrays. Gentle AI specifically requires a successful
+  historical `gentle-ai install` Provisioner receipt; current or recorded
+  `agents` Tags alone never authorize it. The migration removes only proven
+  dots-owned marker blocks and byte-exact native agent files; copied skills,
+  symlinks, and ambiguous files remain in `manual_cleanup`. The optional field
+  is omitted when no historical evidence exists and is never emitted by a dry
+  run.
 - `plan`'s `resolved_source` (a per-machine absolute path) and `deps`'s
   `probe_detail`/`hint` (unstable human prose) are excluded. Agents key on the
   portable, structured fields (`source`, `present`, `warning`, and the

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -95,6 +95,11 @@ dots install --profile workstation --tag adaptive-theme
 
 ```
 
+Tags are declarative selection only: they select Managed Entries, Dependencies,
+Provisioners, and source overrides, but never authorize hidden built-in cleanup
+or historical migration behavior. Historical retirement uses sufficiently
+specific Installation Metadata receipts independently from current selection.
+
 See the [adaptive theme audit](adaptive-theme-audit.md) and the
 [`codegraph` Provisioner specification](#codegraph-spec) for the detailed
 behavior behind those focused capabilities.

--- a/docs/update.md
+++ b/docs/update.md
@@ -9,7 +9,7 @@
 3. **Fast-forwards only.** `update` fetches the upstream and advances the branch with `git merge --ff-only`. If the branch has diverged from its upstream, it cannot be fast-forwarded; `update` reports the divergence and asks you to resolve it manually with Git. It never performs an automatic merge or rebase.
 4. **Recomputes the Install Plan.** After the fast-forward, the manifest is loaded from the updated repository (so a manifest change pulled from upstream is honored) and a fresh Install Plan is computed against the current workstation state, surfacing any new Conflicts or Drift.
 5. **Applies safely.** The post-update install resolves conflicts exactly like `dots install`: interactive TUI by default, text prompts with `--no-tui`, or the conservative skip default with `--yes`. Any `replace` still creates a [Backup Set](../CONTEXT.md) before touching an existing target.
-6. **Runs provisioners and convergence.** After the file plan is applied, `update` runs the same selected Provisioners as `install`, then converges marker-owned instruction cleanup for the native Agent CLI Baseline. Provisioners run only when file application was not canceled; `--dry-run` renders the plan without executing it. If Conflict Resolution is canceled, the whole run aborts before any tool-managed configuration changes.
+6. **Runs provisioners and historical retirement.** After the file plan is applied, `update` runs the same selected Provisioners as `install`, then evaluates historical retirement from Installation Metadata evidence. Current Tags never authorize cleanup. Provisioners and retirement run only when file application was not canceled; `--dry-run` renders the plan without executing either. If Conflict Resolution is canceled, the whole run aborts before any tool-managed configuration changes.
 
 ## Versioning model
 
@@ -149,20 +149,20 @@ During update or upgrade, selection evolution reports gentle-ai and Engram
 Dependencies plus their gentle-ai/skills Provisioners as removed surfaces. This
 report is informational: dots does not uninstall binaries, delete directories,
 remove Dependency Installation Metadata, or erase historical Provisioner
-receipts. After Managed Configuration succeeds, dots removes only known
+receipts. After Managed Configuration succeeds, a successful historical
+`gentle-ai install` Provisioner receipt authorizes dots to remove only known
 marker-delimited gentle-ai trigger/persona/Engram blocks and the dots-owned
-global-rules block from supported instruction files. Unmarked and co-owned
-content, complete files, authentication, and Secret state are
-preserved.
+global-rules block from supported instruction files. An Installed Selection or
+current `agents` Tag alone is never evidence. Unmarked and co-owned content,
+complete files, authentication, symlinks, and Secret state are preserved;
+non-regular targets are reported for manual cleanup.
 
 To remove residual gentle-ai state, first review it outside dots (for example
 `~/.gentle-ai`, agent instruction files, generated skills, and any external
 gentle-ai/Engram installation). Use the vendor's explicit uninstall flow or
 remove reviewed residual paths manually only after confirming their ownership.
 Do not delete entire shared agent configuration directories, authentication
-files, or historical dots receipts. The retired implementation remains under a
-non-Profile manifest tag only until #371 removes it; production Profiles never
-select that tag. OpenCode's `web` Managed Entry composes its MCP subset directly
+files, or historical dots receipts. OpenCode's `web` Managed Entry composes its MCP subset directly
 into the native `~/.config/opencode/opencode.json`, so
 `--profile agents --profile web` does not depend on `core` shell configuration.
 

--- a/internal/agentinstructions/trigger_rules.go
+++ b/internal/agentinstructions/trigger_rules.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/yersonargotev/dots/internal/textblock"
 )
@@ -166,30 +167,40 @@ type instructionTarget struct {
 	path  string
 }
 
+// RetirementReport records only state that a narrow historical migration
+// removed or deliberately left for the user. Paths are home-relative for
+// portable reports.
+type RetirementReport struct {
+	Removed       []string `json:"removed"`
+	ManualCleanup []string `json:"manual_cleanup"`
+}
+
 // RetireGentleAIState removes only marker-delimited instruction content whose
-// ownership is explicit. It preserves instruction files and unmarked content;
-// retired Codex delegation state is handled by a separate evidence-gated migration.
-func RetireGentleAIState(home string) error {
+// ownership is explicit. It preserves instruction files and unmarked content,
+// and reports non-regular targets for manual cleanup instead of following them.
+func RetireGentleAIState(home string) (RetirementReport, error) {
+	report := RetirementReport{Removed: []string{}, ManualCleanup: []string{}}
 	var errs []error
-	for _, path := range instructionPaths(home, []string{"codex", "claude-code", "opencode", "antigravity", "vscode-copilot"}) {
-		if err := removeMarkedBlocks(
-			path,
+	for _, target := range instructionTargets(home, []string{"codex", "claude-code", "opencode", "antigravity", "vscode-copilot"}) {
+		removed, manual, err := removeMarkedBlocks(
+			target.path,
 			textblock.Markers{Start: gentleAITriggerRulesStart, End: gentleAITriggerRulesEnd},
 			textblock.Markers{Start: gentleAIPersonaStart, End: gentleAIPersonaEnd},
 			textblock.Markers{Start: gentleAIEngramStart, End: gentleAIEngramEnd},
 			textblock.Markers{Start: dotsRulesStart, End: dotsRulesEnd},
-		); err != nil {
+		)
+		label := homeRelativePath(home, target.path)
+		if removed {
+			report.Removed = append(report.Removed, label+" Gentle AI blocks")
+		}
+		if manual {
+			report.ManualCleanup = append(report.ManualCleanup, label)
+		}
+		if err != nil {
 			errs = append(errs, err)
 		}
 	}
-	return errors.Join(errs...)
-}
-
-// RetirementReport records only state that the narrow migration removed or
-// deliberately left for the user. Paths are home-relative for portable reports.
-type RetirementReport struct {
-	Removed       []string `json:"removed"`
-	ManualCleanup []string `json:"manual_cleanup"`
+	return report, errors.Join(errs...)
 }
 
 // RetireCodexDelegation removes exact dots-owned delegation state. It fails
@@ -311,29 +322,40 @@ func addCopilotPortablePolicyTargets(add func(agent, path string), agent, home s
 	add(agent, filepath.Join(home, ".copilot", "copilot-instructions.md"))
 }
 
-func removeMarkedBlocks(path string, markers ...textblock.Markers) error {
-	content, err := os.ReadFile(path)
+func removeMarkedBlocks(path string, markers ...textblock.Markers) (removed, manual bool, err error) {
+	info, err := os.Lstat(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil
+			return false, false, nil
 		}
-		return fmt.Errorf("read agent instructions %s: %w", path, err)
+		return false, false, fmt.Errorf("inspect agent instructions %s: %w", path, err)
 	}
-	info, err := os.Stat(path)
+	if !info.Mode().IsRegular() {
+		return false, true, nil
+	}
+	content, err := os.ReadFile(path)
 	if err != nil {
-		return fmt.Errorf("stat agent instructions %s: %w", path, err)
+		return false, false, fmt.Errorf("read agent instructions %s: %w", path, err)
 	}
 	updated, err := textblock.Remove(string(content), markers...)
 	if err != nil {
-		return fmt.Errorf("remove marked agent instruction blocks from %s: %w", path, err)
+		return false, false, fmt.Errorf("remove marked agent instruction blocks from %s: %w", path, err)
 	}
 	if updated == string(content) {
-		return nil
+		return false, false, nil
 	}
 	if err := os.WriteFile(path, []byte(updated), info.Mode().Perm()); err != nil {
-		return fmt.Errorf("write agent instructions %s: %w", path, err)
+		return false, false, fmt.Errorf("write agent instructions %s: %w", path, err)
 	}
-	return nil
+	return true, false, nil
+}
+
+func homeRelativePath(home, path string) string {
+	relative, err := filepath.Rel(home, path)
+	if err != nil || relative == "." || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) || filepath.IsAbs(relative) {
+		return path
+	}
+	return "~/" + filepath.ToSlash(relative)
 }
 
 func removeCodexDelegation(path string) (removed, manual bool, err error) {

--- a/internal/agentinstructions/trigger_rules_test.go
+++ b/internal/agentinstructions/trigger_rules_test.go
@@ -3,6 +3,7 @@ package agentinstructions
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -153,8 +154,12 @@ func TestRetireGentleAIStateRemovesOnlyOwnedMarkerBlocks(t *testing.T) {
 		}
 	}
 
-	if err := RetireGentleAIState(home); err != nil {
+	report, err := RetireGentleAIState(home)
+	if err != nil {
 		t.Fatalf("RetireGentleAIState() error = %v", err)
+	}
+	if len(report.Removed) != len(paths) || len(report.ManualCleanup) != 0 {
+		t.Fatalf("RetireGentleAIState() report = %#v, want one removal per instruction target", report)
 	}
 
 	for _, path := range paths {
@@ -182,6 +187,69 @@ func TestRetireGentleAIStateRemovesOnlyOwnedMarkerBlocks(t *testing.T) {
 		if err != nil || info.Mode().Perm() != 0o640 {
 			t.Errorf("instruction file mode = %v, %v; want 0640", info, err)
 		}
+	}
+}
+
+func TestRetireGentleAIStatePreservesAndReportsSymlinks(t *testing.T) {
+	home := t.TempDir()
+	target := filepath.Join(home, "user-owned.md")
+	content := gentleAITriggerRulesStart + "\nowned\n" + gentleAITriggerRulesEnd + "\n"
+	if err := os.WriteFile(target, []byte(content), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(home, ".codex", "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, path); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := RetireGentleAIState(home)
+	if err != nil {
+		t.Fatalf("RetireGentleAIState() error = %v", err)
+	}
+	if len(report.Removed) != 0 || !reflect.DeepEqual(report.ManualCleanup, []string{"~/.codex/AGENTS.md"}) {
+		t.Fatalf("RetireGentleAIState() report = %#v", report)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil || string(got) != content {
+		t.Fatalf("symlink target changed: %q, %v", got, err)
+	}
+}
+
+func TestRetireGentleAIStateReportsPartialFailureWithoutChangingMalformedFile(t *testing.T) {
+	home := t.TempDir()
+	codexPath := filepath.Join(home, ".codex", "AGENTS.md")
+	claudePath := filepath.Join(home, ".claude", "CLAUDE.md")
+	for _, path := range []string{codexPath, claudePath} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	malformed := "before\n" + gentleAITriggerRulesStart + "\nunclosed\n"
+	if err := os.WriteFile(codexPath, []byte(malformed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	owned := gentleAIPersonaStart + "\nowned\n" + gentleAIPersonaEnd + "\nuser\n"
+	if err := os.WriteFile(claudePath, []byte(owned), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := RetireGentleAIState(home)
+	if err == nil {
+		t.Fatal("RetireGentleAIState() error = nil, want malformed marker failure")
+	}
+	if !reflect.DeepEqual(report.Removed, []string{"~/.claude/CLAUDE.md Gentle AI blocks"}) {
+		t.Fatalf("RetireGentleAIState() report = %#v", report)
+	}
+	got, readErr := os.ReadFile(codexPath)
+	if readErr != nil || string(got) != malformed {
+		t.Fatalf("malformed instructions changed: %q, %v", got, readErr)
+	}
+	got, readErr = os.ReadFile(claudePath)
+	if readErr != nil || string(got) != "\nuser\n" {
+		t.Fatalf("independent valid target was not retired: %q, %v", got, readErr)
 	}
 }
 

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/selectedsurface"
-	"github.com/yersonargotev/dots/internal/tagpolicy"
 )
 
 const (
@@ -514,20 +513,7 @@ func dependency(dep manifest.Dependency, origin Origin) Dependency {
 }
 
 func behaviors(tags []string) []Behavior {
-	result := []Behavior{}
-	for _, action := range tagpolicy.Actions(tags) {
-		result = append(result, Behavior{Action: string(action), Description: behaviorDescription(action)})
-	}
-	return result
-}
-
-func behaviorDescription(action tagpolicy.Action) string {
-	switch action {
-	case tagpolicy.ActionRetireGentleAIState:
-		return "Retire dots-owned Gentle AI state."
-	default:
-		return "Allowlisted selection behavior."
-	}
+	return []Behavior{}
 }
 
 func summaryProfile(name string, p manifest.Profile) ProfileSummary {

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -137,7 +137,7 @@ func TestRegistrylessCatalogDerivesSurfaceTags(t *testing.T) {
 	}
 }
 
-func TestProfileDetailIncludesOriginAndBehavior(t *testing.T) {
+func TestProfileDetailIncludesOriginWithoutBuiltInTagBehavior(t *testing.T) {
 	got, err := Profile(fixtureManifest(), "core", Options{OS: "all"})
 	if err != nil {
 		t.Fatal(err)
@@ -149,8 +149,8 @@ func TestProfileDetailIncludesOriginAndBehavior(t *testing.T) {
 	if len(detail.ProfileDependencies) != 0 {
 		t.Fatalf("profile dependencies = %#v, want empty compatibility field", detail.ProfileDependencies)
 	}
-	if len(detail.Behaviors) != 1 || detail.Behaviors[0].Action != "retire-gentle-ai-state" {
-		t.Fatalf("behaviors = %#v", detail.Behaviors)
+	if len(detail.Behaviors) != 0 {
+		t.Fatalf("behaviors = %#v, want Tags to remain declarative selection only", detail.Behaviors)
 	}
 }
 

--- a/internal/cli/agent_baseline_test.go
+++ b/internal/cli/agent_baseline_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/yersonargotev/dots/internal/cli"
 )
 
-func TestAgentsProfileInstallsNativeBaselineAndRetiresOwnedInstructionsInSandbox(t *testing.T) {
+func TestAgentsProfileInstallsNativeBaselineWithoutAuthorizingHistoricalCleanup(t *testing.T) {
 	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
 	if err != nil {
 		t.Fatalf("resolve repository root: %v", err)
@@ -97,17 +97,13 @@ Keep this unmarked user-owned content.
 
 	gotInstructions, err := os.ReadFile(instructions)
 	if err != nil {
-		t.Fatalf("read retired instructions: %v", err)
+		t.Fatalf("read historical instructions: %v", err)
 	}
-	for _, removed := range []string{"gentle-ai:trigger-rules", "gentle-ai:engram-protocol", "dots:rules", "retired trigger rules", "retired Engram instructions", "retired global rules"} {
-		if strings.Contains(string(gotInstructions), removed) {
-			t.Errorf("retirement kept %q:\n%s", removed, gotInstructions)
-		}
+	if !bytes.Equal(gotInstructions, []byte(legacy)) {
+		t.Errorf("agents selection changed historical instructions without Provisioner evidence:\n%s", gotInstructions)
 	}
-	for _, preserved := range []string{"user-owned before", "## User instructions", "Keep this unmarked user-owned content."} {
-		if !strings.Contains(string(gotInstructions), preserved) {
-			t.Errorf("retirement removed %q:\n%s", preserved, gotInstructions)
-		}
+	if strings.Contains(output.String(), "Historical retirement:") {
+		t.Errorf("agents selection reported historical retirement without evidence:\n%s", output.String())
 	}
 
 	opencodeTarget := filepath.Join(home, ".config", "opencode", "opencode.json")

--- a/internal/cli/delegation_retirement.go
+++ b/internal/cli/delegation_retirement.go
@@ -20,18 +20,40 @@ var retiredDelegationSkillsArgs = []string{
 	"--agent", "codex", "--skill", "delegation", "--global", "--copy",
 }
 
-// retireHistoricalDelegation runs only after the install/update path succeeded.
-// Current manifests cannot select the retired surface, so metadata is the sole
-// migration authority.
-func retireHistoricalDelegation(meta state.Metadata, home string) (*agentinstructions.RetirementReport, error) {
-	if !hasHistoricalDelegationEvidence(meta) {
+// retireHistoricalAgentState runs only after the install/update path succeeded.
+// Historical Provisioner receipts are the sole migration authority; current
+// Tag selection never authorizes cleanup.
+func retireHistoricalAgentState(meta state.Metadata, home string) (*agentinstructions.RetirementReport, error) {
+	gentleAI := hasHistoricalGentleAIEvidence(meta)
+	delegation := hasHistoricalDelegationEvidence(meta)
+	if !gentleAI && !delegation {
 		return nil, nil
 	}
-	report, err := agentinstructions.RetireCodexDelegation(home)
-	if err != nil {
-		return nil, err
+	report := agentinstructions.RetirementReport{Removed: []string{}, ManualCleanup: []string{}}
+	if gentleAI {
+		gentleReport, err := agentinstructions.RetireGentleAIState(home)
+		if err != nil {
+			return nil, err
+		}
+		appendRetirementReport(&report, gentleReport)
+	}
+	if delegation {
+		delegationReport, err := agentinstructions.RetireCodexDelegation(home)
+		if err != nil {
+			return nil, err
+		}
+		appendRetirementReport(&report, delegationReport)
 	}
 	return &report, nil
+}
+
+func hasHistoricalGentleAIEvidence(meta state.Metadata) bool {
+	for _, record := range meta.Provisioners {
+		if record.Tool == "gentle-ai" && record.Executable == "gentle-ai" && record.Status == "provisioned" && len(record.Args) > 0 && record.Args[0] == "install" {
+			return true
+		}
+	}
+	return false
 }
 
 func hasHistoricalDelegationEvidence(meta state.Metadata) bool {
@@ -72,11 +94,16 @@ func stringSlicesEqual(left, right []string) bool {
 	return true
 }
 
-func renderDelegationRetirement(w io.Writer, report *agentinstructions.RetirementReport) {
+func appendRetirementReport(report *agentinstructions.RetirementReport, addition agentinstructions.RetirementReport) {
+	report.Removed = append(report.Removed, addition.Removed...)
+	report.ManualCleanup = append(report.ManualCleanup, addition.ManualCleanup...)
+}
+
+func renderHistoricalRetirement(w io.Writer, report *agentinstructions.RetirementReport) {
 	if report == nil {
 		return
 	}
-	fmt.Fprintln(w, "Delegation retirement:")
+	fmt.Fprintln(w, "Historical retirement:")
 	if len(report.Removed) == 0 {
 		fmt.Fprintln(w, "  Removed: (none)")
 	} else {

--- a/internal/cli/delegation_retirement_test.go
+++ b/internal/cli/delegation_retirement_test.go
@@ -29,13 +29,36 @@ func TestHistoricalDelegationEvidenceIsNarrow(t *testing.T) {
 	}
 }
 
+func TestHistoricalGentleAIEvidenceRequiresSuccessfulInstallReceipt(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		meta state.Metadata
+		want bool
+	}{
+		{name: "no evidence", meta: state.Metadata{}, want: false},
+		{name: "Installed Selection agents only", meta: state.Metadata{InstalledSelection: &state.InstalledSelection{Profiles: []string{"agents"}, ResolvedTags: []string{"agents"}}}, want: false},
+		{name: "legacy receipt", meta: state.Metadata{Provisioners: []state.ProvisionerRecord{{Profile: "agents", Tool: "gentle-ai", Executable: "gentle-ai", Args: []string{"install", "--scope", "global"}, Status: "provisioned"}}}, want: true},
+		{name: "current receipt", meta: state.Metadata{Provisioners: []state.ProvisionerRecord{{Profiles: []string{"agents"}, Tags: []string{"agents"}, Tool: "gentle-ai", Executable: "gentle-ai", Args: []string{"install", "--agents", "codex"}, Status: "provisioned"}}}, want: true},
+		{name: "failed install", meta: state.Metadata{Provisioners: []state.ProvisionerRecord{{Tool: "gentle-ai", Executable: "gentle-ai", Args: []string{"install"}, Status: "failed"}}}, want: false},
+		{name: "missing dependency", meta: state.Metadata{Provisioners: []state.ProvisionerRecord{{Tool: "gentle-ai", Executable: "gentle-ai", Args: []string{"install"}, Status: "missing-dependencies"}}}, want: false},
+		{name: "uninstall receipt", meta: state.Metadata{Provisioners: []state.ProvisionerRecord{{Tool: "gentle-ai", Executable: "gentle-ai", Args: []string{"uninstall", "--yes"}, Status: "provisioned"}}}, want: false},
+		{name: "wrong executable", meta: state.Metadata{Provisioners: []state.ProvisionerRecord{{Tool: "gentle-ai", Executable: "npx", Args: []string{"install"}, Status: "provisioned"}}}, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasHistoricalGentleAIEvidence(tc.meta); got != tc.want {
+				t.Fatalf("hasHistoricalGentleAIEvidence() = %t, want %t", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestRenderDelegationRetirementIncludesRemovedAndManualCleanup(t *testing.T) {
 	var out bytes.Buffer
-	renderDelegationRetirement(&out, &agentinstructions.RetirementReport{
+	renderHistoricalRetirement(&out, &agentinstructions.RetirementReport{
 		Removed:       []string{"~/.codex/AGENTS.md delegation blocks"},
 		ManualCleanup: []string{"~/.agents/skills/delegation"},
 	})
-	for _, want := range []string{"Delegation retirement:", "Removed: ~/.codex/AGENTS.md delegation blocks", "Manual cleanup: ~/.agents/skills/delegation"} {
+	for _, want := range []string{"Historical retirement:", "Removed: ~/.codex/AGENTS.md delegation blocks", "Manual cleanup: ~/.agents/skills/delegation"} {
 		if !strings.Contains(out.String(), want) {
 			t.Fatalf("report missing %q:\n%s", want, out.String())
 		}

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/yersonargotev/dots/internal/agentinstructions"
 	"github.com/yersonargotev/dots/internal/backups"
 	"github.com/yersonargotev/dots/internal/codexconfig"
 	"github.com/yersonargotev/dots/internal/deps"
@@ -25,7 +24,6 @@ import (
 	"github.com/yersonargotev/dots/internal/provision"
 	"github.com/yersonargotev/dots/internal/selection"
 	"github.com/yersonargotev/dots/internal/state"
-	"github.com/yersonargotev/dots/internal/tagpolicy"
 	"github.com/yersonargotev/dots/internal/tui"
 	"github.com/yersonargotev/dots/internal/version"
 )
@@ -282,7 +280,7 @@ func newInstallCommand() *cobra.Command {
 				}
 				return err
 			}
-			retirement, err := retireHistoricalDelegation(meta, paths.Home)
+			retirement, err := retireHistoricalAgentState(meta, paths.Home)
 			if err != nil {
 				return err
 			}
@@ -291,7 +289,7 @@ func newInstallCommand() *cobra.Command {
 				return err
 			}
 			if !wantsJSON(cmd) {
-				renderDelegationRetirement(cmd.OutOrStdout(), retirement)
+				renderHistoricalRetirement(cmd.OutOrStdout(), retirement)
 			}
 			if wantsJSON(cmd) {
 				return emitOK(cmd, installReport{RepositoryRefresh: prep.Refresh, DryRun: false, Selection: effective.Report, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan, BackupSets: createdBackups, Retirement: retirement})
@@ -519,16 +517,6 @@ func runProvisionersWithOptionsAndEnvironment(cmd *cobra.Command, m manifest.Man
 	}
 	if recordErr := recordProvisionerMetadata(stateRoot, sourceRoot, report); recordErr != nil {
 		return report, recordErr
-	}
-	for _, action := range tagpolicy.Actions(report.Tags) {
-		var cleanupErr error
-		switch action {
-		case tagpolicy.ActionRetireGentleAIState:
-			cleanupErr = agentinstructions.RetireGentleAIState(home)
-		}
-		if cleanupErr != nil {
-			return report, errors.Join(err, cleanupErr)
-		}
 	}
 	if err != nil {
 		return report, err

--- a/internal/cli/install_provision_test.go
+++ b/internal/cli/install_provision_test.go
@@ -139,16 +139,17 @@ entries:
     strategy: symlink
     tags: [core]
 `)
-	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, Provisioners: []state.ProvisionerRecord{{
-		Tool: "skills", Executable: "npx", Args: []string{"--yes", "skills@1.5.12", "add", "yersonargotev/dots/skills/delegation", "--agent", "codex", "--skill", "delegation", "--global", "--copy"},
-	}}}); err != nil {
+	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, Provisioners: []state.ProvisionerRecord{
+		{Tool: "skills", Executable: "npx", Args: []string{"--yes", "skills@1.5.12", "add", "yersonargotev/dots/skills/delegation", "--agent", "codex", "--skill", "delegation", "--global", "--copy"}},
+		{Profiles: []string{"agents"}, Tags: []string{"agents"}, Tool: "gentle-ai", Executable: "gentle-ai", Args: []string{"install", "--scope", "global", "--agents", "codex"}, Status: "provisioned"},
+	}}); err != nil {
 		t.Fatalf("save historical metadata: %v", err)
 	}
 	agentsPath := filepath.Join(home, ".codex", "AGENTS.md")
 	if err := os.MkdirAll(filepath.Dir(agentsPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	legacy := "before\n<!-- dots:delegation -->\nowned\n<!-- /dots:delegation -->\nafter\n"
+	legacy := "before\n<!-- gentle-ai:trigger-rules -->\nretired\n<!-- /gentle-ai:trigger-rules -->\n<!-- dots:delegation -->\nowned\n<!-- /dots:delegation -->\nafter\n"
 	if err := os.WriteFile(agentsPath, []byte(legacy), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -165,7 +166,7 @@ entries:
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(string(got), "dots:delegation") || !strings.Contains(out.String(), "Delegation retirement:") {
+	if strings.Contains(string(got), "dots:delegation") || strings.Contains(string(got), "gentle-ai:trigger-rules") || !strings.Contains(out.String(), "Historical retirement:") || !strings.Contains(out.String(), "Gentle AI blocks") {
 		t.Fatalf("historical retirement was not reported and applied\ninstructions:\n%s\noutput:\n%s", got, out.String())
 	}
 

--- a/internal/cli/install_selection_test.go
+++ b/internal/cli/install_selection_test.go
@@ -386,6 +386,67 @@ provisioners:
 	}
 }
 
+func TestInstallHistoricalRetirementFailurePreservesPreviousSelection(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	previous := state.InstalledSelection{Profiles: []string{"old"}, ResolvedTags: []string{"old"}}
+	if err := state.Save(state.Path(stateRoot), state.Metadata{
+		Version:            state.CurrentVersion,
+		InstalledSelection: &previous,
+		Provisioners: []state.ProvisionerRecord{{
+			Profile: "agents", Tool: "gentle-ai", Executable: "gentle-ai", Args: []string{"install", "--scope", "global"}, Status: "provisioned",
+		}},
+	}); err != nil {
+		t.Fatalf("seed historical metadata: %v", err)
+	}
+	instructions := filepath.Join(home, ".codex", "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(instructions), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	malformed := "before\n<!-- gentle-ai:trigger-rules -->\nunclosed\n"
+	if err := os.WriteFile(instructions, []byte(malformed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writeCLISource(t, sourceRoot, "configs/zsh/zshrc", "managed\n")
+	manifestPath := writeCLIManifest(t, home, `version: 1
+profiles:
+  new:
+    tags: [core]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [core]
+`)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"install", "--yes", "--acknowledge-selection-change", "--skip-deps", "--profile", "new",
+		"--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot,
+	})
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("Execute() error = nil, want malformed historical retirement failure\noutput:\n%s", out.String())
+	}
+
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.InstalledSelection == nil || !reflect.DeepEqual(*meta.InstalledSelection, previous) {
+		t.Fatalf("InstalledSelection = %#v, want previous %#v", meta.InstalledSelection, previous)
+	}
+	got, err := os.ReadFile(instructions)
+	if err != nil || string(got) != malformed {
+		t.Fatalf("malformed instructions changed: %q, %v", got, err)
+	}
+}
+
 func TestInstallWithoutExplicitProfileMutatesNothing(t *testing.T) {
 	home := t.TempDir()
 	sourceRoot := t.TempDir()

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -315,7 +315,7 @@ func runUpdateWorkflow(cmd *cobra.Command, opts updateOptions, emit bool) (updat
 		if _, err := runProvisionersWithOptions(cmd, *m, provisionOpts, paths.Home, paths.StateRoot, paths.SourceRoot); err != nil {
 			return updateReport{}, err
 		}
-		report.Retirement, err = retireHistoricalDelegation(meta, paths.Home)
+		report.Retirement, err = retireHistoricalAgentState(meta, paths.Home)
 		if err != nil {
 			return updateReport{}, err
 		}
@@ -324,7 +324,7 @@ func runUpdateWorkflow(cmd *cobra.Command, opts updateOptions, emit bool) (updat
 			return updateReport{}, err
 		}
 		if !wantsJSON(cmd) {
-			renderDelegationRetirement(out, report.Retirement)
+			renderHistoricalRetirement(out, report.Retirement)
 		}
 	}
 	if wantsJSON(cmd) && emit {

--- a/internal/cli/update_provision_test.go
+++ b/internal/cli/update_provision_test.go
@@ -99,16 +99,17 @@ func TestUpdateRetiresHistoricalDelegationAfterSuccessfulApply(t *testing.T) {
 	stubDir := t.TempDir()
 	writeExecStub(t, filepath.Join(stubDir, "claude"), "#!/bin/sh\nexit 0\n")
 	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, Provisioners: []state.ProvisionerRecord{{
-		Tool: "skills", Executable: "npx", Args: []string{"--yes", "skills@1.5.12", "add", "yersonargotev/dots/skills/delegation", "--agent", "codex", "--skill", "delegation", "--global", "--copy"},
-	}}}); err != nil {
+	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, Provisioners: []state.ProvisionerRecord{
+		{Tool: "skills", Executable: "npx", Args: []string{"--yes", "skills@1.5.12", "add", "yersonargotev/dots/skills/delegation", "--agent", "codex", "--skill", "delegation", "--global", "--copy"}},
+		{Profile: "agents", Tool: "gentle-ai", Executable: "gentle-ai", Args: []string{"install", "--scope", "global"}, Status: "provisioned"},
+	}}); err != nil {
 		t.Fatalf("save historical metadata: %v", err)
 	}
 	agentsPath := filepath.Join(home, ".codex", "AGENTS.md")
 	if err := os.MkdirAll(filepath.Dir(agentsPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(agentsPath, []byte("before\n<!-- argote:subagent-delegation -->\nowned\n<!-- /argote:subagent-delegation -->\nafter\n"), 0o600); err != nil {
+	if err := os.WriteFile(agentsPath, []byte("before\n<!-- gentle-ai:engram-protocol -->\nretired\n<!-- /gentle-ai:engram-protocol -->\n<!-- argote:subagent-delegation -->\nowned\n<!-- /argote:subagent-delegation -->\nafter\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	_, sourceRoot := newInstalledRepo(t, map[string]string{
@@ -121,7 +122,7 @@ func TestUpdateRetiresHistoricalDelegationAfterSuccessfulApply(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(string(got), "argote:subagent-delegation") || !strings.Contains(out, "Delegation retirement:") {
+	if strings.Contains(string(got), "argote:subagent-delegation") || strings.Contains(string(got), "gentle-ai:engram-protocol") || !strings.Contains(out, "Historical retirement:") || !strings.Contains(out, "Gentle AI blocks") {
 		t.Fatalf("historical retirement was not reported and applied\ninstructions:\n%s\noutput:\n%s", got, out)
 	}
 }

--- a/internal/cli/upgrade_test.go
+++ b/internal/cli/upgrade_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/yersonargotev/dots/internal/cli"
+	"github.com/yersonargotev/dots/internal/state"
 )
 
 func TestUpgradeDryRunPreviewsBinaryAndSourceOfTruthWithoutModifying(t *testing.T) {
@@ -143,6 +144,21 @@ entries:
 `,
 	})
 	saveInstalledSelection(t, stateRoot, "default")
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta.Provisioners = []state.ProvisionerRecord{{Profile: "agents", Tool: "gentle-ai", Executable: "gentle-ai", Args: []string{"install", "--scope", "global"}, Status: "provisioned"}}
+	if err := state.Save(state.Path(stateRoot), meta); err != nil {
+		t.Fatal(err)
+	}
+	instructions := filepath.Join(home, ".codex", "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(instructions), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(instructions, []byte("before\n<!-- gentle-ai:persona -->\nretired\n<!-- /gentle-ai:persona -->\nafter\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
 
 	cmd := cli.NewRootCommand()
 	var out bytes.Buffer
@@ -157,6 +173,10 @@ entries:
 	}
 	if _, err := os.Readlink(filepath.Join(home, ".tmux.conf")); err != nil {
 		t.Fatalf("continuation did not install updated Managed Entry: %v", err)
+	}
+	got, err := os.ReadFile(instructions)
+	if err != nil || strings.Contains(string(got), "gentle-ai:persona") || !strings.Contains(out.String(), "Historical retirement:") {
+		t.Fatalf("upgrade continuation did not expose historical retirement: %q, %v\noutput:\n%s", got, err, out.String())
 	}
 }
 

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -696,12 +696,6 @@ func (m Manifest) validateTagRegistry() error {
 		if !tagpolicy.IsAllowedKind(tag.Kind) {
 			return fmt.Errorf("tags[%q].kind must be one of surface, cleanup, compatibility", name)
 		}
-		if expectedKind, isBehaviorTag := tagpolicy.ExpectedKind(name); isBehaviorTag && tag.Kind != expectedKind {
-			return fmt.Errorf("tags[%q].kind must be %q", name, expectedKind)
-		}
-		if (tag.Kind == "cleanup" || tag.Kind == "compatibility") && !tagpolicy.IsBehaviorTag(name) {
-			return fmt.Errorf("tags[%q].kind %q requires a supported behavior tag", name, tag.Kind)
-		}
 		if !tagpolicy.IsAllowedStatus(tag.Status) {
 			return fmt.Errorf("tags[%q].status must be one of current, legacy", name)
 		}
@@ -1107,7 +1101,7 @@ func resolveSelection(m Manifest, profileNames []string, extraTags []string, all
 	}
 	for _, tag := range extraTags {
 		if m.Tags != nil {
-			if _, declared := m.Tags[tag]; !declared && !tagpolicy.IsBehaviorTag(tag) {
+			if _, declared := m.Tags[tag]; !declared {
 				return Selection{}, fmt.Errorf("tag %q is not declared", tag)
 			}
 		}

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -109,8 +109,6 @@ provisioners:
 		{"override key", strings.Replace(valid, "source_overrides: {legacy-core:", "source_overrides: {missing:", 1), `entries[0].source_overrides[0] tag "missing" is not declared`},
 		{"provisioner reference", strings.Replace(valid, "    tags: [agents]\n    spec:", "    tags: [missing]\n    spec:", 1), `provisioners[0].tags[0] tag "missing" is not declared`},
 		{"invalid kind", strings.Replace(valid, "kind: surface", "kind: command", 1), `tags["core"].kind must be one of surface, cleanup, compatibility`},
-		{"behavior kind mismatch", strings.Replace(valid, "  agents:\n    description: retire Gentle AI state\n    kind: surface", "  agents:\n    description: retire Gentle AI state\n    kind: cleanup", 1), `tags["agents"].kind must be "surface"`},
-		{"unallowlisted behavior tag", strings.Replace(valid, "  legacy-core:\n    description: old baseline selector\n    kind: surface", "  legacy-core:\n    description: old baseline selector\n    kind: cleanup", 1), `tags["legacy-core"].kind "cleanup" requires a supported behavior tag`},
 		{"replacement source current", strings.Replace(valid, "status: legacy\n    replaced_by", "status: current\n    replaced_by", 1), `tags["legacy-core"].replaced_by requires status legacy`},
 		{"replacement target legacy", strings.Replace(valid, "status: current", "status: legacy", 1), `tags["legacy-core"].replaced_by "core" must reference a current tag`},
 	}

--- a/internal/selection/selection.go
+++ b/internal/selection/selection.go
@@ -9,7 +9,6 @@ import (
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/selectedsurface"
 	"github.com/yersonargotev/dots/internal/state"
-	"github.com/yersonargotev/dots/internal/tagpolicy"
 )
 
 // Source identifies where a selection-aware command obtained its intent.
@@ -309,7 +308,7 @@ func staleExtraTags(m manifest.Manifest, extraTags []string) []string {
 	if m.Tags != nil {
 		var stale []string
 		for _, tag := range orderedUnique(extraTags) {
-			if _, declared := m.Tags[tag]; !declared && !tagpolicy.IsBehaviorTag(tag) {
+			if _, declared := m.Tags[tag]; !declared {
 				stale = append(stale, tag)
 			}
 		}
@@ -334,7 +333,7 @@ func staleExtraTags(m manifest.Manifest, extraTags []string) []string {
 	}
 	var stale []string
 	for _, tag := range orderedUnique(extraTags) {
-		if !declared[tag] && !tagpolicy.IsBehaviorTag(tag) {
+		if !declared[tag] {
 			stale = append(stale, tag)
 		}
 	}

--- a/internal/tagpolicy/tagpolicy.go
+++ b/internal/tagpolicy/tagpolicy.go
@@ -1,37 +1,6 @@
-// Package tagpolicy owns the closed set of tag-triggered behavior. Install
-// Manifests may select these tags, but they cannot define shell commands or
-// other executable behavior.
+// Package tagpolicy owns the allowed Tag registry classifications. Tags are
+// declarative selection only and never trigger built-in Go behavior.
 package tagpolicy
-
-// Action is a reviewed, built-in behavior that may be selected by one or more
-// behavior tags.
-type Action string
-
-const (
-	ActionRetireGentleAIState Action = "retire-gentle-ai-state"
-)
-
-type behaviorPolicy struct {
-	kind   string
-	action Action
-}
-
-var behaviorByTag = map[string]behaviorPolicy{
-	"agents": {kind: "surface", action: ActionRetireGentleAIState},
-}
-
-// IsBehaviorTag reports whether tag has an allowlisted effect beyond ordinary
-// manifest surface selection.
-func IsBehaviorTag(tag string) bool {
-	_, ok := behaviorByTag[tag]
-	return ok
-}
-
-// ExpectedKind returns the only registry kind permitted for a behavior tag.
-func ExpectedKind(tag string) (string, bool) {
-	policy, ok := behaviorByTag[tag]
-	return policy.kind, ok
-}
 
 // IsAllowedKind reports whether kind is a supported registry classification.
 func IsAllowedKind(kind string) bool {
@@ -51,19 +20,4 @@ func IsAllowedStatus(status string) bool {
 	default:
 		return false
 	}
-}
-
-// Actions returns the deterministic set of built-in actions selected by tags.
-func Actions(tags []string) []Action {
-	present := make(map[Action]bool)
-	for _, tag := range tags {
-		if policy, ok := behaviorByTag[tag]; ok {
-			present[policy.action] = true
-		}
-	}
-	actions := make([]Action, 0, 1)
-	if present[ActionRetireGentleAIState] {
-		actions = append(actions, ActionRetireGentleAIState)
-	}
-	return actions
 }

--- a/internal/tagpolicy/tagpolicy_test.go
+++ b/internal/tagpolicy/tagpolicy_test.go
@@ -2,13 +2,6 @@ package tagpolicy
 
 import "testing"
 
-func TestActionsUsesClosedPolicy(t *testing.T) {
-	got := Actions([]string{"agents", "codex-delegation", "without-codex-spark-delegation", "unrelated"})
-	if len(got) != 1 || got[0] != ActionRetireGentleAIState {
-		t.Fatalf("Actions() = %#v, want only %q", got, ActionRetireGentleAIState)
-	}
-}
-
 func TestRegistryValuesAreAllowlisted(t *testing.T) {
 	for _, kind := range []string{"surface", "cleanup", "compatibility"} {
 		if !IsAllowedKind(kind) {
@@ -25,19 +18,5 @@ func TestRegistryValuesAreAllowlisted(t *testing.T) {
 	}
 	if IsAllowedStatus("retired") {
 		t.Error("IsAllowedStatus(retired) = true, want false")
-	}
-}
-
-func TestExpectedKindMatchesEachBehaviorTag(t *testing.T) {
-	for tag, want := range map[string]string{"agents": "surface"} {
-		got, ok := ExpectedKind(tag)
-		if !ok || got != want {
-			t.Errorf("ExpectedKind(%q) = %q, %t; want %q, true", tag, got, ok, want)
-		}
-	}
-	for _, retired := range []string{"codex-delegation", "without-codex-delegation", "codex-spark-delegation", "without-codex-spark-delegation"} {
-		if _, ok := ExpectedKind(retired); ok {
-			t.Fatalf("ExpectedKind(%q) reports retired behavior", retired)
-		}
 	}
 }


### PR DESCRIPTION
Closes #433

## PR Type

- [ ] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [x] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Moves Gentle AI cleanup into the terminal historical-retirement workflow.
- Requires a successful historical `gentle-ai install` receipt and removes all built-in cleanup authority from current Tags.
- Preserves marker ownership, modes, symlinks/non-regular targets, fail-closed ordering, and portable retirement reporting.

## Changes

| File | Change |
|------|--------|
| `internal/cli/delegation_retirement.go` | Composes Gentle AI and delegation retirement from historical Installation Metadata evidence. |
| `internal/agentinstructions/trigger_rules.go` | Reports removed/manual Gentle AI targets while preserving non-regular targets and file modes. |
| `internal/tagpolicy`, manifest, selection, catalog | Removes the final built-in action selected by the `agents` Tag while retaining compatible empty behavior arrays. |
| CLI tests | Covers false positives, legacy/current receipts, ownership, partial failures, terminal ordering, and sandboxed install/update/upgrade. |
| Domain and active docs | Documents declarative Tags and evidence-gated historical retirement. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go build ./...`
- [x] `go generate ./internal/catalog` (clean diff)
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Compiled-binary sandbox: `dots plan --output json` and `dots install --yes --skip-deps --profile agents` with explicit temporary home/source/state roots; plan exit 0, zero Provisioners, instruction SHA-256 unchanged, Installed Selection `agents`, no retirement report.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked one issue with an admitted Delivery Contract using `Closes #433`.
- [x] Added exactly one `type:*` label.
- [x] Delivery Evidence records the Contract Source snapshot, Acceptance coverage, and Independent review.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

### Contract Source snapshot

Kind: composed delivery ticket (child #433 plus native parent #427).

- Child: `I_kwDOSzLlmM8AAAABMEOyZg`, https://github.com/yersonargotev/dots/issues/433, updated `2026-08-09T21:01:49Z`, SHA-256 `bb9b5db75f950b8a12429a9799497006ec53a4471a5cea15485ad4750af70569`.
- Parent: `I_kwDOSzLlmM8AAAABMEODWA`, https://github.com/yersonargotev/dots/issues/427, updated `2026-08-09T20:58:54Z`, SHA-256 `294db5b0d8a1d718b2b5ae57f3a09dbe61720b13db334c248eac4eea7ade823c`.
- Category/readiness: `enhancement`; only triage state `ready-for-agent`.
- Child relationships: parent #427 open (`2026-08-09T20:58:54Z`); no subissues; blocked by #432 closed (`2026-08-09T22:57:39Z`); blocks none.
- Parent relationships: no parent/blockers/blocked issues; subissues #428 closed (`2026-08-09T21:33:49Z`), #429 closed (`2026-08-09T21:57:24Z`), #430 closed (`2026-08-09T22:22:37Z`), #431 closed (`2026-08-09T22:40:54Z`), #432 closed (`2026-08-09T22:57:39Z`), #433 open (`2026-08-09T21:01:49Z`).
- Comments at snapshot/revalidation: none on child or parent.

<details><summary>Exact child body</summary>

```markdown
### Pre-flight checks

- [x] I searched existing issues and this is not a duplicate.
- [x] The scope is small enough for one reviewable work unit.

### Desired outcome

Selecting the current `agents` Tag no longer triggers hidden cleanup. Gentle AI retirement runs only when sufficiently specific historical Installation Metadata proves dots previously installed that capability, and it continues preserving user-owned content.

### Current-state gap

The `agents` Tag currently activates Gentle AI instruction cleanup after Provisioners apply, even when Installation Metadata contains no proof that Gentle AI was previously installed. This makes a current declarative Tag double as migration authority and weakens the locality and safety of both concepts.

### What to build

Move Gentle AI cleanup into the terminal historical-retirement workflow. Gate it on a sufficiently specific historical Provisioner receipt, not merely a current or recorded `agents` Tag. Preserve marker-based ownership checks, deterministic reporting, terminal-success ordering, and fail-closed errors. Remove the last hidden built-in behavior from current Tag selection.

### Key interfaces

- Installation Metadata — supplies historical evidence without becoming current selection intent.
- Historical retirement workflow — inspects evidence after successful application and before terminal Installed Selection recording.
- Agent instruction filesystem adapter — removes only marker-owned content and preserves unrelated bytes and file modes.
- Text and JSON reports — communicate removed or manual-cleanup outcomes consistently where applicable.

### Acceptance criteria

- [ ] Selecting `agents` without historical Gentle AI evidence performs no Gentle AI cleanup.
- [ ] A sufficiently specific historical Gentle AI Provisioner receipt authorizes retirement for legacy and current metadata shapes.
- [ ] Installed Selection containing `agents` alone is not sufficient evidence.
- [ ] Cleanup removes only recognized marker-delimited dots-owned blocks across supported agent instruction targets.
- [ ] Unmarked content, unrelated authentication/configuration, file mode, symlinks, and user-modified content are preserved or reported for manual handling as appropriate.
- [ ] Malformed markers and filesystem errors fail closed without recording a new Installed Selection.
- [ ] Install, update, and upgrade preserve terminal-success ordering and expose consistent retirement results.
- [ ] Current Tag selection contains no built-in cleanup action after the migration.
- [ ] Focused false-positive, positive-evidence, ownership, partial-failure, and sandboxed end-to-end tests pass.
- [ ] Active documentation describes Tags as declarative selection only.

### Non-goals

- Building a generic migration framework before a second migration demonstrates a common seam.
- Deleting copied skills or arbitrary user-owned agent files without exact ownership evidence.
- Changing the Agent CLI Baseline, current Provisioners, or Installed Selection reduction semantics.

### Validation notes

- Run focused retirement, instruction ownership, install, update, and upgrade tests followed by the full CI-equivalent suite.
- Use temporary home and state roots and stub every external executable; never touch the real home or network.
- Verify current `agents` selection and historical evidence independently.

```
</details>

<details><summary>Exact parent body</summary>

```markdown
### Pre-flight checks

- [x] I searched existing issues and this is not a duplicate.
- [x] The scope clearly identifies independently reviewable slices.

### Desired outcome

Profiles are removable, composable names for ordered Tag selections rather than a second owner of installation behavior. For the same effective Tags and operating system, dots produces one deterministic Selected Surface regardless of whether the operator selected those Tags through a Profile or explicit `--tag` flags. Historical migrations remain evidence-gated and separate from current Tag selection.

### Current-state gap

Profiles currently may own Dependencies directly in addition to selecting Tags. This makes equivalent selections diverge: the `desktop` Profile selects the Desktop Nerd Font while explicit `--tag desktop` does not, and the composite `workstation` Profile duplicates that Dependency to reproduce the desktop surface. Selection by Tags and operating system is also recalculated across several modules, while the `agents` Tag still activates a hidden Gentle AI cleanup action rather than selecting only declarative surface. These seams make adding or removing Profiles more transversal than the domain model promises.

## Problem Statement

As an operator maintaining several workstation roles, I cannot treat Profiles as lightweight, removable compositions of Tags because Profiles can carry installation behavior that their Tags do not. Equivalent intent can therefore produce different Dependencies, composite Profiles must duplicate declarations, and retiring a capability can require unrelated callers to understand hidden Tag behavior.

## Solution

Make Profile a pure named union of Tags. Define Selected Surface as the deterministic Managed Entries, resolved source overrides, Dependencies, and Provisioners applicable to effective Tags and the operating system. Move capability-wide Dependencies into Tag-scoped Dependency Sets, deepen Selected Surface evaluation behind one cohesive module, and migrate historical cleanup authority from current Tags to proven Installation Metadata. Preserve the existing explicit Installed Selection and reduction-safety contracts.

## User Stories

1. As a dots operator, I want a Profile to mean only a named set of Tags, so that I can understand it without inspecting hidden Dependencies.
2. As a dots operator, I want `--profile desktop` and `--tag desktop` to select the same surface, so that equivalent intent behaves consistently.
3. As a dots operator, I want composite Profiles to reuse Tag-owned capabilities, so that they do not duplicate dependency declarations.
4. As a dots operator, I want to add a new Profile by listing existing Tags, so that adding a workstation role does not require changes across the installer.
5. As a dots operator, I want to remove a Profile without removing its Tags, so that other Profiles and explicit Tag selections continue working.
6. As a dots operator, I want a removed recorded Profile to block before mutation, so that dots never guesses replacement intent.
7. As a dots operator, I want Profile retirement not to uninstall historical artifacts automatically, so that dots never deletes state without explicit authority.
8. As a dots operator, I want legacy Profiles to remain explicitly queryable while being hidden from normal discovery, so that staged retirement remains understandable.
9. As a user of an alternate Install Manifest, I want a precise validation error for retired Profile Dependencies, so that I know how to migrate them.
10. As a user updating an older Installed Repository, I want dots to read its historical Profile Dependencies for evolution comparison, so that the schema cleanup does not prevent a safe update.
11. As an automation author, I want deterministic Selected Surface ordering, so that machine-readable reports remain stable.
12. As an automation author, I want the existing catalog envelope to remain schema-compatible during this change, so that a removed concept does not cause an unrelated schema break.
13. As a maintainer, I want Dependencies owned by the narrowest declarative surface that requires them, so that ownership remains local.
14. As a maintainer, I want capability-wide Dependencies selected by Tags, so that every route to the same capability has the same prerequisites.
15. As a maintainer, I want one Selected Surface evaluation rule, so that selection changes are fixed and tested in one place.
16. As a maintainer, I want command modules to consume Selected Surface instead of recreating Tag and operating-system filters, so that callers receive leverage from a deeper module.
17. As a maintainer, I want Install Catalog, Dependency Plan, Install Plan, status, doctor, and installed reporting to agree on selection, so that diagnostics do not contradict installation.
18. As a maintainer, I want current Tags to select declarative surface only, so that selecting a capability does not trigger unrelated hidden cleanup.
19. As a maintainer, I want historical cleanup gated by Installation Metadata evidence, so that user-owned files are not changed merely because a current Tag was selected.
20. As a maintainer, I want Gentle AI retirement isolated from Profile schema cleanup, so that each risky change is independently reviewable.
21. As a contributor, I want the domain glossary and ADR for composable Profiles to state the same invariants as the code, so that future changes do not reintroduce Profile-owned behavior.
22. As a release maintainer, I want each delivery slice to remain green and demonstrable, so that the architectural change can ship incrementally.

## Implementation Decisions

- `Profile` is the sole canonical domain term. The duplicate `Install Profile` term is retired.
- A Profile contains descriptive metadata, lifecycle status, and an ordered list of Tags. Profiles do not contain other Profiles and do not own Dependencies, Managed Entries, or Provisioners.
- A Tag is the elemental declarative selection intent. Tags do not directly trigger built-in Go behavior.
- Selected Surface is the ordered, de-duplicated set of Managed Entries, resolved source overrides, Dependencies, and Provisioners selected by effective Tags and the operating system.
- Selected Surface excludes filesystem state, Drift, Conflicts, Install Plan actions, and historical migrations.
- Dependencies belong to the narrowest owning declaration: a Managed Entry, a Provisioner, or a Tag-scoped Dependency Set for capability-wide prerequisites.
- Equivalent effective Tags on the same operating system produce the same Selected Surface regardless of Profile or explicit Tag provenance. Provenance remains reportable but does not change selection.
- The repository manifest moves the Desktop Nerd Font to a `desktop` Dependency Set and Playwright CLI to a `web` Dependency Set. The composite `workstation` Profile no longer duplicates the font.
- Normal manifest loading rejects `profiles[].dependencies` with actionable migration guidance while retaining manifest version 1.
- Historical manifest loading may accept the retired field only to compare pre-refresh selection evolution. It does not make the field valid for a new install.
- A Profile may transition to `legacy` for discovery purposes. Removing it does not redirect intent; a recorded missing Profile blocks before mutation and requires a complete explicit replacement.
- Profile removal does not prune historical inventory or uninstall artifacts.
- The catalog JSON presentation adapter temporarily retains `profile_dependencies` as an empty array until a separately planned envelope-version change. The domain and human presentation no longer expose Profile Dependencies.
- Selected Surface evaluation is deepened as in-process computation. Cobra, YAML, Installation Metadata, filesystem mutation, and text/JSON presentation remain adapters rather than entering the selection interface.
- Interfaces are introduced only at demonstrated I/O substitution seams and live with their consumers. Pure selection accepts and returns concrete values.
- Gentle AI cleanup moves to an evidence-gated historical migration based on sufficiently specific Installation Metadata, preserving marker-based ownership checks and fail-closed behavior.
- The work is delivered in three ordered Delivery Units: pure Profiles, deep Selected Surface evaluation, and evidence-gated historical migrations.
- `CONTEXT.md` and manifest documentation are updated, and ADR-0013 receives an amendment rather than creating a separate architectural decision.

## Testing Decisions

- The primary test seam is existing machine-readable command behavior: manifest validation, Dependency Plan, Install Catalog, and selection-evolution output. Tests assert observable outcomes rather than internal helper calls.
- For Darwin and Linux, every repository Profile is compared with an explicit selection of its resolved Tags; both must expose the same Selected Surface.
- A focused regression proves that `--profile desktop` and `--tag desktop` both include the Desktop Nerd Font.
- A focused regression proves that `--profile web` and `--tag web` both include Playwright CLI.
- A manifest test proves that Profile Dependencies are rejected with migration guidance during normal loading.
- An update test proves that a previous manifest containing Profile Dependencies can still be read for selection-evolution comparison before refresh.
- Catalog tests prove that human output omits Profile Dependencies while schema-version-compatible JSON emits an empty compatibility field.
- Selected Surface tests exercise ordering, de-duplication, Tag/OS matching, source overrides, Profile equivalence, and absence of filesystem I/O through the module interface.
- Existing command tests remain the prior art for command-level JSON envelopes, and existing selection-evolution tests remain the prior art for historical manifest comparison.
- Historical migration tests distinguish positive metadata evidence, irrelevant current Tags, ambiguous or missing evidence, malformed markers, user-owned content, and partial filesystem failure.
- Full validation matches CI: formatting, vet, build, test, manifest validation, catalog generation checks, and sandboxed CLI commands that never target the real home.

### Key interfaces

- Install Manifest Profile declaration — Profile-owned Dependencies are retired; ordered Tags remain.
- Selected Surface evaluation — effective Tags plus operating system determine declarative selected surface independently of provenance.
- `dots deps plan` and Install Catalog machine-readable output — equivalent Profile and Tag selections agree.
- Selection evolution during `dots update` — historical manifests remain comparable without accepting retired schema for current installation.
- Installed Selection change handling — missing or reduced intent still blocks or requires explicit acknowledgement before mutation.
- Historical retirement workflow — Installation Metadata evidence authorizes cleanup; current Tag selection does not.

### Requirements

- The implementation must preserve explicit Profile and Tag intent and ordered Tag union semantics.
- The implementation must preserve the fail-before-mutation behavior for missing recorded Profiles.
- The implementation must not infer, redirect, merge, or silently replace Installed Selection.
- The implementation must keep the Install Manifest declarative and must not introduce dynamic Go plugins.
- The implementation must keep each Delivery Unit independently reviewable and green.
- The implementation must preserve JSON compatibility unless a separately authorized envelope-version change is required.

## Out of Scope

- Dynamic Go plugins or runtime code discovery for Profiles or Tags.
- Nested Profiles or recursive Profile inheritance.
- Automatic replacement of a removed Profile.
- Automatic uninstall or pruning caused by Profile removal.
- Changing the Installed Selection reduction acknowledgement contract.
- Reworking filesystem planning, Conflict resolution, Drift detection, or uninstall semantics.
- Performing all three Delivery Units in one pull request.
- Removing the temporary catalog JSON compatibility field as part of this specification.
- Generalizing every historical migration before the Gentle AI path demonstrates the seam.

### Acceptance criteria

- [ ] Profiles contain no Dependencies and compose only ordered Tags plus descriptive lifecycle metadata.
- [ ] Capability-wide Dependencies are Tag-scoped and composite Profiles contain no duplicated prerequisites.
- [ ] Equivalent Profile and explicit Tag selections produce the same Selected Surface on Darwin and Linux.
- [ ] Normal loading rejects retired Profile Dependencies with actionable guidance; update can still compare a historical manifest that contains them.
- [ ] Selected Surface selection is concentrated behind one cohesive in-process module and consumed consistently by its callers.
- [ ] Current Tags no longer trigger hidden cleanup behavior.
- [ ] Gentle AI cleanup runs only with sufficient historical Installation Metadata evidence and preserves user-owned content.
- [ ] Installed Selection blocking, reduction acknowledgement, and no-pruning behavior remain unchanged.
- [ ] Human and machine-readable contracts remain consistent, including the temporary empty catalog compatibility field.
- [ ] The glossary, manifest documentation, and ADR-0013 describe the final domain model.
- [ ] Each child Delivery Unit has a complete Delivery Contract, native parent relationship, and correct blocking edges.

### Validation notes

- `gofmt -l .`
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- `go generate ./internal/catalog`
- `go run ./cmd/dots manifest validate --file dots.yaml`
- Compare Profile and explicit Tag dependency/catalog output for both supported operating systems where the command permits an OS selector.
- Run any home/state behavior with temporary `--home`, `--source-root`, and `--state-root` paths; never use the real home.

## Further Notes

- This specification deepens ADR-0013 rather than replacing explicit composable Profiles.
- ADR-0014 continues to govern Installed Selection persistence, evolution, replacement, and reduction safety.
- The architecture deliberately applies ports and adapters only at real I/O seams. The pure selection core does not require interface indirection.
- The broad file count in the Codex delegation retirement was mostly required by safe compatibility and migration behavior; this specification targets the avoidable second sources of truth revealed by that change.

```
</details>

### Reviewed head

- `525e2946e0b5762806bb0bb56eb83548f242c8a2`

### Acceptance coverage

- No-evidence and Installed Selection-only false positives: `TestAgentsProfileInstallsNativeBaselineWithoutAuthorizingHistoricalCleanup`, `TestHistoricalGentleAIEvidenceRequiresSuccessfulInstallReceipt`.
- Legacy/current positive receipts and near misses: `TestHistoricalGentleAIEvidenceRequiresSuccessfulInstallReceipt`.
- Marker ownership, unmarked bytes, modes, symlinks, and manual cleanup: `TestRetireGentleAIStateRemovesOnlyOwnedMarkerBlocks`, `TestRetireGentleAIStatePreservesAndReportsSymlinks`.
- Malformed/partial failure and terminal Installed Selection preservation: `TestRetireGentleAIStateReportsPartialFailureWithoutChangingMalformedFile`, `TestInstallHistoricalRetirementFailurePreservesPreviousSelection`.
- Install/update/upgrade ordering and reporting: `TestInstallRetiresHistoricalDelegationOnlyAfterSuccessfulApply`, `TestUpdateRetiresHistoricalDelegationAfterSuccessfulApply`, `TestUpgradeContinueReusesUpdateWorkflow`.
- No current Tag action and active documentation: catalog/tagpolicy/manifest/selection tests plus `CONTEXT.md`, ADR 0013, manifest/update/output-contract docs.

### Automated validation

Passed at reviewed head: `gofmt -l .`, `go vet ./...`, `go build ./...`, `go test ./...`, `go generate ./internal/catalog` with clean diff, and manifest validation. Focused affected-package tests also passed.

### Manual verification

A temporary real binary built from `./cmd/dots` ran plan and install against explicit temporary home/state roots and the repository Source of Truth. Observed: exit 0, zero selected Provisioners, unchanged instruction-file SHA-256 before/after current `agents` selection, Installed Selection `agents`, and no historical-retirement text. Positive receipts, malformed markers, symlinks, and install/update/upgrade paths use deterministic filesystem/metadata fixtures and are covered by the automated tests above.

### Independent review

- Spec: 0 actionable findings. The reviewer confirmed receipt specificity, Installed Selection false-positive protection, terminal ordering, ownership safety/reporting, and scope.
- Standards: 0 actionable findings and 0 baseline smell observations. The reviewer confirmed repository rules, ADRs, safety, error propagation, and test coverage.
<!-- delivery-issue:evidence:end -->