### PR TITLE
fix(nvim): preserve managed plugin specs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,11 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Install Neovim for managed configuration tests
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes neovim
+
       - name: Check formatting
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,6 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Install Neovim for managed configuration tests
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes neovim
-
       - name: Check formatting
         run: |
           set -euo pipefail

--- a/configs/nvim/lua/config/lazy.lua
+++ b/configs/nvim/lua/config/lazy.lua
@@ -42,6 +42,7 @@ require("lazy").setup({
   }, -- automatically check for plugin updates
   performance = {
     rtp = {
+      paths = { vim.fn.expand("~/.config/dots/nvim") },
       -- disable some rtp plugins
       disabled_plugins = {
         "gzip",

--- a/internal/cli/issue446_nvim_runtimepath_test.go
+++ b/internal/cli/issue446_nvim_runtimepath_test.go
@@ -12,11 +12,6 @@ import (
 )
 
 func TestRepositoryNeovimLoaderKeepsManagedPluginSpecsDiscoverable(t *testing.T) {
-	nvim, err := exec.LookPath("nvim")
-	if err != nil {
-		t.Skip("nvim is not installed; CI installs it for this repository-level integration test")
-	}
-
 	repositoryRoot, err := filepath.Abs(filepath.Join("..", ".."))
 	if err != nil {
 		t.Fatalf("resolve repository root: %v", err)
@@ -39,6 +34,12 @@ profiles:
   default:
     tags: [core]
 entries:
+  - source: configs/nvim/lazy-lock.json
+    target: nvim/lazy-lock.json
+    target_root: xdg-state
+    strategy: copy
+    ownership: seeded
+    tags: [core]
   - source: configs/nvim/loader.lua
     target: ~/.config/nvim/init.lua
     strategy: copy
@@ -73,6 +74,26 @@ entries:
 	if target, err := os.Readlink(managedRoot); err != nil || target != managedSource {
 		t.Fatalf("managed Neovim root = (%q, %v), want symlink to %q", target, err, managedSource)
 	}
+	if info, err := os.Stat(filepath.Join(stateHome, "nvim", "lazy-lock.json")); err != nil || !info.Mode().IsRegular() {
+		t.Fatalf("seeded Neovim lockfile = (%v, %v), want regular XDG state file", info, err)
+	}
+	lazyConfig, err := os.ReadFile(filepath.Join(managedRoot, "lua", "config", "lazy.lua"))
+	if err != nil {
+		t.Fatalf("read installed lazy config: %v", err)
+	}
+	const managedPathOption = `paths = { vim.fn.expand("~/.config/dots/nvim") }`
+	if !strings.Contains(string(lazyConfig), managedPathOption) {
+		t.Fatalf("lazy config does not preserve the managed root through performance.rtp.paths")
+	}
+	if pluginSpecs, err := filepath.Glob(filepath.Join(managedRoot, "lua", "plugins", "*.lua")); err != nil || len(pluginSpecs) == 0 {
+		t.Fatalf("installed managed plugin specs = (%v, %v), want at least one", pluginSpecs, err)
+	}
+
+	nvim, err := exec.LookPath("nvim")
+	if err != nil {
+		t.Log("nvim is not installed; the hermetic installed-configuration assertions passed")
+		return
+	}
 
 	// This local lazy.nvim stub reproduces the runtime-path reset at the public
 	// setup boundary without cloning plugins or reading the operator's home.
@@ -96,6 +117,12 @@ local function find_colorscheme(spec)
 end
 
 function M.setup(opts)
+	local original_notify = vim.notify
+	local notifications = {}
+	vim.notify = function(message, level, notify_opts)
+		table.insert(notifications, message)
+		return original_notify(message, level, notify_opts)
+	end
   local reset = vim.tbl_get(opts, "performance", "rtp", "reset") ~= false
   if reset then
     vim.opt.runtimepath = {
@@ -113,6 +140,9 @@ function M.setup(opts)
   vim.g.dots_test_managed_on_rtp = vim.tbl_contains(vim.opt.runtimepath:get(), vim.fn.expand("~/.config/dots/nvim"))
   local plugin_specs = vim.api.nvim_get_runtime_file("lua/plugins/*.lua", true)
   vim.g.dots_test_plugin_specs = #plugin_specs
+	if #plugin_specs == 0 then
+		vim.notify('No specs found for module "plugins"', vim.log.levels.ERROR, { title = "lazy.nvim" })
+	end
   for _, spec_path in ipairs(plugin_specs) do
     if spec_path:match("/colorscheme.lua$") then
       vim.g.dots_test_requested_colorscheme = find_colorscheme(dofile(spec_path))
@@ -121,6 +151,8 @@ function M.setup(opts)
   if vim.g.dots_test_requested_colorscheme then
     vim.cmd("colorscheme " .. vim.g.dots_test_requested_colorscheme)
   end
+	vim.g.dots_test_lazy_notifications = #notifications
+	vim.notify = original_notify
 end
 
 return M
@@ -134,9 +166,10 @@ return M
 		`local reset = vim.g.dots_test_rtp_reset == true`,
 		`local managed = vim.g.dots_test_managed_on_rtp == true`,
 		`local specs = (vim.g.dots_test_plugin_specs or 0) > 0`,
+		`local notifications = vim.g.dots_test_lazy_notifications == 0`,
 		`local requested = vim.g.dots_test_requested_colorscheme == "catppuccin-mocha"`,
 		`local active = vim.g.colors_name == "catppuccin-mocha"`,
-		`if not (reset and managed and specs and requested and active) then vim.api.nvim_err_writeln("lazy reset=" .. tostring(reset) .. ", managed root=" .. tostring(managed) .. ", plugin specs=" .. tostring(specs) .. ", requested theme=" .. tostring(requested) .. ", active theme=" .. tostring(active)); vim.cmd("cquit 42") end`,
+		`if not (reset and managed and specs and notifications and requested and active) then vim.api.nvim_err_writeln("lazy reset=" .. tostring(reset) .. ", managed root=" .. tostring(managed) .. ", plugin specs=" .. tostring(specs) .. ", notifications=" .. tostring(notifications) .. ", requested theme=" .. tostring(requested) .. ", active theme=" .. tostring(active)); vim.cmd("cquit 42") end`,
 	}, "; ")
 	cmd := exec.Command(nvim, "--headless", "-c", "lua "+assertion, "-c", "qa!")
 	cmd.Env = append(issue446BaseEnv(),

--- a/internal/cli/issue446_nvim_runtimepath_test.go
+++ b/internal/cli/issue446_nvim_runtimepath_test.go
@@ -1,0 +1,173 @@
+package cli_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/cli"
+)
+
+func TestRepositoryNeovimLoaderKeepsManagedPluginSpecsDiscoverable(t *testing.T) {
+	nvim, err := exec.LookPath("nvim")
+	if err != nil {
+		t.Skip("nvim is not installed; CI installs it for this repository-level integration test")
+	}
+
+	repositoryRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	configHome := filepath.Join(home, ".config")
+	dataHome := filepath.Join(home, ".local", "share")
+	stateHome := filepath.Join(home, ".local", "state")
+	cacheHome := filepath.Join(home, ".cache")
+	dotsStateRoot := filepath.Join(home, ".local", "state", "dots")
+	managedRoot := filepath.Join(configHome, "dots", "nvim")
+	managedSource := filepath.Join(sourceRoot, "configs", "nvim")
+	if err := os.CopyFS(managedSource, os.DirFS(filepath.Join(repositoryRoot, "configs", "nvim"))); err != nil {
+		t.Fatalf("copy managed Neovim source: %v", err)
+	}
+	manifestPath := filepath.Join(sourceRoot, "dots.yaml")
+	writeIssue446File(t, manifestPath, `version: 1
+profiles:
+  default:
+    tags: [core]
+entries:
+  - source: configs/nvim/loader.lua
+    target: ~/.config/nvim/init.lua
+    strategy: copy
+    tags: [core]
+  - source: configs/nvim
+    target: ~/.config/dots/nvim
+    strategy: symlink
+    tags: [core]
+`)
+	for key, value := range map[string]string{
+		"HOME":             home,
+		"XDG_CONFIG_HOME":  configHome,
+		"XDG_DATA_HOME":    dataHome,
+		"XDG_STATE_HOME":   stateHome,
+		"XDG_CACHE_HOME":   cacheHome,
+		"DOTS_STATE_ROOT":  dotsStateRoot,
+		"DOTS_SOURCE_ROOT": sourceRoot,
+	} {
+		t.Setenv(key, value)
+	}
+	var stdout, stderr bytes.Buffer
+	code := cli.Run([]string{
+		"install", "--yes", "--skip-deps", "--profile", "default",
+		"--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", dotsStateRoot,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("install Neovim fixture code = %d, want 0\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+	}
+	if info, err := os.Lstat(filepath.Join(configHome, "nvim", "init.lua")); err != nil || !info.Mode().IsRegular() {
+		t.Fatalf("native Neovim loader = (%v, %v), want regular file", info, err)
+	}
+	if target, err := os.Readlink(managedRoot); err != nil || target != managedSource {
+		t.Fatalf("managed Neovim root = (%q, %v), want symlink to %q", target, err, managedSource)
+	}
+
+	// This local lazy.nvim stub reproduces the runtime-path reset at the public
+	// setup boundary without cloning plugins or reading the operator's home.
+	lazyStub := filepath.Join(dataHome, "nvim", "lazy", "lazy.nvim", "lua", "lazy", "init.lua")
+	writeIssue446File(t, lazyStub, `
+local M = {}
+
+local function find_colorscheme(spec)
+  if type(spec) ~= "table" then
+    return nil
+  end
+  if spec[1] == "LazyVim/LazyVim" and type(spec.opts) == "table" then
+    return spec.opts.colorscheme
+  end
+  for _, child in ipairs(spec) do
+    local colorscheme = find_colorscheme(child)
+    if colorscheme then
+      return colorscheme
+    end
+  end
+end
+
+function M.setup(opts)
+  local reset = vim.tbl_get(opts, "performance", "rtp", "reset") ~= false
+  if reset then
+    vim.opt.runtimepath = {
+      vim.fn.stdpath("config"),
+      vim.fn.stdpath("data") .. "/site",
+      vim.env.VIMRUNTIME,
+      vim.fn.stdpath("config") .. "/after",
+    }
+  end
+  for _, path in ipairs(vim.tbl_get(opts, "performance", "rtp", "paths") or {}) do
+    vim.opt.runtimepath:append(path)
+  end
+
+  vim.g.dots_test_rtp_reset = reset
+  vim.g.dots_test_managed_on_rtp = vim.tbl_contains(vim.opt.runtimepath:get(), vim.fn.expand("~/.config/dots/nvim"))
+  local plugin_specs = vim.api.nvim_get_runtime_file("lua/plugins/*.lua", true)
+  vim.g.dots_test_plugin_specs = #plugin_specs
+  for _, spec_path in ipairs(plugin_specs) do
+    if spec_path:match("/colorscheme.lua$") then
+      vim.g.dots_test_requested_colorscheme = find_colorscheme(dofile(spec_path))
+    end
+  end
+  if vim.g.dots_test_requested_colorscheme then
+    vim.cmd("colorscheme " .. vim.g.dots_test_requested_colorscheme)
+  end
+end
+
+return M
+`)
+	writeIssue446File(t,
+		filepath.Join(dataHome, "nvim", "site", "colors", "catppuccin-mocha.vim"),
+		"let g:colors_name = 'catppuccin-mocha'\n",
+	)
+
+	assertion := strings.Join([]string{
+		`local reset = vim.g.dots_test_rtp_reset == true`,
+		`local managed = vim.g.dots_test_managed_on_rtp == true`,
+		`local specs = (vim.g.dots_test_plugin_specs or 0) > 0`,
+		`local requested = vim.g.dots_test_requested_colorscheme == "catppuccin-mocha"`,
+		`local active = vim.g.colors_name == "catppuccin-mocha"`,
+		`if not (reset and managed and specs and requested and active) then vim.api.nvim_err_writeln("lazy reset=" .. tostring(reset) .. ", managed root=" .. tostring(managed) .. ", plugin specs=" .. tostring(specs) .. ", requested theme=" .. tostring(requested) .. ", active theme=" .. tostring(active)); vim.cmd("cquit 42") end`,
+	}, "; ")
+	cmd := exec.Command(nvim, "--headless", "-c", "lua "+assertion, "-c", "qa!")
+	cmd.Env = append(issue446BaseEnv(),
+		"HOME="+home,
+		"XDG_CONFIG_HOME="+configHome,
+		"XDG_DATA_HOME="+dataHome,
+		"XDG_STATE_HOME="+stateHome,
+		"XDG_CACHE_HOME="+cacheHome,
+	)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("managed Neovim startup: %v\n%s", err, output)
+	}
+}
+
+func issue446BaseEnv() []string {
+	var env []string
+	for _, value := range os.Environ() {
+		if strings.HasPrefix(value, "HOME=") || strings.HasPrefix(value, "XDG_") || strings.HasPrefix(value, "NVIM_APPNAME=") {
+			continue
+		}
+		env = append(env, value)
+	}
+	return env
+}
+
+func writeIssue446File(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create %s parent: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
Closes #446

## PR Type

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Preserve the separately Managed Neovim root when Lazy resets `runtimepath`.
- Restore repository-owned plugin specs and the Catppuccin Mocha fallback.
- Add a hermetic Temporary Home Test for the installed loader/Lazy boundary.

## Changes

| File | Change |
|------|--------|
| `configs/nvim/lua/config/lazy.lua` | Register `~/.config/dots/nvim` through Lazy's supported `performance.rtp.paths`. |
| `internal/cli/issue446_nvim_runtimepath_test.go` | Install the Neovim topology in temporary XDG roots and verify reset, specs, notifications, theme, and seeded lock state without network access. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] Compiled binary: `dots manifest validate --file dots.yaml`
- [x] Sandboxed compiled-binary plan: `dots plan --output json --file dots.yaml --profile core --source-root "$PWD" --home <tmp>/home --state-root <tmp>/state`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] All config behavior used temporary HOME/XDG/source/state roots.

## Contributor Checklist

- [x] Linked one issue with an admitted Delivery Contract using `Closes #446`.
- [x] Added exactly one `type:*` label.
- [x] Delivery Evidence records the Contract Source snapshot, acceptance coverage, and independent review.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Documentation remains accurate; no workflow or user documentation change is required.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

### Contract Source snapshot

- Kind: standalone issue body
- Source ID: `I_kwDOSzLlmM8AAAABMOyqeA`
- URL: https://github.com/yersonargotev/dots/issues/446
- Updated at: `2026-08-11T01:25:57Z`
- SHA-256: `93217b3e8ea7ce7d9f1925513a391e0a45dcf5944680a6c515613b4ed80f07c1`
- Category/readiness: `bug`; `ready-for-agent`
- Native relationships: no parent, sub-issues, blockers, or blocking issues
- Reviewed head: `c5a74d72b467fc2d87dbe625f1fb440573c494e7`

### Acceptance coverage

- The Temporary Home Test installs the loader as a regular file, the Managed Configuration as a symlink, and the lockfile as Seeded Runtime State under XDG state.
- The hermetic assertions require `performance.rtp.paths` to retain the managed root and confirm installed plugin specs exist without network or operator-home access.
- With Neovim available, the local Lazy boundary stub requires runtime-path reset to stay enabled, captures zero missing-spec notifications, and verifies requested and active `catppuccin-mocha`.
- The compiled-binary Install Plan confirms `core` still selects the lockfile copy, loader copy, and managed-config symlink.

### Automated validation

- `gofmt -l .` — pass, no output
- `go vet ./...` — pass
- `go build ./...` — pass
- `go test ./...` — pass
- `go test ./internal/cli -run TestRepositoryNeovimLoaderKeepsManagedPluginSpecsDiscoverable -count=1` — pass with Neovim
- Compiled test binary with `PATH=/usr/bin:/bin` — pass; hermetic assertions also pass without Neovim

### Manual verification

- Temporary binary: `go build -o <tmp>/bin/dots ./cmd/dots` — pass
- `<tmp>/bin/dots manifest validate --file dots.yaml` — `manifest is valid`
- Sandboxed `dots plan --output json ... --profile core` — exit 0/status `ok`; verified the three expected Neovim actions and strategies

### Independent review

- Standards review of `origin/main...c5a74d7` — PASS, no actionable findings
- Spec review against #446 of `origin/main...c5a74d7` — PASS, no actionable findings
<!-- delivery-issue:evidence:end -->
