### PR TITLE
feat(catalog): explain profile item provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ state:
 ```bash
 dots catalog profiles
 dots catalog map workstation
+dots catalog why workstation atuin
 dots catalog compare core workstation
 dots catalog compare core workstation --output json
 ```
@@ -93,7 +94,15 @@ dots catalog compare core workstation --output json
 `catalog map` keeps composite Profiles readable by grouping the portable
 surface under each resolved Tag and showing compact Managed Entry, unique
 Dependency, and Provisioner counts. Use `catalog profile` when you need the
-exhaustive item-by-item view.
+exhaustive item-by-item view. Use `catalog why PROFILE QUERY` for the inverse
+question: it traces an exact Dependency name, Managed Entry target or resolved
+source, or Provisioner tool or identity back to the Profile Tags and manifest
+declarations that selected it. For example,
+`dots catalog why workstation ~/.config/zed/settings.json` explains the winning
+Source of Truth source and any source override. This is a portable catalog
+answer only; it does not inspect Installed Selection, Drift, or other machine
+state. Add `--os darwin`, `--os linux`, or `--os all` to choose the catalog
+surface, and `--output json` for the machine-readable explanation.
 
 Then inspect the current machine state:
 

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -420,10 +420,10 @@ func contributingDependencyTags(profileTags []string, declarations []Dependency)
 	return contributingTags(profileTags, declared, "")
 }
 
-func contributingTags(profileTags, itemTags []string, extra string) []string {
+func contributingTags(profileTags, itemTags []string, sourceOverrideTag string) []string {
 	result := []string{}
 	for _, profileTag := range profileTags {
-		if contains(itemTags, profileTag) || profileTag == extra {
+		if contains(itemTags, profileTag) || profileTag == sourceOverrideTag {
 			result = append(result, profileTag)
 		}
 	}

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -38,6 +38,41 @@ type Report struct {
 	Tag            *Detail          `json:"tag,omitempty"`
 	Comparison     *Comparison      `json:"comparison,omitempty"`
 	Map            *ProfileMap      `json:"map,omitempty"`
+	Why            *Why             `json:"why,omitempty"`
+}
+
+// Why explains the manifest provenance of exact items in one Profile's
+// portable selected surface. It never contains workstation or installed state.
+type Why struct {
+	Profile      string     `json:"profile"`
+	Query        string     `json:"query"`
+	ResolvedTags []string   `json:"resolved_tags"`
+	Matches      []WhyMatch `json:"matches"`
+}
+
+// WhyMatch is one selected catalog item that exactly matched a query. The
+// type-specific payload is populated only for the reported Type.
+type WhyMatch struct {
+	Type             string         `json:"type"`
+	Identity         string         `json:"identity"`
+	ContributingTags []string       `json:"contributing_tags"`
+	Dependency       *WhyDependency `json:"dependency,omitempty"`
+	Entry            *WhyEntry      `json:"entry,omitempty"`
+	Provisioner      *Provisioner   `json:"provisioner,omitempty"`
+}
+
+// WhyDependency preserves every selected declaration because one Dependency
+// can be contributed by multiple manifest surfaces.
+type WhyDependency struct {
+	Name         string       `json:"name"`
+	Declarations []Dependency `json:"declarations"`
+}
+
+// WhyEntry records the resolved Source of Truth and the source-override Tag
+// that won, when applicable.
+type WhyEntry struct {
+	Entry             Entry  `json:"entry"`
+	SourceOverrideTag string `json:"source_override_tag,omitempty"`
 }
 
 // Hidden records items deliberately omitted from a compact current-only list.
@@ -107,14 +142,15 @@ type DependencySet struct {
 
 // Entry describes one portable Managed Entry selected by the queried intent.
 type Entry struct {
-	Source       string       `json:"source"`
-	Target       string       `json:"target"`
-	TargetRoot   string       `json:"target_root,omitempty"`
-	Strategy     string       `json:"strategy"`
-	Ownership    string       `json:"ownership,omitempty"`
-	Tags         []string     `json:"tags"`
-	OS           []string     `json:"os"`
-	Dependencies []Dependency `json:"dependencies"`
+	Source            string       `json:"source"`
+	Target            string       `json:"target"`
+	TargetRoot        string       `json:"target_root,omitempty"`
+	Strategy          string       `json:"strategy"`
+	Ownership         string       `json:"ownership,omitempty"`
+	Tags              []string     `json:"tags"`
+	OS                []string     `json:"os"`
+	Dependencies      []Dependency `json:"dependencies"`
+	sourceOverrideTag string
 }
 
 // SourceOverride records a source change activated by a selected Tag. It is
@@ -311,6 +347,96 @@ func MapProfile(m manifest.Manifest, name string, opts Options) (Report, error) 
 	return report, nil
 }
 
+// ExplainProfileItem returns every selected item that exactly matches query.
+// Dependencies match by name, Managed Entries by target or resolved source,
+// and Provisioners by tool or identity.
+func ExplainProfileItem(m manifest.Manifest, profileName, query string, opts Options) (Report, error) {
+	report, err := Profile(m, profileName, opts)
+	if err != nil {
+		return Report{}, err
+	}
+	detail := report.Profile
+	why := Why{
+		Profile:      profileName,
+		Query:        query,
+		ResolvedTags: clone(detail.ResolvedTags),
+		Matches:      []WhyMatch{},
+	}
+
+	declarations := []Dependency{}
+	for _, dependency := range detail.Dependencies {
+		if dependency.Name == query {
+			declarations = append(declarations, dependency)
+		}
+	}
+	if len(declarations) > 0 {
+		why.Matches = append(why.Matches, WhyMatch{
+			Type:             "dependency",
+			Identity:         query,
+			ContributingTags: contributingDependencyTags(detail.ResolvedTags, declarations),
+			Dependency:       &WhyDependency{Name: query, Declarations: declarations},
+		})
+	}
+
+	for _, entry := range detail.Entries {
+		if entry.Target != query && entry.Source != query {
+			continue
+		}
+		why.Matches = append(why.Matches, WhyMatch{
+			Type:             "entry",
+			Identity:         entry.Target,
+			ContributingTags: contributingTags(detail.ResolvedTags, entry.Tags, entry.sourceOverrideTag),
+			Entry:            &WhyEntry{Entry: entry, SourceOverrideTag: entry.sourceOverrideTag},
+		})
+	}
+
+	for i := range detail.Provisioners {
+		provisioner := detail.Provisioners[i]
+		matchesIdentity := provisioner.Identity != "" && provisioner.Identity == query
+		if provisioner.Tool != query && !matchesIdentity {
+			continue
+		}
+		why.Matches = append(why.Matches, WhyMatch{
+			Type:             "provisioner",
+			Identity:         provisionerIdentity(provisioner),
+			ContributingTags: contributingTags(detail.ResolvedTags, provisioner.Tags, ""),
+			Provisioner:      &provisioner,
+		})
+	}
+
+	if len(why.Matches) == 0 {
+		return Report{}, fmt.Errorf("profile %q does not select an item matching %q for OS %s", profileName, query, report.OS)
+	}
+	report.Profile = nil
+	report.Why = &why
+	return report, nil
+}
+
+func contributingDependencyTags(profileTags []string, declarations []Dependency) []string {
+	declared := []string{}
+	for _, declaration := range declarations {
+		declared = append(declared, declaration.Origin.Tags...)
+	}
+	return contributingTags(profileTags, declared, "")
+}
+
+func contributingTags(profileTags, itemTags []string, extra string) []string {
+	result := []string{}
+	for _, profileTag := range profileTags {
+		if contains(itemTags, profileTag) || profileTag == extra {
+			result = append(result, profileTag)
+		}
+	}
+	return result
+}
+
+func provisionerIdentity(provisioner Provisioner) string {
+	if provisioner.Identity != "" {
+		return provisioner.Identity
+	}
+	return provisioner.Tool
+}
+
 func surfaceCount(detail *Detail) SurfaceCount {
 	dependencies := make(map[string]struct{}, len(detail.Dependencies))
 	for _, dependency := range detail.Dependencies {
@@ -353,7 +479,7 @@ func buildDetail(m manifest.Manifest, name, description, status, kind, replacedB
 	}
 	for _, selected := range surface.Entries {
 		entry := selected.Entry
-		item := Entry{Source: selected.Source, Target: entry.Target, TargetRoot: entry.TargetRoot, Strategy: entry.Strategy, Ownership: entry.Ownership, Tags: clone(entry.Tags), OS: declaredOS(entry.OS), Dependencies: []Dependency{}}
+		item := Entry{Source: selected.Source, Target: entry.Target, TargetRoot: entry.TargetRoot, Strategy: entry.Strategy, Ownership: entry.Ownership, Tags: clone(entry.Tags), OS: declaredOS(entry.OS), Dependencies: []Dependency{}, sourceOverrideTag: selected.OverrideTag}
 		for _, dep := range entry.Dependencies {
 			item.Dependencies = append(item.Dependencies, dependency(dep, Origin{Type: "entry", Name: entry.Target, Tags: clone(entry.Tags)}))
 		}

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -228,6 +228,84 @@ func TestMapProfileRejectsUnknownProfile(t *testing.T) {
 	}
 }
 
+func TestExplainProfileItemPreservesDependencyOrigins(t *testing.T) {
+	m := manifest.Manifest{
+		Profiles: map[string]manifest.Profile{"workstation": {Tags: []string{"core", "agents"}}},
+		Dependencies: []manifest.DependencySet{{
+			Tags:         []string{"core"},
+			Dependencies: []manifest.Dependency{{Name: "shared-tool"}},
+		}},
+		Entries: []manifest.Entry{{
+			Source: "base", Target: "~/.shared", Strategy: "copy", Tags: []string{"agents"},
+			Dependencies: []manifest.Dependency{{Name: "shared-tool", Requirement: manifest.DependencyRequirementRequired}},
+		}},
+	}
+
+	got, err := ExplainProfileItem(m, "workstation", "shared-tool", Options{OS: "all"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Profile != nil || got.Why == nil {
+		t.Fatalf("report = %#v", got)
+	}
+	if !reflect.DeepEqual(got.Why.ResolvedTags, []string{"core", "agents"}) {
+		t.Fatalf("resolved tags = %#v", got.Why.ResolvedTags)
+	}
+	if len(got.Why.Matches) != 1 {
+		t.Fatalf("matches = %#v", got.Why.Matches)
+	}
+	match := got.Why.Matches[0]
+	if match.Type != "dependency" || !reflect.DeepEqual(match.ContributingTags, []string{"core", "agents"}) {
+		t.Fatalf("match = %#v", match)
+	}
+	if match.Dependency == nil || len(match.Dependency.Declarations) != 2 {
+		t.Fatalf("dependency = %#v", match.Dependency)
+	}
+	if got := match.Dependency.Declarations[1].Origin; got.Type != "entry" || got.Name != "~/.shared" {
+		t.Fatalf("second origin = %#v", got)
+	}
+}
+
+func TestExplainProfileItemReportsEntryOverrideAndProvisioners(t *testing.T) {
+	m := fixtureManifest()
+
+	entryReport, err := ExplainProfileItem(m, "desktop", "adaptive", Options{OS: "all"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := entryReport.Why.Matches[0]
+	if entry.Type != "entry" || entry.Identity != "~/.example" || entry.Entry == nil {
+		t.Fatalf("entry match = %#v", entry)
+	}
+	if entry.Entry.SourceOverrideTag != "theme" || !reflect.DeepEqual(entry.ContributingTags, []string{"theme"}) {
+		t.Fatalf("entry explanation = %#v", entry)
+	}
+
+	provisionerReport, err := ExplainProfileItem(m, "desktop", "codex", Options{OS: "all"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	provisioner := provisionerReport.Why.Matches[0]
+	if provisioner.Type != "provisioner" || provisioner.Identity != "demo" || provisioner.Provisioner == nil {
+		t.Fatalf("provisioner match = %#v", provisioner)
+	}
+	if provisioner.Provisioner.Operation != "mcp" || !reflect.DeepEqual(provisioner.ContributingTags, []string{"theme"}) {
+		t.Fatalf("provisioner explanation = %#v", provisioner)
+	}
+}
+
+func TestExplainProfileItemHonorsOSAndRejectsUnknownQueries(t *testing.T) {
+	m := fixtureManifest()
+	_, err := ExplainProfileItem(m, "desktop", "adaptive", Options{OS: "linux"})
+	if err == nil || err.Error() != `profile "desktop" does not select an item matching "adaptive" for OS linux` {
+		t.Fatalf("error = %v", err)
+	}
+	_, err = ExplainProfileItem(m, "missing", "adaptive", Options{OS: "all"})
+	if err == nil || err.Error() != `profile "missing" not found` {
+		t.Fatalf("unknown profile error = %v", err)
+	}
+}
+
 func fixtureManifest() manifest.Manifest {
 	return manifest.Manifest{
 		Tags: map[string]manifest.Tag{

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -294,6 +294,30 @@ func TestExplainProfileItemReportsEntryOverrideAndProvisioners(t *testing.T) {
 	}
 }
 
+func TestExplainProfileItemMatchesEntryTargetOnApplicableOS(t *testing.T) {
+	m := fixtureManifest()
+
+	got, err := ExplainProfileItem(m, "desktop", "~/.example", Options{OS: "darwin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Why.Matches) != 1 {
+		t.Fatalf("matches = %#v", got.Why.Matches)
+	}
+	match := got.Why.Matches[0]
+	if match.Type != "entry" || match.Identity != "~/.example" || match.Entry == nil {
+		t.Fatalf("entry match = %#v", match)
+	}
+	if match.Entry.Entry.Source != "adaptive" || match.Entry.SourceOverrideTag != "theme" {
+		t.Fatalf("entry explanation = %#v", match.Entry)
+	}
+
+	_, err = ExplainProfileItem(m, "desktop", "~/.example", Options{OS: "linux"})
+	if err == nil || err.Error() != `profile "desktop" does not select an item matching "~/.example" for OS linux` {
+		t.Fatalf("linux error = %v", err)
+	}
+}
+
 func TestExplainProfileItemReportsAllProvisionerMatchesAcrossPlatforms(t *testing.T) {
 	m := manifest.Manifest{
 		Profiles: map[string]manifest.Profile{"agents": {Tags: []string{"agents"}}},

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -294,6 +294,43 @@ func TestExplainProfileItemReportsEntryOverrideAndProvisioners(t *testing.T) {
 	}
 }
 
+func TestExplainProfileItemReportsAllProvisionerMatchesAcrossPlatforms(t *testing.T) {
+	m := manifest.Manifest{
+		Profiles: map[string]manifest.Profile{"agents": {Tags: []string{"agents"}}},
+		Provisioners: []manifest.Provisioner{
+			{Tool: "codex", Tags: []string{"agents"}, OS: []string{"darwin"}, Spec: manifest.ProvisionerSpec{MCP: "alpha"}},
+			{Tool: "codex", Tags: []string{"agents"}, OS: []string{"linux"}, Spec: manifest.ProvisionerSpec{MCP: "beta"}},
+		},
+	}
+
+	all, err := ExplainProfileItem(m, "agents", "codex", Options{OS: "all"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all.Why.Matches) != 2 {
+		t.Fatalf("all-platform matches = %#v", all.Why.Matches)
+	}
+	if got := []string{all.Why.Matches[0].Identity, all.Why.Matches[1].Identity}; !reflect.DeepEqual(got, []string{"alpha", "beta"}) {
+		t.Fatalf("all-platform identities = %#v", got)
+	}
+
+	darwin, err := ExplainProfileItem(m, "agents", "codex", Options{OS: "darwin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(darwin.Why.Matches) != 1 || darwin.Why.Matches[0].Identity != "alpha" {
+		t.Fatalf("darwin matches = %#v", darwin.Why.Matches)
+	}
+
+	linux, err := ExplainProfileItem(m, "agents", "codex", Options{OS: "linux"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(linux.Why.Matches) != 1 || linux.Why.Matches[0].Identity != "beta" {
+		t.Fatalf("linux matches = %#v", linux.Why.Matches)
+	}
+}
+
 func TestExplainProfileItemHonorsOSAndRejectsUnknownQueries(t *testing.T) {
 	m := fixtureManifest()
 	_, err := ExplainProfileItem(m, "desktop", "adaptive", Options{OS: "linux"})

--- a/internal/cli/catalog.go
+++ b/internal/cli/catalog.go
@@ -187,54 +187,36 @@ func newCatalogTagCommand() *cobra.Command {
 }
 
 func loadCatalogProfile(cmd *cobra.Command, name string) (catalog.Report, error) {
-	file, sourceRoot, osName, err := catalogCommandOptions(cmd)
-	if err != nil {
-		return catalog.Report{}, err
-	}
-	m, err := loadCatalogManifest(cmd, file, sourceRoot)
-	if err != nil {
-		return catalog.Report{}, err
-	}
-	return catalog.Profile(*m, name, catalog.Options{OS: osName})
+	return loadCatalogReport(cmd, func(m manifest.Manifest, opts catalog.Options) (catalog.Report, error) {
+		return catalog.Profile(m, name, opts)
+	})
 }
 
 func loadCatalogTag(cmd *cobra.Command, name string) (catalog.Report, error) {
-	file, sourceRoot, osName, err := catalogCommandOptions(cmd)
-	if err != nil {
-		return catalog.Report{}, err
-	}
-	m, err := loadCatalogManifest(cmd, file, sourceRoot)
-	if err != nil {
-		return catalog.Report{}, err
-	}
-	return catalog.Tag(*m, name, catalog.Options{OS: osName})
+	return loadCatalogReport(cmd, func(m manifest.Manifest, opts catalog.Options) (catalog.Report, error) {
+		return catalog.Tag(m, name, opts)
+	})
 }
 
 func loadCatalogComparison(cmd *cobra.Command, from, to string) (catalog.Report, error) {
-	file, sourceRoot, osName, err := catalogCommandOptions(cmd)
-	if err != nil {
-		return catalog.Report{}, err
-	}
-	m, err := loadCatalogManifest(cmd, file, sourceRoot)
-	if err != nil {
-		return catalog.Report{}, err
-	}
-	return catalog.CompareProfiles(*m, from, to, catalog.Options{OS: osName})
+	return loadCatalogReport(cmd, func(m manifest.Manifest, opts catalog.Options) (catalog.Report, error) {
+		return catalog.CompareProfiles(m, from, to, opts)
+	})
 }
 
 func loadCatalogMap(cmd *cobra.Command, name string) (catalog.Report, error) {
-	file, sourceRoot, osName, err := catalogCommandOptions(cmd)
-	if err != nil {
-		return catalog.Report{}, err
-	}
-	m, err := loadCatalogManifest(cmd, file, sourceRoot)
-	if err != nil {
-		return catalog.Report{}, err
-	}
-	return catalog.MapProfile(*m, name, catalog.Options{OS: osName})
+	return loadCatalogReport(cmd, func(m manifest.Manifest, opts catalog.Options) (catalog.Report, error) {
+		return catalog.MapProfile(m, name, opts)
+	})
 }
 
 func loadCatalogWhy(cmd *cobra.Command, profile, query string) (catalog.Report, error) {
+	return loadCatalogReport(cmd, func(m manifest.Manifest, opts catalog.Options) (catalog.Report, error) {
+		return catalog.ExplainProfileItem(m, profile, query, opts)
+	})
+}
+
+func loadCatalogReport(cmd *cobra.Command, build func(manifest.Manifest, catalog.Options) (catalog.Report, error)) (catalog.Report, error) {
 	file, sourceRoot, osName, err := catalogCommandOptions(cmd)
 	if err != nil {
 		return catalog.Report{}, err
@@ -243,7 +225,7 @@ func loadCatalogWhy(cmd *cobra.Command, profile, query string) (catalog.Report, 
 	if err != nil {
 		return catalog.Report{}, err
 	}
-	return catalog.ExplainProfileItem(*m, profile, query, catalog.Options{OS: osName})
+	return build(*m, catalog.Options{OS: osName})
 }
 
 func renderOrEmitCatalog(cmd *cobra.Command, report catalog.Report, render func(*cobra.Command, catalog.Report)) error {

--- a/internal/cli/catalog.go
+++ b/internal/cli/catalog.go
@@ -56,8 +56,27 @@ func newCatalogCommand() *cobra.Command {
 	cmd.AddCommand(newCatalogProfileCommand())
 	cmd.AddCommand(newCatalogCompareCommand())
 	cmd.AddCommand(newCatalogMapCommand())
+	cmd.AddCommand(newCatalogWhyCommand())
 	cmd.AddCommand(newCatalogTagsCommand(load))
 	cmd.AddCommand(newCatalogTagCommand())
+	return cmd
+}
+
+func newCatalogWhyCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "why PROFILE QUERY",
+		Short:        "Explain why a profile selects an item",
+		Args:         cobra.ExactArgs(2),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			report, err := loadCatalogWhy(cmd, args[0], args[1])
+			if err != nil {
+				return err
+			}
+			return renderOrEmitCatalog(cmd, report, renderCatalogWhy)
+		},
+	}
+	cmd.ValidArgsFunction = completeCatalogWhy
 	return cmd
 }
 
@@ -215,6 +234,18 @@ func loadCatalogMap(cmd *cobra.Command, name string) (catalog.Report, error) {
 	return catalog.MapProfile(*m, name, catalog.Options{OS: osName})
 }
 
+func loadCatalogWhy(cmd *cobra.Command, profile, query string) (catalog.Report, error) {
+	file, sourceRoot, osName, err := catalogCommandOptions(cmd)
+	if err != nil {
+		return catalog.Report{}, err
+	}
+	m, err := loadCatalogManifest(cmd, file, sourceRoot)
+	if err != nil {
+		return catalog.Report{}, err
+	}
+	return catalog.ExplainProfileItem(*m, profile, query, catalog.Options{OS: osName})
+}
+
 func renderOrEmitCatalog(cmd *cobra.Command, report catalog.Report, render func(*cobra.Command, catalog.Report)) error {
 	if wantsJSON(cmd) {
 		return emitOK(cmd, report)
@@ -272,6 +303,45 @@ func completeCatalogTags(cmd *cobra.Command, args []string, toComplete string) (
 		values = append(values, tag.Name)
 	}
 	return matchingCatalogValues(values, toComplete), cobra.ShellCompDirectiveNoFileComp
+}
+
+func completeCatalogWhy(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) == 0 {
+		return completeCatalogProfiles(cmd, args, toComplete)
+	}
+	if len(args) > 1 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	report, err := loadCatalogProfile(cmd, args[0])
+	if err != nil || report.Profile == nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	detail := report.Profile
+	values := []string{}
+	for _, dependency := range detail.Dependencies {
+		values = appendUniqueCatalogValue(values, dependency.Name)
+	}
+	for _, entry := range detail.Entries {
+		values = appendUniqueCatalogValue(values, entry.Target)
+		values = appendUniqueCatalogValue(values, entry.Source)
+	}
+	for _, provisioner := range detail.Provisioners {
+		values = appendUniqueCatalogValue(values, provisioner.Tool)
+		values = appendUniqueCatalogValue(values, provisioner.Identity)
+	}
+	return matchingCatalogValues(values, toComplete), cobra.ShellCompDirectiveNoFileComp
+}
+
+func appendUniqueCatalogValue(values []string, value string) []string {
+	if value == "" {
+		return values
+	}
+	for _, existing := range values {
+		if existing == value {
+			return values
+		}
+	}
+	return append(values, value)
 }
 
 func loadCatalogCompletionReport(cmd *cobra.Command) (catalog.Report, error) {

--- a/internal/cli/catalog_golden_test.go
+++ b/internal/cli/catalog_golden_test.go
@@ -50,3 +50,26 @@ func TestCatalogComparisonJSONGolden(t *testing.T) {
 	}
 	assertGolden(t, "envelope_catalog_compare.golden", stdout.Bytes())
 }
+
+func TestCatalogWhyTextGolden(t *testing.T) {
+	manifestPath := writeCatalogManifest(t)
+	cmd := NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"catalog", "why", "desktop", "theme-tool", "--file", manifestPath, "--os", "all"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	assertGolden(t, "catalog_why.golden", out.Bytes())
+}
+
+func TestCatalogWhyJSONGolden(t *testing.T) {
+	manifestPath := writeCatalogManifest(t)
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"catalog", "why", "desktop", "theme-tool", "--file", manifestPath, "--os", "all", "--output", "json"}, &stdout, &stderr)
+	if code != ExitOK {
+		t.Fatalf("Run() exit code = %d\nstderr:\n%s\nstdout:\n%s", code, stderr.String(), stdout.String())
+	}
+	assertGolden(t, "envelope_catalog_why.golden", stdout.Bytes())
+}

--- a/internal/cli/catalog_test.go
+++ b/internal/cli/catalog_test.go
@@ -351,22 +351,6 @@ func TestCatalogJSONAndErrorsUseTheOutputContract(t *testing.T) {
 	}
 }
 
-func TestCatalogWhyTextOutputIsStable(t *testing.T) {
-	manifestPath := writeCatalogManifest(t)
-	var stdout, stderr bytes.Buffer
-	if code := Run([]string{"catalog", "why", "desktop", "theme-tool", "--file", manifestPath, "--os", "all"}, &stdout, &stderr); code != ExitOK {
-		t.Fatalf("Run() exit code = %d, stderr = %s", code, stderr.String())
-	}
-	want := "Why profile \"desktop\" selects \"theme-tool\" (OS: all)\n" +
-		"desktop\n" +
-		"└─ dependency theme-tool\n" +
-		"   ├─ selected by tags: theme\n" +
-		"   └─ declared by dependency_set tags=theme (required)\n"
-	if stdout.String() != want {
-		t.Fatalf("output:\n%s\nwant:\n%s", stdout.String(), want)
-	}
-}
-
 func TestCatalogDetailsRequireExactlyOneName(t *testing.T) {
 	cmd := NewRootCommand()
 	var out bytes.Buffer

--- a/internal/cli/catalog_test.go
+++ b/internal/cli/catalog_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/yersonargotev/dots/internal/catalog"
 )
 
 func TestCatalogCommandsRenderManifestOnlyViews(t *testing.T) {
@@ -60,6 +61,24 @@ func TestCatalogCommandsRenderManifestOnlyViews(t *testing.T) {
 			name:  "profile comparison renders a directional delta",
 			args:  []string{"catalog", "compare", "core", "desktop", "--file", manifestPath, "--os", "all"},
 			want:  []string{"Profile comparison: core -> desktop", "Added:", "+ tag theme", "+ dependency theme-tool", "+ entry adaptive -> ~/.example (copy)", "+ provisioner codex (mcp: demo)", "Removed:", "Shared:"},
+			avoid: []string{"must-not-leak"},
+		},
+		{
+			name:  "why traces a dependency to its profile tag",
+			args:  []string{"catalog", "why", "desktop", "theme-tool", "--file", manifestPath, "--os", "all"},
+			want:  []string{"Why profile \"desktop\" selects \"theme-tool\" (OS: all)", "desktop", "dependency theme-tool", "selected by tags: theme", "declared by dependency_set tags=theme"},
+			avoid: []string{"must-not-leak", "Installed Selection", "Drift"},
+		},
+		{
+			name:  "why explains the winning entry source override",
+			args:  []string{"catalog", "why", "desktop", "adaptive", "--file", manifestPath, "--os", "all"},
+			want:  []string{"entry ~/.example", "selected by tags: theme", "adaptive -> ~/.example (copy; source override: theme)"},
+			avoid: []string{"must-not-leak"},
+		},
+		{
+			name:  "why matches a provisioner identity",
+			args:  []string{"catalog", "why", "desktop", "demo", "--file", manifestPath, "--os", "all"},
+			want:  []string{"provisioner demo", "selected by tags: theme", "codex mcp: demo"},
 			avoid: []string{"must-not-leak"},
 		},
 	}
@@ -156,6 +175,29 @@ func TestCatalogDetailCompletionUsesManifestNames(t *testing.T) {
 	if directive != cobra.ShellCompDirectiveNoFileComp {
 		t.Fatalf("tag completion directive = %v", directive)
 	}
+
+	whyCmd, _, err := root.Find([]string{"catalog", "why"})
+	if err != nil {
+		t.Fatalf("find why: %v", err)
+	}
+	if err := whyCmd.InheritedFlags().Set("file", manifestPath); err != nil {
+		t.Fatalf("set why file: %v", err)
+	}
+	if err := whyCmd.InheritedFlags().Set("os", "all"); err != nil {
+		t.Fatalf("set why os: %v", err)
+	}
+	profiles, directive = whyCmd.ValidArgsFunction(whyCmd, nil, "d")
+	if !reflect.DeepEqual(profiles, []string{"desktop"}) {
+		t.Fatalf("why profile completion = %#v", profiles)
+	}
+	items, directive := whyCmd.ValidArgsFunction(whyCmd, []string{"desktop"}, "")
+	wantItems := []string{"theme-tool", "~/.example", "adaptive", "codex", "demo"}
+	if !reflect.DeepEqual(items, wantItems) {
+		t.Fatalf("why item completion = %#v, want %#v", items, wantItems)
+	}
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Fatalf("why completion directive = %v", directive)
+	}
 }
 
 func TestCatalogJSONAndErrorsUseTheOutputContract(t *testing.T) {
@@ -178,6 +220,56 @@ func TestCatalogJSONAndErrorsUseTheOutputContract(t *testing.T) {
 	}
 	if _, ok := data["profile"].(map[string]any); !ok {
 		t.Fatalf("profile detail missing from data: %#v", data)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"catalog", "why", "desktop", "theme-tool", "--file", manifestPath, "--os", "all", "--output", "json"}, &stdout, &stderr); code != ExitOK {
+		t.Fatalf("why Run() exit code = %d, stderr = %s", code, stderr.String())
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("decode why JSON: %v\n%s", err, stdout.String())
+	}
+	if result.Command != "catalog why" || result.Status != statusOK {
+		t.Fatalf("why envelope = %#v", result)
+	}
+	data, ok = result.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("why data = %#v", result.Data)
+	}
+	why, ok := data["why"].(map[string]any)
+	if !ok || why["profile"] != "desktop" || why["query"] != "theme-tool" {
+		t.Fatalf("why explanation missing from data: %#v", data)
+	}
+	var stableWhy struct {
+		Data struct {
+			Why catalog.Why `json:"why"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &stableWhy); err != nil {
+		t.Fatalf("decode stable why payload: %v", err)
+	}
+	wantWhy := catalog.Why{
+		Profile:      "desktop",
+		Query:        "theme-tool",
+		ResolvedTags: []string{"core", "theme"},
+		Matches: []catalog.WhyMatch{{
+			Type:             "dependency",
+			Identity:         "theme-tool",
+			ContributingTags: []string{"theme"},
+			Dependency: &catalog.WhyDependency{
+				Name: "theme-tool",
+				Declarations: []catalog.Dependency{{
+					Name:        "theme-tool",
+					Requirement: "required",
+					Probes:      []string{"theme-tool"},
+					Origin:      catalog.Origin{Type: "dependency_set", Tags: []string{"theme"}},
+				}},
+			},
+		}},
+	}
+	if !reflect.DeepEqual(stableWhy.Data.Why, wantWhy) {
+		t.Fatalf("why payload = %#v, want %#v", stableWhy.Data.Why, wantWhy)
 	}
 
 	stdout.Reset()
@@ -245,6 +337,34 @@ func TestCatalogJSONAndErrorsUseTheOutputContract(t *testing.T) {
 	if result.Command != "catalog profile" || result.Status != statusError || result.Error != `profile "missing" not found` {
 		t.Fatalf("unknown-profile envelope = %#v", result)
 	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"catalog", "why", "desktop", "missing", "--file", manifestPath, "--os", "linux", "--output", "json"}, &stdout, &stderr); code != ExitError {
+		t.Fatalf("unknown why query exit code = %d", code)
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("decode why error JSON: %v\n%s", err, stdout.String())
+	}
+	if result.Command != "catalog why" || result.Status != statusError || result.Error != `profile "desktop" does not select an item matching "missing" for OS linux` {
+		t.Fatalf("unknown why-query envelope = %#v", result)
+	}
+}
+
+func TestCatalogWhyTextOutputIsStable(t *testing.T) {
+	manifestPath := writeCatalogManifest(t)
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"catalog", "why", "desktop", "theme-tool", "--file", manifestPath, "--os", "all"}, &stdout, &stderr); code != ExitOK {
+		t.Fatalf("Run() exit code = %d, stderr = %s", code, stderr.String())
+	}
+	want := "Why profile \"desktop\" selects \"theme-tool\" (OS: all)\n" +
+		"desktop\n" +
+		"└─ dependency theme-tool\n" +
+		"   ├─ selected by tags: theme\n" +
+		"   └─ declared by dependency_set tags=theme (required)\n"
+	if stdout.String() != want {
+		t.Fatalf("output:\n%s\nwant:\n%s", stdout.String(), want)
+	}
 }
 
 func TestCatalogDetailsRequireExactlyOneName(t *testing.T) {
@@ -254,6 +374,17 @@ func TestCatalogDetailsRequireExactlyOneName(t *testing.T) {
 	cmd.SetErr(&out)
 	cmd.SetArgs([]string{"catalog", "profile"})
 	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "accepts 1 arg(s), received 0") {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestCatalogWhyRequiresProfileAndQuery(t *testing.T) {
+	cmd := NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"catalog", "why", "desktop"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "accepts 2 arg(s), received 1") {
 		t.Fatalf("Execute() error = %v", err)
 	}
 }

--- a/internal/cli/render_catalog.go
+++ b/internal/cli/render_catalog.go
@@ -170,7 +170,7 @@ func renderCatalogWhy(cmd *cobra.Command, report catalog.Report) {
 		case "entry":
 			renderCatalogWhyEntry(w, continuation, match.Entry)
 		case "provisioner":
-			renderCatalogWhyProvisioner(w, continuation, match.Provisioner)
+			renderCatalogWhyProvisioner(w, continuation, match.Identity, match.Provisioner)
 		}
 	}
 }
@@ -199,13 +199,9 @@ func renderCatalogWhyEntry(w io.Writer, prefix string, entry *catalog.WhyEntry) 
 	fmt.Fprintf(w, "%s└─ %s -> %s (%s)\n", prefix, entry.Entry.Source, entry.Entry.Target, entry.Entry.Strategy)
 }
 
-func renderCatalogWhyProvisioner(w io.Writer, prefix string, provisioner *catalog.Provisioner) {
+func renderCatalogWhyProvisioner(w io.Writer, prefix, identity string, provisioner *catalog.Provisioner) {
 	if provisioner == nil {
 		return
-	}
-	identity := provisioner.Identity
-	if identity == "" {
-		identity = provisioner.Tool
 	}
 	fmt.Fprintf(w, "%s└─ %s %s: %s\n", prefix, provisioner.Tool, provisioner.Operation, identity)
 }

--- a/internal/cli/render_catalog.go
+++ b/internal/cli/render_catalog.go
@@ -147,6 +147,69 @@ func renderCatalogMap(cmd *cobra.Command, report catalog.Report) {
 	)
 }
 
+func renderCatalogWhy(cmd *cobra.Command, report catalog.Report) {
+	why := report.Why
+	if why == nil {
+		return
+	}
+	w := cmd.OutOrStdout()
+	fmt.Fprintf(w, "Why profile %q selects %q (OS: %s)\n", why.Profile, why.Query, report.OS)
+	fmt.Fprintf(w, "%s\n", why.Profile)
+	for matchIndex, match := range why.Matches {
+		matchBranch := "├─"
+		continuation := "│  "
+		if matchIndex == len(why.Matches)-1 {
+			matchBranch = "└─"
+			continuation = "   "
+		}
+		fmt.Fprintf(w, "%s %s %s\n", matchBranch, match.Type, match.Identity)
+		fmt.Fprintf(w, "%s├─ selected by tags: %s\n", continuation, catalogList(match.ContributingTags))
+		switch match.Type {
+		case "dependency":
+			renderCatalogWhyDependency(w, continuation, match.Dependency)
+		case "entry":
+			renderCatalogWhyEntry(w, continuation, match.Entry)
+		case "provisioner":
+			renderCatalogWhyProvisioner(w, continuation, match.Provisioner)
+		}
+	}
+}
+
+func renderCatalogWhyDependency(w io.Writer, prefix string, dependency *catalog.WhyDependency) {
+	if dependency == nil {
+		return
+	}
+	for index, declaration := range dependency.Declarations {
+		branch := "├─"
+		if index == len(dependency.Declarations)-1 {
+			branch = "└─"
+		}
+		fmt.Fprintf(w, "%s%s declared by %s (%s)\n", prefix, branch, renderCatalogOrigin(declaration.Origin), declaration.Requirement)
+	}
+}
+
+func renderCatalogWhyEntry(w io.Writer, prefix string, entry *catalog.WhyEntry) {
+	if entry == nil {
+		return
+	}
+	if entry.SourceOverrideTag != "" {
+		fmt.Fprintf(w, "%s└─ %s -> %s (%s; source override: %s)\n", prefix, entry.Entry.Source, entry.Entry.Target, entry.Entry.Strategy, entry.SourceOverrideTag)
+		return
+	}
+	fmt.Fprintf(w, "%s└─ %s -> %s (%s)\n", prefix, entry.Entry.Source, entry.Entry.Target, entry.Entry.Strategy)
+}
+
+func renderCatalogWhyProvisioner(w io.Writer, prefix string, provisioner *catalog.Provisioner) {
+	if provisioner == nil {
+		return
+	}
+	identity := provisioner.Identity
+	if identity == "" {
+		identity = provisioner.Tool
+	}
+	fmt.Fprintf(w, "%s└─ %s %s: %s\n", prefix, provisioner.Tool, provisioner.Operation, identity)
+}
+
 func countLabel(count int, singular, plural string) string {
 	if count == 1 {
 		return singular

--- a/internal/cli/testdata/catalog_why.golden
+++ b/internal/cli/testdata/catalog_why.golden
@@ -1,0 +1,5 @@
+Why profile "desktop" selects "theme-tool" (OS: all)
+desktop
+└─ dependency theme-tool
+   ├─ selected by tags: theme
+   └─ declared by dependency_set tags=theme (required)

--- a/internal/cli/testdata/envelope_catalog_why.golden
+++ b/internal/cli/testdata/envelope_catalog_why.golden
@@ -1,0 +1,99 @@
+{
+  "schema_version": "7",
+  "command": "catalog why",
+  "status": "ok",
+  "data": {
+    "os": "all",
+    "metadata_origin": "declared",
+    "profiles": [
+      {
+        "name": "core",
+        "description": "Core profile",
+        "status": "current",
+        "tags": [
+          "core"
+        ]
+      },
+      {
+        "name": "desktop",
+        "description": "Desktop profile",
+        "status": "current",
+        "tags": [
+          "core",
+          "theme"
+        ]
+      },
+      {
+        "name": "old",
+        "description": "",
+        "status": "legacy",
+        "tags": [
+          "old"
+        ]
+      }
+    ],
+    "tags": [
+      {
+        "name": "core",
+        "description": "Core configuration",
+        "kind": "surface",
+        "status": "current",
+        "origin": "declared"
+      },
+      {
+        "name": "old",
+        "description": "Compatibility profile",
+        "kind": "surface",
+        "status": "legacy",
+        "replaced_by": "core",
+        "origin": "declared"
+      },
+      {
+        "name": "theme",
+        "description": "Theme configuration",
+        "kind": "surface",
+        "status": "current",
+        "origin": "declared"
+      }
+    ],
+    "hidden": {
+      "profiles": 0,
+      "tags": 0
+    },
+    "why": {
+      "profile": "desktop",
+      "query": "theme-tool",
+      "resolved_tags": [
+        "core",
+        "theme"
+      ],
+      "matches": [
+        {
+          "type": "dependency",
+          "identity": "theme-tool",
+          "contributing_tags": [
+            "theme"
+          ],
+          "dependency": {
+            "name": "theme-tool",
+            "declarations": [
+              {
+                "name": "theme-tool",
+                "requirement": "required",
+                "probes": [
+                  "theme-tool"
+                ],
+                "origin": {
+                  "type": "dependency_set",
+                  "tags": [
+                    "theme"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Closes #454

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds `dots catalog why PROFILE QUERY` to trace a selected item back to its Profile Tags and exact manifest declarations.
- Explains Dependencies, Managed Entries (including the winning source override), and Provisioners in compact text or the stable JSON envelope.
- Keeps the query portable and read-only, with OS-aware selection, exact matching, contextual shell completion, and no workstation-state reads.

## Changes

| File | Change |
|------|--------|
| `internal/catalog/catalog.go` | Adds the provenance report model and exact selected-item query while preserving all Dependency origins. |
| `internal/cli/catalog.go` | Adds the Cobra command, manifest-only loading, and Profile/item completion. |
| `internal/cli/render_catalog.go` | Renders a compact provenance tree for human output. |
| `internal/catalog/catalog_test.go` | Covers origin preservation, source overrides, Provisioners, and OS filtering. |
| `internal/cli/catalog_test.go` | Covers text/JSON stability, errors, exact args, and contextual completion. |
| `README.md` | Documents the new workflow and its portable catalog boundary. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan not applicable: this read-only catalog command does not inspect or change target-home behavior.
- [x] `go build ./...`
- [x] Manual read-only smoke tests against `dots.yaml` for a multi-origin Dependency and a Managed Entry JSON explanation.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] CLI validation used explicit `--file dots.yaml` and read-only `catalog why`; no home, state, package-manager, or network behavior was exercised.

## Delivery Evidence

- Contract Source: standalone issue #454, revalidated open with `enhancement` + `ready-for-agent`, no native parent/sub-issues/blockers; `updatedAt` `2026-08-12T03:30:52Z`; body SHA-256 `1c1206fae4bd1790d4623bc6949a30db2cd977e849f4255ac140d245ae119768`.
- Acceptance coverage: exact Dependency/Entry/Provisioner matching; all Dependency origins; ordered contributing Tags; resolved override provenance; concrete/all OS behavior; non-zero error envelopes; text and JSON stability; two-stage completion; README boundary documentation.
- Independent review: Standards and Spec reviews ran separately against `origin/main...87a12d4`; both re-reviews report no findings after fixes.

## Contributor Checklist

- [x] Linked one issue with an admitted Delivery Contract using `Closes #454`.
- [x] Added exactly one `type:*` label.
- [x] Delivery Evidence records the Contract Source snapshot, Acceptance coverage, and Independent review.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs for the new CLI workflow.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
