### PR TITLE
feat(herdr): distinguish expanded sidebar rows

### DIFF
--- a/configs/herdr/config-adaptive.toml
+++ b/configs/herdr/config-adaptive.toml
@@ -42,6 +42,20 @@ position = "bottom-center"
 [ui.sound]
 enabled = true
 
+[ui.sidebar.spaces]
+row_gap = 1
+rows = [
+  ["state_icon", { token = "workspace", fg = "#89b4fa", bold = true }],
+  [{ token = "branch", fg = "#6c7086", dim = true }, "git_status"],
+]
+
+[ui.sidebar.agents]
+row_gap = 1
+rows = [
+  ["state_icon", { token = "agent", fg = "#cba6f7", bold = true }, "state_text"],
+  [{ token = "workspace", fg = "#6c7086" }, "tab"],
+]
+
 [keys]
 prefix = "ctrl+a"
 

--- a/configs/herdr/config.toml
+++ b/configs/herdr/config.toml
@@ -36,6 +36,20 @@ position = "bottom-center"
 [ui.sound]
 enabled = true
 
+[ui.sidebar.spaces]
+row_gap = 1
+rows = [
+  ["state_icon", { token = "workspace", fg = "#89b4fa", bold = true }],
+  [{ token = "branch", fg = "#6c7086", dim = true }, "git_status"],
+]
+
+[ui.sidebar.agents]
+row_gap = 1
+rows = [
+  ["state_icon", { token = "agent", fg = "#cba6f7", bold = true }, "state_text"],
+  [{ token = "workspace", fg = "#6c7086" }, "tab"],
+]
+
 [keys]
 prefix = "ctrl+a"
 

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -3624,6 +3624,24 @@ func TestRepositoryHerdrConfigSupportsAdaptiveThemeOverride(t *testing.T) {
 	}
 
 	defaultText := string(defaultConfig)
+	for section, want := range map[string]string{
+		"spaces": `[ui.sidebar.spaces]
+row_gap = 1
+rows = [
+  ["state_icon", { token = "workspace", fg = "#89b4fa", bold = true }],
+  [{ token = "branch", fg = "#6c7086", dim = true }, "git_status"],
+]`,
+		"agents": `[ui.sidebar.agents]
+row_gap = 1
+rows = [
+  ["state_icon", { token = "agent", fg = "#cba6f7", bold = true }, "state_text"],
+  [{ token = "workspace", fg = "#6c7086" }, "tab"],
+]`,
+	} {
+		if got := herdrConfigSection(t, defaultText, "[ui.sidebar."+section+"]"); got != want {
+			t.Fatalf("default Herdr %s sidebar section =:\n%s\nwant:\n%s", section, got, want)
+		}
+	}
 	for _, want := range []string{
 		`previous_workspace = "prefix+alt+k"`,
 		`next_workspace = "prefix+alt+j"`,
@@ -3672,6 +3690,19 @@ func herdrConfigWithoutTheme(t *testing.T, config string) string {
 	}
 	themeEnd := themeStart + len("[theme]") + nextSection + 1
 	return body[:themeStart] + body[themeEnd:]
+}
+
+func herdrConfigSection(t *testing.T, config, header string) string {
+	t.Helper()
+	start := strings.Index(config, header)
+	if start == -1 {
+		t.Fatalf("Herdr config missing %s section:\n%s", header, config)
+	}
+	section := config[start:]
+	if nextSection := strings.Index(section[len(header):], "\n["); nextSection != -1 {
+		section = section[:len(header)+nextSection]
+	}
+	return strings.TrimSpace(section)
 }
 
 func TestRepositoryGhosttyConfigDoesNotForwardObsoleteHerdrCommandShortcuts(t *testing.T) {


### PR DESCRIPTION
Closes #448

## PR Type

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Give expanded Herdr Space and Agent rows distinct Catppuccin foreground accents.
- Preserve the Agent, state, workspace, and tab information while adding one blank row between entries.
- Lock the default and adaptive layouts to the same non-theme representation.

## Changes

| File | Change |
|------|--------|
| `configs/herdr/config.toml` | Configure the default expanded Space and Agent row layouts. |
| `configs/herdr/config-adaptive.toml` | Apply the same non-theme layout to the adaptive source override. |
| `internal/manifest/manifest_test.go` | Assert the exact row gaps, token order, colors, and styles. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `/tmp/dots-448-verify.SJfiTb/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan: `/tmp/dots-448-verify.SJfiTb/dots plan --output json --file dots.yaml --profile core --source-root "$PWD" --home /tmp/dots-448-verify.SJfiTb/home --state-root /tmp/dots-448-verify.SJfiTb/state`
- [x] `HERDR_CONFIG_PATH="$PWD/configs/herdr/config.toml" herdr config check`
- [x] `HERDR_CONFIG_PATH="$PWD/configs/herdr/config-adaptive.toml" herdr config check`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration during delivery validation.
- [x] CLI validation used temporary home, source, and state roots.

## Contributor Checklist

- [x] Linked one issue with an admitted Delivery Contract using `Closes #448`.
- [x] Added exactly one `type:*` label.
- [x] Delivery Evidence records the Contract Source snapshot, Acceptance coverage, and Independent review.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Documentation or agent-instruction updates are not required for this configuration-only change.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

### Contract Source

- Kind: standalone issue body
- Issue body node ID: `I_kwDOSzLlmM8AAAABMYzk5w`
- URL: https://github.com/yersonargotev/dots/issues/448
- Updated at: `2026-08-12T01:44:06Z`
- SHA-256: `a1b3e6db622804de0bb6ede879c63acd9bd02296902c5bb5bf30587906fdf054`
- Category: `enhancement`
- Readiness: `ready-for-agent`
- Native relationships: no parent, sub-issues, blocked-by, or blocking relationships

### Reviewed head

- `8ce0bb0cfdf605e87b9457688b815a166410f367`

### Acceptance coverage

- Both Herdr sources contain the exact Space and Agent layouts with `row_gap = 1`.
- Agent rows preserve both the `agent` and `tab` tokens.
- The existing non-theme synchronization invariant covers both source variants.
- Exact section assertions fail on token, style, color, or row-gap drift.
- Both sources pass Herdr 0.8.0 native config validation.

### Automated validation

- `gofmt -l .` — passed with no output.
- `go vet ./...` — passed.
- `go build ./...` — passed.
- `go test ./...` — passed.
- `go test ./internal/manifest -run TestRepositoryHerdrConfigSupportsAdaptiveThemeOverride -count=1` — passed.
- `git diff --check` — passed.

### Manual verification

- Both `HERDR_CONFIG_PATH=... herdr config check` commands returned `config: ok`.
- A temporary built `dots` binary reported `manifest is valid`.
- Sandboxed `dots plan` completed with status `ok`, 19 actions, and zero conflicts without reading or writing the real home or state roots.

### Independent review

- Standards review of `origin/main...8ce0bb0` — passed with zero actionable findings.
- Spec review against #448 — passed with zero actionable findings.
<!-- delivery-issue:evidence:end -->
