### PR TITLE
fix(agents): close retirement symlink race

### DIFF
--- a/internal/agentinstructions/trigger_rules.go
+++ b/internal/agentinstructions/trigger_rules.go
@@ -337,6 +337,9 @@ func addCopilotPortablePolicyTargets(add func(agent, path string), agent, home s
 type markedBlockFileOps struct {
 	lstat    func(string) (os.FileInfo, error)
 	openFile func(string, int, os.FileMode) (*os.File, error)
+	// beforeWrite is a deterministic test seam for replacement immediately
+	// before descriptor-scoped mutation. Production leaves it nil.
+	beforeWrite func()
 }
 
 func systemMarkedBlockFileOps() markedBlockFileOps {
@@ -429,6 +432,9 @@ func removeMarkedBlocksWithFileOps(path string, ops markedBlockFileOps, markers 
 	}
 	if err := validateMarkedBlockPath(path, writeInfo, ops.lstat); err != nil {
 		return false, false, err
+	}
+	if ops.beforeWrite != nil {
+		ops.beforeWrite()
 	}
 	if err := file.Truncate(0); err != nil {
 		return false, false, fmt.Errorf("truncate agent instructions %s: %w", path, err)

--- a/internal/agentinstructions/trigger_rules.go
+++ b/internal/agentinstructions/trigger_rules.go
@@ -3,6 +3,7 @@ package agentinstructions
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -180,10 +181,18 @@ type RetirementReport struct {
 // and reports non-regular targets for manual cleanup instead of following them.
 func RetireGentleAIState(home string) (RetirementReport, error) {
 	report := RetirementReport{Removed: []string{}, ManualCleanup: []string{}}
+	ops, root, err := rootedMarkedBlockFileOps(home)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return report, nil
+		}
+		return report, fmt.Errorf("open agent instructions home %s: %w", home, err)
+	}
 	var errs []error
 	for _, target := range instructionTargets(home, []string{"codex", "claude-code", "opencode", "antigravity", "vscode-copilot"}) {
-		removed, manual, err := removeMarkedBlocks(
+		removed, manual, err := removeMarkedBlocksWithFileOps(
 			target.path,
+			ops,
 			textblock.Markers{Start: gentleAITriggerRulesStart, End: gentleAITriggerRulesEnd},
 			textblock.Markers{Start: gentleAIPersonaStart, End: gentleAIPersonaEnd},
 			textblock.Markers{Start: gentleAIEngramStart, End: gentleAIEngramEnd},
@@ -199,6 +208,9 @@ func RetireGentleAIState(home string) (RetirementReport, error) {
 		if err != nil {
 			errs = append(errs, err)
 		}
+	}
+	if err := root.Close(); err != nil {
+		errs = append(errs, fmt.Errorf("close agent instructions home %s: %w", home, err))
 	}
 	return report, errors.Join(errs...)
 }
@@ -322,8 +334,36 @@ func addCopilotPortablePolicyTargets(add func(agent, path string), agent, home s
 	add(agent, filepath.Join(home, ".copilot", "copilot-instructions.md"))
 }
 
-func removeMarkedBlocks(path string, markers ...textblock.Markers) (removed, manual bool, err error) {
-	info, err := os.Lstat(path)
+type markedBlockFileOps struct {
+	lstat    func(string) (os.FileInfo, error)
+	openFile func(string, int, os.FileMode) (*os.File, error)
+}
+
+func systemMarkedBlockFileOps() markedBlockFileOps {
+	return markedBlockFileOps{lstat: os.Lstat, openFile: os.OpenFile}
+}
+
+func rootedMarkedBlockFileOps(home string) (markedBlockFileOps, *os.Root, error) {
+	root, err := os.OpenRoot(home)
+	if err != nil {
+		return markedBlockFileOps{}, nil, err
+	}
+	ops := systemMarkedBlockFileOps()
+	ops.openFile = func(path string, flag int, perm os.FileMode) (*os.File, error) {
+		relative, err := filepath.Rel(home, path)
+		if err != nil {
+			return nil, fmt.Errorf("resolve agent instructions relative to home: %w", err)
+		}
+		if !filepath.IsLocal(relative) {
+			return nil, fmt.Errorf("agent instructions path %s escapes home %s", path, home)
+		}
+		return root.OpenFile(relative, flag, perm)
+	}
+	return ops, root, nil
+}
+
+func removeMarkedBlocksWithFileOps(path string, ops markedBlockFileOps, markers ...textblock.Markers) (removed, manual bool, err error) {
+	info, err := ops.lstat(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return false, false, nil
@@ -333,9 +373,32 @@ func removeMarkedBlocks(path string, markers ...textblock.Markers) (removed, man
 	if !info.Mode().IsRegular() {
 		return false, true, nil
 	}
-	content, err := os.ReadFile(path)
+	file, err := ops.openFile(path, os.O_RDONLY, 0)
 	if err != nil {
-		return false, false, fmt.Errorf("read agent instructions %s: %w", path, err)
+		return false, false, fmt.Errorf("open agent instructions %s: %w", path, err)
+	}
+	openedInfo, err := file.Stat()
+	if err != nil {
+		return false, false, errors.Join(
+			fmt.Errorf("inspect opened agent instructions %s: %w", path, err),
+			closeMarkedBlockFile(file, path, "after failed inspection"),
+		)
+	}
+	if !openedInfo.Mode().IsRegular() || !os.SameFile(info, openedInfo) {
+		return false, false, errors.Join(
+			fmt.Errorf("agent instructions %s changed before opening", path),
+			closeMarkedBlockFile(file, path, "after identity mismatch"),
+		)
+	}
+	content, err := io.ReadAll(file)
+	if err != nil {
+		return false, false, errors.Join(
+			fmt.Errorf("read agent instructions %s: %w", path, err),
+			closeMarkedBlockFile(file, path, "after failed read"),
+		)
+	}
+	if err := file.Close(); err != nil {
+		return false, false, fmt.Errorf("close agent instructions %s after reading: %w", path, err)
 	}
 	updated, err := textblock.Remove(string(content), markers...)
 	if err != nil {
@@ -344,10 +407,63 @@ func removeMarkedBlocks(path string, markers ...textblock.Markers) (removed, man
 	if updated == string(content) {
 		return false, false, nil
 	}
-	if err := os.WriteFile(path, []byte(updated), info.Mode().Perm()); err != nil {
+	if err := validateMarkedBlockPath(path, openedInfo, ops.lstat); err != nil {
+		return false, false, err
+	}
+	file, err = ops.openFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return false, false, fmt.Errorf("open agent instructions %s for writing: %w", path, err)
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			removed = false
+			err = errors.Join(err, fmt.Errorf("close agent instructions %s after writing: %w", path, closeErr))
+		}
+	}()
+	writeInfo, err := file.Stat()
+	if err != nil {
+		return false, false, fmt.Errorf("inspect writable agent instructions %s: %w", path, err)
+	}
+	if !writeInfo.Mode().IsRegular() || !os.SameFile(openedInfo, writeInfo) {
+		return false, false, fmt.Errorf("agent instructions %s changed before writing", path)
+	}
+	if err := validateMarkedBlockPath(path, writeInfo, ops.lstat); err != nil {
+		return false, false, err
+	}
+	if err := file.Truncate(0); err != nil {
+		return false, false, fmt.Errorf("truncate agent instructions %s: %w", path, err)
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return false, false, fmt.Errorf("rewind agent instructions %s: %w", path, err)
+	}
+	if _, err := io.WriteString(file, updated); err != nil {
 		return false, false, fmt.Errorf("write agent instructions %s: %w", path, err)
 	}
+	if err := file.Sync(); err != nil {
+		return false, false, fmt.Errorf("sync agent instructions %s: %w", path, err)
+	}
+	if err := validateMarkedBlockPath(path, writeInfo, ops.lstat); err != nil {
+		return false, false, err
+	}
 	return true, false, nil
+}
+
+func validateMarkedBlockPath(path string, openedInfo os.FileInfo, lstat func(string) (os.FileInfo, error)) error {
+	currentInfo, err := lstat(path)
+	if err != nil {
+		return fmt.Errorf("reinspect agent instructions %s: %w", path, err)
+	}
+	if !currentInfo.Mode().IsRegular() || !os.SameFile(openedInfo, currentInfo) {
+		return fmt.Errorf("agent instructions %s changed during retirement", path)
+	}
+	return nil
+}
+
+func closeMarkedBlockFile(file *os.File, path, phase string) error {
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close agent instructions %s %s: %w", path, phase, err)
+	}
+	return nil
 }
 
 func homeRelativePath(home, path string) string {

--- a/internal/agentinstructions/trigger_rules_test.go
+++ b/internal/agentinstructions/trigger_rules_test.go
@@ -1,11 +1,15 @@
 package agentinstructions
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/yersonargotev/dots/internal/textblock"
 )
 
 func TestRetireCodexDelegationRemovesOnlyKnownOwnedState(t *testing.T) {
@@ -215,6 +219,205 @@ func TestRetireGentleAIStatePreservesAndReportsSymlinks(t *testing.T) {
 	got, err := os.ReadFile(target)
 	if err != nil || string(got) != content {
 		t.Fatalf("symlink target changed: %q, %v", got, err)
+	}
+}
+
+func TestRetireGentleAIStateRejectsInstructionPathOutsideHome(t *testing.T) {
+	home := t.TempDir()
+	outside := t.TempDir()
+	path := filepath.Join(outside, "AGENTS.md")
+	content := gentleAITriggerRulesStart + "\nowned\n" + gentleAITriggerRulesEnd + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(home, ".codex")); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := RetireGentleAIState(home)
+	if err == nil {
+		t.Fatal("RetireGentleAIState() error = nil, want path escape failure")
+	}
+	if len(report.Removed) != 0 {
+		t.Fatalf("RetireGentleAIState() report = %#v, want no removal", report)
+	}
+	got, readErr := os.ReadFile(path)
+	if readErr != nil || string(got) != content {
+		t.Fatalf("outside-home instructions changed: %q, %v", got, readErr)
+	}
+}
+
+func TestRemoveMarkedBlocksRejectsSymlinkReplacementBeforeOpen(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "instructions.md")
+	target := filepath.Join(dir, "user-owned.md")
+	owned := gentleAITriggerRulesStart + "\nowned\n" + gentleAITriggerRulesEnd + "\n"
+	userOwned := "keep user-owned target\n"
+	if err := os.WriteFile(path, []byte(owned), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte(userOwned), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ops := systemMarkedBlockFileOps()
+	systemLstat := ops.lstat
+	replaced := false
+	ops.lstat = func(name string) (os.FileInfo, error) {
+		info, err := systemLstat(name)
+		if err != nil || replaced {
+			return info, err
+		}
+		replaced = true
+		if err := os.Remove(name); err != nil {
+			t.Fatalf("remove checked instructions: %v", err)
+		}
+		if err := os.Symlink(target, name); err != nil {
+			t.Fatalf("replace instructions with symlink: %v", err)
+		}
+		return info, nil
+	}
+
+	removed, manual, err := removeMarkedBlocksWithFileOps(
+		path,
+		ops,
+		textblock.Markers{Start: gentleAITriggerRulesStart, End: gentleAITriggerRulesEnd},
+	)
+	if err == nil {
+		t.Fatal("removeMarkedBlocksWithFileOps() error = nil, want replacement failure")
+	}
+	if removed || manual {
+		t.Fatalf("removeMarkedBlocksWithFileOps() = (%v, %v, %v), want no reported mutation", removed, manual, err)
+	}
+	got, readErr := os.ReadFile(target)
+	if readErr != nil || string(got) != userOwned {
+		t.Fatalf("replacement symlink target changed: %q, %v", got, readErr)
+	}
+}
+
+func TestRemoveMarkedBlocksRejectsSymlinkReplacementAfterOpen(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "instructions.md")
+	checked := filepath.Join(dir, "checked-instructions.md")
+	target := filepath.Join(dir, "user-owned.md")
+	owned := gentleAITriggerRulesStart + "\nowned\n" + gentleAITriggerRulesEnd + "\n"
+	userOwned := "keep user-owned target\n"
+	if err := os.WriteFile(path, []byte(owned), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte(userOwned), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ops := systemMarkedBlockFileOps()
+	systemOpenFile := ops.openFile
+	ops.openFile = func(name string, flag int, perm os.FileMode) (*os.File, error) {
+		file, err := systemOpenFile(name, flag, perm)
+		if err != nil {
+			return nil, err
+		}
+		if err := os.Rename(name, checked); err != nil {
+			file.Close()
+			t.Fatalf("move checked instructions: %v", err)
+		}
+		if err := os.Symlink(target, name); err != nil {
+			file.Close()
+			t.Fatalf("replace instructions with symlink: %v", err)
+		}
+		return file, nil
+	}
+
+	removed, manual, err := removeMarkedBlocksWithFileOps(
+		path,
+		ops,
+		textblock.Markers{Start: gentleAITriggerRulesStart, End: gentleAITriggerRulesEnd},
+	)
+	if err == nil {
+		t.Fatal("removeMarkedBlocksWithFileOps() error = nil, want replacement failure")
+	}
+	if removed || manual {
+		t.Fatalf("removeMarkedBlocksWithFileOps() = (%v, %v, %v), want no reported mutation", removed, manual, err)
+	}
+	got, readErr := os.ReadFile(target)
+	if readErr != nil || string(got) != userOwned {
+		t.Fatalf("replacement symlink target changed: %q, %v", got, readErr)
+	}
+	got, readErr = os.ReadFile(checked)
+	if readErr != nil || string(got) != owned {
+		t.Fatalf("checked instructions changed: %q, %v", got, readErr)
+	}
+}
+
+func TestRemoveMarkedBlocksRejectsDeletionAfterOpen(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "instructions.md")
+	owned := gentleAITriggerRulesStart + "\nowned\n" + gentleAITriggerRulesEnd + "\n"
+	if err := os.WriteFile(path, []byte(owned), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	ops := systemMarkedBlockFileOps()
+	systemOpenFile := ops.openFile
+	ops.openFile = func(name string, flag int, perm os.FileMode) (*os.File, error) {
+		file, err := systemOpenFile(name, flag, perm)
+		if err != nil {
+			return nil, err
+		}
+		if err := os.Remove(name); err != nil {
+			file.Close()
+			t.Fatalf("delete checked instructions: %v", err)
+		}
+		return file, nil
+	}
+
+	removed, manual, err := removeMarkedBlocksWithFileOps(
+		path,
+		ops,
+		textblock.Markers{Start: gentleAITriggerRulesStart, End: gentleAITriggerRulesEnd},
+	)
+	if err == nil {
+		t.Fatal("removeMarkedBlocksWithFileOps() error = nil, want deletion failure")
+	}
+	if removed || manual {
+		t.Fatalf("removeMarkedBlocksWithFileOps() = (%v, %v, %v), want no reported mutation", removed, manual, err)
+	}
+	if _, statErr := os.Lstat(path); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("deleted instructions recreated: %v", statErr)
+	}
+}
+
+func TestRetireGentleAIStateDoesNotRewriteUnownedInstructions(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".codex", "AGENTS.md")
+	content := "user-owned instructions\n"
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o440); err != nil {
+		t.Fatal(err)
+	}
+	modified := time.Unix(1_700_000_000, 0)
+	if err := os.Chtimes(path, modified, modified); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := RetireGentleAIState(home)
+	if err != nil {
+		t.Fatalf("RetireGentleAIState() error = %v", err)
+	}
+	if len(report.Removed) != 0 || len(report.ManualCleanup) != 0 {
+		t.Fatalf("RetireGentleAIState() report = %#v, want no change", report)
+	}
+	got, readErr := os.ReadFile(path)
+	if readErr != nil || string(got) != content {
+		t.Fatalf("unowned instructions changed: %q, %v", got, readErr)
+	}
+	info, statErr := os.Stat(path)
+	if statErr != nil || info.Mode().Perm() != 0o440 || !info.ModTime().Equal(modified) {
+		t.Fatalf("unowned instructions metadata = (%v, %v), want mode 0440 and mtime %v", info, statErr, modified)
 	}
 }
 

--- a/internal/agentinstructions/trigger_rules_test.go
+++ b/internal/agentinstructions/trigger_rules_test.go
@@ -348,6 +348,50 @@ func TestRemoveMarkedBlocksRejectsSymlinkReplacementAfterOpen(t *testing.T) {
 	}
 }
 
+func TestRemoveMarkedBlocksRejectsSymlinkReplacementBeforeMutation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "instructions.md")
+	checked := filepath.Join(dir, "checked-instructions.md")
+	target := filepath.Join(dir, "user-owned.md")
+	owned := gentleAITriggerRulesStart + "\nowned\n" + gentleAITriggerRulesEnd + "\n"
+	userOwned := "keep user-owned target\n"
+	if err := os.WriteFile(path, []byte(owned), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte(userOwned), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ops := systemMarkedBlockFileOps()
+	ops.beforeWrite = func() {
+		if err := os.Rename(path, checked); err != nil {
+			t.Fatalf("move checked instructions: %v", err)
+		}
+		if err := os.Symlink(target, path); err != nil {
+			t.Fatalf("replace instructions with symlink: %v", err)
+		}
+	}
+
+	removed, manual, err := removeMarkedBlocksWithFileOps(
+		path,
+		ops,
+		textblock.Markers{Start: gentleAITriggerRulesStart, End: gentleAITriggerRulesEnd},
+	)
+	if err == nil {
+		t.Fatal("removeMarkedBlocksWithFileOps() error = nil, want replacement failure")
+	}
+	if removed || manual {
+		t.Fatalf("removeMarkedBlocksWithFileOps() = (%v, %v, %v), want no reported mutation", removed, manual, err)
+	}
+	got, readErr := os.ReadFile(target)
+	if readErr != nil || string(got) != userOwned {
+		t.Fatalf("replacement symlink target changed: %q, %v", got, readErr)
+	}
+	if info, statErr := os.Lstat(path); statErr != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("replacement symlink changed: %v, %v", info, statErr)
+	}
+}
+
 func TestRemoveMarkedBlocksRejectsDeletionAfterOpen(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "instructions.md")


### PR DESCRIPTION
Closes #440

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Confines Gentle AI retirement file opens to the selected home with `os.Root`.
- Reads and writes only a validated regular-file identity through descriptors.
- Adds deterministic coverage for path replacement, deletion, escape, and no-rewrite behavior.

## Changes

| File | Change |
|------|--------|
| `internal/agentinstructions/trigger_rules.go` | Uses rooted file operations, identity revalidation, and descriptor-scoped mutation for marker retirement. |
| `internal/agentinstructions/trigger_rules_test.go` | Covers symlink replacement at each vulnerable phase, deletion, outside-home paths, and read-only unowned files. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed real-binary install verified symlink preservation/manual reporting and outside-home rejection.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] CLI validation used `/tmp/dots-issue-440-manual.M1irFm` with explicit temporary `--home`, `--source-root`, and `--state-root` values.

## Contributor Checklist

- [x] Linked one issue with an admitted Delivery Contract using `Closes #440`.
- [x] Added exactly one `type:*` label.
- [x] Delivery Evidence records the Contract Source snapshot, Acceptance coverage, and Independent review.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated tests for changed filesystem behavior; no user documentation change was required.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

### Contract Source snapshot

Kind: composed delivery ticket #440 with native parent specification #427.

| Source | Node ID | URL | `updatedAt` | SHA-256 of exact raw UTF-8 body |
|---|---|---|---|---|
| Ticket #440 | `I_kwDOSzLlmM8AAAABMExYTQ` | https://github.com/yersonargotev/dots/issues/440 | `2026-08-09T23:33:06Z` | `e4cdf2ef15d549881ca3e6e889e4047fee2766eeb06fc200063ed64ce1c0d197` |
| Parent #427 | `I_kwDOSzLlmM8AAAABMEODWA` | https://github.com/yersonargotev/dots/issues/427 | `2026-08-09T20:58:54Z` | `294db5b0d8a1d718b2b5ae57f3a09dbe61720b13db334c248eac4eea7ade823c` |

Labels at admission/revalidation: #440 category `bug`, readiness `ready-for-agent`; #427 category `enhancement`, readiness `ready-for-agent`. No conflicting triage labels.

Native relationships at revalidation:

- #440 parent: #427 OPEN (`I_kwDOSzLlmM8AAAABMEODWA`, `2026-08-09T20:58:54Z`).
- #440 sub-issues, blocked-by, blocking: none.
- #427 blocked-by and blocking: none.
- #427 sub-issues: #428 CLOSED (`2026-08-09T21:33:49Z`), #429 CLOSED (`2026-08-09T21:57:24Z`), #430 CLOSED (`2026-08-09T22:22:37Z`), #431 CLOSED (`2026-08-09T22:40:54Z`), #432 CLOSED (`2026-08-09T22:57:39Z`), #433 CLOSED (`2026-08-09T23:22:04Z`), #440 OPEN (`2026-08-09T23:33:06Z`), #441 OPEN (`2026-08-09T23:33:07Z`).

### Reviewed head

- `91a0ee15c351b7ea41d61710e4bb004ee58c931b`

### Acceptance coverage

- Initial symlink/manual cleanup: `TestRetireGentleAIStatePreservesAndReportsSymlinks` plus real-binary sandbox verification.
- Before-open, after-read-open, and immediately-before-mutation replacement: `TestRemoveMarkedBlocksRejectsSymlinkReplacementBeforeOpen`, `TestRemoveMarkedBlocksRejectsSymlinkReplacementAfterOpen`, and `TestRemoveMarkedBlocksRejectsSymlinkReplacementBeforeMutation`.
- Deletion and no recreation: `TestRemoveMarkedBlocksRejectsDeletionAfterOpen`.
- Outside-home confinement: `TestRetireGentleAIStateRejectsInstructionPathOutsideHome` plus real-binary failure verification.
- Owned-block removal, unrelated bytes, mode preservation, malformed markers, and no rewrite without blocks: existing retirement tests plus `TestRetireGentleAIStateDoesNotRewriteUnownedInstructions`.
- Terminal Installed Selection safety: existing CLI historical-retirement failure tests and sandbox state assertion.

### Automated validation

Passed at reviewed head: `gofmt -l .`, `go vet ./...`, `go build ./...`, `go test ./...`, `GOTOOLCHAIN=go1.24.0 go test ./internal/agentinstructions -count=1`, `go test -race ./internal/agentinstructions -count=1`, and manifest validation.

### Manual verification

A real binary built from `./cmd/dots` was exercised only under `/tmp/dots-issue-440-manual.M1irFm`:

- Historical-evidence install with a final `~/.codex/AGENTS.md` symlink exited 0, reported `Manual cleanup`, preserved the symlink, and retained the target SHA-256.
- Historical-evidence install with `.codex` escaping the selected home exited 1 with `path escapes from parent`, retained the outside target SHA-256, and did not record `installed_selection`.

### Independent review

- Spec: 0 actionable findings after adding deterministic coverage immediately before descriptor mutation.
- Standards: 0 actionable findings. A concern about mutating the validated inode after rename was withdrawn after comparison with the contract: the replacement symlink/destination remains untouched and terminal success is prevented.
<!-- delivery-issue:evidence:end -->
