### PR TITLE
feat(core): install and configure tuicr

### DIFF
--- a/configs/tuicr/config.toml
+++ b/configs/tuicr/config.toml
@@ -1,0 +1,1 @@
+theme = "catppuccin-mocha"

--- a/dots.yaml
+++ b/dots.yaml
@@ -303,6 +303,20 @@ entries:
     os:
       - darwin
       - linux
+  - source: configs/tuicr/config.toml
+    target: ~/.config/tuicr/config.toml
+    strategy: copy
+    ownership: toml-subset
+    tags:
+      - core
+    os:
+      - darwin
+      - linux
+    dependencies:
+      - name: tuicr
+        command: tuicr
+        brew: agavra/tap/tuicr
+        linux_homebrew: true
   - source: configs/dots/theme.sh
     target: ~/.config/dots/theme.sh
     strategy: symlink

--- a/internal/cli/provision_test_helpers_test.go
+++ b/internal/cli/provision_test_helpers_test.go
@@ -56,6 +56,7 @@ func writeManifestDependencyStubs(t *testing.T, dir string) {
 		"rg",
 		"starship",
 		"tmux",
+		"tuicr",
 		"unzip",
 		"uv",
 		"warp-terminal",

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -2314,6 +2314,61 @@ func TestRepositoryManifestIncludesMVPConfigurationSet(t *testing.T) {
 	}
 }
 
+func TestRepositoryManifestIncludesTuicrCoreConfiguration(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", ".."))
+	manifestPath := filepath.Join(root, "dots.yaml")
+
+	got, err := manifest.LoadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("LoadFile(%q) error = %v", manifestPath, err)
+	}
+
+	if _, ok := got.Profiles["tuicr"]; ok {
+		t.Fatal("repository manifest defines a dedicated tuicr Profile, want core ownership")
+	}
+	if _, ok := got.Tags["tuicr"]; ok {
+		t.Fatal("repository manifest defines a dedicated tuicr Tag, want core ownership")
+	}
+
+	var entry *manifest.Entry
+	for i := range got.Entries {
+		if got.Entries[i].Target == "~/.config/tuicr/config.toml" {
+			entry = &got.Entries[i]
+			break
+		}
+	}
+	if entry == nil {
+		t.Fatal("repository manifest missing tuicr Managed Entry")
+	}
+	if entry.Source != "configs/tuicr/config.toml" || entry.Strategy != "copy" || entry.Ownership != "toml-subset" {
+		t.Fatalf("tuicr config entry = %#v, want copy with TOML Subset Ownership", *entry)
+	}
+	if !sameStrings(entry.Tags, []string{"core"}) || !sameStrings(entry.OS, []string{"darwin", "linux"}) {
+		t.Fatalf("tuicr config scope = tags %#v, OS %#v; want core on darwin and linux", entry.Tags, entry.OS)
+	}
+	if len(entry.Dependencies) != 1 {
+		t.Fatalf("tuicr dependencies = %#v, want one dependency", entry.Dependencies)
+	}
+	dependency := entry.Dependencies[0]
+	if dependency.Name != "tuicr" || dependency.Command != "tuicr" || dependency.Brew != "agavra/tap/tuicr" || !dependency.LinuxHomebrew {
+		t.Fatalf("tuicr dependency = %#v, want command tuicr through agavra/tap/tuicr with Linuxbrew enabled", dependency)
+	}
+
+	config, err := os.ReadFile(filepath.Join(root, entry.Source))
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", entry.Source, err)
+	}
+	if string(config) != "theme = \"catppuccin-mocha\"\n" {
+		t.Fatalf("tuicr config = %q, want Catppuccin Mocha baseline", config)
+	}
+
+	for _, provisioner := range got.Provisioners {
+		if provisioner.Spec.Package == "agavra/tuicr" {
+			t.Fatalf("repository manifest includes tuicr skill Provisioner: %#v", provisioner)
+		}
+	}
+}
+
 func hasString(values []string, want string) bool {
 	for _, value := range values {
 		if value == want {


### PR DESCRIPTION
Closes #444

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Install `tuicr` as part of the Core Development Baseline through its official Homebrew tap.
- Manage a portable `tuicr` TOML baseline with Catppuccin Mocha.
- Preserve user-owned settings through TOML Subset Ownership without adding a Profile, Tag, or skill.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Add the core-scoped `tuicr` Managed Entry and Homebrew Dependency. |
| `configs/tuicr/config.toml` | Set the Source of Truth theme to `catppuccin-mocha`. |
| `internal/manifest/manifest_test.go` | Lock profile scope, provider, ownership, theme, and absence of a skill Provisioner. |
| `internal/cli/provision_test_helpers_test.go` | Stub the new Dependency in real-manifest sandbox installs so tests never reach Homebrew or the network. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan: `/tmp/dots-delivery-444-r2.uw451m/dots plan --file dots.yaml --profile core --source-root "$PWD" --home /tmp/dots-delivery-444-r2.uw451m/plan-home --output json`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targeted home/config paths used `/tmp/dots-delivery-444-r2.uw451m` plus explicit `--home`, `--source-root "$PWD"`, and `--state-root` flags where supported.

## Contributor Checklist

- [x] Linked one issue with an admitted Delivery Contract using `Closes #444`.
- [x] Added exactly one `type:*` label.
- [x] Delivery Evidence records the Contract Source snapshot, Acceptance coverage, and Independent review.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed. No workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

### Contract Source snapshot

- Kind: standalone issue body.
- Body ID: `I_kwDOSzLlmM8AAAABMFEYSw`.
- URL: https://github.com/yersonargotev/dots/issues/444
- Updated at: `2026-08-10T00:51:48Z`.
- SHA-256: `90eebcace0f45156a3354e073736d8980f70fba14475320de09705b5cb82b64c`.
- Category/readiness: `enhancement`, `ready-for-agent`.
- Native relationships: no parent, sub-issues, blocked-by, or blocking relationships.
- Comments at snapshot: none.

### Reviewed candidate

- Base: `origin/main` at `b76acb0d47e2a7962ddf95e25a495694c4332b65`.
- Head: `5f9c00d258057a5a4b48b53921bb9d4c7835a3ad`.

### Acceptance coverage

- Core catalog: a real temporary `dots` binary selected exactly one `tuicr` Managed Entry and Dependency for Linux.
- Sandboxed install: materialized `~/.config/tuicr/config.toml` with `theme = "catppuccin-mocha"` under `/tmp/dots-delivery-444-r2.uw451m/home`.
- TOML ownership: a target-only `mouse = false` key survived reinstall and remained aligned; changing the owned theme produced `status=findings`, `state=drifted`, and exit code `2`.
- Scope: manifest test confirms no `tuicr` Profile, Tag, or skill Provisioner.
- Manifest and repository tests pass.

### Automated validation

- `gofmt -l .` — passed with no output.
- `go vet ./...` — passed.
- `go build ./...` — passed.
- `go test ./...` — passed after adding the `tuicr` dependency probe stub required by real-manifest sandbox installs.
- `go run ./cmd/dots manifest validate --file dots.yaml` — passed.

### Manual verification

- `go build -o /tmp/dots-delivery-444-r2.uw451m/dots ./cmd/dots` — passed.
- Temporary binary `manifest validate` — `manifest is valid`.
- Temporary binary `catalog profile core --file dots.yaml --source-root "$PWD" --os linux --output json` — selected the expected Entry and Dependency.
- Temporary binary `plan --file dots.yaml --profile core --source-root "$PWD" --home /tmp/dots-delivery-444-r2.uw451m/plan-home --output json` — `status=ok`; `tuicr` action was `create`.
- Temporary binary `install --profile core --skip-deps --yes --no-tui` with explicit temporary home/source/state roots and a stubbed `zsh` provisioner executable — exit `0`; expected theme materialized without package-manager or network access.
- Reinstall after adding `mouse = false` — exit `0`; target-only key preserved; `status` reported `ok`.
- Status after changing the dots-owned theme — exit `2`; `tuicr` reported `drifted`.

### CI remediation

- Initial PR CI exposed that real-manifest sandbox installs did not stub the new `tuicr` Dependency and therefore attempted dependency provisioning on Linux.
- `internal/cli/provision_test_helpers_test.go` now includes `tuicr` in the central stub list; the focused regression command and complete local suite pass without invoking Homebrew or the network.

### Independent review

- Standards review of `origin/main...5f9c00d`: no actionable findings and no baseline smells.
- Spec review against #444: no actionable findings or scope creep.
- Observation: feature-specific tests are structural; shared TOML lifecycle tests plus the sandboxed manual lifecycle provide behavioral coverage.
- Observation: Homebrew core now also publishes `tuicr`; the Delivery Contract intentionally retains the upstream-documented `agavra/tap/tuicr` provider for this run.
<!-- delivery-issue:evidence:end -->
