### PR TITLE
feat(manifest): add CodexBar to the desktop profile

### DIFF
--- a/docs/adr/0013-explicit-composable-install-profiles.md
+++ b/docs/adr/0013-explicit-composable-install-profiles.md
@@ -8,10 +8,12 @@ with people who may only want one capability area.
 
 We now require an explicit Profile selection for the repository manifest and make
 Profile composition first-class. The repository no longer defines `default`; it
-has an explicit `core` Profile (`tags: [core]`). Capability Profiles are pure:
-`desktop`, `agents`, `web`, and `mobile` select only their own tag. The
-opinionated `workstation` Profile remains a composite of `core`, `desktop`, and
-`agents`; `web` and `mobile` stay opt-in.
+has an explicit `core` Profile (`tags: [core]`). Capability Profiles are pure
+Tag compositions: `agents`, `web`, and `mobile` select only their own Tag, while
+`desktop` selects `desktop` plus the independently selectable `codexbar` Tag for
+the macOS CodexBar integration. The opinionated `workstation` Profile remains a
+composite of `core`, `desktop`, and `agents`; `codexbar`, `web`, and `mobile`
+stay absent unless selected by another requested Profile or explicit Tag.
 
 `--profile` is repeatable anywhere profile selection is accepted. The effective
 selection is the ordered, de-duplicated union of all selected Profile tags,

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -63,7 +63,7 @@ from compact discovery unless `--all` is supplied.
 |---------|--------|------|-------------|
 | `agents` | current | `agents` | Native configuration for Codex, Claude Code, OpenCode, Antigravity, and Copilot CLI. |
 | `core` | current | `core` | Core dotfiles and general developer tooling without agent, web, or mobile provisioners. |
-| `desktop` | current | `desktop` | Desktop-only configuration and integrations; compose with core when core dotfiles are desired too. |
+| `desktop` | current | `desktop`, `codexbar` | Desktop-only configuration and integrations; compose with core when core dotfiles are desired too. |
 | `mobile` | current | `mobile` | Optional Dart and Flutter mobile development capabilities. |
 | `web` | current | `web` | Optional frontend and browser workbench. |
 | `workstation` | current | `core`, `desktop`, `agents` | Composite core, desktop, and Agent CLI Baseline selection; web and mobile stay opt-in. |
@@ -75,6 +75,7 @@ from compact discovery unless `--all` is supplied.
 | `adaptive-theme` | surface | current | Opt-in adaptive-theme marker and supported app-specific sources or fragments. |  |
 | `agents` | surface | current | Native Agent CLI Baseline for Codex, Claude Code, OpenCode, Antigravity, and Copilot CLI. |  |
 | `codegraph` | surface | current | Opt-in CodeGraph provisioner and Codex SessionStart hook source override. |  |
+| `codexbar` | surface | current | CodexBar menu-bar monitor for AI coding-provider usage limits. |  |
 | `core` | surface | current | Core Development Baseline: shell, terminal, Git, editor, and common developer tooling. |  |
 | `desktop` | surface | current | Desktop terminal/editor configuration and integrations. |  |
 | `mobile` | surface | current | Optional Dart, Flutter, and Android development skills and MCP integrations. |  |
@@ -124,6 +125,11 @@ bootstrap commands after manager installation:
 Bootstrap declarations do not make an action executable by themselves: the
 manager executable must already be on `PATH` or a concrete installer/provider
 must run first.
+
+The `codexbar` set is Darwin-only. It detects `CodexBar.app` in the supported
+macOS application locations and uses the Homebrew cask `codexbar` when the app
+is missing. The `desktop` Profile includes this independently selectable Tag;
+Linux selections remain valid and omit the CodexBar Dependency.
 
 On Linux, when `fnm` is absent, no executable package provider is available, and
 `curl`, `bash`, and `unzip` are present, Node may use the constrained official
@@ -328,6 +334,7 @@ Current dependency package coverage:
 | Dependency | Detection | macOS/Homebrew | Debian/Ubuntu | Fedora | Arch |
 |------------|-----------|----------------|---------------|--------|------|
 | `Desktop Nerd Font` | Font globs `CascadiaCodeNF*` or `CaskaydiaCoveNerdFont*` | `brew install --cask font-cascadia-code-nf` | Manual | Manual | Manual |
+| `CodexBar` | macOS `CodexBar.app` | `brew install --cask codexbar` | Not selected | Not selected | Not selected |
 | `zsh` | `zsh` | `zsh` | `zsh` | `zsh` | `zsh` |
 | `git` | `git` | `git` | `git` | `git` | `git` |
 | `starship` | `starship` | `starship` | User-local / Linuxbrew opt-in/manual | `starship` | `starship` |

--- a/dots.yaml
+++ b/dots.yaml
@@ -8,6 +8,10 @@ tags:
     description: Desktop terminal/editor configuration and integrations.
     kind: surface
     status: current
+  codexbar:
+    description: CodexBar menu-bar monitor for AI coding-provider usage limits.
+    kind: surface
+    status: current
   agents:
     description: Native Agent CLI Baseline for Codex, Claude Code, OpenCode, Antigravity, and Copilot CLI.
     kind: surface
@@ -39,6 +43,7 @@ profiles:
     status: current
     tags:
       - desktop
+      - codexbar
   agents:
     description: Native configuration for Codex, Claude Code, OpenCode, Antigravity, and Copilot CLI.
     status: current
@@ -73,6 +78,14 @@ dependencies:
         font_match: "CascadiaCodeNF*"
         font_fallback_matches:
           - "CaskaydiaCoveNerdFont*"
+  - tags:
+      - codexbar
+    os:
+      - darwin
+    dependencies:
+      - name: CodexBar
+        darwin_app: CodexBar.app
+        brew_cask: codexbar
   - tags:
       - web
     os:

--- a/internal/deps/plan_test.go
+++ b/internal/deps/plan_test.go
@@ -1,6 +1,7 @@
 package deps_test
 
 import (
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -102,6 +103,40 @@ func TestPlanUsesDarwinAppAsAlternativeToCommandProbe(t *testing.T) {
 				t.Fatalf("Actions = %#v, want len %d", report.Actions, tt.wantActions)
 			}
 		})
+	}
+}
+
+func TestRepositoryManifestPlansCodexBarCaskOnDarwinOnly(t *testing.T) {
+	m, err := manifest.LoadFile(filepath.Join("..", "..", "dots.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	darwin, err := deps.Plan(*m, deps.Options{
+		ExtraTags: []string{"codexbar"}, OS: "darwin", AppLookup: appLookupSet(),
+	}, lookupSet("brew"), fontLookupSet(), deps.TierHomebrew)
+	if err != nil {
+		t.Fatalf("Darwin Plan() error = %v", err)
+	}
+	if len(darwin.Actions) != 1 {
+		t.Fatalf("Darwin Actions = %#v, want one CodexBar action", darwin.Actions)
+	}
+	action := darwin.Actions[0]
+	if action.Dependency != "CodexBar" || action.Package != "codexbar" || action.Executable != "brew" {
+		t.Fatalf("Darwin CodexBar action = %#v, want brew cask action", action)
+	}
+	if want := []string{"install", "--cask", "codexbar"}; !reflect.DeepEqual(action.Args, want) {
+		t.Fatalf("Darwin CodexBar Args = %#v, want %#v", action.Args, want)
+	}
+
+	linux, err := deps.Plan(*m, deps.Options{
+		ExtraTags: []string{"codexbar"}, OS: "linux", AppLookup: appLookupSet("CodexBar.app"),
+	}, lookupSet("brew"), fontLookupSet(), deps.TierHomebrew)
+	if err != nil {
+		t.Fatalf("Linux Plan() error = %v", err)
+	}
+	if len(linux.Actions) != 0 {
+		t.Fatalf("Linux Actions = %#v, want no CodexBar action", linux.Actions)
 	}
 }
 

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -786,6 +786,46 @@ func TestRepositoryManifestWebDependencySetIncludesPlaywrightCLI(t *testing.T) {
 	}
 }
 
+func TestRepositoryManifestDesktopProfileIncludesDarwinCodexBarDependency(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", ".."))
+	manifestPath := filepath.Join(root, "dots.yaml")
+
+	got, err := manifest.LoadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("LoadFile(%q) error = %v", manifestPath, err)
+	}
+
+	tag, ok := got.Tags["codexbar"]
+	if !ok {
+		t.Fatal("repository manifest missing codexbar tag")
+	}
+	if tag.Kind != "surface" || tag.Status != "current" {
+		t.Fatalf("codexbar tag = %#v, want current surface tag", tag)
+	}
+
+	selection, err := manifest.ResolveSelection(*got, []string{"desktop"}, nil)
+	if err != nil {
+		t.Fatalf("ResolveSelection(desktop) error = %v", err)
+	}
+	if want := []string{"desktop", "codexbar"}; !reflect.DeepEqual(selection.Tags, want) {
+		t.Fatalf("desktop selection tags = %#v, want %#v", selection.Tags, want)
+	}
+
+	darwin := selectedsurface.Evaluate(*got, []string{"codexbar"}, "darwin")
+	if len(darwin.Dependencies) != 1 {
+		t.Fatalf("Darwin codexbar dependencies = %#v, want one dependency", darwin.Dependencies)
+	}
+	codexbar := darwin.Dependencies[0]
+	if codexbar.Name != "CodexBar" || codexbar.DarwinApp != "CodexBar.app" || codexbar.BrewCask != "codexbar" {
+		t.Fatalf("CodexBar dependency = %#v, want CodexBar.app detection and codexbar cask", codexbar)
+	}
+
+	linux := selectedsurface.Evaluate(*got, []string{"codexbar"}, "linux")
+	if len(linux.Dependencies) != 0 {
+		t.Fatalf("Linux codexbar dependencies = %#v, want none", linux.Dependencies)
+	}
+}
+
 func TestRepositoryManifestDefinesNativeAgentCLIBaseline(t *testing.T) {
 	root := filepath.Clean(filepath.Join("..", ".."))
 	manifestPath := filepath.Join(root, "dots.yaml")


### PR DESCRIPTION
Closes #456

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds an independently selectable `codexbar` Tag to the Install Manifest.
- Makes the `desktop` Profile select CodexBar on Darwin through its official Homebrew cask.
- Documents and tests the Darwin-only Selected Surface and Linux exclusion.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Declares the Tag, composes it into `desktop`, and adds the Darwin CodexBar Dependency Set. |
| `internal/manifest/manifest_test.go` | Verifies Tag metadata, Profile resolution, application/cask metadata, and Linux exclusion. |
| `internal/deps/plan_test.go` | Verifies the exact missing-app Homebrew cask action and absence of Linux actions. |
| `docs/manifest.md` | Synchronizes the Install Catalog and dependency coverage. |
| `docs/adr/0013-explicit-composable-install-profiles.md` | Records the intentional `desktop` Profile composition exception. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go build ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed manual catalog and dependency checks used a temporary compiled binary plus explicit `--os` and `--home` values.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked one issue with an admitted Delivery Contract using `Closes #456`.
- [x] Added exactly one `type:*` label.
- [x] Delivery Evidence records the Contract Source snapshot, Acceptance coverage, and Independent review.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

### Contract Source snapshot

- Kind: complete standalone issue body
- Issue/body node ID: `I_kwDOSzLlmM8AAAABMn8ShQ`
- URL: https://github.com/yersonargotev/dots/issues/456
- `updatedAt`: `2026-08-13T13:54:01Z`
- SHA-256 of exact raw UTF-8 body: `e433790306787049ba34f5a0a1091b765bb784948349dcb25a533f87a6d6f611`
- Category: `enhancement`
- Readiness: `ready-for-agent` (only triage-state label)
- Native relationships: parent none; sub-issues none; blocked by none; blocking none
- Comments at snapshot: none

<details>
<summary>Exact Contract Source body</summary>

### Pre-flight checks
- [x] I searched existing issues and this is not a duplicate.
- [x] The scope is small enough for one reviewable work unit or clearly identifies slices.

### Desired outcome

The Install Manifest exposes CodexBar as an independently selectable `codexbar` Tag and includes that Tag in the `desktop` Profile. On macOS, selecting `desktop` or explicitly selecting `codexbar` makes CodexBar part of the Selected Surface and provides reviewed Homebrew cask installation guidance.

### Current-state gap

`dots.yaml` has no `codexbar` Tag or Dependency, so the `desktop` Profile cannot select the CodexBar menu-bar application. CodexBar's official installation contract is macOS 14+ with `brew install --cask codexbar`.

### Requirements

- Declare a current surface Tag named `codexbar` with a concise description of the CodexBar menu-bar usage monitor.
- Add `codexbar` to the ordered Tags selected directly by the `desktop` Profile while preserving its existing `desktop` Tag.
- Declare a tag-scoped CodexBar Dependency for Darwin only.
- Detect the installed application through the `CodexBar.app` bundle and render Homebrew installation through the `codexbar` cask.
- Keep Linux selection valid: the `codexbar` Tag must select no CodexBar Dependency outside Darwin.
- Regenerate or update the Install Catalog documentation so the new Tag, Profile composition, and Dependency are documented from the Source of Truth.
- Amend ADR 0013 so its capability-Profile description records the intentional `desktop` composition exception and does not contradict the Install Manifest.
- Add focused repository-manifest coverage proving the Tag, Profile composition, Darwin dependency metadata, and Linux exclusion.

### Key interfaces

- `dots.yaml` Tag catalog — add `codexbar` as a current surface Tag.
- `dots.yaml` `desktop` Profile — ordered Tags become `desktop`, `codexbar`.
- `dots.yaml` tag-scoped Dependency Set — `CodexBar`, `darwin_app: CodexBar.app`, `brew_cask: codexbar`, Darwin only.
- Install Catalog generated in `docs/manifest.md` — reflects the manifest change.
- `docs/adr/0013-explicit-composable-install-profiles.md` — records that `desktop` selects `desktop` plus `codexbar`, while the other capability Profiles remain single-Tag selections.

### Non-goals

- Do not manage CodexBar provider settings, API keys, cookies, credentials, login items, or application-owned configuration.
- Do not add CodexBar to `core`, `agents`, `web`, `mobile`, or `workstation` Profiles.
- Do not add Linux CLI, AUR, Waybar, GNOME, or other desktop-shell integrations.
- Do not introduce a new Dependency provider or change generic profile-selection semantics.
- Do not install CodexBar against the operator's real home during validation.

### Acceptance criteria

- [ ] Manifest validation succeeds with a current surface `codexbar` Tag.
- [ ] Resolving the `desktop` Profile yields the ordered effective Tags `desktop`, `codexbar`.
- [ ] On Darwin, the `codexbar` Tag selects one CodexBar Dependency detected by `CodexBar.app` and planned as `brew install --cask codexbar` when absent.
- [ ] On Linux, the `codexbar` Tag does not select or plan a CodexBar Dependency.
- [ ] `docs/manifest.md` is synchronized with `dots.yaml` and documents the new Tag, updated `desktop` Profile composition, and CodexBar dependency coverage.
- [ ] ADR 0013 no longer claims that `desktop` selects only its homonymous Tag and explains the scoped CodexBar composition.
- [ ] Existing profiles, Managed Entries, Dependencies, and Provisioners retain their behavior outside this scoped addition.

### Validation notes

- `go run ./cmd/dots manifest validate --file dots.yaml`
- Focused repository manifest and catalog tests.
- `go generate ./internal/catalog` followed by its doc-sync test.
- `gofmt -l .`
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- Build a temporary `dots` binary and inspect the `desktop`/`codexbar` Selected Surface for Darwin and Linux without using the operator's real home.

### Source

- CodexBar official README: https://github.com/steipete/CodexBar#install

</details>

### Reviewed head

- `a97f76178a421766d66463fecdb336b891b38cb5`

### Acceptance coverage

- Manifest validation and current surface Tag: direct CLI validation plus manifest test.
- Ordered `desktop`, `codexbar` resolution: manifest test and manual `catalog map desktop --os darwin`.
- Darwin app detection and exact cask action: manifest metadata test, deterministic Dependency Plan test, and manual installed-app check.
- Linux exclusion: Selected Surface test, Dependency Plan test, and manual `catalog tag codexbar --os linux`.
- Catalog and ADR: generated catalog sync test and direct documentation review.
- No unrelated behavior change: full CI-equivalent suite and independent diff review.

### Automated validation

- PASS — `go run ./cmd/dots manifest validate --file dots.yaml`
- PASS — focused `internal/manifest`, `internal/deps`, and `internal/catalog` tests
- PASS — `gofmt -l .` (no output)
- PASS — `go vet ./...`
- PASS — `go build ./...`
- PASS — `go test ./...`

### Manual verification

- PASS — temporary compiled binary, `catalog map desktop --os darwin --output json`: Tags were `desktop`, `codexbar`; CodexBar surface contained one Dependency.
- PASS — `catalog tag codexbar --os darwin --output json`: selected the Darwin-only CodexBar Dependency Set.
- PASS — `catalog tag codexbar --os linux --output json`: selected no Dependencies and reported the Darwin set as not applicable.
- PASS — `deps check --tag codexbar --home <tmp> --output json`: detected the installed `CodexBar.app` as present without writing configuration.

### Independent review

- Standards: no findings; no documented-standard violations or reportable baseline smells.
- Spec: no findings; all #456 requirements and non-goals matched the diff.
<!-- delivery-issue:evidence:end -->
