### PR TITLE
feat(catalog): add a compact profile map

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,15 @@ state:
 
 ```bash
 dots catalog profiles
+dots catalog map workstation
 dots catalog compare core workstation
 dots catalog compare core workstation --output json
 ```
+
+`catalog map` keeps composite Profiles readable by grouping the portable
+surface under each resolved Tag and showing compact Managed Entry, unique
+Dependency, and Provisioner counts. Use `catalog profile` when you need the
+exhaustive item-by-item view.
 
 Then inspect the current machine state:
 

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -37,6 +37,7 @@ type Report struct {
 	Profile        *Detail          `json:"profile,omitempty"`
 	Tag            *Detail          `json:"tag,omitempty"`
 	Comparison     *Comparison      `json:"comparison,omitempty"`
+	Map            *ProfileMap      `json:"map,omitempty"`
 }
 
 // Hidden records items deliberately omitted from a compact current-only list.
@@ -187,6 +188,29 @@ type ComparisonCounts struct {
 	Behaviors       int `json:"behaviors"`
 }
 
+// ProfileMap is a compact view of how a Profile's resolved Tags contribute to
+// its portable surface. Total counts describe the composed Profile and do not
+// double-count Dependencies selected through multiple origins or Tags.
+type ProfileMap struct {
+	Profile     string       `json:"profile"`
+	Description string       `json:"description"`
+	Status      string       `json:"status"`
+	Tags        []TagSurface `json:"tags"`
+	Total       SurfaceCount `json:"total"`
+}
+
+type TagSurface struct {
+	Name        string       `json:"name"`
+	Description string       `json:"description"`
+	Surface     SurfaceCount `json:"surface"`
+}
+
+type SurfaceCount struct {
+	Entries      int `json:"entries"`
+	Dependencies int `json:"dependencies"`
+	Provisioners int `json:"provisioners"`
+}
+
 // Build returns deterministic Profile and Tag summaries. The manifest must
 // already have passed manifest validation.
 func Build(m manifest.Manifest, opts Options) (Report, error) {
@@ -253,6 +277,50 @@ func CompareProfiles(m manifest.Manifest, from, to string, opts Options) (Report
 	}
 	fromReport.Profile = nil
 	return fromReport, nil
+}
+
+// MapProfile returns a compact, Tag-oriented view of a Profile's portable
+// surface. It uses the same selection rules as the exhaustive Profile and Tag
+// reports and never reads workstation or Installation Metadata state.
+func MapProfile(m manifest.Manifest, name string, opts Options) (Report, error) {
+	report, err := Profile(m, name, opts)
+	if err != nil {
+		return Report{}, err
+	}
+	detail := report.Profile
+	profileMap := ProfileMap{
+		Profile:     detail.Name,
+		Description: detail.Description,
+		Status:      detail.Status,
+		Tags:        []TagSurface{},
+		Total:       surfaceCount(detail),
+	}
+	for _, tagName := range detail.ResolvedTags {
+		tagReport, err := Tag(m, tagName, opts)
+		if err != nil {
+			return Report{}, err
+		}
+		profileMap.Tags = append(profileMap.Tags, TagSurface{
+			Name:        tagReport.Tag.Name,
+			Description: tagReport.Tag.Description,
+			Surface:     surfaceCount(tagReport.Tag),
+		})
+	}
+	report.Profile = nil
+	report.Map = &profileMap
+	return report, nil
+}
+
+func surfaceCount(detail *Detail) SurfaceCount {
+	dependencies := make(map[string]struct{}, len(detail.Dependencies))
+	for _, dependency := range detail.Dependencies {
+		dependencies[dependency.Name] = struct{}{}
+	}
+	return SurfaceCount{
+		Entries:      len(detail.Entries),
+		Dependencies: len(dependencies),
+		Provisioners: len(detail.Provisioners),
+	}
 }
 
 // Tag returns a detailed, exact Tag view. Registryless manifests derive a

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -190,6 +190,44 @@ func TestCompareProfilesRejectsUnknownProfile(t *testing.T) {
 	}
 }
 
+func TestMapProfileCountsTagSurfacesAndDeduplicatesTotalDependencies(t *testing.T) {
+	m := fixtureManifest()
+	m.Dependencies = append(m.Dependencies, manifest.DependencySet{
+		Tags:         []string{"agents"},
+		Dependencies: []manifest.Dependency{{Name: "set-tool"}, {Name: "agent-tool"}},
+	})
+
+	got, err := MapProfile(m, "desktop", Options{OS: "all"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Profile != nil || got.Map == nil {
+		t.Fatalf("report = %#v", got)
+	}
+	if got.Map.Profile != "desktop" || got.Map.Status != "current" {
+		t.Fatalf("map identity = %#v", got.Map)
+	}
+	wantTags := []TagSurface{
+		{Name: "core", Description: "Core", Surface: SurfaceCount{Dependencies: 1}},
+		{Name: "agents", Description: "Agents", Surface: SurfaceCount{Dependencies: 2}},
+		{Name: "theme", Description: "Theme", Surface: SurfaceCount{Entries: 1, Dependencies: 2, Provisioners: 1}},
+	}
+	if !reflect.DeepEqual(got.Map.Tags, wantTags) {
+		t.Fatalf("tag surfaces = %#v, want %#v", got.Map.Tags, wantTags)
+	}
+	wantTotal := SurfaceCount{Entries: 1, Dependencies: 4, Provisioners: 1}
+	if got.Map.Total != wantTotal {
+		t.Fatalf("total = %#v, want %#v", got.Map.Total, wantTotal)
+	}
+}
+
+func TestMapProfileRejectsUnknownProfile(t *testing.T) {
+	_, err := MapProfile(fixtureManifest(), "missing", Options{OS: "all"})
+	if err == nil || err.Error() != `profile "missing" not found` {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func fixtureManifest() manifest.Manifest {
 	return manifest.Manifest{
 		Tags: map[string]manifest.Tag{

--- a/internal/cli/catalog.go
+++ b/internal/cli/catalog.go
@@ -55,8 +55,27 @@ func newCatalogCommand() *cobra.Command {
 	cmd.AddCommand(newCatalogProfilesCommand(load))
 	cmd.AddCommand(newCatalogProfileCommand())
 	cmd.AddCommand(newCatalogCompareCommand())
+	cmd.AddCommand(newCatalogMapCommand())
 	cmd.AddCommand(newCatalogTagsCommand(load))
 	cmd.AddCommand(newCatalogTagCommand())
+	return cmd
+}
+
+func newCatalogMapCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "map PROFILE",
+		Short:        "Show how a profile composes its portable surface",
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			report, err := loadCatalogMap(cmd, args[0])
+			if err != nil {
+				return err
+			}
+			return renderOrEmitCatalog(cmd, report, renderCatalogMap)
+		},
+	}
+	cmd.ValidArgsFunction = completeCatalogProfiles
 	return cmd
 }
 
@@ -182,6 +201,18 @@ func loadCatalogComparison(cmd *cobra.Command, from, to string) (catalog.Report,
 		return catalog.Report{}, err
 	}
 	return catalog.CompareProfiles(*m, from, to, catalog.Options{OS: osName})
+}
+
+func loadCatalogMap(cmd *cobra.Command, name string) (catalog.Report, error) {
+	file, sourceRoot, osName, err := catalogCommandOptions(cmd)
+	if err != nil {
+		return catalog.Report{}, err
+	}
+	m, err := loadCatalogManifest(cmd, file, sourceRoot)
+	if err != nil {
+		return catalog.Report{}, err
+	}
+	return catalog.MapProfile(*m, name, catalog.Options{OS: osName})
 }
 
 func renderOrEmitCatalog(cmd *cobra.Command, report catalog.Report, render func(*cobra.Command, catalog.Report)) error {

--- a/internal/cli/catalog_test.go
+++ b/internal/cli/catalog_test.go
@@ -34,6 +34,12 @@ func TestCatalogCommandsRenderManifestOnlyViews(t *testing.T) {
 			avoid: []string{"Tags:"},
 		},
 		{
+			name:  "profile map renders a compact tag-oriented surface",
+			args:  []string{"catalog", "map", "desktop", "--file", manifestPath, "--os", "all"},
+			want:  []string{"Profile map \"desktop\" (OS: all)", "desktop", "├─ core — Core configuration", "└─ theme — Theme configuration", "1 entry · 1 dependency · 1 provisioner", "Total: 1 entry · 1 unique dependency · 1 provisioner"},
+			avoid: []string{"must-not-leak", "Source overrides:", "Excluded surfaces:"},
+		},
+		{
 			name:  "tag list focuses current tags",
 			args:  []string{"catalog", "tags", "--file", manifestPath, "--os", "all"},
 			want:  []string{"Tags (OS: all; metadata: declared)", "- theme (surface, current, declared)", "Hidden legacy tags: 1"},
@@ -118,6 +124,21 @@ func TestCatalogDetailCompletionUsesManifestNames(t *testing.T) {
 		t.Fatalf("profile completion directive = %v", directive)
 	}
 
+	mapCmd, _, err := root.Find([]string{"catalog", "map"})
+	if err != nil {
+		t.Fatalf("find map: %v", err)
+	}
+	if err := mapCmd.InheritedFlags().Set("file", manifestPath); err != nil {
+		t.Fatalf("set map file: %v", err)
+	}
+	profiles, directive = mapCmd.ValidArgsFunction(mapCmd, nil, "d")
+	if !reflect.DeepEqual(profiles, []string{"desktop"}) {
+		t.Fatalf("map completion = %#v", profiles)
+	}
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Fatalf("map completion directive = %v", directive)
+	}
+
 	tagCmd, _, err := root.Find([]string{"catalog", "tag"})
 	if err != nil {
 		t.Fatalf("find tag: %v", err)
@@ -179,6 +200,26 @@ func TestCatalogJSONAndErrorsUseTheOutputContract(t *testing.T) {
 	}
 	if strings.Contains(stdout.String(), "must-not-leak") {
 		t.Fatalf("JSON leaked provisioner environment value: %s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"catalog", "map", "desktop", "--file", manifestPath, "--os", "all", "--output", "json"}, &stdout, &stderr); code != ExitOK {
+		t.Fatalf("map Run() exit code = %d, stderr = %s", code, stderr.String())
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("decode map JSON: %v\n%s", err, stdout.String())
+	}
+	if result.Command != "catalog map" || result.Status != statusOK {
+		t.Fatalf("map envelope = %#v", result)
+	}
+	data, ok = result.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("map data = %#v", result.Data)
+	}
+	profileMap, ok := data["map"].(map[string]any)
+	if !ok || profileMap["profile"] != "desktop" {
+		t.Fatalf("map missing from data: %#v", data)
 	}
 
 	stdout.Reset()

--- a/internal/cli/render_catalog.go
+++ b/internal/cli/render_catalog.go
@@ -112,6 +112,48 @@ func renderCatalogComparison(cmd *cobra.Command, report catalog.Report) {
 	)
 }
 
+func renderCatalogMap(cmd *cobra.Command, report catalog.Report) {
+	profileMap := report.Map
+	if profileMap == nil {
+		return
+	}
+	w := cmd.OutOrStdout()
+	fmt.Fprintf(w, "Profile map %q (OS: %s)\n", profileMap.Profile, report.OS)
+	if profileMap.Description != "" {
+		fmt.Fprintf(w, "%s\n", profileMap.Description)
+	}
+	fmt.Fprintf(w, "%s\n", profileMap.Profile)
+	for i, tag := range profileMap.Tags {
+		branch := "├─"
+		continuation := "│  "
+		if i == len(profileMap.Tags)-1 {
+			branch = "└─"
+			continuation = "   "
+		}
+		fmt.Fprintf(w, "%s %s", branch, tag.Name)
+		if tag.Description != "" {
+			fmt.Fprintf(w, " — %s", tag.Description)
+		}
+		fmt.Fprintf(w, "\n%s└─ %d %s · %d %s · %d %s\n", continuation,
+			tag.Surface.Entries, countLabel(tag.Surface.Entries, "entry", "entries"),
+			tag.Surface.Dependencies, countLabel(tag.Surface.Dependencies, "dependency", "dependencies"),
+			tag.Surface.Provisioners, countLabel(tag.Surface.Provisioners, "provisioner", "provisioners"),
+		)
+	}
+	fmt.Fprintf(w, "Total: %d %s · %d unique %s · %d %s\n",
+		profileMap.Total.Entries, countLabel(profileMap.Total.Entries, "entry", "entries"),
+		profileMap.Total.Dependencies, countLabel(profileMap.Total.Dependencies, "dependency", "dependencies"),
+		profileMap.Total.Provisioners, countLabel(profileMap.Total.Provisioners, "provisioner", "provisioners"),
+	)
+}
+
+func countLabel(count int, singular, plural string) string {
+	if count == 1 {
+		return singular
+	}
+	return plural
+}
+
 func renderCatalogComparisonSurface(w io.Writer, heading, marker string, surface catalog.ComparisonSurface) {
 	fmt.Fprintf(w, "%s:\n", heading)
 	empty := len(surface.ResolvedTags) == 0 && len(surface.Dependencies) == 0 && len(surface.Entries) == 0 && len(surface.SourceOverrides) == 0 && len(surface.Provisioners) == 0 && len(surface.Behaviors) == 0


### PR DESCRIPTION
Closes #450

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds `dots catalog map PROFILE`, a compact Tag-oriented view of a Profile's portable surface.
- Preserves the existing JSON envelope with a structured map report for agents and scripts.
- Keeps the command fully read-only and independent from workstation and Installation Metadata state.

```text
workstation
├─ core
│  └─ 19 entries · 27 dependencies · 1 provisioner
├─ desktop
│  └─ 8 entries · 4 dependencies · 0 provisioners
└─ agents
   └─ 7 entries · 6 dependencies · 0 provisioners
Total: 34 entries · 36 unique dependencies · 1 provisioner
```

## Changes

| File | Change |
|------|--------|
| `internal/catalog/catalog.go` | Adds the structured Profile map model and deterministic surface counting. |
| `internal/cli/catalog.go` | Registers the `catalog map PROFILE` command and Profile completion. |
| `internal/cli/render_catalog.go` | Renders the compact terminal tree. |
| `internal/catalog/catalog_test.go` | Covers per-Tag counts, total Dependency deduplication, and unknown Profiles. |
| `internal/cli/catalog_test.go` | Covers text, JSON envelope, and shell completion behavior. |
| `README.md` | Adds the new discovery command to the quickstart. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan not applicable: the command reads only the portable catalog and does not inspect home/config paths.
- [x] `go build ./...`
- [x] `go run ./cmd/dots catalog map workstation --os all`
- [x] `go run ./cmd/dots catalog map workstation --os all --output json`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] No validation targeted home/config paths; all exercised behavior was manifest-only catalog inspection.

## Delivery Evidence

- Contract Source: standalone body of #450, verified open with `enhancement` and `ready-for-agent` at `2026-08-12T02:18:09Z`; SHA-256 `68d54b5b8f911f3bc63d9fb4b1e18800038ff041a267b879b170014a76cbb66a`.
- Acceptance coverage: command shape, deterministic Tag counts, unique total Dependencies, JSON envelope, unknown Profile behavior, completion, and unchanged existing commands are covered by focused tests and the full suite.
- Independent review: requested from the maintainer; this intentionally small surprise PR is ready for morning evaluation.

## Contributor Checklist

- [x] Linked one issue with an admitted Delivery Contract using `Closes #450`.
- [x] Added exactly one `type:*` label.
- [x] Delivery Evidence records the Contract Source snapshot, Acceptance coverage, and Independent review status.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs when CLI behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
