### PR TITLE
fix(herdr): restore contextual space selection styling

### DIFF
--- a/configs/herdr/config-adaptive.toml
+++ b/configs/herdr/config-adaptive.toml
@@ -45,8 +45,8 @@ enabled = true
 [ui.sidebar.spaces]
 row_gap = 1
 rows = [
-  ["state_icon", { token = "workspace", fg = "#89b4fa", bold = true }],
-  [{ token = "branch", fg = "#6c7086", dim = true }, "git_status"],
+  ["state_icon", "workspace"],
+  ["branch", "git_status"],
 ]
 
 [ui.sidebar.agents]

--- a/configs/herdr/config.toml
+++ b/configs/herdr/config.toml
@@ -39,8 +39,8 @@ enabled = true
 [ui.sidebar.spaces]
 row_gap = 1
 rows = [
-  ["state_icon", { token = "workspace", fg = "#89b4fa", bold = true }],
-  [{ token = "branch", fg = "#6c7086", dim = true }, "git_status"],
+  ["state_icon", "workspace"],
+  ["branch", "git_status"],
 ]
 
 [ui.sidebar.agents]

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -3628,8 +3628,8 @@ func TestRepositoryHerdrConfigSupportsAdaptiveThemeOverride(t *testing.T) {
 		"spaces": `[ui.sidebar.spaces]
 row_gap = 1
 rows = [
-  ["state_icon", { token = "workspace", fg = "#89b4fa", bold = true }],
-  [{ token = "branch", fg = "#6c7086", dim = true }, "git_status"],
+  ["state_icon", "workspace"],
+  ["branch", "git_status"],
 ]`,
 		"agents": `[ui.sidebar.agents]
 row_gap = 1


### PR DESCRIPTION
Closes #452

## PR Type

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Restore Herdr's contextual selected, active, and inactive styles for expanded Space names.
- Let branches reinforce the same state distinction while preserving the two-row layout and spacing.
- Keep the default and adaptive sources synchronized and lock the exact layout with repository validation.

## Changes

| File | Change |
|------|--------|
| `configs/herdr/config.toml` | Remove fixed inline Space name and branch styles so Herdr can apply contextual styles. |
| `configs/herdr/config-adaptive.toml` | Apply the same non-theme Space layout to the adaptive source override. |
| `internal/manifest/manifest_test.go` | Assert the exact unstyled Space token layout. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `gofmt -l .`
- [x] Temporary built binary: `dots manifest validate --file dots.yaml`
- [x] Sandboxed plan: `dots plan --output json --file dots.yaml --profile core --source-root "$PWD" --home <tmp>/home --state-root <tmp>/state`
- [x] `HERDR_CONFIG_PATH="$PWD/configs/herdr/config.toml" herdr config check`
- [x] `HERDR_CONFIG_PATH="$PWD/configs/herdr/config-adaptive.toml" herdr config check`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] Delivery validation did not write to real local configuration. A user-authorized live Herdr preview performed before delivery admission was reverted before this run.
- [x] CLI validation used temporary home and state roots plus an explicit Source of Truth root.

## Contributor Checklist

- [x] Linked one issue with an admitted Delivery Contract using `Closes #452`.
- [x] Added exactly one `type:*` label.
- [x] Delivery Evidence records the Contract Source snapshot, Acceptance coverage, and Independent review.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Documentation or agent-instruction updates are not required for this configuration-only correction.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

### Contract Source

- Kind: standalone issue body
- Issue body node ID: `I_kwDOSzLlmM8AAAABMZGTiA`
- URL: https://github.com/yersonargotev/dots/issues/452
- Updated at: `2026-08-12T02:40:21Z`
- SHA-256: `712d8e577e04dec9e6dd1c67114fe5ec09a891165b455cabf3cad0aacecdb3ae`
- Category: `bug`
- Readiness: `ready-for-agent`
- Native relationships: no parent, sub-issues, blocked-by, or blocking relationships

### Reviewed head

- `64c9b0cbd184c6ccae5bb816936fdf40e6de2eab`

### Acceptance coverage

- Both Herdr sources retain `row_gap = 1` and use exact unstyled rows `[["state_icon", "workspace"], ["branch", "git_status"]]`.
- No fixed Space token foreground, bold, or dim overrides remain.
- Agent rows are unchanged and retain both `agent` and `tab` tokens.
- The existing non-theme synchronization invariant covers the default and adaptive sources.
- Exact section assertions fail on token, style, ordering, or spacing drift.
- Both sources pass Herdr 0.8.0 native config validation.

### Automated validation

- `gofmt -l .` — passed with no output.
- `go vet ./...` — passed.
- `go build ./...` — passed.
- `go test ./...` — passed.
- `go test ./internal/manifest -run TestRepositoryHerdrConfigSupportsAdaptiveThemeOverride -count=1` — passed.
- `git diff --check origin/main...HEAD` — passed.

### Manual verification

- Both `HERDR_CONFIG_PATH=... herdr config check` commands returned `config: ok`.
- A temporary built `dots` binary reported `manifest is valid`.
- A sandboxed JSON Install Plan returned status `ok`, exit 0, 19 actions, and zero conflicts.
- A user-authorized live preview showed `dots` visibly active through primary bold text and a mauve branch while inactive Spaces were subdued; the live configuration was reverted before delivery admission.

### Independent review

- Standards review of `origin/main...64c9b0c` — passed with zero actionable findings and zero smell-baseline findings.
- Spec review against #452 — passed with zero missing, partial, incorrect, or out-of-scope behavior findings.
<!-- delivery-issue:evidence:end -->
