### PR TITLE
feat(selection): normalize legacy tag replacements

### DIFF
--- a/docs/agents/output-contract.md
+++ b/docs/agents/output-contract.md
@@ -106,7 +106,7 @@ prose the text surface prints:
   agents can distinguish aligned Managed Entries from an incomplete full-profile
   setup. Read dependency readiness for those commands from `doctor`.
 - `status`, `doctor`, `plan`, `deps check`, `deps plan`, `update`, and `upgrade` include
-  `data.selection` with `source` (`explicit` or `recorded`), ordered `profiles`,
+  `data.selection` with `source` (`explicit`, `recorded`, or `migration`), ordered `profiles`,
   explicit `extra_tags`, and recomputed `effective_tags`. When no selection
   flags are supplied, these commands resolve the recorded Profile names and
   extra Tags against the current Install Manifest; the stored `resolved_tags`
@@ -119,7 +119,8 @@ prose the text surface prints:
   emitted. A blocking evolution error returns the same delta as
   `data.selection_delta`.
   Any explicit Profile or Tag selection wins completely for that invocation and
-  is never merged with recorded intent.
+  is never merged with recorded intent. `migration` means the operator confirmed
+  normalization of recorded legacy Tag intent to its current replacement Tags.
   If neither source exists, the command returns an execution error (`1`) with
   selection guidance rather than falling back to a manifest `default`. For
   Installation Metadata v1/v2, historical evidence may be reported as a
@@ -155,6 +156,16 @@ prose the text surface prints:
   empty, and `remediation.recommended_command` is included when the evidence
   supports an explicit command. `--yes` and JSON output never confirm a
   candidate.
+- When recorded intent contains a legacy Tag with declared replacement Tags,
+  non-interactive and JSON invocations return exit `1`, `status: "error"`, and
+  error code `legacy-tag-migration-required` before repository, filesystem, or
+  Installation Metadata mutation. Error `data` contains `code`, ordered
+  `tag_migrations` entries with `legacy_tag` and `replacement_tags`, and
+  `remediation.recommended_command`. If an incoming Install Manifest newly
+  declares the recorded Tag as legacy, the recommendation is the interactive
+  base command because its replacement Tags are not valid until Source of Truth
+  refresh. A confirmed interactive migration reports selection source
+  `migration` and successful persistence records only current replacement Tags.
 - Mutating `install`, `update`, and `upgrade` reports may add
   `data.selection.change` when a complete explicit request differs from the
   authoritative Installed Selection. `change.delta` contains stable

--- a/docs/agents/output-contract.md
+++ b/docs/agents/output-contract.md
@@ -38,7 +38,7 @@ state.
 
 ```json
 {
-  "schema_version": "7",
+  "schema_version": "8",
   "command": "doctor",
   "status": "ok",
   "data": { "...": "command-specific report" }
@@ -59,7 +59,7 @@ Schema version `3` introduced this partial-error report allowance:
 
 ```json
 {
-  "schema_version": "7",
+  "schema_version": "8",
   "command": "doctor",
   "status": "error",
   "error": "read manifest: open dots.yaml: no such file or directory"
@@ -202,6 +202,9 @@ prose the text surface prints:
 - Schema version `7` adds the allowlisted `xdg-state` target root, seeded local
   evolution reason, and uninstall `retain` action. These values preserve
   application-owned runtime state while keeping aligned status at exit code 0.
+- Schema version `8` changes Install Catalog `replaced_by` values from one Tag
+  string to an ordered array of current replacement Tags and adds optional
+  `tag_migrations` evidence to selection reports.
 - Plan actions and Status Managed Entry items may add the optional reason
   `source-override-not-selected` and a deterministic `matching_tags` array when
   a conflicting target exactly matches one or more alternate sources whose

--- a/docs/agents/output-contract.md
+++ b/docs/agents/output-contract.md
@@ -120,7 +120,9 @@ prose the text surface prints:
   `data.selection_delta`.
   Any explicit Profile or Tag selection wins completely for that invocation and
   is never merged with recorded intent. `migration` means the operator confirmed
-  normalization of recorded legacy Tag intent to its current replacement Tags.
+  a change from previously recorded intent: either normalization of legacy Tag
+  intent to current replacement Tags or adoption of an unambiguous Installation
+  Metadata v1/v2 Selection Migration Candidate.
   If neither source exists, the command returns an execution error (`1`) with
   selection guidance rather than falling back to a manifest `default`. For
   Installation Metadata v1/v2, historical evidence may be reported as a

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -11,6 +11,7 @@ configuration surface and the configuration currently declared by this repositor
 
 ```yaml
 version: 1
+tags: {}
 profiles: {}
 dependencies: []
 entries: []
@@ -20,6 +21,7 @@ provisioners: []
 | Field | Required | Meaning |
 |-------|----------|---------|
 | `version` | Yes | Manifest schema version. Only `1` is supported. |
+| `tags` | No | Declared selection Tags and their lifecycle metadata. When present, every referenced Tag must be declared. |
 | `profiles` | Yes | Named installation selections. A Profile selects entries and provisioners by matching tags. |
 | `dependencies` | No | Tag-scoped Dependency Sets for shared toolchain baselines selected before Managed Entry and Provisioner Dependencies. |
 | `entries` | Yes | Managed Entries that install repository-owned files or directories into `$HOME`. |
@@ -35,8 +37,9 @@ authoritative Installed Selection when both `--profile` and `--tag` are omitted.
 Any explicit selection flag makes the current invocation's complete selection
 win without rewriting Installation Metadata. Repeat `--profile` to compose
 multiple Profiles by the ordered union of their tags. Commands that expose
-`--tag` can add optional capability tags on top of the selected Profile set
-without creating another Profile. For example, `--tag adaptive-theme` installs the opt-in marker and
+`--tag` can form a complete selection without a Profile or add optional
+capability Tags to a selected Profile set. For example, `--tag adaptive-theme`
+installs the opt-in marker and
 app-specific fragments used by managed configs to follow macOS light appearance
 where the app has a safe seam.
 
@@ -50,6 +53,34 @@ may instead offer an unambiguous candidate for confirmation.
 | Field | Required | Supported values |
 |-------|----------|------------------|
 | `tags` | Yes | Non-empty strings. Entries and Provisioners are selected when at least one tag matches. Optional CLI `--tag` values join this set at runtime. |
+
+## Tags
+
+Declared Tags have a `kind` (`surface`, `cleanup`, or `compatibility`) and a
+`status` (`current` or `legacy`). Every legacy Tag declares an ordered,
+non-empty `replaced_by` sequence of distinct current Tags. Replacement targets
+must be declared and cannot point to another legacy Tag. Current Tags cannot
+declare replacements.
+
+```yaml
+tags:
+  shell:
+    kind: surface
+    status: current
+  terminal:
+    kind: surface
+    status: current
+  old-workstation:
+    kind: compatibility
+    status: legacy
+    replaced_by: [shell, terminal]
+```
+
+The historical scalar spelling (`replaced_by: shell`) remains readable as a
+one-Tag alias. New and updated declarations should use the sequence form.
+Selection expands a legacy alias in declared order, de-duplicates the resulting
+current Tags without reordering them, and reports deterministic migration
+evidence. Persisted successful intent contains only normalized current Tags.
 
 The following compact catalog is generated from the Install Manifest. It lists
 current and legacy declarations; the `dots catalog` command hides legacy items

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -91,12 +91,12 @@ type ProfileSummary struct {
 
 // TagSummary is a compact Tag summary.
 type TagSummary struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Kind        string `json:"kind"`
-	Status      string `json:"status"`
-	ReplacedBy  string `json:"replaced_by,omitempty"`
-	Origin      string `json:"origin"`
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Kind        string   `json:"kind"`
+	Status      string   `json:"status"`
+	ReplacedBy  []string `json:"replaced_by,omitempty"`
+	Origin      string   `json:"origin"`
 }
 
 // Detail explains exactly one Profile or Tag selection without composing it
@@ -106,7 +106,7 @@ type Detail struct {
 	Description         string            `json:"description"`
 	Status              string            `json:"status"`
 	Kind                string            `json:"kind,omitempty"`
-	ReplacedBy          string            `json:"replaced_by,omitempty"`
+	ReplacedBy          []string          `json:"replaced_by,omitempty"`
 	ResolvedTags        []string          `json:"resolved_tags"`
 	Dependencies        []Dependency      `json:"dependencies"`
 	DependencySets      []DependencySet   `json:"dependency_sets"`
@@ -286,7 +286,11 @@ func Profile(m manifest.Manifest, name string, opts Options) (Report, error) {
 		return Report{}, fmt.Errorf("profile %q not found", name)
 	}
 	summary := summaryProfile(name, p)
-	base.Profile = buildDetail(m, name, summary.Description, summary.Status, "", "", unique(p.Tags), base.OS)
+	resolvedTags, _, err := manifest.NormalizeTags(m, p.Tags)
+	if err != nil {
+		return Report{}, fmt.Errorf("normalize catalog profile %q: %w", name, err)
+	}
+	base.Profile = buildDetail(m, name, summary.Description, summary.Status, "", nil, resolvedTags, base.OS)
 	return base, nil
 }
 
@@ -460,12 +464,16 @@ func Tag(m manifest.Manifest, name string, opts Options) (Report, error) {
 		return Report{}, fmt.Errorf("tag %q not found", name)
 	}
 	t := summaryTag(m, name)
-	base.Tag = buildDetail(m, name, t.Description, t.Status, t.Kind, t.ReplacedBy, []string{name}, base.OS)
+	resolvedTags, _, err := manifest.NormalizeTags(m, []string{name})
+	if err != nil {
+		return Report{}, fmt.Errorf("normalize catalog tag %q: %w", name, err)
+	}
+	base.Tag = buildDetail(m, name, t.Description, t.Status, t.Kind, t.ReplacedBy, resolvedTags, base.OS)
 	return base, nil
 }
 
-func buildDetail(m manifest.Manifest, name, description, status, kind, replacedBy string, tags []string, osName string) *Detail {
-	d := &Detail{Name: name, Description: description, Status: status, Kind: kind, ReplacedBy: replacedBy, ResolvedTags: clone(tags), Dependencies: []Dependency{}, DependencySets: []DependencySet{}, ProfileDependencies: []Dependency{}, Entries: []Entry{}, SourceOverrides: []SourceOverride{}, Provisioners: []Provisioner{}, Behaviors: behaviors(tags), Excluded: []ExcludedSurface{}}
+func buildDetail(m manifest.Manifest, name, description, status, kind string, replacedBy, tags []string, osName string) *Detail {
+	d := &Detail{Name: name, Description: description, Status: status, Kind: kind, ReplacedBy: clone(replacedBy), ResolvedTags: clone(tags), Dependencies: []Dependency{}, DependencySets: []DependencySet{}, ProfileDependencies: []Dependency{}, Entries: []Entry{}, SourceOverrides: []SourceOverride{}, Provisioners: []Provisioner{}, Behaviors: behaviors(tags), Excluded: []ExcludedSurface{}}
 	surface, excludedSurface := selectedSurfaces(m, tags, osName)
 	for _, set := range surface.DependencySets {
 		item := DependencySet{Tags: clone(set.Tags), OS: declaredOS(set.OS), Dependencies: []Dependency{}}
@@ -719,7 +727,7 @@ func summaryProfile(name string, p manifest.Profile) ProfileSummary {
 }
 func summaryTag(m manifest.Manifest, name string) TagSummary {
 	if t, ok := m.Tags[name]; ok {
-		return TagSummary{Name: name, Description: t.Description, Kind: t.Kind, Status: t.Status, ReplacedBy: t.ReplacedBy, Origin: MetadataDeclared}
+		return TagSummary{Name: name, Description: t.Description, Kind: t.Kind, Status: t.Status, ReplacedBy: clone(t.ReplacedBy), Origin: MetadataDeclared}
 	}
 	return TagSummary{Name: name, Kind: "surface", Status: "current", Origin: MetadataDerived}
 }
@@ -804,13 +812,4 @@ func contains(values []string, wanted string) bool {
 		}
 	}
 	return false
-}
-func unique(values []string) []string {
-	result := []string{}
-	for _, value := range values {
-		if !contains(result, value) {
-			result = append(result, value)
-		}
-	}
-	return result
 }

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -62,6 +62,26 @@ func TestTagDetailIsPortableSafeAndDescribesExclusions(t *testing.T) {
 	}
 }
 
+func TestLegacyTagAndProfileDetailsUseNormalizedCurrentTags(t *testing.T) {
+	m := fixtureManifest()
+
+	tagReport, err := Tag(m, "old", Options{OS: "all"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"core", "agents"}; !reflect.DeepEqual(tagReport.Tag.ReplacedBy, want) || !reflect.DeepEqual(tagReport.Tag.ResolvedTags, want) {
+		t.Fatalf("legacy Tag detail = %#v, want replacements and resolved Tags %#v", tagReport.Tag, want)
+	}
+
+	profileReport, err := Profile(m, "old", Options{OS: "all"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"core", "agents"}; !reflect.DeepEqual(profileReport.Profile.ResolvedTags, want) {
+		t.Fatalf("legacy Profile resolved Tags = %#v, want %#v", profileReport.Profile.ResolvedTags, want)
+	}
+}
+
 func TestDetailUsesSelectedSurfaceForResolvedEntriesAndActiveOverrides(t *testing.T) {
 	m := manifest.Manifest{
 		Profiles: map[string]manifest.Profile{
@@ -374,7 +394,7 @@ func fixtureManifest() manifest.Manifest {
 			"agents":  {Description: "Agents", Kind: "surface", Status: "current"},
 			"theme":   {Description: "Theme", Kind: "surface", Status: "current"},
 			"cleanup": {Description: "Cleanup", Kind: "cleanup", Status: "current"},
-			"old":     {Description: "Old", Kind: "compatibility", Status: "legacy", ReplacedBy: "core"},
+			"old":     {Description: "Old", Kind: "compatibility", Status: "legacy", ReplacedBy: manifest.ReplacementTags{"core", "agents"}},
 		},
 		Profiles: map[string]manifest.Profile{
 			"core":    {Description: "Core profile", Tags: []string{"core", "agents"}},

--- a/internal/catalog/markdown.go
+++ b/internal/catalog/markdown.go
@@ -27,8 +27,8 @@ func Markdown(m manifest.Manifest) (string, error) {
 	out.WriteString("|-----|------|--------|-------------|-------------|\n")
 	for _, tag := range report.Tags {
 		replacement := ""
-		if tag.ReplacedBy != "" {
-			replacement = "`" + tag.ReplacedBy + "`"
+		if len(tag.ReplacedBy) > 0 {
+			replacement = codeList(tag.ReplacedBy)
 		}
 		fmt.Fprintf(&out, "| `%s` | %s | %s | %s | %s |\n", tag.Name, tag.Kind, tag.Status, markdownCell(tag.Description), replacement)
 	}

--- a/internal/cli/catalog_test.go
+++ b/internal/cli/catalog_test.go
@@ -49,7 +49,7 @@ func TestCatalogCommandsRenderManifestOnlyViews(t *testing.T) {
 		{
 			name: "legacy tag detail remains directly addressable",
 			args: []string{"catalog", "tag", "old", "--file", manifestPath, "--os", "all"},
-			want: []string{"Tag \"old\"", "Status: legacy", "Replaced by: core"},
+			want: []string{"Tag \"old\"", "Status: legacy", "Replaced by: core, theme", "Resolved tags: core, theme"},
 		},
 		{
 			name:  "tag detail renders surfaces and exclusions",
@@ -433,7 +433,7 @@ tags:
     description: Compatibility profile
     kind: surface
     status: legacy
-    replaced_by: core
+    replaced_by: [core, theme]
 profiles:
   core:
     description: Core profile

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -86,24 +86,35 @@ func newInstallCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			requestedSelection, err := selection.Resolve(*m, profiles, extraTags)
-			if err != nil {
-				return err
+			intentProfiles := profiles
+			intentTags := extraTags
+			if len(intentProfiles) == 0 && len(intentTags) == 0 {
+				requestedSelection, err := selection.Resolve(*m, nil, nil)
+				if err != nil {
+					return err
+				}
+				intentProfiles = requestedSelection.Profiles
+				intentTags = requestedSelection.ExtraTags
 			}
 			effective, err := selection.ResolveIntent(*m, selection.Intent{
 				Source:    selection.SourceExplicit,
-				Profiles:  requestedSelection.Profiles,
-				ExtraTags: requestedSelection.ExtraTags,
+				Profiles:  intentProfiles,
+				ExtraTags: intentTags,
 			})
 			if err != nil {
 				return err
 			}
+			selectedProfiles := effective.Profiles
+			selectedTags := effective.ExtraTags
 
 			meta, err := loadInstallationMetadata(paths, stateRoot)
 			if err != nil {
 				return err
 			}
 			effective = selection.CompareInstalled(*m, effective, meta.InstalledSelection, installHostOS)
+			if !wantsJSON(cmd) {
+				renderTagMigrations(cmd.OutOrStdout(), effective.Report.TagMigrations)
+			}
 			proceed, _, err := guardSelectionChange(cmd, &effective, selectionChangePolicy{
 				DryRun: dryRun, Confirmed: yes, Acknowledge: ackSelection,
 			})
@@ -117,7 +128,7 @@ func newInstallCommand() *cobra.Command {
 
 			hostOS := installHostOS
 			hostArch := installHostArch
-			depOptions := deps.Options{Profiles: profiles, ExtraTags: extraTags, OS: hostOS, Arch: hostArch, Home: paths.Home, StateRoot: paths.StateRoot, AppLookup: appInstalled(hostOS, paths.Home), HTTPClient: depsHTTPClient, RollingReleaseURL: depsRollingReleaseURL}
+			depOptions := deps.Options{Profiles: selectedProfiles, ExtraTags: selectedTags, OS: hostOS, Arch: hostArch, Home: paths.Home, StateRoot: paths.StateRoot, AppLookup: appInstalled(hostOS, paths.Home), HTTPClient: depsHTTPClient, RollingReleaseURL: depsRollingReleaseURL}
 			depTier, err := resolveInstallTier(hostOS)
 			if err != nil {
 				return err
@@ -157,7 +168,7 @@ func newInstallCommand() *cobra.Command {
 			}
 
 			if dryRun {
-				p, provPlan, err := buildInstallPlanAndProvisioners(*m, meta, profiles, extraTags, hostOS, paths, prep.SourceReadRoot, prep.LegacyMigrations)
+				p, provPlan, err := buildInstallPlanAndProvisioners(*m, meta, selectedProfiles, selectedTags, hostOS, paths, prep.SourceReadRoot, prep.LegacyMigrations)
 				if err != nil {
 					return err
 				}
@@ -165,7 +176,7 @@ func newInstallCommand() *cobra.Command {
 				if wantsJSON(cmd) {
 					return emitOK(cmd, installReport{RepositoryRefresh: prep.Refresh, DryRun: true, Selection: effective.Report, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan})
 				}
-				if err := renderInstallPlanAndProvisioners(cmd, *m, p, provPlan, profiles); err != nil {
+				if err := renderInstallPlanAndProvisioners(cmd, *m, p, provPlan, selectedProfiles); err != nil {
 					return err
 				}
 				return nil
@@ -219,7 +230,7 @@ func newInstallCommand() *cobra.Command {
 					renderDepsInstallPreview(cmd.OutOrStdout(), depPreview)
 					depsConfirmed = true
 				}
-				p, provPlan, err = buildInstallPlanAndProvisioners(*m, meta, profiles, extraTags, hostOS, paths, prep.SourceReadRoot, prep.LegacyMigrations)
+				p, provPlan, err = buildInstallPlanAndProvisioners(*m, meta, selectedProfiles, selectedTags, hostOS, paths, prep.SourceReadRoot, prep.LegacyMigrations)
 				if err != nil {
 					return err
 				}
@@ -241,7 +252,7 @@ func newInstallCommand() *cobra.Command {
 			}
 
 			if !installPlanReady {
-				p, provPlan, err = buildInstallPlanAndProvisioners(*m, meta, profiles, extraTags, hostOS, paths, prep.SourceReadRoot, prep.LegacyMigrations)
+				p, provPlan, err = buildInstallPlanAndProvisioners(*m, meta, selectedProfiles, selectedTags, hostOS, paths, prep.SourceReadRoot, prep.LegacyMigrations)
 				if err != nil {
 					return err
 				}
@@ -249,7 +260,7 @@ func newInstallCommand() *cobra.Command {
 			}
 
 			if !wantsJSON(cmd) {
-				if err := renderInstallPlanAndProvisioners(cmd, *m, p, provPlan, profiles); err != nil {
+				if err := renderInstallPlanAndProvisioners(cmd, *m, p, provPlan, selectedProfiles); err != nil {
 					return err
 				}
 			}
@@ -273,7 +284,7 @@ func newInstallCommand() *cobra.Command {
 				return nil
 			}
 
-			provResult, err := runProvisionersWithEnvironment(cmd, *m, profiles, extraTags, paths.Home, paths.StateRoot, paths.SourceRoot, dependencyEnvironment)
+			provResult, err := runProvisionersWithEnvironment(cmd, *m, selectedProfiles, selectedTags, paths.Home, paths.StateRoot, paths.SourceRoot, dependencyEnvironment)
 			if err != nil {
 				if wantsJSON(cmd) {
 					return installProvisionerError{err: err, report: installReport{RepositoryRefresh: prep.Refresh, DryRun: false, Selection: effective.Report, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan, BackupSets: createdBackups, ProvisionerResults: &provResult}}
@@ -315,10 +326,15 @@ func newInstallCommand() *cobra.Command {
 
 func renderInstallPlanAndProvisioners(cmd *cobra.Command, m manifest.Manifest, p plan.Plan, provPlan provision.Plan, profiles []string) error {
 	renderPlan(cmd.OutOrStdout(), p)
-	if err := renderSkippedEntryHint(cmd.OutOrStdout(), m, profiles, runtime.GOOS); err != nil {
-		return err
+	if len(profiles) > 0 {
+		if err := renderSkippedEntryHint(cmd.OutOrStdout(), m, profiles, runtime.GOOS); err != nil {
+			return err
+		}
 	}
 	renderProvisionPlan(cmd.OutOrStdout(), provPlan)
+	if len(profiles) == 0 {
+		return nil
+	}
 	return renderSkippedProvisionerHint(cmd.OutOrStdout(), m, profiles, runtime.GOOS)
 }
 

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -112,9 +112,6 @@ func newInstallCommand() *cobra.Command {
 				return err
 			}
 			effective = selection.CompareInstalled(*m, effective, meta.InstalledSelection, installHostOS)
-			if !wantsJSON(cmd) {
-				renderTagMigrations(cmd.OutOrStdout(), effective.Report.TagMigrations)
-			}
 			proceed, _, err := guardSelectionChange(cmd, &effective, selectionChangePolicy{
 				DryRun: dryRun, Confirmed: yes, Acknowledge: ackSelection,
 			})

--- a/internal/cli/install_selection_test.go
+++ b/internal/cli/install_selection_test.go
@@ -81,6 +81,137 @@ entries:
 	}
 }
 
+func TestInstallTagOnlySelectionAppliesAndRecordsWithoutProfile(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	writeCLISource(t, sourceRoot, "configs/zsh/zshrc", "managed\n")
+	manifestPath := writeCLIManifest(t, home, `version: 1
+tags:
+  zsh:
+    description: Zsh configuration
+    kind: surface
+    status: current
+profiles:
+  workstation:
+    tags: [zsh]
+entries:
+  - source: configs/zsh/zshrc
+    target: ~/.zshrc
+    strategy: symlink
+    tags: [zsh]
+`)
+
+	var out, errOut bytes.Buffer
+	code := cli.Run([]string{
+		"install", "--yes", "--skip-deps", "--output", "json", "--tag", "zsh",
+		"--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot,
+	}, &out, &errOut)
+	if code != cli.ExitOK {
+		t.Fatalf("exit code = %d, want %d\nstdout:\n%s\nstderr:\n%s", code, cli.ExitOK, out.String(), errOut.String())
+	}
+	if _, err := os.Readlink(filepath.Join(home, ".zshrc")); err != nil {
+		t.Fatalf("Tag-only install did not apply Managed Entry: %v", err)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load metadata: %v", err)
+	}
+	if meta.InstalledSelection == nil {
+		t.Fatal("InstalledSelection = nil")
+	}
+	if len(meta.InstalledSelection.Profiles) != 0 {
+		t.Fatalf("Profiles = %#v, want none", meta.InstalledSelection.Profiles)
+	}
+	if got, want := meta.InstalledSelection.ExtraTags, []string{"zsh"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ExtraTags = %#v, want %#v", got, want)
+	}
+	if got, want := meta.InstalledSelection.ResolvedTags, []string{"zsh"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ResolvedTags = %#v, want %#v", got, want)
+	}
+
+	dryHome := t.TempDir()
+	dryStateRoot := filepath.Join(t.TempDir(), "state")
+	cmd := cli.NewRootCommand()
+	out.Reset()
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"install", "--dry-run", "--skip-deps", "--tag", "zsh",
+		"--file", manifestPath, "--home", dryHome, "--source-root", sourceRoot, "--state-root", dryStateRoot,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("human Tag-only dry run error = %v\noutput:\n%s", err, out.String())
+	}
+	if !strings.Contains(out.String(), "Plan for tags only (tags: zsh)") {
+		t.Fatalf("human Tag-only output missing selection:\n%s", out.String())
+	}
+	if _, err := os.Stat(dryStateRoot); !os.IsNotExist(err) {
+		t.Fatalf("dry run created state root: %v", err)
+	}
+}
+
+func TestInstallLegacyTagNormalizesBeforeApplyAndReportsJSONEvidence(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	writeCLISource(t, sourceRoot, "configs/zsh", "zsh\n")
+	writeCLISource(t, sourceRoot, "configs/starship", "starship\n")
+	manifestPath := writeCLIManifest(t, home, `version: 1
+tags:
+  zsh: {description: Zsh, kind: surface, status: current}
+  starship: {description: Starship, kind: surface, status: current}
+  core:
+    description: Legacy core
+    kind: compatibility
+    status: legacy
+    replaced_by: [zsh, starship]
+profiles:
+  shell:
+    tags: [zsh, starship]
+entries:
+  - {source: configs/zsh, target: ~/.zshrc, strategy: symlink, tags: [zsh]}
+  - {source: configs/starship, target: ~/.config/starship.toml, strategy: symlink, tags: [starship]}
+`)
+
+	var out, errOut bytes.Buffer
+	code := cli.Run([]string{
+		"install", "--yes", "--skip-deps", "--output", "json",
+		"--tag", "core", "--tag", "zsh", "--tag", "core",
+		"--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot,
+	}, &out, &errOut)
+	if code != cli.ExitOK {
+		t.Fatalf("exit code = %d, want %d\nstdout:\n%s\nstderr:\n%s", code, cli.ExitOK, out.String(), errOut.String())
+	}
+	for _, target := range []string{".zshrc", filepath.Join(".config", "starship.toml")} {
+		if _, err := os.Readlink(filepath.Join(home, target)); err != nil {
+			t.Fatalf("normalized legacy install did not apply %s: %v", target, err)
+		}
+	}
+	for _, want := range []string{`"tag_migrations"`, `"legacy_tag": "core"`, `"replacement_tags": [`, `"zsh"`, `"starship"`} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("JSON output missing %q:\n%s", want, out.String())
+		}
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load metadata: %v", err)
+	}
+	if meta.InstalledSelection == nil {
+		t.Fatal("InstalledSelection = nil")
+	}
+	if got, want := meta.InstalledSelection.ExtraTags, []string{"zsh", "starship"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ExtraTags = %#v, want %#v", got, want)
+	}
+	if got, want := meta.InstalledSelection.ResolvedTags, []string{"zsh", "starship"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ResolvedTags = %#v, want %#v", got, want)
+	}
+}
+
 func TestInstallFailurePreservesPreviousInstalledSelection(t *testing.T) {
 	home := t.TempDir()
 	sourceRoot := t.TempDir()

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -22,7 +22,7 @@ const (
 // binary. Renaming, removing, or repurposing a field in any command's JSON
 // `data` is a breaking change to the Agent Output Contract and must bump this
 // value.
-const schemaVersion = "7"
+const schemaVersion = "8"
 
 // Envelope statuses. They mirror the semantic exit codes: ok->0, findings->2,
 // error->1.

--- a/internal/cli/output_golden_test.go
+++ b/internal/cli/output_golden_test.go
@@ -178,7 +178,7 @@ func TestEnvelopeGolden(t *testing.T) {
 						RecommendedCommand: "dots update --tag zsh --tag git",
 					},
 				},
-				Error: "legacy-tag-migration-required: recorded legacy Tag intent requires interactive confirmation; provide complete current intent with dots update --tag zsh --tag git",
+				Error: "legacy-tag-migration-required: recorded legacy Tag intent requires confirmation; use remediation command dots update --tag zsh --tag git",
 			},
 			golden: "envelope_legacy_tag_migration_required.golden",
 		},

--- a/internal/cli/output_golden_test.go
+++ b/internal/cli/output_golden_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/yersonargotev/dots/internal/doctor"
 	"github.com/yersonargotev/dots/internal/gitrepo"
 	inst "github.com/yersonargotev/dots/internal/installed"
+	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/provision"
 	"github.com/yersonargotev/dots/internal/selection"
@@ -51,6 +52,7 @@ func TestEnvelopeGolden(t *testing.T) {
 	}
 	installSelection := selection.Report{
 		Source: selection.SourceExplicit, Profiles: []string{"default"}, ExtraTags: []string{}, EffectiveTags: []string{"default"},
+		TagMigrations: []manifest.TagReplacement{{LegacyTag: "legacy-default", ReplacementTags: []string{"default"}}},
 		Change: &selection.Change{
 			Delta: selection.Delta{
 				Previous: selection.Snapshot{Profiles: []string{"core", "work"}, ExtraTags: []string{"adaptive-theme"}, EffectiveTags: []string{"core", "work", "adaptive-theme"}},
@@ -160,6 +162,25 @@ func TestEnvelopeGolden(t *testing.T) {
 				Error: "selection-migration-required: Installation Metadata predates authoritative Installed Selection; run dots install --profile core --tag adaptive-theme",
 			},
 			golden: "envelope_selection_migration_required.golden",
+		},
+		{
+			name: "legacy Tag migration required",
+			env: envelope{
+				SchemaVersion: schemaVersion,
+				Command:       "update",
+				Status:        statusError,
+				Data: legacyTagMigrationErrorData{
+					Code: legacyTagMigrationRequiredCode,
+					TagMigrations: []manifest.TagReplacement{{
+						LegacyTag: "core", ReplacementTags: []string{"zsh", "git"},
+					}},
+					Remediation: legacyTagMigrationRemediation{
+						RecommendedCommand: "dots update --tag zsh --tag git",
+					},
+				},
+				Error: "legacy-tag-migration-required: recorded legacy Tag intent requires interactive confirmation; provide complete current intent with dots update --tag zsh --tag git",
+			},
+			golden: "envelope_legacy_tag_migration_required.golden",
 		},
 		{
 			name: "plan",

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -86,8 +86,8 @@ func decodeEnvelope(t *testing.T, out string) testEnvelope {
 	if err := json.Unmarshal([]byte(out), &env); err != nil {
 		t.Fatalf("stdout is not a JSON envelope: %v\noutput:\n%s", err, out)
 	}
-	if env.SchemaVersion != "7" {
-		t.Fatalf("schema_version = %q, want \"7\"", env.SchemaVersion)
+	if env.SchemaVersion != "8" {
+		t.Fatalf("schema_version = %q, want \"8\"", env.SchemaVersion)
 	}
 	if env.Command != "status" {
 		t.Fatalf("command = %q, want \"status\"", env.Command)
@@ -101,8 +101,8 @@ func decodeEnvelopeForCommand(t *testing.T, out string, command string) testEnve
 	if err := json.Unmarshal([]byte(out), &env); err != nil {
 		t.Fatalf("stdout is not a JSON envelope: %v\noutput:\n%s", err, out)
 	}
-	if env.SchemaVersion != "7" {
-		t.Fatalf("schema_version = %q, want \"7\"", env.SchemaVersion)
+	if env.SchemaVersion != "8" {
+		t.Fatalf("schema_version = %q, want \"8\"", env.SchemaVersion)
 	}
 	if env.Command != command {
 		t.Fatalf("command = %q, want %q", env.Command, command)

--- a/internal/cli/read_selection_test.go
+++ b/internal/cli/read_selection_test.go
@@ -146,6 +146,57 @@ entries:
 	}
 }
 
+func TestReadOnlyRecordedLegacyTagRequiresCurrentExplicitIntent(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	writeCLISource(t, sourceRoot, "configs/new", "new\n")
+	manifestPath := writeCLIManifest(t, sourceRoot, `version: 1
+tags:
+  core: {description: Core, kind: surface, status: current}
+  new: {description: New, kind: surface, status: current}
+  old:
+    description: Old
+    kind: compatibility
+    status: legacy
+    replaced_by: [new]
+profiles:
+  core:
+    tags: [core]
+entries:
+  - {source: configs/new, target: ~/.new, strategy: symlink, tags: [new]}
+`)
+	if err := state.Save(state.Path(stateRoot), state.Metadata{
+		Version: state.CurrentVersion,
+		InstalledSelection: &state.InstalledSelection{
+			Profiles: []string{"core"}, ExtraTags: []string{"old"}, ResolvedTags: []string{"core", "old"},
+		},
+	}); err != nil {
+		t.Fatalf("save Installed Selection: %v", err)
+	}
+
+	args := selectionCommandArgs([]string{"plan"}, manifestPath, home, sourceRoot, stateRoot, false)
+	code, data, envelopeError := runSelectionJSON(t, args)
+	if code != cli.ExitError || !strings.Contains(envelopeError, legacyTagMigrationCodeForTest) {
+		t.Fatalf("recorded legacy selection = code %d error %q", code, envelopeError)
+	}
+	if got := data["code"]; got != legacyTagMigrationCodeForTest {
+		t.Fatalf("data.code = %v, want %q", got, legacyTagMigrationCodeForTest)
+	}
+	if got := data["remediation"].(map[string]any)["recommended_command"]; got != "dots install --profile core --tag new" {
+		t.Fatalf("recommended command = %v", got)
+	}
+
+	explicitArgs := append([]string{"plan", "--profile", "core", "--tag", "new"}, args[1:]...)
+	code, explicitData, envelopeError := runSelectionJSON(t, explicitArgs)
+	if code != cli.ExitOK || envelopeError != "" {
+		t.Fatalf("explicit current selection = code %d error %q", code, envelopeError)
+	}
+	assertSelectionJSON(t, explicitData, "explicit", []string{"core"}, []string{"new"}, []string{"core", "new"})
+}
+
+const legacyTagMigrationCodeForTest = "legacy-tag-migration-required"
+
 func TestReadOnlySelectionTextReportsSource(t *testing.T) {
 	home := t.TempDir()
 	sourceRoot := t.TempDir()

--- a/internal/cli/read_selection_test.go
+++ b/internal/cli/read_selection_test.go
@@ -193,6 +193,20 @@ entries:
 		t.Fatalf("explicit current selection = code %d error %q", code, envelopeError)
 	}
 	assertSelectionJSON(t, explicitData, "explicit", []string{"core"}, []string{"new"}, []string{"core", "new"})
+
+	var stdout, stderr bytes.Buffer
+	code = cli.Run([]string{
+		"plan", "--tag", "old", "--file", manifestPath,
+		"--home", home, "--source-root", sourceRoot, "--state-root", t.TempDir(),
+	}, &stdout, &stderr)
+	if code != cli.ExitOK {
+		t.Fatalf("explicit legacy text plan = code %d\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{"legacy Tag normalization: old -> new", "transitional alias"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("explicit legacy text output missing %q:\n%s", want, stdout.String())
+		}
+	}
 }
 
 const legacyTagMigrationCodeForTest = "legacy-tag-migration-required"

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -129,15 +129,20 @@ func renderEffectiveSelection(profile string, profiles, tags []string, report *s
 	if report == nil {
 		return rendered
 	}
-	return fmt.Sprintf("%s [selection: %s]", rendered, report.Source)
+	rendered = fmt.Sprintf("%s [selection: %s]", rendered, report.Source)
+	if report.Source == selection.SourceMigration {
+		return rendered
+	}
+	for _, migration := range report.TagMigrations {
+		rendered += fmt.Sprintf(" [legacy Tag normalization: %s -> %s; transitional alias]",
+			migration.LegacyTag, strings.Join(migration.ReplacementTags, ","))
+	}
+	return rendered
 }
 
 func renderSelectionReport(w io.Writer, report selection.Report) {
 	fmt.Fprintf(w, "Selection: source=%s profiles=%s extra-tags=%s effective-tags=%s\n\n",
 		report.Source, renderSelectionValues(report.Profiles), renderSelectionValues(report.ExtraTags), renderSelectionValues(report.EffectiveTags))
-	if report.Source != selection.SourceMigration {
-		renderTagMigrations(w, report.TagMigrations)
-	}
 	if report.Delta == nil {
 		return
 	}

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -143,6 +143,9 @@ func renderEffectiveSelection(profile string, profiles, tags []string, report *s
 func renderSelectionReport(w io.Writer, report selection.Report) {
 	fmt.Fprintf(w, "Selection: source=%s profiles=%s extra-tags=%s effective-tags=%s\n\n",
 		report.Source, renderSelectionValues(report.Profiles), renderSelectionValues(report.ExtraTags), renderSelectionValues(report.EffectiveTags))
+	if report.Source != selection.SourceMigration {
+		renderTagMigrations(w, report.TagMigrations)
+	}
 	if report.Delta == nil {
 		return
 	}

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -135,6 +135,9 @@ func renderEffectiveSelection(profile string, profiles, tags []string, report *s
 func renderSelectionReport(w io.Writer, report selection.Report) {
 	fmt.Fprintf(w, "Selection: source=%s profiles=%s extra-tags=%s effective-tags=%s\n\n",
 		report.Source, renderSelectionValues(report.Profiles), renderSelectionValues(report.ExtraTags), renderSelectionValues(report.EffectiveTags))
+	if report.Source != selection.SourceMigration {
+		renderTagMigrations(w, report.TagMigrations)
+	}
 	if report.Delta == nil {
 		return
 	}

--- a/internal/cli/render_catalog.go
+++ b/internal/cli/render_catalog.go
@@ -61,8 +61,8 @@ func renderCatalogTagsTo(w io.Writer, tags []catalog.TagSummary) {
 		if tag.Description != "" {
 			fmt.Fprintf(w, ": %s", tag.Description)
 		}
-		if tag.ReplacedBy != "" {
-			fmt.Fprintf(w, " [replaced by: %s]", tag.ReplacedBy)
+		if len(tag.ReplacedBy) > 0 {
+			fmt.Fprintf(w, " [replaced by: %s]", catalogList(tag.ReplacedBy))
 		}
 		fmt.Fprintln(w)
 	}
@@ -258,8 +258,8 @@ func renderCatalogDetail(w io.Writer, label string, report catalog.Report, detai
 	if detail.Kind != "" {
 		fmt.Fprintf(w, "Kind: %s\n", detail.Kind)
 	}
-	if detail.ReplacedBy != "" {
-		fmt.Fprintf(w, "Replaced by: %s\n", detail.ReplacedBy)
+	if len(detail.ReplacedBy) > 0 {
+		fmt.Fprintf(w, "Replaced by: %s\n", catalogList(detail.ReplacedBy))
 	}
 	fmt.Fprintf(w, "Resolved tags: %s\n", catalogList(detail.ResolvedTags))
 	renderCatalogDependencySets(w, detail.DependencySets)

--- a/internal/cli/selection_migration.go
+++ b/internal/cli/selection_migration.go
@@ -64,7 +64,17 @@ func resolveReadOnlySelection(m manifest.Manifest, meta state.Metadata, profiles
 	// existing resolution path. In particular, malformed explicit values must
 	// still be reported by selection.ResolveReadOnly.
 	if len(profiles) > 0 || len(extraTags) > 0 || meta.InstalledSelection != nil {
-		return selection.ResolveReadOnly(m, profiles, extraTags, meta.InstalledSelection)
+		effective, err := selection.ResolveReadOnly(m, profiles, extraTags, meta.InstalledSelection)
+		if err != nil {
+			return selection.Effective{}, err
+		}
+		if effective.Report.Source == selection.SourceRecorded && len(effective.Report.TagMigrations) > 0 {
+			return selection.Effective{}, &legacyTagMigrationRequiredError{
+				migrations:         effective.Report.TagMigrations,
+				recommendedCommand: recommendedSelectionCommand("dots install", effective),
+			}
+		}
+		return effective, nil
 	}
 	if meta.Version != 1 && meta.Version != 2 {
 		return selection.ResolveReadOnly(m, profiles, extraTags, nil)

--- a/internal/cli/tag_migration.go
+++ b/internal/cli/tag_migration.go
@@ -30,7 +30,7 @@ type legacyTagMigrationRequiredError struct {
 
 func (e *legacyTagMigrationRequiredError) Error() string {
 	return legacyTagMigrationRequiredCode +
-		": recorded legacy Tag intent requires interactive confirmation; provide complete current intent with " + e.recommendedCommand
+		": recorded legacy Tag intent requires confirmation; use remediation command " + e.recommendedCommand
 }
 
 func (e *legacyTagMigrationRequiredError) JSONErrorData() any {
@@ -50,6 +50,9 @@ func guardRecordedTagMigration(cmd *cobra.Command, effective selection.Effective
 	required := &legacyTagMigrationRequiredError{
 		migrations:         effective.Report.TagMigrations,
 		recommendedCommand: explicitSelectionCommand(cmd, effective),
+	}
+	if effective.Report.Delta != nil {
+		required.recommendedCommand = cmd.Root().Name() + " " + commandName(cmd)
 	}
 	if nonInteractive || wantsJSON(cmd) {
 		return selection.Effective{}, required

--- a/internal/cli/tag_migration.go
+++ b/internal/cli/tag_migration.go
@@ -1,0 +1,110 @@
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/selection"
+)
+
+const legacyTagMigrationRequiredCode = "legacy-tag-migration-required"
+
+type legacyTagMigrationRemediation struct {
+	RecommendedCommand string `json:"recommended_command"`
+}
+
+type legacyTagMigrationErrorData struct {
+	Code          string                        `json:"code"`
+	TagMigrations []manifest.TagReplacement     `json:"tag_migrations"`
+	Remediation   legacyTagMigrationRemediation `json:"remediation"`
+}
+
+type legacyTagMigrationRequiredError struct {
+	migrations         []manifest.TagReplacement
+	recommendedCommand string
+}
+
+func (e *legacyTagMigrationRequiredError) Error() string {
+	return legacyTagMigrationRequiredCode +
+		": recorded legacy Tag intent requires interactive confirmation; provide complete current intent with " + e.recommendedCommand
+}
+
+func (e *legacyTagMigrationRequiredError) JSONErrorData() any {
+	return legacyTagMigrationErrorData{
+		Code:          legacyTagMigrationRequiredCode,
+		TagMigrations: e.migrations,
+		Remediation: legacyTagMigrationRemediation{
+			RecommendedCommand: e.recommendedCommand,
+		},
+	}
+}
+
+func guardRecordedTagMigration(cmd *cobra.Command, effective selection.Effective, nonInteractive bool) (selection.Effective, error) {
+	if effective.Report.Source != selection.SourceRecorded || len(effective.Report.TagMigrations) == 0 {
+		return effective, nil
+	}
+	required := &legacyTagMigrationRequiredError{
+		migrations:         effective.Report.TagMigrations,
+		recommendedCommand: explicitSelectionCommand(cmd, effective),
+	}
+	if nonInteractive || wantsJSON(cmd) {
+		return selection.Effective{}, required
+	}
+
+	renderTagMigrations(cmd.OutOrStdout(), effective.Report.TagMigrations)
+	confirmed, err := confirmRecordedTagMigration(cmd.InOrStdin(), cmd.OutOrStdout())
+	if err != nil {
+		return selection.Effective{}, err
+	}
+	if !confirmed {
+		return selection.Effective{}, required
+	}
+	effective.Report.Source = selection.SourceMigration
+	return effective, nil
+}
+
+func explicitSelectionCommand(cmd *cobra.Command, effective selection.Effective) string {
+	return recommendedSelectionCommand(cmd.Root().Name()+" "+commandName(cmd), effective)
+}
+
+func recommendedSelectionCommand(command string, effective selection.Effective) string {
+	parts := strings.Fields(command)
+	for _, profile := range effective.Profiles {
+		parts = append(parts, "--profile", profile)
+	}
+	for _, tag := range effective.ExtraTags {
+		parts = append(parts, "--tag", tag)
+	}
+	return strings.Join(parts, " ")
+}
+
+func renderTagMigrations(w io.Writer, migrations []manifest.TagReplacement) {
+	for _, migration := range migrations {
+		fmt.Fprintf(w, "Legacy Tag normalization: %s -> %s\n", migration.LegacyTag, strings.Join(migration.ReplacementTags, ","))
+		fmt.Fprintf(w, "Warning: Tag %q is a transitional alias; use its current replacement Tags.\n", migration.LegacyTag)
+	}
+	if len(migrations) > 0 {
+		fmt.Fprintln(w)
+	}
+}
+
+func confirmRecordedTagMigration(r io.Reader, w io.Writer) (bool, error) {
+	fmt.Fprint(w, "Migrate the recorded legacy Tag intent before continuing? [y/N] ")
+	scanner := bufio.NewScanner(r)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return false, fmt.Errorf("read legacy Tag migration confirmation: %w", err)
+		}
+		return false, nil
+	}
+	switch strings.ToLower(strings.TrimSpace(scanner.Text())) {
+	case "y", "yes":
+		return true, nil
+	default:
+		return false, nil
+	}
+}

--- a/internal/cli/testdata/envelope_catalog_compare.golden
+++ b/internal/cli/testdata/envelope_catalog_compare.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "7",
+  "schema_version": "8",
   "command": "catalog compare",
   "status": "ok",
   "data": {
@@ -45,7 +45,10 @@
         "description": "Compatibility profile",
         "kind": "surface",
         "status": "legacy",
-        "replaced_by": "core",
+        "replaced_by": [
+          "core",
+          "theme"
+        ],
         "origin": "declared"
       },
       {

--- a/internal/cli/testdata/envelope_catalog_tag.golden
+++ b/internal/cli/testdata/envelope_catalog_tag.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "7",
+  "schema_version": "8",
   "command": "catalog tag",
   "status": "ok",
   "data": {
@@ -45,7 +45,10 @@
         "description": "Compatibility profile",
         "kind": "surface",
         "status": "legacy",
-        "replaced_by": "core",
+        "replaced_by": [
+          "core",
+          "theme"
+        ],
         "origin": "declared"
       },
       {

--- a/internal/cli/testdata/envelope_catalog_why.golden
+++ b/internal/cli/testdata/envelope_catalog_why.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "7",
+  "schema_version": "8",
   "command": "catalog why",
   "status": "ok",
   "data": {
@@ -45,7 +45,10 @@
         "description": "Compatibility profile",
         "kind": "surface",
         "status": "legacy",
-        "replaced_by": "core",
+        "replaced_by": [
+          "core",
+          "theme"
+        ],
         "origin": "declared"
       },
       {

--- a/internal/cli/testdata/envelope_deps_check.golden
+++ b/internal/cli/testdata/envelope_deps_check.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "7",
+  "schema_version": "8",
   "command": "deps check",
   "status": "findings",
   "data": {

--- a/internal/cli/testdata/envelope_deps_plan.golden
+++ b/internal/cli/testdata/envelope_deps_plan.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "7",
+  "schema_version": "8",
   "command": "deps plan",
   "status": "findings",
   "data": {

--- a/internal/cli/testdata/envelope_doctor.golden
+++ b/internal/cli/testdata/envelope_doctor.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "7",
+  "schema_version": "8",
   "command": "doctor",
   "status": "findings",
   "data": {

--- a/internal/cli/testdata/envelope_install.golden
+++ b/internal/cli/testdata/envelope_install.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "7",
+  "schema_version": "8",
   "command": "install",
   "status": "ok",
   "data": {
@@ -12,6 +12,14 @@
       "extra_tags": [],
       "effective_tags": [
         "default"
+      ],
+      "tag_migrations": [
+        {
+          "legacy_tag": "legacy-default",
+          "replacement_tags": [
+            "default"
+          ]
+        }
       ],
       "change": {
         "delta": {
@@ -148,6 +156,14 @@
         "extra_tags": [],
         "effective_tags": [
           "default"
+        ],
+        "tag_migrations": [
+          {
+            "legacy_tag": "legacy-default",
+            "replacement_tags": [
+              "default"
+            ]
+          }
         ],
         "change": {
           "delta": {

--- a/internal/cli/testdata/envelope_installed.golden
+++ b/internal/cli/testdata/envelope_installed.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "7",
+  "schema_version": "8",
   "command": "installed",
   "status": "ok",
   "data": {

--- a/internal/cli/testdata/envelope_legacy_tag_migration_required.golden
+++ b/internal/cli/testdata/envelope_legacy_tag_migration_required.golden
@@ -1,0 +1,21 @@
+{
+  "schema_version": "8",
+  "command": "update",
+  "status": "error",
+  "data": {
+    "code": "legacy-tag-migration-required",
+    "tag_migrations": [
+      {
+        "legacy_tag": "core",
+        "replacement_tags": [
+          "zsh",
+          "git"
+        ]
+      }
+    ],
+    "remediation": {
+      "recommended_command": "dots update --tag zsh --tag git"
+    }
+  },
+  "error": "legacy-tag-migration-required: recorded legacy Tag intent requires interactive confirmation; provide complete current intent with dots update --tag zsh --tag git"
+}

--- a/internal/cli/testdata/envelope_legacy_tag_migration_required.golden
+++ b/internal/cli/testdata/envelope_legacy_tag_migration_required.golden
@@ -17,5 +17,5 @@
       "recommended_command": "dots update --tag zsh --tag git"
     }
   },
-  "error": "legacy-tag-migration-required: recorded legacy Tag intent requires interactive confirmation; provide complete current intent with dots update --tag zsh --tag git"
+  "error": "legacy-tag-migration-required: recorded legacy Tag intent requires confirmation; use remediation command dots update --tag zsh --tag git"
 }

--- a/internal/cli/testdata/envelope_plan.golden
+++ b/internal/cli/testdata/envelope_plan.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "7",
+  "schema_version": "8",
   "command": "plan",
   "status": "findings",
   "data": {

--- a/internal/cli/testdata/envelope_selection_migration_required.golden
+++ b/internal/cli/testdata/envelope_selection_migration_required.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "7",
+  "schema_version": "8",
   "command": "status",
   "status": "error",
   "data": {

--- a/internal/cli/testdata/envelope_status.golden
+++ b/internal/cli/testdata/envelope_status.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "7",
+  "schema_version": "8",
   "command": "status",
   "status": "findings",
   "data": {

--- a/internal/cli/testdata/envelope_uninstall.golden
+++ b/internal/cli/testdata/envelope_uninstall.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "7",
+  "schema_version": "8",
   "command": "uninstall",
   "status": "ok",
   "data": {

--- a/internal/cli/testdata/envelope_update.golden
+++ b/internal/cli/testdata/envelope_update.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "7",
+  "schema_version": "8",
   "command": "update",
   "status": "ok",
   "data": {

--- a/internal/cli/testdata/envelope_update_selection_error.golden
+++ b/internal/cli/testdata/envelope_update_selection_error.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "7",
+  "schema_version": "8",
   "command": "update",
   "status": "error",
   "data": {

--- a/internal/cli/testdata/envelope_upgrade.golden
+++ b/internal/cli/testdata/envelope_upgrade.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "7",
+  "schema_version": "8",
   "command": "upgrade",
   "status": "ok",
   "data": {

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -224,6 +224,10 @@ func runUpdateWorkflow(cmd *cobra.Command, opts updateOptions, emit bool) (updat
 		}
 		return updateReport{}, err
 	}
+	effective, err = guardRecordedTagMigration(cmd, effective, opts.yes || opts.dryRun)
+	if err != nil {
+		return updateReport{}, err
+	}
 	legacyMigrations, err := repositoryrefresh.CaptureLegacyTargets(*previousManifest, *incomingManifest, meta, paths.SourceRoot, paths.Home, paths.XDGStateHome, preRefresh.OldRev)
 	if err != nil {
 		return updateReport{}, err

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -169,6 +169,9 @@ func resolveUpdateSelection(cmd *cobra.Command, manifestPath string, paths resol
 	if err == nil && effective.Report.Source == selection.SourceExplicit {
 		effective = selection.CompareInstalled(*m, effective, meta.InstalledSelection, runtime.GOOS)
 	}
+	if err == nil {
+		effective, err = guardRecordedTagMigration(cmd, effective, opts.yes || opts.dryRun)
+	}
 	return m, effective, err
 }
 

--- a/internal/cli/update_selection_test.go
+++ b/internal/cli/update_selection_test.go
@@ -86,6 +86,165 @@ entries:
 	}
 }
 
+func TestUpdateNonInteractiveRecordedLegacyTagRequiresStructuredMigration(t *testing.T) {
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	_, sourceRoot := newInstalledRepo(t, map[string]string{
+		"configs/new": "new\n",
+		"dots.yaml": `version: 1
+tags:
+  core:
+    description: Core
+    kind: surface
+    status: current
+  new:
+    description: New capability
+    kind: surface
+    status: current
+  old:
+    description: Legacy capability
+    kind: compatibility
+    status: legacy
+    replaced_by: [new]
+profiles:
+  core:
+    tags: [core]
+entries:
+  - source: configs/new
+    target: ~/.new
+    strategy: symlink
+    tags: [new]
+`,
+	})
+	previous := state.InstalledSelection{
+		Profiles: []string{"core"}, ExtraTags: []string{"old"}, ResolvedTags: []string{"core", "old"},
+	}
+	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, InstalledSelection: &previous}); err != nil {
+		t.Fatalf("seed Installed Selection: %v", err)
+	}
+
+	var out, errOut bytes.Buffer
+	code := cli.Run([]string{
+		"update", "--yes", "--output", "json", "--file", filepath.Join(sourceRoot, "dots.yaml"),
+		"--home", home, "--source-root", sourceRoot, "--state-root", stateRoot,
+	}, &out, &errOut)
+	if code != cli.ExitError {
+		t.Fatalf("exit code = %d, want %d\nstdout:\n%s\nstderr:\n%s", code, cli.ExitError, out.String(), errOut.String())
+	}
+	for _, want := range []string{
+		`"code": "legacy-tag-migration-required"`,
+		`"legacy_tag": "old"`,
+		`"replacement_tags": [`,
+		`"recommended_command": "dots update --profile core --tag new"`,
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("JSON output missing %q:\n%s", want, out.String())
+		}
+	}
+	if _, err := os.Lstat(filepath.Join(home, ".new")); !os.IsNotExist(err) {
+		t.Fatalf("migration gate applied Managed Configuration: %v", err)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load metadata: %v", err)
+	}
+	if meta.InstalledSelection == nil || !reflect.DeepEqual(*meta.InstalledSelection, previous) {
+		t.Fatalf("InstalledSelection = %#v, want previous %#v", meta.InstalledSelection, previous)
+	}
+
+	out.Reset()
+	errOut.Reset()
+	code = cli.Run([]string{
+		"update", "--yes", "--acknowledge-selection-change", "--output", "json", "--profile", "core", "--tag", "new",
+		"--file", filepath.Join(sourceRoot, "dots.yaml"),
+		"--home", home, "--source-root", sourceRoot, "--state-root", stateRoot,
+	}, &out, &errOut)
+	if code != cli.ExitOK {
+		t.Fatalf("explicit current selection exit code = %d, want %d\nstdout:\n%s\nstderr:\n%s", code, cli.ExitOK, out.String(), errOut.String())
+	}
+	meta, err = state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load normalized metadata: %v", err)
+	}
+	if got, want := meta.InstalledSelection.ExtraTags, []string{"new"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("normalized ExtraTags = %#v, want %#v", got, want)
+	}
+}
+
+func TestUpdateInteractiveRecordedLegacyTagConfirmsAndPersistsNormalizedIntent(t *testing.T) {
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	_, sourceRoot := newInstalledRepo(t, map[string]string{
+		"configs/new": "new\n",
+		"dots.yaml": `version: 1
+tags:
+  core: {description: Core, kind: surface, status: current}
+  new: {description: New capability, kind: surface, status: current}
+  old:
+    description: Legacy capability
+    kind: compatibility
+    status: legacy
+    replaced_by: [new]
+profiles:
+  core:
+    tags: [core]
+entries:
+  - source: configs/new
+    target: ~/.new
+    strategy: symlink
+    tags: [new]
+`,
+	})
+	previous := state.InstalledSelection{
+		Profiles: []string{"core"}, ExtraTags: []string{"old"}, ResolvedTags: []string{"core", "old"},
+	}
+	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, InstalledSelection: &previous}); err != nil {
+		t.Fatalf("seed Installed Selection: %v", err)
+	}
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetIn(strings.NewReader("y\ny\n"))
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"update", "--no-tui", "--file", filepath.Join(sourceRoot, "dots.yaml"),
+		"--home", home, "--source-root", sourceRoot, "--state-root", stateRoot,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("update Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+	for _, want := range []string{
+		"Legacy Tag normalization: old -> new",
+		`Warning: Tag "old" is a transitional alias`,
+		"Selection: source=migration profiles=core extra-tags=new effective-tags=core,new",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output missing %q:\n%s", want, out.String())
+		}
+	}
+	if _, err := os.Readlink(filepath.Join(home, ".new")); err != nil {
+		t.Fatalf("confirmed migration did not apply Managed Entry: %v", err)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load metadata: %v", err)
+	}
+	if meta.InstalledSelection == nil {
+		t.Fatal("InstalledSelection = nil")
+	}
+	if got, want := meta.InstalledSelection.ExtraTags, []string{"new"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ExtraTags = %#v, want %#v", got, want)
+	}
+	if got, want := meta.InstalledSelection.ResolvedTags, []string{"core", "new"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ResolvedTags = %#v, want %#v", got, want)
+	}
+}
+
 func TestUpdatePreflightUsesSelectedManifestFile(t *testing.T) {
 	requireGitCLI(t)
 	home := t.TempDir()

--- a/internal/cli/update_selection_test.go
+++ b/internal/cli/update_selection_test.go
@@ -173,6 +173,48 @@ entries:
 	}
 }
 
+func TestUpdateExplicitLegacyTagReportsHumanMigrationEvidence(t *testing.T) {
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	_, sourceRoot := newInstalledRepo(t, map[string]string{
+		"configs/new": "new\n",
+		"dots.yaml": `version: 1
+tags:
+  new: {description: New capability, kind: surface, status: current}
+  old:
+    description: Legacy capability
+    kind: compatibility
+    status: legacy
+    replaced_by: [new]
+profiles:
+  core: {tags: [new]}
+entries:
+  - source: configs/new
+    target: ~/.new
+    strategy: symlink
+    tags: [new]
+`,
+	})
+	previous := state.InstalledSelection{ExtraTags: []string{"new"}, ResolvedTags: []string{"new"}}
+	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, InstalledSelection: &previous}); err != nil {
+		t.Fatalf("seed Installed Selection: %v", err)
+	}
+
+	out := runBareUpdate(t, "--yes", "--tag", "old", "--file", filepath.Join(sourceRoot, "dots.yaml"),
+		"--home", home, "--source-root", sourceRoot, "--state-root", stateRoot)
+	for _, want := range []string{
+		"Legacy Tag normalization: old -> new",
+		`Warning: Tag "old" is a transitional alias`,
+		"Selection: source=explicit profiles=(none) extra-tags=new effective-tags=new",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
 func TestUpdateInteractiveRecordedLegacyTagConfirmsAndPersistsNormalizedIntent(t *testing.T) {
 	home := t.TempDir()
 	stateRoot := t.TempDir()

--- a/internal/cli/update_selection_test.go
+++ b/internal/cli/update_selection_test.go
@@ -245,6 +245,131 @@ entries:
 	}
 }
 
+func TestUpdateIncomingLegacyTagRequiresConfirmationBeforeRepositoryMutation(t *testing.T) {
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	origin, sourceRoot := newInstalledRepo(t, map[string]string{
+		"configs/core": "core\n",
+		"dots.yaml": `version: 1
+tags:
+  core: {description: Core, kind: surface, status: current}
+profiles:
+  shell: {tags: [core]}
+entries:
+  - {source: configs/core, target: ~/.core, strategy: symlink, tags: [core]}
+`,
+	})
+	previous := state.InstalledSelection{ExtraTags: []string{"core"}, ResolvedTags: []string{"core"}}
+	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, InstalledSelection: &previous}); err != nil {
+		t.Fatalf("seed Installed Selection: %v", err)
+	}
+	advanceUpstream(t, origin, "replace core Tag", map[string]string{
+		"configs/zsh": "zsh\n",
+		"configs/git": "git\n",
+		"dots.yaml": `version: 1
+tags:
+  zsh: {description: Zsh, kind: surface, status: current}
+  git: {description: Git, kind: surface, status: current}
+  core:
+    description: Legacy core
+    kind: compatibility
+    status: legacy
+    replaced_by: [zsh, git]
+profiles:
+  shell: {tags: [zsh, git]}
+entries:
+  - {source: configs/zsh, target: ~/.zshrc, strategy: symlink, tags: [zsh]}
+  - {source: configs/git, target: ~/.gitconfig, strategy: symlink, tags: [git]}
+`,
+	})
+	beforeRevision := runGitOutput(t, sourceRoot, "rev-parse", "HEAD")
+
+	var out, errOut bytes.Buffer
+	code := cli.Run([]string{
+		"update", "--yes", "--output", "json", "--file", filepath.Join(sourceRoot, "dots.yaml"),
+		"--home", home, "--source-root", sourceRoot, "--state-root", stateRoot,
+	}, &out, &errOut)
+	if code != cli.ExitError {
+		t.Fatalf("exit code = %d, want %d\nstdout:\n%s\nstderr:\n%s", code, cli.ExitError, out.String(), errOut.String())
+	}
+	for _, want := range []string{`"code": "legacy-tag-migration-required"`, `"legacy_tag": "core"`, `"replacement_tags": [`, `"recommended_command": "dots update"`} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("JSON output missing %q:\n%s", want, out.String())
+		}
+	}
+	if afterRevision := runGitOutput(t, sourceRoot, "rev-parse", "HEAD"); afterRevision != beforeRevision {
+		t.Fatalf("Installed Repository advanced before migration confirmation: %s -> %s", beforeRevision, afterRevision)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load metadata: %v", err)
+	}
+	if meta.InstalledSelection == nil || !reflect.DeepEqual(*meta.InstalledSelection, previous) {
+		t.Fatalf("InstalledSelection = %#v, want previous %#v", meta.InstalledSelection, previous)
+	}
+
+	out.Reset()
+	errOut.Reset()
+	code = cli.Run([]string{
+		"update", "--dry-run", "--output", "json", "--file", filepath.Join(sourceRoot, "dots.yaml"),
+		"--home", home, "--source-root", sourceRoot, "--state-root", stateRoot,
+	}, &out, &errOut)
+	if code != cli.ExitError || !strings.Contains(out.String(), `"recommended_command": "dots update"`) {
+		t.Fatalf("dry-run migration = code %d\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
+	}
+	if afterRevision := runGitOutput(t, sourceRoot, "rev-parse", "HEAD"); afterRevision != beforeRevision {
+		t.Fatalf("dry-run advanced Installed Repository: %s -> %s", beforeRevision, afterRevision)
+	}
+
+	cmd := cli.NewRootCommand()
+	out.Reset()
+	cmd.SetIn(strings.NewReader("n\n"))
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"update", "--no-tui", "--file", filepath.Join(sourceRoot, "dots.yaml"),
+		"--home", home, "--source-root", sourceRoot, "--state-root", stateRoot,
+	})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), legacyTagMigrationCodeForTest) {
+		t.Fatalf("declined incoming migration error = %v\noutput:\n%s", err, out.String())
+	}
+	if afterRevision := runGitOutput(t, sourceRoot, "rev-parse", "HEAD"); afterRevision != beforeRevision {
+		t.Fatalf("declined migration advanced Installed Repository: %s -> %s", beforeRevision, afterRevision)
+	}
+	meta, err = state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load metadata after decline: %v", err)
+	}
+	if meta.InstalledSelection == nil || !reflect.DeepEqual(*meta.InstalledSelection, previous) {
+		t.Fatalf("InstalledSelection after decline = %#v, want previous %#v", meta.InstalledSelection, previous)
+	}
+
+	cmd = cli.NewRootCommand()
+	out.Reset()
+	cmd.SetIn(strings.NewReader("y\ny\n"))
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"update", "--no-tui", "--file", filepath.Join(sourceRoot, "dots.yaml"),
+		"--home", home, "--source-root", sourceRoot, "--state-root", stateRoot,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("confirmed incoming migration error = %v\noutput:\n%s", err, out.String())
+	}
+	if !strings.Contains(out.String(), "Legacy Tag normalization: core -> zsh,git") {
+		t.Fatalf("confirmed incoming migration output missing evidence:\n%s", out.String())
+	}
+	meta, err = state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load migrated metadata: %v", err)
+	}
+	if got, want := meta.InstalledSelection.ExtraTags, []string{"zsh", "git"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("migrated ExtraTags = %#v, want %#v", got, want)
+	}
+}
+
 func TestUpdatePreflightUsesSelectedManifestFile(t *testing.T) {
 	requireGitCLI(t)
 	home := t.TempDir()

--- a/internal/cli/upgrade_test.go
+++ b/internal/cli/upgrade_test.go
@@ -180,6 +180,68 @@ entries:
 	}
 }
 
+func TestUpgradeContinuePreservesExplicitLegacyTagEvidence(t *testing.T) {
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	_, sourceRoot := newInstalledRepo(t, map[string]string{
+		"configs/new": "new\n",
+		"dots.yaml": `version: 1
+tags:
+  new: {description: New capability, kind: surface, status: current}
+  old:
+    description: Legacy capability
+    kind: compatibility
+    status: legacy
+    replaced_by: [new]
+profiles:
+  core: {tags: [new]}
+entries:
+  - source: configs/new
+    target: ~/.new
+    strategy: symlink
+    tags: [new]
+`,
+	})
+	previous := state.InstalledSelection{ExtraTags: []string{"new"}, ResolvedTags: []string{"new"}}
+	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, InstalledSelection: &previous}); err != nil {
+		t.Fatalf("seed Installed Selection: %v", err)
+	}
+
+	baseArgs := []string{
+		"upgrade", "--continue", "--yes", "--selection-source", "explicit", "--selection-tag", "old",
+		"--file", filepath.Join(sourceRoot, "dots.yaml"), "--home", home,
+		"--source-root", sourceRoot, "--state-root", stateRoot,
+	}
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(baseArgs)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("human continuation error = %v\noutput:\n%s", err, out.String())
+	}
+	for _, want := range []string{"Legacy Tag normalization: old -> new", `Warning: Tag "old" is a transitional alias`} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("human continuation missing %q:\n%s", want, out.String())
+		}
+	}
+
+	out.Reset()
+	cmd = cli.NewRootCommand()
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(append(baseArgs, "--output", "json"))
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("JSON continuation error = %v\noutput:\n%s", err, out.String())
+	}
+	for _, want := range []string{`"command": "upgrade"`, `"legacy_tag": "old"`, `"replacement_tags": [`, `"new"`} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("JSON continuation missing %q:\n%s", want, out.String())
+		}
+	}
+}
+
 func TestUpgradeContinueJSONEmitsUpgradeReportWithBinaryPhase(t *testing.T) {
 	requireGitCLI(t)
 	home := t.TempDir()

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -35,14 +35,49 @@ type Profile struct {
 	Tags        []string `yaml:"tags"`
 }
 
+// ReplacementTags is the ordered set of current Tags that supersede a legacy
+// Tag. It accepts the historical scalar YAML form as a one-item set while JSON
+// always represents it as an array.
+type ReplacementTags []string
+
+// UnmarshalYAML accepts both the historical scalar spelling and the current
+// ordered sequence spelling of replaced_by.
+func (r *ReplacementTags) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.ScalarNode:
+		var replacement string
+		if err := value.Decode(&replacement); err != nil {
+			return fmt.Errorf("decode replacement tag: %w", err)
+		}
+		*r = ReplacementTags{replacement}
+		return nil
+	case yaml.SequenceNode:
+		var replacements []string
+		if err := value.Decode(&replacements); err != nil {
+			return fmt.Errorf("decode replacement tags: %w", err)
+		}
+		*r = replacements
+		return nil
+	default:
+		return fmt.Errorf("replacement tags must be a tag or a sequence of tags")
+	}
+}
+
 // Tag describes a declared selection tag. The registry is optional for v1
 // compatibility; when present, every tag referenced by the manifest must be
 // declared here.
 type Tag struct {
-	Description string `yaml:"description,omitempty"`
-	Kind        string `yaml:"kind"`
-	Status      string `yaml:"status"`
-	ReplacedBy  string `yaml:"replaced_by,omitempty"`
+	Description string          `yaml:"description,omitempty"`
+	Kind        string          `yaml:"kind"`
+	Status      string          `yaml:"status"`
+	ReplacedBy  ReplacementTags `yaml:"replaced_by,omitempty"`
+}
+
+// TagReplacement records one legacy Tag expansion applied during selection
+// normalization.
+type TagReplacement struct {
+	LegacyTag       string   `json:"legacy_tag"`
+	ReplacementTags []string `json:"replacement_tags"`
 }
 
 type Entry struct {
@@ -699,18 +734,28 @@ func (m Manifest) validateTagRegistry() error {
 		if !tagpolicy.IsAllowedStatus(tag.Status) {
 			return fmt.Errorf("tags[%q].status must be one of current, legacy", name)
 		}
-		if tag.ReplacedBy == "" {
-			continue
+		if tag.Status == "legacy" && len(tag.ReplacedBy) == 0 {
+			return fmt.Errorf("tags[%q].replaced_by must contain at least one current tag", name)
 		}
-		if tag.Status != "legacy" {
+		if tag.Status != "legacy" && len(tag.ReplacedBy) > 0 {
 			return fmt.Errorf("tags[%q].replaced_by requires status legacy", name)
 		}
-		replacement, ok := m.Tags[tag.ReplacedBy]
-		if !ok {
-			return fmt.Errorf("tags[%q].replaced_by %q is not declared", name, tag.ReplacedBy)
-		}
-		if replacement.Status != "current" {
-			return fmt.Errorf("tags[%q].replaced_by %q must reference a current tag", name, tag.ReplacedBy)
+		replacementSeen := make(map[string]bool, len(tag.ReplacedBy))
+		for i, replacementName := range tag.ReplacedBy {
+			if strings.TrimSpace(replacementName) == "" {
+				return fmt.Errorf("tags[%q].replaced_by[%d] must not be empty", name, i)
+			}
+			if replacementSeen[replacementName] {
+				return fmt.Errorf("tags[%q].replaced_by[%d] duplicates %q", name, i, replacementName)
+			}
+			replacementSeen[replacementName] = true
+			replacement, ok := m.Tags[replacementName]
+			if !ok {
+				return fmt.Errorf("tags[%q].replaced_by %q is not declared", name, replacementName)
+			}
+			if replacement.Status != "current" {
+				return fmt.Errorf("tags[%q].replaced_by %q must reference a current tag", name, replacementName)
+			}
 		}
 	}
 	return nil
@@ -1027,14 +1072,59 @@ func containsControl(value string) bool {
 	return strings.ContainsFunc(value, unicode.IsControl)
 }
 
-// Selection describes the ordered Profile and Tag union selected by a command.
+// Selection describes the ordered Profile and normalized current Tag union
+// selected by a command.
 // Profiles preserves the user-supplied Profile order after de-duplication; Tags
 // preserves the ordered union of all selected Profile tags plus explicit --tag
 // values. Profile is a compatibility label for existing metadata and prose.
 type Selection struct {
-	Profile  string
-	Profiles []string
-	Tags     []string
+	Profile      string
+	Profiles     []string
+	Tags         []string
+	Replacements []TagReplacement
+}
+
+// NormalizeTags resolves legacy aliases to current Tags and returns migration
+// evidence in first-use order. Both the resulting Tags and evidence are
+// de-duplicated without changing input or declaration order.
+func NormalizeTags(m Manifest, tags []string) ([]string, []TagReplacement, error) {
+	normalized := make([]string, 0, len(tags))
+	seen := make(map[string]bool, len(tags))
+	add := func(tag string) {
+		if seen[tag] {
+			return
+		}
+		seen[tag] = true
+		normalized = append(normalized, tag)
+	}
+
+	replacements := make([]TagReplacement, 0)
+	legacySeen := make(map[string]bool)
+	for _, name := range tags {
+		if m.Tags == nil {
+			add(name)
+			continue
+		}
+		tag, ok := m.Tags[name]
+		if !ok {
+			return nil, nil, fmt.Errorf("tag %q is not declared", name)
+		}
+		if tag.Status != "legacy" {
+			add(name)
+			continue
+		}
+		if !legacySeen[name] {
+			legacySeen[name] = true
+			replacements = append(replacements, TagReplacement{
+				LegacyTag:       name,
+				ReplacementTags: append([]string(nil), tag.ReplacedBy...),
+			})
+		}
+		for _, replacement := range tag.ReplacedBy {
+			add(replacement)
+		}
+	}
+	return normalized, replacements, nil
 }
 
 // SelectedProfileNames returns the repeatable profile list when present, or the
@@ -1049,9 +1139,9 @@ func SelectedProfileNames(profile string, profiles []string) []string {
 	return []string{profile}
 }
 
-// ResolveSelection validates selected Profile names and returns their ordered,
-// de-duplicated tag union. Repository manifests without a legacy default Profile
-// require an explicit Profile so install never falls back to an implicit baseline.
+// ResolveSelection validates selected Profile and Tag names and returns their
+// ordered, de-duplicated current Tag union. A legacy default Profile is inferred
+// only when neither Profiles nor explicit Tags supply selection intent.
 func ResolveSelection(m Manifest, profileNames []string, extraTags []string) (Selection, error) {
 	return resolveSelection(m, profileNames, extraTags, true)
 }
@@ -1089,7 +1179,7 @@ func resolveSelection(m Manifest, profileNames []string, extraTags []string, all
 			addTag(tag)
 		}
 	}
-	if len(profiles) == 0 && allowDefault {
+	if len(profileNames) == 0 && len(extraTags) == 0 && allowDefault {
 		if profile, ok := m.Profiles["default"]; ok {
 			profiles = append(profiles, "default")
 			for _, tag := range profile.Tags {
@@ -1107,7 +1197,11 @@ func resolveSelection(m Manifest, profileNames []string, extraTags []string, all
 		}
 		addTag(tag)
 	}
-	return Selection{Profile: strings.Join(profiles, ","), Profiles: profiles, Tags: tags}, nil
+	normalizedTags, replacements, err := NormalizeTags(m, tags)
+	if err != nil {
+		return Selection{}, err
+	}
+	return Selection{Profile: strings.Join(profiles, ","), Profiles: profiles, Tags: normalizedTags, Replacements: replacements}, nil
 }
 
 // MatchesOS reports whether an item's OS filter admits the current OS. An empty

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -63,7 +63,7 @@ tags:
     description: old baseline selector
     kind: surface
     status: legacy
-    replaced_by: core
+    replaced_by: [core, agents]
   agents:
     description: retire Gentle AI state
     kind: surface
@@ -94,8 +94,17 @@ provisioners:
 	if got.Profiles["default"].Description != "default workstation" || got.Profiles["default"].Status != "current" {
 		t.Fatalf("Profile = %#v, want description and status", got.Profiles["default"])
 	}
-	if got.Tags["legacy-core"].ReplacedBy != "core" {
+	if want := []string{"core", "agents"}; !reflect.DeepEqual([]string(got.Tags["legacy-core"].ReplacedBy), want) {
 		t.Fatalf("legacy tag = %#v, want replacement", got.Tags["legacy-core"])
+	}
+
+	scalar := strings.Replace(valid, "replaced_by: [core, agents]", "replaced_by: core", 1)
+	got, err = manifest.Parse([]byte(scalar))
+	if err != nil {
+		t.Fatalf("Parse() scalar replacement error = %v", err)
+	}
+	if want := []string{"core"}; !reflect.DeepEqual([]string(got.Tags["legacy-core"].ReplacedBy), want) {
+		t.Fatalf("scalar legacy tag = %#v, want replacement %#v", got.Tags["legacy-core"], want)
 	}
 
 	tests := []struct {
@@ -109,8 +118,12 @@ provisioners:
 		{"override key", strings.Replace(valid, "source_overrides: {legacy-core:", "source_overrides: {missing:", 1), `entries[0].source_overrides[0] tag "missing" is not declared`},
 		{"provisioner reference", strings.Replace(valid, "    tags: [agents]\n    spec:", "    tags: [missing]\n    spec:", 1), `provisioners[0].tags[0] tag "missing" is not declared`},
 		{"invalid kind", strings.Replace(valid, "kind: surface", "kind: command", 1), `tags["core"].kind must be one of surface, cleanup, compatibility`},
+		{"legacy missing replacement", strings.Replace(valid, "    replaced_by: [core, agents]\n", "", 1), `tags["legacy-core"].replaced_by must contain at least one current tag`},
+		{"empty replacement", strings.Replace(valid, "replaced_by: [core, agents]", `replaced_by: [core, ""]`, 1), `tags["legacy-core"].replaced_by[1] must not be empty`},
+		{"duplicate replacement", strings.Replace(valid, "replaced_by: [core, agents]", "replaced_by: [core, core]", 1), `tags["legacy-core"].replaced_by[1] duplicates "core"`},
 		{"replacement source current", strings.Replace(valid, "status: legacy\n    replaced_by", "status: current\n    replaced_by", 1), `tags["legacy-core"].replaced_by requires status legacy`},
-		{"replacement target legacy", strings.Replace(valid, "status: current", "status: legacy", 1), `tags["legacy-core"].replaced_by "core" must reference a current tag`},
+		{"replacement target undeclared", strings.Replace(valid, "replaced_by: [core, agents]", "replaced_by: [missing]", 1), `tags["legacy-core"].replaced_by "missing" is not declared`},
+		{"replacement target legacy chain", strings.Replace(valid, "    status: current\n  legacy-core:", "    status: legacy\n    replaced_by: agents\n  legacy-core:", 1), `tags["legacy-core"].replaced_by "core" must reference a current tag`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -3817,6 +3830,60 @@ func TestResolveSelectionComposesProfilesInOrder(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got.Tags, []string{"core", "agents", "web", "sdd"}) {
 		t.Fatalf("Tags = %#v", got.Tags)
+	}
+}
+
+func TestNormalizeTagsExpandsLegacyAliasesInDeclaredOrder(t *testing.T) {
+	m := manifest.Manifest{Tags: map[string]manifest.Tag{
+		"core":       {Kind: "surface", Status: "current"},
+		"agents":     {Kind: "surface", Status: "current"},
+		"web":        {Kind: "surface", Status: "current"},
+		"legacy":     {Kind: "compatibility", Status: "legacy", ReplacedBy: manifest.ReplacementTags{"core", "agents"}},
+		"legacy-web": {Kind: "compatibility", Status: "legacy", ReplacedBy: manifest.ReplacementTags{"agents", "web"}},
+	}}
+
+	tags, replacements, err := manifest.NormalizeTags(m, []string{"legacy", "agents", "legacy", "legacy-web", "core"})
+	if err != nil {
+		t.Fatalf("NormalizeTags() error = %v", err)
+	}
+	if want := []string{"core", "agents", "web"}; !reflect.DeepEqual(tags, want) {
+		t.Fatalf("tags = %#v, want %#v", tags, want)
+	}
+	wantReplacements := []manifest.TagReplacement{
+		{LegacyTag: "legacy", ReplacementTags: []string{"core", "agents"}},
+		{LegacyTag: "legacy-web", ReplacementTags: []string{"agents", "web"}},
+	}
+	if !reflect.DeepEqual(replacements, wantReplacements) {
+		t.Fatalf("replacements = %#v, want %#v", replacements, wantReplacements)
+	}
+
+	if _, _, err := manifest.NormalizeTags(m, []string{"missing"}); err == nil || err.Error() != `tag "missing" is not declared` {
+		t.Fatalf("NormalizeTags(missing) error = %v", err)
+	}
+}
+
+func TestResolveSelectionAllowsTagsWithoutInferringDefaultAndNormalizesAliases(t *testing.T) {
+	m := manifest.Manifest{
+		Tags: map[string]manifest.Tag{
+			"core":   {Kind: "surface", Status: "current"},
+			"agents": {Kind: "surface", Status: "current"},
+			"legacy": {Kind: "compatibility", Status: "legacy", ReplacedBy: manifest.ReplacementTags{"core", "agents"}},
+		},
+		Profiles: map[string]manifest.Profile{"default": {Tags: []string{"core"}}},
+	}
+
+	got, err := manifest.ResolveSelection(m, nil, []string{"legacy", "core"})
+	if err != nil {
+		t.Fatalf("ResolveSelection() error = %v", err)
+	}
+	if len(got.Profiles) != 0 || got.Profile != "" {
+		t.Fatalf("Profiles = %#v, want no inferred default", got.Profiles)
+	}
+	if want := []string{"core", "agents"}; !reflect.DeepEqual(got.Tags, want) {
+		t.Fatalf("Tags = %#v, want %#v", got.Tags, want)
+	}
+	if want := []manifest.TagReplacement{{LegacyTag: "legacy", ReplacementTags: []string{"core", "agents"}}}; !reflect.DeepEqual(got.Replacements, want) {
+		t.Fatalf("Replacements = %#v, want %#v", got.Replacements, want)
 	}
 }
 

--- a/internal/selection/selection.go
+++ b/internal/selection/selection.go
@@ -97,6 +97,11 @@ type Effective struct {
 	ExtraTags []string
 	Selection manifest.Selection
 	Report    Report
+
+	// intentExtraTags preserves the authoritative pre-normalization input for
+	// repository evolution and binary continuation. Persisted ExtraTags remain
+	// normalized current Tags.
+	intentExtraTags []string
 }
 
 // Intent is the authoritative Profile and explicit extra Tag input together
@@ -151,8 +156,9 @@ func ResolveIntent(m manifest.Manifest, intent Intent) (Effective, error) {
 	orderedExtraTags := orderedUnique(normalizedExtraTags)
 	effectiveTags := cloneStrings(resolved.Tags)
 	return Effective{
-		Profiles:  cloneStrings(orderedProfiles),
-		ExtraTags: cloneStrings(orderedExtraTags),
+		Profiles:        cloneStrings(orderedProfiles),
+		ExtraTags:       cloneStrings(orderedExtraTags),
+		intentExtraTags: cloneStrings(intent.ExtraTags),
 		Selection: manifest.Selection{
 			Profile:      resolved.Profile,
 			Profiles:     cloneStrings(orderedProfiles),
@@ -171,10 +177,14 @@ func ResolveIntent(m manifest.Manifest, intent Intent) (Effective, error) {
 
 // Intent returns a detached copy of the authoritative inputs used to build e.
 func (e Effective) Intent() Intent {
+	extraTags := e.intentExtraTags
+	if extraTags == nil {
+		extraTags = e.ExtraTags
+	}
 	return Intent{
 		Source:    e.Report.Source,
 		Profiles:  cloneStrings(e.Profiles),
-		ExtraTags: cloneStrings(e.ExtraTags),
+		ExtraTags: cloneStrings(extraTags),
 	}
 }
 

--- a/internal/selection/selection.go
+++ b/internal/selection/selection.go
@@ -195,6 +195,7 @@ func CompareEvolution(previousManifest, currentManifest manifest.Manifest, previ
 		if err != nil {
 			return Effective{}, err
 		}
+		current.Report.TagMigrations = mergeTagReplacements(previous.Report.TagMigrations, current.Report.TagMigrations)
 		delta.Current = snapshot(current)
 		previousSurface := selectedSurface(previousManifest, previous.Selection, osName)
 		currentSurface := selectedSurface(currentManifest, current.Selection, osName)
@@ -528,6 +529,25 @@ func cloneTagReplacements(values []manifest.TagReplacement) []manifest.TagReplac
 		result[i] = manifest.TagReplacement{
 			LegacyTag:       replacement.LegacyTag,
 			ReplacementTags: cloneStrings(replacement.ReplacementTags),
+		}
+	}
+	return result
+}
+
+func mergeTagReplacements(groups ...[]manifest.TagReplacement) []manifest.TagReplacement {
+	var result []manifest.TagReplacement
+	seen := make(map[string]bool)
+	for _, values := range groups {
+		for _, replacement := range values {
+			key := replacement.LegacyTag + "\x00" + strings.Join(replacement.ReplacementTags, "\x00")
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			result = append(result, manifest.TagReplacement{
+				LegacyTag:       replacement.LegacyTag,
+				ReplacementTags: cloneStrings(replacement.ReplacementTags),
+			})
 		}
 	}
 	return result

--- a/internal/selection/selection.go
+++ b/internal/selection/selection.go
@@ -28,12 +28,13 @@ var ErrSelectionRequired = errors.New("selection required: provide --profile or 
 // Report is the stable, portable description of the selection used by a
 // command.
 type Report struct {
-	Source        Source   `json:"source"`
-	Profiles      []string `json:"profiles"`
-	ExtraTags     []string `json:"extra_tags"`
-	EffectiveTags []string `json:"effective_tags"`
-	Delta         *Delta   `json:"delta,omitempty"`
-	Change        *Change  `json:"change,omitempty"`
+	Source        Source                    `json:"source"`
+	Profiles      []string                  `json:"profiles"`
+	ExtraTags     []string                  `json:"extra_tags"`
+	EffectiveTags []string                  `json:"effective_tags"`
+	TagMigrations []manifest.TagReplacement `json:"tag_migrations,omitempty"`
+	Delta         *Delta                    `json:"delta,omitempty"`
+	Change        *Change                   `json:"change,omitempty"`
 }
 
 // Snapshot is the portable selection state on one side of an evolution.
@@ -141,23 +142,29 @@ func ResolveIntent(m manifest.Manifest, intent Intent) (Effective, error) {
 	if err != nil {
 		return Effective{}, fmt.Errorf("%s selection: %w", intent.Source, err)
 	}
+	normalizedExtraTags, _, err := manifest.NormalizeTags(m, intent.ExtraTags)
+	if err != nil {
+		return Effective{}, fmt.Errorf("%s selection: %w", intent.Source, err)
+	}
 
 	orderedProfiles := cloneStrings(resolved.Profiles)
-	orderedExtraTags := orderedUnique(intent.ExtraTags)
+	orderedExtraTags := orderedUnique(normalizedExtraTags)
 	effectiveTags := cloneStrings(resolved.Tags)
 	return Effective{
 		Profiles:  cloneStrings(orderedProfiles),
 		ExtraTags: cloneStrings(orderedExtraTags),
 		Selection: manifest.Selection{
-			Profile:  resolved.Profile,
-			Profiles: cloneStrings(orderedProfiles),
-			Tags:     cloneStrings(effectiveTags),
+			Profile:      resolved.Profile,
+			Profiles:     cloneStrings(orderedProfiles),
+			Tags:         cloneStrings(effectiveTags),
+			Replacements: cloneTagReplacements(resolved.Replacements),
 		},
 		Report: Report{
 			Source:        intent.Source,
 			Profiles:      orderedProfiles,
 			ExtraTags:     orderedExtraTags,
 			EffectiveTags: effectiveTags,
+			TagMigrations: cloneTagReplacements(resolved.Replacements),
 		},
 	}, nil
 }
@@ -459,7 +466,11 @@ func Resolve(m manifest.Manifest, profiles, extraTags []string) (state.Installed
 	if err != nil {
 		return state.InstalledSelection{}, err
 	}
-	return installedSelection(resolved.Profiles, extraTags, resolved.Tags), nil
+	normalizedExtraTags, _, err := manifest.NormalizeTags(m, extraTags)
+	if err != nil {
+		return state.InstalledSelection{}, err
+	}
+	return installedSelection(resolved.Profiles, normalizedExtraTags, resolved.Tags), nil
 }
 
 // InstalledSelection converts effective command selection into the
@@ -506,4 +517,18 @@ func orderedUnique(values []string) []string {
 
 func cloneStrings(values []string) []string {
 	return append(make([]string, 0, len(values)), values...)
+}
+
+func cloneTagReplacements(values []manifest.TagReplacement) []manifest.TagReplacement {
+	if len(values) == 0 {
+		return nil
+	}
+	result := make([]manifest.TagReplacement, len(values))
+	for i, replacement := range values {
+		result[i] = manifest.TagReplacement{
+			LegacyTag:       replacement.LegacyTag,
+			ReplacementTags: cloneStrings(replacement.ReplacementTags),
+		}
+	}
+	return result
 }

--- a/internal/selection/selection_test.go
+++ b/internal/selection/selection_test.go
@@ -437,8 +437,12 @@ func TestCompareEvolutionUsesTagRegistryForStaleExtraTags(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResolveIntent() error = %v", err)
 	}
-	if _, err := selection.CompareEvolution(m, m, previous, "linux"); err != nil {
+	evolved, err := selection.CompareEvolution(m, m, previous, "linux")
+	if err != nil {
 		t.Fatalf("CompareEvolution() error = %v, want declared legacy tag to remain selectable", err)
+	}
+	if want := []manifest.TagReplacement{{LegacyTag: "legacy-option", ReplacementTags: []string{"core"}}}; !reflect.DeepEqual(evolved.Report.TagMigrations, want) {
+		t.Fatalf("TagMigrations = %#v, want preserved evidence %#v", evolved.Report.TagMigrations, want)
 	}
 
 	_, err = selection.ResolveIntent(m, selection.Intent{

--- a/internal/selection/selection_test.go
+++ b/internal/selection/selection_test.go
@@ -426,7 +426,7 @@ func TestCompareEvolutionUsesTagRegistryForStaleExtraTags(t *testing.T) {
 	m := manifest.Manifest{
 		Tags: map[string]manifest.Tag{
 			"core":          {Kind: "surface", Status: "current"},
-			"legacy-option": {Kind: "compatibility", Status: "legacy", ReplacedBy: "core"},
+			"legacy-option": {Kind: "compatibility", Status: "legacy", ReplacedBy: manifest.ReplacementTags{"core"}},
 		},
 		Profiles: map[string]manifest.Profile{"core": {Tags: []string{"core"}}},
 		Entries:  []manifest.Entry{{Target: ".core", Tags: []string{"core"}}},
@@ -557,6 +557,120 @@ func TestResolveReadOnlyRecomputesRecordedSelection(t *testing.T) {
 	if want := []string{"shared", "extra"}; !reflect.DeepEqual(got.ExtraTags, want) {
 		t.Fatalf("ExtraTags = %#v, want %#v", got.ExtraTags, want)
 	}
+}
+
+func TestResolveIntentNormalizesLegacyExtraTagsBeforeSelection(t *testing.T) {
+	m := loadSelectionManifest(t, `version: 1
+tags:
+  core:
+    kind: surface
+    status: current
+  shell:
+    kind: surface
+    status: current
+  legacy-shell:
+    kind: compatibility
+    status: legacy
+    replaced_by: [core, shell]
+profiles:
+  core:
+    tags: [core]
+entries:
+  - source: shell
+    target: .shell
+    strategy: copy
+    tags: [shell]
+`)
+
+	got, err := selection.ResolveIntent(m, selection.Intent{
+		Source:    selection.SourceExplicit,
+		Profiles:  []string{"core"},
+		ExtraTags: []string{"legacy-shell", "shell", "legacy-shell", "core"},
+	})
+	if err != nil {
+		t.Fatalf("ResolveIntent() error = %v", err)
+	}
+	if want := []string{"core", "shell"}; !reflect.DeepEqual(got.ExtraTags, want) {
+		t.Fatalf("ExtraTags = %#v, want normalized current Tags %#v", got.ExtraTags, want)
+	}
+	if want := []string{"core", "shell"}; !reflect.DeepEqual(got.Selection.Tags, want) {
+		t.Fatalf("Selection Tags = %#v, want normalized current Tags %#v", got.Selection.Tags, want)
+	}
+	if want := []string{"core", "shell"}; !reflect.DeepEqual(got.Report.EffectiveTags, want) {
+		t.Fatalf("EffectiveTags = %#v, want normalized current Tags %#v", got.Report.EffectiveTags, want)
+	}
+
+	installed := got.InstalledSelection(state.Provenance{})
+	if want := []string{"core", "shell"}; !reflect.DeepEqual(installed.ExtraTags, want) {
+		t.Fatalf("Installed ExtraTags = %#v, want normalized current Tags %#v", installed.ExtraTags, want)
+	}
+	if want := []string{"core", "shell"}; !reflect.DeepEqual(installed.ResolvedTags, want) {
+		t.Fatalf("Installed ResolvedTags = %#v, want normalized current Tags %#v", installed.ResolvedTags, want)
+	}
+
+	reportJSON, err := json.Marshal(got.Report)
+	if err != nil {
+		t.Fatalf("json.Marshal(Report) error = %v", err)
+	}
+	wantEvidence := `"tag_migrations":[{"legacy_tag":"legacy-shell","replacement_tags":["core","shell"]}]`
+	if !strings.Contains(string(reportJSON), wantEvidence) {
+		t.Fatalf("Report JSON = %s, want deterministic evidence %s", reportJSON, wantEvidence)
+	}
+}
+
+func TestResolveIntentNormalizesRecordedLegacyExtraTags(t *testing.T) {
+	m := loadSelectionManifest(t, `version: 1
+tags:
+  current:
+    kind: surface
+    status: current
+  legacy:
+    kind: compatibility
+    status: legacy
+    replaced_by: [current]
+profiles:
+  current:
+    tags: [current]
+entries:
+  - source: current
+    target: .current
+    strategy: copy
+    tags: [current]
+`)
+
+	got, err := selection.ResolveIntent(m, selection.Intent{
+		Source:    selection.SourceRecorded,
+		ExtraTags: []string{"legacy", "current", "legacy"},
+	})
+	if err != nil {
+		t.Fatalf("ResolveIntent() error = %v", err)
+	}
+	if got.Report.Source != selection.SourceRecorded {
+		t.Fatalf("Source = %q, want %q", got.Report.Source, selection.SourceRecorded)
+	}
+	if want := []string{"current"}; !reflect.DeepEqual(got.ExtraTags, want) {
+		t.Fatalf("ExtraTags = %#v, want %#v", got.ExtraTags, want)
+	}
+	reportJSON, err := json.Marshal(got.Report)
+	if err != nil {
+		t.Fatalf("json.Marshal(Report) error = %v", err)
+	}
+	if count := strings.Count(string(reportJSON), `"legacy_tag":"legacy"`); count != 1 {
+		t.Fatalf("Report JSON = %s, want one deduplicated legacy migration", reportJSON)
+	}
+}
+
+func loadSelectionManifest(t *testing.T, source string) manifest.Manifest {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "dots.yaml")
+	if err := os.WriteFile(path, []byte(source), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	m, err := manifest.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+	return *m
 }
 
 func TestResolveReadOnlyRequiresInvocationOrRecordedSelection(t *testing.T) {

--- a/internal/selection/selection_test.go
+++ b/internal/selection/selection_test.go
@@ -498,23 +498,17 @@ func TestResolveReadOnlyExplicitSelectionWinsCompletely(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResolveReadOnly() error = %v", err)
 	}
-	want := selection.Effective{
-		Profiles:  []string{"web"},
-		ExtraTags: []string{"explicit"},
-		Selection: manifest.Selection{
-			Profile:  "web",
-			Profiles: []string{"web"},
-			Tags:     []string{"web", "explicit"},
-		},
-		Report: selection.Report{
-			Source:        selection.SourceExplicit,
-			Profiles:      []string{"web"},
-			ExtraTags:     []string{"explicit"},
-			EffectiveTags: []string{"web", "explicit"},
-		},
+	if want := []string{"web"}; !reflect.DeepEqual(got.Profiles, want) {
+		t.Fatalf("Profiles = %#v, want %#v", got.Profiles, want)
 	}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("ResolveReadOnly() = %#v, want %#v", got, want)
+	if want := []string{"explicit"}; !reflect.DeepEqual(got.ExtraTags, want) {
+		t.Fatalf("ExtraTags = %#v, want %#v", got.ExtraTags, want)
+	}
+	if want := []string{"web", "explicit"}; !reflect.DeepEqual(got.Selection.Tags, want) || !reflect.DeepEqual(got.Report.EffectiveTags, want) {
+		t.Fatalf("effective Tags = selection %#v report %#v, want %#v", got.Selection.Tags, got.Report.EffectiveTags, want)
+	}
+	if got.Report.Source != selection.SourceExplicit {
+		t.Fatalf("Source = %q, want %q", got.Report.Source, selection.SourceExplicit)
 	}
 }
 
@@ -602,6 +596,9 @@ entries:
 	}
 	if want := []string{"core", "shell"}; !reflect.DeepEqual(got.Report.EffectiveTags, want) {
 		t.Fatalf("EffectiveTags = %#v, want normalized current Tags %#v", got.Report.EffectiveTags, want)
+	}
+	if want := []string{"legacy-shell", "shell", "legacy-shell", "core"}; !reflect.DeepEqual(got.Intent().ExtraTags, want) {
+		t.Fatalf("Intent ExtraTags = %#v, want original ordered input %#v", got.Intent().ExtraTags, want)
 	}
 
 	installed := got.InstalledSelection(state.Provenance{})


### PR DESCRIPTION
Closes #460

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Supports ordered one-to-many legacy Tag replacements with validation and deterministic normalization evidence.
- Makes explicit Tag-only installation a complete selection and persists only normalized current Tags after terminal success.
- Guards recorded legacy intent across update/upgrade, including incoming-manifest transitions and binary continuation, with confirmation or structured remediation.

## Changes

| File | Change |
|------|--------|
| `internal/manifest`, `internal/catalog` | Parse, validate, normalize, and render ordered replacement Tags while retaining scalar YAML compatibility. |
| `internal/selection` | Normalize aliases before Selected Surface evaluation, preserve ordered migration evidence through evolution, and keep pre-normalization intent only for continuation. |
| `internal/cli` | Enable Tag-only install, add human/JSON migration reporting and confirmation, protect mutation boundaries, and preserve evidence across update/upgrade. |
| `docs/manifest.md`, `docs/agents/output-contract.md` | Document replacement arrays, schema v8, `source=migration`, and `legacy-tag-migration-required`. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go build ./...`
- [x] `go generate ./internal/catalog` (no generated drift)
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan/install using an explicit legacy Tag verified ordered normalization, transitional warning, JSON evidence, normalized Installed Selection, and no-intent pre-mutation failure.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit `--home`, `--source-root`, and `--state-root` values.

## Delivery Evidence

### Contract Source snapshot

- Primary issue: #460, node `I_kwDOSzLlmM8AAAABNwYtUQ`, state `OPEN`, updated `2026-08-21T20:58:40Z`, body SHA-256 `6a7cea51cd9e70c4a655cdd5df313a9698de6c48394162bc2c7d2e81f6771dfa`.
- Parent specification: #458, node `I_kwDOSzLlmM8AAAABNwWsDA`, state `OPEN`, updated `2026-08-21T20:58:58Z`, body SHA-256 `51841dc8530ec7cc6f354565ac6fb02076ff08bf7455b72ce3aab7adb1971ed9`.
- Admission: labels `enhancement`, `ready-for-agent`; parent #458; no sub-issues or blockers. Revalidated unchanged immediately before PR creation.

### Acceptance coverage

- Manifest and catalog tests cover ordered/non-empty/distinct replacements, scalar compatibility, missing/current/legacy/chained target validation, and deterministic rendering.
- Selection and CLI tests cover explicit/recorded normalization, ordered deduplication, Tag-only mutation, human/JSON evidence, normalized persistence, no-intent failure, and existing Profile/reduction behavior.
- Update/upgrade tests cover incoming-manifest aliases, `--yes`, dry run, decline, interactive confirmation, failure preservation, structured remediation, and binary continuation.
- Sandboxed manual verification used only temporary home/source/state roots and confirmed actual symlinks plus normalized metadata.

### Independent review

- Standards review: approved HEAD `1127a47` with no actionable findings.
- Spec review against composed #460 + #458 contract: approved HEAD `1127a47` with no actionable findings.
- Residual risk: low; a real binary replacement is represented by separately tested continuation serialization and continuation execution.

### Release classification

- User-visible CLI behavior and stable JSON output changed; include this feature in release notes.

## Contributor Checklist

- [x] Linked one issue with an admitted Delivery Contract using `Closes #460`.
- [x] Added exactly one `type:*` label.
- [x] Delivery Evidence records the Contract Source snapshot, Acceptance coverage, and Independent review.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.
