### PR TITLE
refactor(manifest): atomize desktop and agent capabilities

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -210,7 +210,7 @@ The `core` Profile's intended workstation role: an ordered preset of atomic shel
 _Avoid_: minimal shell, everything profile, desktop baseline
 
 **Agent CLI Baseline**:
-The `agents` Tag's intended workstation role: the supported agent command-line tools plus their dots-owned native Managed Configuration and required support Dependencies. Generated memory, context, skills, global rules, and specialized web or mobile capabilities remain outside the baseline.
+The `agents` Profile's intended workstation role: the atomic `codex`, `claude`, `opencode`, `antigravity`, and `copilot` Tags, each pairing one supported Agent CLI requirement with its dots-owned native Managed Configuration. Shared prerequisites remain internal declarations selected by their consumers. Generated memory, context, skills, global rules, and specialized web or mobile capabilities remain outside the baseline.
 _Avoid_: agent setup, AI tools profile, generated agent environment
 
 **Delivery Contract**:

--- a/configs/ghostty/README.md
+++ b/configs/ghostty/README.md
@@ -2,7 +2,7 @@
 
 `configs/ghostty/config.ghostty` is the repository-managed Ghostty terminal
 configuration installed as `~/.config/ghostty/config.ghostty` (symlink strategy,
-`desktop` tag, `darwin`+`linux`). It uses Ghostty's current canonical filename.
+`ghostty` Tag, `darwin`+`linux`). It uses Ghostty's current canonical filename.
 
 The Source of Truth is this repository. The installed file is a link to the
 tracked source; runtime state, generated files, and machine-local overrides stay
@@ -10,14 +10,14 @@ outside version control.
 
 ## Prerequisites
 
-- **`ghostty`** — declared for the desktop profile; macOS detection accepts
+- **`ghostty`** — declared for the atomic `ghostty` Tag; macOS detection accepts
   either the `ghostty` command or `Ghostty.app`, installed through the
   `ghostty` Homebrew cask.
-- **Desktop Nerd Font** — declared on the `desktop` profile as shared desktop
-  infrastructure. Ghostty consumes this shared requirement for the managed
-  `font-family` baseline (`Cascadia Code NF`). The primary macOS package is the
-  Homebrew cask `font-cascadia-code-nf`, detected through `CascadiaCodeNF*` font
-  files. Compatible current Nerd Fonts files such as
+- **Desktop Nerd Font** — selected internally by the `ghostty`, `warp`, and
+  `zed` Tags as shared desktop infrastructure. Ghostty consumes this requirement
+  for the managed `font-family` baseline (`Cascadia Code NF`). The primary
+  macOS package is the Homebrew cask `font-cascadia-code-nf`, detected through
+  `CascadiaCodeNF*` font files. Compatible current Nerd Fonts files such as
   `CaskaydiaCoveNerdFont*` also satisfy the dependency.
 
 `dots install` does not install packages. `dots deps plan` and the explicit

--- a/configs/warp/README.md
+++ b/configs/warp/README.md
@@ -2,7 +2,8 @@
 
 `configs/warp/settings.toml` and `configs/warp/keybindings.yaml` are the
 repository-managed Warp terminal preference slice. They are copied into stable
-channel config paths for macOS and Linux through the `desktop` profile.
+channel config paths for macOS and Linux through the atomic `warp` Tag, which
+the `desktop` Profile selects.
 
 The Source of Truth is intentionally small: theme, terminal font family,
 terminal font size, and authored keybindings. Warp writes changes from its UI

--- a/configs/zed/README.md
+++ b/configs/zed/README.md
@@ -1,7 +1,7 @@
 # Zed configuration
 
 `configs/zed/` is the repository-managed authored configuration for the
-[Zed](https://zed.dev) editor (`desktop` tag, `darwin`+`linux`). Zed settings
+[Zed](https://zed.dev) editor (`zed` Tag, `darwin`+`linux`). Zed settings
 are a regular co-owned JSONC target; keymaps and the authored theme remain
 repository-owned symlinks:
 
@@ -20,9 +20,9 @@ control.
 
 ## Prerequisites
 
-- **`zed`** — declared as an advisory dependency for the desktop profile.
-- **Desktop Nerd Font** — declared on the `desktop` profile, not on Zed itself,
-  so Ghostty-only or other desktop slices can satisfy the same shared font
+- **`zed`** — declared as an advisory dependency for the atomic `zed` Tag.
+- **Desktop Nerd Font** — selected internally by the `ghostty`, `warp`, and
+  `zed` Tags, so any one of those desktop slices can satisfy the same shared font
   requirement without selecting Zed. The primary macOS package is the Homebrew
   cask `font-cascadia-code-nf`, detected through `CascadiaCodeNF*` font files.
   Compatible installed files such as `CaskaydiaCoveNerdFont*` also satisfy the
@@ -60,7 +60,7 @@ The live `~/.config/zed/` directory was classified before adoption:
 | Category | Examples | Repository decision |
 | --- | --- | --- |
 | **Portable** | panel docks, `vim_mode`, `theme` (system/One Light/Catppuccin Mocha (blue)), `icon_theme`, `ui_font_family`, Copilot/agent preferences, declared extensions, the two intentional keybindings, the custom Catppuccin blue theme | Managed in `configs/zed/`. |
-| **Machine-specific** | `buffer_font_family` and font sizes. Zed has no user-level local include (no `settings.local.json`), so these stay in the shared `settings.json`; the Nerd Font is modeled as a shared desktop advisory dependency instead of Zed-owned state. | Kept in `settings.json`; font handled via the desktop dependency declaration. |
+| **Machine-specific** | `buffer_font_family` and font sizes. Zed has no user-level local include (no `settings.local.json`), so these stay in the shared `settings.json`; the Nerd Font is modeled as a shared desktop advisory dependency instead of Zed-owned state. | Kept in `settings.json`; font handled by the shared dependency declaration selected by each desktop application Tag. |
 | **Generated** | `conversations/`, `prompts/`, compiled `extensions/`, extension index/DB, caches, logs | Never committed (see `.gitignore`). |
 | **Private** | secrets, authenticated state (Copilot auth lives outside the authored files), private paths, machine IDs | Excluded. |
 

--- a/docs/adr/0013-explicit-composable-install-profiles.md
+++ b/docs/adr/0013-explicit-composable-install-profiles.md
@@ -59,6 +59,22 @@ recorded intent use only atomic Tags. Explicit Tags may form a complete
 selection without a Profile; an invocation with neither Profiles nor Tags still
 fails before mutation when no recorded intent is available.
 
+The `desktop` Profile is the ordered preset `ghostty`, `warp`, `zed`, and
+`codexbar`. The `agents` Profile is the ordered preset `codex`, `claude`,
+`opencode`, `antigravity`, and `copilot`; each Agent Tag pairs its CLI
+requirement with its dots-owned native Managed Configuration. The
+`workstation` Profile includes the first three desktop capabilities and all five
+Agent capabilities but continues to exclude `codexbar`. Shared font and `jq`
+requirements remain internal Dependency Sets selected by every consumer that
+needs them, so they are deduplicated without becoming artificial Tags.
+
+The former broad `desktop` and `agents` Tags are hidden legacy compatibility
+aliases. `desktop` expands only to `ghostty`, `warp`, and `zed`, deliberately
+excluding the Profile-only `codexbar` addition; `agents` expands to the five
+Agent capability Tags. Neither alias directly owns a Managed Entry, Dependency
+Set, or Provisioner. OpenCode and Antigravity keep their composed JSON targets,
+and Codex keeps its independent source-override behavior.
+
 ## Amendment: evidence-gated historical retirement
 
 Tags select declarative surface only and do not trigger built-in Go cleanup.

--- a/docs/agents/output-contract.md
+++ b/docs/agents/output-contract.md
@@ -188,9 +188,9 @@ prose the text surface prints:
   specific historical Installation Metadata evidence for retired Gentle AI or
   Codex delegation capabilities, `data.retirement` records portable `removed`
   and `manual_cleanup` arrays. Gentle AI specifically requires a successful
-  historical `gentle-ai install` Provisioner receipt; current or recorded
-  legacy or recorded `agents` intent alone never authorizes it. The migration removes only proven
-  dots-owned marker blocks and byte-exact native agent files; copied skills,
+  historical `gentle-ai install` Provisioner receipt; neither explicit legacy
+  `agents` input nor a recorded `agents` Tag authorizes it. The migration
+  removes only proven dots-owned marker blocks and byte-exact native agent files; copied skills,
   symlinks, and ambiguous files remain in `manual_cleanup`. The optional field
   is omitted when no historical evidence exists and is never emitted by a dry
   run.

--- a/docs/agents/output-contract.md
+++ b/docs/agents/output-contract.md
@@ -189,7 +189,7 @@ prose the text surface prints:
   Codex delegation capabilities, `data.retirement` records portable `removed`
   and `manual_cleanup` arrays. Gentle AI specifically requires a successful
   historical `gentle-ai install` Provisioner receipt; current or recorded
-  `agents` Tags alone never authorize it. The migration removes only proven
+  legacy or recorded `agents` intent alone never authorizes it. The migration removes only proven
   dots-owned marker blocks and byte-exact native agent files; copied skills,
   symlinks, and ambiguous files remain in `manual_cleanup`. The optional field
   is omitted when no historical evidence exists and is never emitted by a dry

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -320,31 +320,31 @@ Current Managed Entries:
 | `configs/herdr/config.toml` (`adaptive-theme` override: `configs/herdr/config-adaptive.toml`) | `~/.config/herdr/config.toml` | `copy` | `core` | `darwin` | `herdr`; owns TOML subset |
 | `configs/zellij/config.kdl` (`adaptive-theme` override: `configs/zellij/config-adaptive.kdl`) | `~/.config/zellij/config.kdl` | `copy` | `core` | `darwin`, `linux` | `zellij`; whole-target ownership |
 | `configs/zellij/layouts/default.kdl` | `~/.config/zellij/layouts/default.kdl` | `symlink` | `core` | `darwin`, `linux` | `zellij` |
-| `configs/ghostty/config.ghostty` | `~/.config/ghostty/config.ghostty` | `symlink` | `desktop` | `darwin`, `linux` | `ghostty` |
+| `configs/ghostty/config.ghostty` | `~/.config/ghostty/config.ghostty` | `symlink` | `ghostty` | `darwin`, `linux` | `ghostty` |
 | `configs/ghostty/adaptive/adaptive-theme.ghostty` | `~/.config/ghostty/adaptive-theme.ghostty` | `symlink` | `adaptive-theme` | `darwin` | None |
-| `configs/warp/settings.toml` | `~/.warp/settings.toml` | `copy` | `desktop` | `darwin` | None |
-| `configs/warp/keybindings.yaml` | `~/.warp/keybindings.yaml` | `copy` | `desktop` | `darwin` | None |
-| `configs/warp/settings.toml` | `~/.config/warp-terminal/settings.toml` | `copy` | `desktop` | `linux` | `Warp` |
-| `configs/warp/keybindings.yaml` | `~/.config/warp-terminal/keybindings.yaml` | `copy` | `desktop` | `linux` | `Warp` |
+| `configs/warp/settings.toml` | `~/.warp/settings.toml` | `copy` | `warp` | `darwin` | None |
+| `configs/warp/keybindings.yaml` | `~/.warp/keybindings.yaml` | `copy` | `warp` | `darwin` | None |
+| `configs/warp/settings.toml` | `~/.config/warp-terminal/settings.toml` | `copy` | `warp` | `linux` | `Warp` |
+| `configs/warp/keybindings.yaml` | `~/.config/warp-terminal/keybindings.yaml` | `copy` | `warp` | `linux` | `Warp` |
 | `configs/atuin/config.toml` | `~/.config/atuin/config.toml` | `copy` | `core` | `darwin`, `linux` | `atuin`; owns TOML subset |
 | `configs/atuin/themes/catppuccin-mocha.toml` | `~/.config/atuin/themes/catppuccin-mocha.toml` | `symlink` | `core` | `darwin`, `linux` | `atuin` |
 | `configs/bat/config` | `~/.config/bat/config` | `copy` | `core` | `darwin`, `linux` | `bat`; whole-target ownership |
 | `configs/nvim/lazy-lock.json` | `$XDG_STATE_HOME/nvim/lazy-lock.json` | `copy` (`seeded`) | `core` | `darwin`, `linux` | None |
 | `configs/nvim/loader.lua` | `~/.config/nvim/init.lua` | `copy` | `core` | `darwin`, `linux` | `neovim` |
 | `configs/nvim` | `~/.config/dots/nvim` | `symlink` | `core` | `darwin`, `linux` | None |
-| `configs/zed/settings.json` | `~/.config/zed/settings.json` | `copy` (`jsonc-subset`) | `desktop` | `darwin`, `linux` | `zed` |
-| `configs/zed/keymap.json` | `~/.config/zed/keymap.json` | `copy` (`seeded`) | `desktop` | `darwin`, `linux` | `zed` |
-| `configs/zed/themes/catppuccin-blue.json` | `~/.config/zed/themes/catppuccin-blue.json` | `symlink` | `desktop` | `darwin`, `linux` | `zed` |
-| `configs/claude/settings.json` | `~/.claude/settings.json` | `copy` | `agents` | `darwin`, `linux` | None; owns JSON subset |
-| `configs/claude/statusline-command.sh` | `~/.claude/statusline-command.sh` | `copy` | `agents` | `darwin`, `linux` | None |
-| `configs/codex/config.toml` (`codegraph` override: `configs/codex/config-codegraph.toml`) | `~/.codex/config.toml` | `copy` | `agents` | `darwin`, `linux` | None; owns TOML subset; CodeGraph tag adds a Codex SessionStart hook |
-| `configs/copilot/settings.json` | `~/.copilot/settings.json` | `copy` | `agents` | `darwin`, `linux` | None; owns JSON subset |
-| `configs/copilot/statusline-command.sh` | `~/.copilot/statusline-command.sh` | `copy` | `agents` | `darwin`, `linux` | None |
-| `configs/antigravity/settings.json` | `~/.gemini/antigravity-cli/settings.json` | `copy` | `agents` | `darwin`, `linux` | None; owns the broad Antigravity JSON baseline |
+| `configs/zed/settings.json` | `~/.config/zed/settings.json` | `copy` (`jsonc-subset`) | `zed` | `darwin`, `linux` | `zed` |
+| `configs/zed/keymap.json` | `~/.config/zed/keymap.json` | `copy` (`seeded`) | `zed` | `darwin`, `linux` | `zed` |
+| `configs/zed/themes/catppuccin-blue.json` | `~/.config/zed/themes/catppuccin-blue.json` | `symlink` | `zed` | `darwin`, `linux` | `zed` |
+| `configs/claude/settings.json` | `~/.claude/settings.json` | `copy` | `claude` | `darwin`, `linux` | None; owns JSON subset |
+| `configs/claude/statusline-command.sh` | `~/.claude/statusline-command.sh` | `copy` | `claude` | `darwin`, `linux` | None |
+| `configs/codex/config.toml` (`codegraph` override: `configs/codex/config-codegraph.toml`) | `~/.codex/config.toml` | `copy` | `codex` | `darwin`, `linux` | None; owns TOML subset; CodeGraph tag adds a Codex SessionStart hook |
+| `configs/copilot/settings.json` | `~/.copilot/settings.json` | `copy` | `copilot` | `darwin`, `linux` | None; owns JSON subset |
+| `configs/copilot/statusline-command.sh` | `~/.copilot/statusline-command.sh` | `copy` | `copilot` | `darwin`, `linux` | None |
+| `configs/antigravity/settings.json` | `~/.gemini/antigravity-cli/settings.json` | `copy` | `antigravity` | `darwin`, `linux` | None; owns the broad Antigravity JSON baseline |
 | `configs/antigravity/mobile-mcp-settings.json` | `~/.gemini/antigravity-cli/settings.json` | `copy` | `mobile` | `darwin`, `linux` | None; owns only the Dart/Flutter MCP JSON subset |
 | `configs/vscode/settings.json` | `~/Library/Application Support/Code/User/settings.json` | `copy` | `mobile` | `darwin` | None; owns JSON subset enabling Dart MCP for GitHub Copilot in VS Code |
 | `configs/vscode/settings.json` | `~/.config/Code/User/settings.json` | `copy` | `mobile` | `linux` | None; owns JSON subset enabling Dart MCP for GitHub Copilot in VS Code |
-| `configs/opencode/opencode.json` | `~/.config/opencode/opencode.json` | `copy` | `agents` | `darwin`, `linux` | None; owns only the native JSON baseline subset |
+| `configs/opencode/opencode.json` | `~/.config/opencode/opencode.json` | `copy` | `opencode` | `darwin`, `linux` | None; owns only the native JSON baseline subset |
 | `configs/opencode/mcp.json` | `~/.config/opencode/opencode.json` | `copy` | `web` | `darwin`, `linux` | `opencode`; contributes the Chrome DevTools JSON subset alongside the native baseline |
 
 ## Dependencies

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -92,31 +92,36 @@ from compact discovery unless `--all` is supplied.
 
 | Profile | Status | Tags | Description |
 |---------|--------|------|-------------|
-| `agents` | current | `agents` | Native configuration for Codex, Claude Code, OpenCode, Antigravity, and Copilot CLI. |
+| `agents` | current | `codex`, `claude`, `opencode`, `antigravity`, `copilot` | Native configuration for Codex, Claude Code, OpenCode, Antigravity, and Copilot CLI. |
 | `core` | current | `zsh`, `zimfw`, `git`, `starship`, `tmux`, `herdr`, `zellij`, `atuin`, `neovim`, `tuicr`, `bat`, `node`, `rust`, `go`, `uv`, `pnpm`, `bun`, `fzf`, `zoxide`, `lazygit`, `eza`, `ripgrep`, `delta`, `fd`, `gh`, `jq` | Core dotfiles and general developer tooling without agent, web, or mobile provisioners. |
-| `desktop` | current | `desktop`, `codexbar` | Desktop-only configuration and integrations; compose with core when core dotfiles are desired too. |
+| `desktop` | current | `ghostty`, `warp`, `zed`, `codexbar` | Desktop-only configuration and integrations; compose with core when core dotfiles are desired too. |
 | `mobile` | current | `mobile` | Optional Dart and Flutter mobile development capabilities. |
 | `web` | current | `web` | Optional frontend and browser workbench. |
-| `workstation` | current | `zsh`, `zimfw`, `git`, `starship`, `tmux`, `herdr`, `zellij`, `atuin`, `neovim`, `tuicr`, `bat`, `node`, `rust`, `go`, `uv`, `pnpm`, `bun`, `fzf`, `zoxide`, `lazygit`, `eza`, `ripgrep`, `delta`, `fd`, `gh`, `jq`, `desktop`, `agents` | Composite core, desktop, and Agent CLI Baseline selection; web and mobile stay opt-in. |
+| `workstation` | current | `zsh`, `zimfw`, `git`, `starship`, `tmux`, `herdr`, `zellij`, `atuin`, `neovim`, `tuicr`, `bat`, `node`, `rust`, `go`, `uv`, `pnpm`, `bun`, `fzf`, `zoxide`, `lazygit`, `eza`, `ripgrep`, `delta`, `fd`, `gh`, `jq`, `ghostty`, `warp`, `zed`, `codex`, `claude`, `opencode`, `antigravity`, `copilot` | Composite core, desktop, and Agent CLI Baseline selection; web and mobile stay opt-in. |
 
 ### Tags
 
 | Tag | Kind | Status | Description | Replacement |
 |-----|------|--------|-------------|-------------|
 | `adaptive-theme` | surface | current | Opt-in adaptive-theme marker and supported app-specific sources or fragments. |  |
-| `agents` | surface | current | Native Agent CLI Baseline for Codex, Claude Code, OpenCode, Antigravity, and Copilot CLI. |  |
+| `agents` | compatibility | legacy | Legacy Agent CLI Baseline alias; use the five atomic Agent capability Tags. | `codex`, `claude`, `opencode`, `antigravity`, `copilot` |
+| `antigravity` | surface | current | Antigravity CLI requirement and dots-owned native configuration. |  |
 | `atuin` | surface | current | Atuin shell history configuration and Catppuccin theme. |  |
 | `bat` | surface | current | bat syntax-highlighting pager configuration. |  |
 | `bun` | surface | current | Bun JavaScript runtime and toolkit. |  |
+| `claude` | surface | current | Claude Code CLI requirement and dots-owned native configuration. |  |
 | `codegraph` | surface | current | Opt-in CodeGraph provisioner and Codex SessionStart hook source override. |  |
+| `codex` | surface | current | Codex CLI requirement and dots-owned native configuration. |  |
 | `codexbar` | surface | current | CodexBar menu-bar monitor for AI coding-provider usage limits. |  |
+| `copilot` | surface | current | Copilot CLI requirement and dots-owned native configuration. |  |
 | `core` | compatibility | legacy | Legacy Core Development Baseline alias; use the atomic replacement Tags. | `zsh`, `zimfw`, `git`, `starship`, `tmux`, `herdr`, `zellij`, `atuin`, `neovim`, `tuicr`, `bat`, `node`, `rust`, `go`, `uv`, `pnpm`, `bun`, `fzf`, `zoxide`, `lazygit`, `eza`, `ripgrep`, `delta`, `fd`, `gh`, `jq` |
 | `delta` | surface | current | Delta syntax-highlighting pager for Git diffs. |  |
-| `desktop` | surface | current | Desktop terminal/editor configuration and integrations. |  |
+| `desktop` | compatibility | legacy | Legacy desktop alias; use the Ghostty, Warp, and Zed capability Tags. | `ghostty`, `warp`, `zed` |
 | `eza` | surface | current | eza modern directory listing utility. |  |
 | `fd` | surface | current | fd filesystem search utility. |  |
 | `fzf` | surface | current | fzf command-line fuzzy finder. |  |
 | `gh` | surface | current | GitHub CLI for repository and workflow operations. |  |
+| `ghostty` | surface | current | Ghostty terminal configuration and application requirement. |  |
 | `git` | surface | current | Portable Git configuration and native Git entrypoint. |  |
 | `go` | surface | current | Go language toolchain. |  |
 | `herdr` | surface | current | Herdr terminal theme configuration on macOS. |  |
@@ -125,6 +130,7 @@ from compact discovery unless `--all` is supplied.
 | `mobile` | surface | current | Optional Dart, Flutter, and Android development skills and MCP integrations. |  |
 | `neovim` | surface | current | Neovim configuration and seeded plugin lockfile. |  |
 | `node` | surface | current | Node.js LTS toolchain managed through fnm. |  |
+| `opencode` | surface | current | OpenCode CLI requirement and dots-owned native configuration. |  |
 | `pnpm` | surface | current | pnpm JavaScript package manager. |  |
 | `ripgrep` | surface | current | ripgrep recursive text search utility. |  |
 | `rust` | surface | current | Rust stable toolchain managed through rustup. |  |
@@ -132,7 +138,9 @@ from compact discovery unless `--all` is supplied.
 | `tmux` | surface | current | Tmux terminal multiplexer configuration. |  |
 | `tuicr` | surface | current | tuicr terminal interface configuration. |  |
 | `uv` | surface | current | uv Python project and package manager. |  |
+| `warp` | surface | current | Warp terminal settings and keybindings. |  |
 | `web` | surface | current | Optional frontend/browser workbench with web skills and Chrome DevTools integrations. |  |
+| `zed` | surface | current | Zed editor settings, keybindings, and authored theme. |  |
 | `zellij` | surface | current | Zellij terminal workspace configuration and default layout. |  |
 | `zimfw` | surface | current | Zim framework module configuration and managed runtime provisioning. |  |
 | `zoxide` | surface | current | zoxide smarter directory navigator. |  |
@@ -170,12 +178,14 @@ ADR 0010 is now composed from atomic Dependency-only Tags: `node`, `rust`,
 `go`, `uv`, `pnpm`, `bun`, `fzf`, `zoxide`, `lazygit`, `eza`, `ripgrep`,
 `delta`, `fd`, `gh`, and `jq`. The internal `unzip` prerequisite follows the
 `node` Tag because the constrained fnm bootstrap consumes it; it is not an
-artificial catalog capability. The `agents` set requires Codex, Claude Code,
-OpenCode, Antigravity, Copilot CLI, and shares `jq` intentionally with the
-atomic `jq` capability. Linux Homebrew fallback is explicit with
-`linux_homebrew: true`; GUI apps and fonts stay manual unless they have
-validated Linux support. Node and Rust use constrained built-in toolchain
-bootstrap commands after manager installation:
+artificial catalog capability. The atomic `codex`, `claude`, `opencode`,
+`antigravity`, and `copilot` sets each pair one Agent CLI requirement with its
+Managed Configuration. An internal set selected by `claude` and `copilot`
+shares `jq` without making it a compulsory standalone selection. The Desktop
+Nerd Font is similarly selected by `ghostty`, `warp`, and `zed`. Linux Homebrew
+fallback is explicit with `linux_homebrew: true`; GUI apps and fonts stay manual
+unless they have validated Linux support. Node and Rust use constrained
+built-in toolchain bootstrap commands after manager installation:
 `fnm install --lts` for Node LTS and `rustup default stable` for Rust stable.
 Bootstrap declarations do not make an action executable by themselves: the
 manager executable must already be on `PATH` or a concrete installer/provider
@@ -184,6 +194,7 @@ must run first.
 The `codexbar` set is Darwin-only. It detects `CodexBar.app` in the supported
 macOS application locations and uses the Homebrew cask `codexbar` when the app
 is missing. The `desktop` Profile includes this independently selectable Tag;
+the legacy `desktop` alias expands only to `ghostty`, `warp`, and `zed`.
 Linux selections remain valid and omit the CodexBar Dependency.
 
 On Linux, when `fnm` is absent, no executable package provider is available, and

--- a/docs/update.md
+++ b/docs/update.md
@@ -133,7 +133,7 @@ failed Managed Entry or Provisioner work preserve the previous intent.
 
 ## Profiles and provisioners
 
-Provisioners are scoped by the same resolved tags as file entries. There is no implicit default Profile; reuse a recorded Installed Selection, choose `core`, compose pure capability Profiles such as `--profile agents --profile web`, or use `workstation` for `core + desktop + agents`. The `desktop` Profile selects desktop configuration and non-web desktop integrations. The `agents` Profile is the native Agent CLI Baseline: Codex, Claude Code, OpenCode, Antigravity, Copilot CLI, shared `jq`, and their dots-owned native Managed Configuration. It does not select gentle-ai, Engram, Context7, generated permissions, SDD/persona operations, third-party engineering skills, or dots-owned global agent rules. The `core` Profile includes the atomic `gh` and `jq` capabilities; either Tag may also be selected independently. CodeGraph, `web`, and `mobile` retain independent opt-in intent. The `web` Profile composes its Chrome DevTools overlay over OpenCode's native JSON baseline without replacing it. Use `workstation` when you explicitly want core, desktop integrations, and the Agent CLI Baseline together; web and mobile remain separate opt-ins.
+Provisioners are scoped by the same resolved tags as file entries. There is no implicit default Profile; reuse a recorded Installed Selection, choose `core`, compose pure capability Profiles such as `--profile agents --profile web`, or use `workstation` for `core + desktop + agents`. The `desktop` Profile selects the atomic `ghostty`, `warp`, `zed`, and `codexbar` Tags. The `agents` Profile is the native Agent CLI Baseline: atomic `codex`, `claude`, `opencode`, `antigravity`, and `copilot` Tags, each pairing its CLI requirement with dots-owned native Managed Configuration; `claude` and `copilot` share the internal `jq` requirement. It does not select gentle-ai, Engram, Context7, generated permissions, SDD/persona operations, third-party engineering skills, or dots-owned global agent rules. The `core` Profile includes the atomic `gh` and `jq` capabilities; either Tag may also be selected independently. CodeGraph, `web`, and `mobile` retain independent opt-in intent. The `web` Profile composes its Chrome DevTools overlay over OpenCode's native JSON baseline without replacing it. Use `workstation` when you explicitly want core, Ghostty/Warp/Zed, and the Agent CLI Baseline together; CodexBar, web, and mobile remain separate opt-ins.
 
 The retired Codex delegation capability follows the normal Installed Selection
 safety contract. A recorded `codex-delegation` Profile or explicit extra Tag
@@ -153,7 +153,7 @@ receipts. After Managed Configuration succeeds, a successful historical
 `gentle-ai install` Provisioner receipt authorizes dots to remove only known
 marker-delimited gentle-ai trigger/persona/Engram blocks and the dots-owned
 global-rules block from supported instruction files. An Installed Selection or
-current `agents` Tag alone is never evidence. Unmarked and co-owned content,
+legacy or recorded `agents` intent alone is never evidence. Unmarked and co-owned content,
 complete files, authentication, symlinks, and Secret state are preserved;
 non-regular targets are reported for manual cleanup.
 

--- a/docs/update.md
+++ b/docs/update.md
@@ -152,9 +152,9 @@ remove Dependency Installation Metadata, or erase historical Provisioner
 receipts. After Managed Configuration succeeds, a successful historical
 `gentle-ai install` Provisioner receipt authorizes dots to remove only known
 marker-delimited gentle-ai trigger/persona/Engram blocks and the dots-owned
-global-rules block from supported instruction files. An Installed Selection or
-legacy or recorded `agents` intent alone is never evidence. Unmarked and co-owned content,
-complete files, authentication, symlinks, and Secret state are preserved;
+global-rules block from supported instruction files. Neither explicit legacy
+`agents` input nor a recorded `agents` Tag is evidence. Unmarked and co-owned
+content, complete files, authentication, symlinks, and Secret state are preserved;
 non-regular targets are reported for manual cleanup.
 
 To remove residual gentle-ai state, first review it outside dots (for example

--- a/dots.yaml
+++ b/dots.yaml
@@ -135,18 +135,60 @@ tags:
       - fd
       - gh
       - jq
-  desktop:
-    description: Desktop terminal/editor configuration and integrations.
+  ghostty:
+    description: Ghostty terminal configuration and application requirement.
+    kind: surface
+    status: current
+  warp:
+    description: Warp terminal settings and keybindings.
+    kind: surface
+    status: current
+  zed:
+    description: Zed editor settings, keybindings, and authored theme.
     kind: surface
     status: current
   codexbar:
     description: CodexBar menu-bar monitor for AI coding-provider usage limits.
     kind: surface
     status: current
-  agents:
-    description: Native Agent CLI Baseline for Codex, Claude Code, OpenCode, Antigravity, and Copilot CLI.
+  desktop:
+    description: Legacy desktop alias; use the Ghostty, Warp, and Zed capability Tags.
+    kind: compatibility
+    status: legacy
+    replaced_by:
+      - ghostty
+      - warp
+      - zed
+  codex:
+    description: Codex CLI requirement and dots-owned native configuration.
     kind: surface
     status: current
+  claude:
+    description: Claude Code CLI requirement and dots-owned native configuration.
+    kind: surface
+    status: current
+  opencode:
+    description: OpenCode CLI requirement and dots-owned native configuration.
+    kind: surface
+    status: current
+  antigravity:
+    description: Antigravity CLI requirement and dots-owned native configuration.
+    kind: surface
+    status: current
+  copilot:
+    description: Copilot CLI requirement and dots-owned native configuration.
+    kind: surface
+    status: current
+  agents:
+    description: Legacy Agent CLI Baseline alias; use the five atomic Agent capability Tags.
+    kind: compatibility
+    status: legacy
+    replaced_by:
+      - codex
+      - claude
+      - opencode
+      - antigravity
+      - copilot
   web:
     description: Optional frontend/browser workbench with web skills and Chrome DevTools integrations.
     kind: surface
@@ -198,13 +240,19 @@ profiles:
     description: Desktop-only configuration and integrations; compose with core when core dotfiles are desired too.
     status: current
     tags:
-      - desktop
+      - ghostty
+      - warp
+      - zed
       - codexbar
   agents:
     description: Native configuration for Codex, Claude Code, OpenCode, Antigravity, and Copilot CLI.
     status: current
     tags:
-      - agents
+      - codex
+      - claude
+      - opencode
+      - antigravity
+      - copilot
   web:
     description: Optional frontend and browser workbench.
     status: current
@@ -245,11 +293,19 @@ profiles:
       - fd
       - gh
       - jq
-      - desktop
-      - agents
+      - ghostty
+      - warp
+      - zed
+      - codex
+      - claude
+      - opencode
+      - antigravity
+      - copilot
 dependencies:
   - tags:
-      - desktop
+      - ghostty
+      - warp
+      - zed
     os:
       - darwin
       - linux
@@ -481,7 +537,7 @@ dependencies:
         dnf: jq
         pacman: jq
   - tags:
-      - agents
+      - codex
     os:
       - darwin
       - linux
@@ -490,22 +546,53 @@ dependencies:
         command: codex
         rolling_user_local:
           recipe: codex
+  - tags:
+      - claude
+    os:
+      - darwin
+      - linux
+    dependencies:
       - name: Claude Code
         command: claude
         rolling_user_local:
           recipe: claude
+  - tags:
+      - opencode
+    os:
+      - darwin
+      - linux
+    dependencies:
       - name: OpenCode
         command: opencode
         rolling_user_local:
           recipe: opencode
+  - tags:
+      - antigravity
+    os:
+      - darwin
+      - linux
+    dependencies:
       - name: Antigravity
         command: agy
         rolling_user_local:
           recipe: antigravity
+  - tags:
+      - copilot
+    os:
+      - darwin
+      - linux
+    dependencies:
       - name: Copilot CLI
         command: copilot
         rolling_user_local:
           recipe: copilot
+  - tags:
+      - claude
+      - copilot
+    os:
+      - darwin
+      - linux
+    dependencies:
       - name: jq
         command: jq
         brew: jq
@@ -712,7 +799,7 @@ entries:
     target: ~/.config/ghostty/config.ghostty
     strategy: symlink
     tags:
-      - desktop
+      - ghostty
     os:
       - darwin
       - linux
@@ -739,21 +826,21 @@ entries:
     target: ~/.warp/settings.toml
     strategy: copy
     tags:
-      - desktop
+      - warp
     os:
       - darwin
   - source: configs/warp/keybindings.yaml
     target: ~/.warp/keybindings.yaml
     strategy: copy
     tags:
-      - desktop
+      - warp
     os:
       - darwin
   - source: configs/warp/settings.toml
     target: ~/.config/warp-terminal/settings.toml
     strategy: copy
     tags:
-      - desktop
+      - warp
     os:
       - linux
     dependencies:
@@ -763,7 +850,7 @@ entries:
     target: ~/.config/warp-terminal/keybindings.yaml
     strategy: copy
     tags:
-      - desktop
+      - warp
     os:
       - linux
     dependencies:
@@ -873,7 +960,7 @@ entries:
     strategy: copy
     ownership: jsonc-subset
     tags:
-      - desktop
+      - zed
     os:
       - darwin
       - linux
@@ -886,7 +973,7 @@ entries:
     strategy: copy
     ownership: seeded
     tags:
-      - desktop
+      - zed
     os:
       - darwin
       - linux
@@ -898,7 +985,7 @@ entries:
     target: ~/.config/zed/themes/catppuccin-blue.json
     strategy: symlink
     tags:
-      - desktop
+      - zed
     os:
       - darwin
       - linux
@@ -911,7 +998,7 @@ entries:
     strategy: copy
     ownership: json-subset
     tags:
-      - agents
+      - claude
     os:
       - darwin
       - linux
@@ -919,7 +1006,7 @@ entries:
     target: ~/.claude/statusline-command.sh
     strategy: copy
     tags:
-      - agents
+      - claude
     os:
       - darwin
       - linux
@@ -930,7 +1017,7 @@ entries:
     strategy: copy
     ownership: toml-subset
     tags:
-      - agents
+      - codex
     os:
       - darwin
       - linux
@@ -939,7 +1026,7 @@ entries:
     strategy: copy
     ownership: json-subset
     tags:
-      - agents
+      - copilot
     os:
       - darwin
       - linux
@@ -947,7 +1034,7 @@ entries:
     target: ~/.copilot/statusline-command.sh
     strategy: copy
     tags:
-      - agents
+      - copilot
     os:
       - darwin
       - linux
@@ -956,7 +1043,7 @@ entries:
     strategy: copy
     ownership: json-subset
     tags:
-      - agents
+      - antigravity
     os:
       - darwin
       - linux
@@ -990,7 +1077,7 @@ entries:
     strategy: copy
     ownership: json-subset
     tags:
-      - agents
+      - opencode
     os:
       - darwin
       - linux

--- a/internal/cli/ghostty_config_test.go
+++ b/internal/cli/ghostty_config_test.go
@@ -90,12 +90,12 @@ func TestGhosttyDesktopProfileInstallsAndReportsAlignedInSandbox(t *testing.T) {
 	if ghosttyEntry == nil {
 		t.Fatal("dots manifest missing Ghostty managed entry")
 	}
-	if !slices.Contains(ghosttyEntry.Tags, "desktop") {
-		t.Fatalf("Ghostty managed entry tags = %#v, want desktop", ghosttyEntry.Tags)
+	if !slices.Contains(ghosttyEntry.Tags, "ghostty") {
+		t.Fatalf("Ghostty managed entry tags = %#v, want ghostty", ghosttyEntry.Tags)
 	}
 	foundDesktopFontDependency := false
 	for _, set := range manifestFile.Dependencies {
-		if !slices.Contains(set.Tags, "desktop") {
+		if !slices.Contains(set.Tags, "ghostty") || !slices.Contains(set.Tags, "warp") || !slices.Contains(set.Tags, "zed") {
 			continue
 		}
 		for _, dep := range set.Dependencies {
@@ -106,7 +106,7 @@ func TestGhosttyDesktopProfileInstallsAndReportsAlignedInSandbox(t *testing.T) {
 		}
 	}
 	if !foundDesktopFontDependency {
-		t.Fatalf("desktop dependency set is missing font-cascadia-code-nf with CascadiaCodeNF* and Caskaydia fallback")
+		t.Fatalf("shared atomic desktop dependency set is missing font-cascadia-code-nf with CascadiaCodeNF* and Caskaydia fallback")
 	}
 
 	localExample := filepath.Join(repoRoot, "configs", "ghostty", "config.local.ghostty.example")

--- a/internal/cli/install_selection_test.go
+++ b/internal/cli/install_selection_test.go
@@ -216,6 +216,69 @@ func TestRepositoryAtomicCoreTagsInstallIndependentlyInTemporaryHome(t *testing.
 	}
 }
 
+func TestRepositoryAtomicDesktopAndAgentTagsInstallIndependentlyInTemporaryHome(t *testing.T) {
+	repositoryRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(repositoryRoot, "dots.yaml")
+	tests := []struct {
+		tag      string
+		present  []string
+		excluded []string
+	}{
+		{
+			tag:      "ghostty",
+			present:  []string{filepath.Join(".config", "ghostty", "config.ghostty")},
+			excluded: []string{filepath.Join(".warp", "settings.toml"), filepath.Join(".config", "zed", "settings.json")},
+		},
+		{
+			tag:      "codex",
+			present:  []string{filepath.Join(".codex", "config.toml")},
+			excluded: []string{filepath.Join(".claude", "settings.json"), filepath.Join(".config", "opencode", "opencode.json")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tag, func(t *testing.T) {
+			home := t.TempDir()
+			stateRoot := t.TempDir()
+			fakeRealHome := t.TempDir()
+			t.Setenv("HOME", fakeRealHome)
+
+			var out, errOut bytes.Buffer
+			code := cli.Run([]string{
+				"install", "--yes", "--skip-deps", "--output", "json", "--tag", tt.tag,
+				"--file", manifestPath, "--home", home, "--source-root", repositoryRoot, "--state-root", stateRoot,
+			}, &out, &errOut)
+			if code != cli.ExitOK {
+				t.Fatalf("exit code = %d, want %d\nstdout:\n%s\nstderr:\n%s", code, cli.ExitOK, out.String(), errOut.String())
+			}
+
+			meta, err := state.Load(state.Path(stateRoot))
+			if err != nil {
+				t.Fatalf("load Installation Metadata: %v", err)
+			}
+			if meta.InstalledSelection == nil || !reflect.DeepEqual(meta.InstalledSelection.ExtraTags, []string{tt.tag}) || !reflect.DeepEqual(meta.InstalledSelection.ResolvedTags, []string{tt.tag}) {
+				t.Fatalf("Installed Selection = %#v, want only Tag %q", meta.InstalledSelection, tt.tag)
+			}
+			for _, target := range tt.present {
+				if _, err := os.Lstat(filepath.Join(home, target)); err != nil {
+					t.Errorf("Tag %q did not install %s: %v", tt.tag, target, err)
+				}
+			}
+			for _, target := range tt.excluded {
+				if _, err := os.Lstat(filepath.Join(home, target)); !os.IsNotExist(err) {
+					t.Errorf("Tag %q installed unrelated target %s: %v", tt.tag, target, err)
+				}
+			}
+			if entries, err := os.ReadDir(fakeRealHome); err != nil || len(entries) != 0 {
+				t.Fatalf("install touched inherited HOME %q: entries=%v err=%v", fakeRealHome, entries, err)
+			}
+		})
+	}
+}
+
 func TestInstallLegacyTagNormalizesBeforeApplyAndReportsJSONEvidence(t *testing.T) {
 	home := t.TempDir()
 	sourceRoot := t.TempDir()

--- a/internal/cli/warp_config_test.go
+++ b/internal/cli/warp_config_test.go
@@ -116,8 +116,8 @@ func TestWarpDesktopProfileInstallsAndReportsAlignedInSandbox(t *testing.T) {
 		if entry.Strategy != "copy" {
 			t.Fatalf("Warp entry %s -> %s strategy = %q, want copy", entry.Source, entry.Target, entry.Strategy)
 		}
-		if !slices.Contains(entry.Tags, "desktop") {
-			t.Fatalf("Warp entry %s -> %s tags = %#v, want desktop", entry.Source, entry.Target, entry.Tags)
+		if !slices.Contains(entry.Tags, "warp") {
+			t.Fatalf("Warp entry %s -> %s tags = %#v, want warp", entry.Source, entry.Target, entry.Tags)
 		}
 		wantOS := "linux"
 		if strings.HasPrefix(entry.Target, "~/.warp/") {

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -799,7 +799,7 @@ func TestRepositoryManifestWebDependencySetIncludesPlaywrightCLI(t *testing.T) {
 	}
 }
 
-func TestRepositoryManifestDesktopProfileIncludesDarwinCodexBarDependency(t *testing.T) {
+func TestRepositoryManifestDeclaresAtomicDesktopCapabilities(t *testing.T) {
 	root := filepath.Clean(filepath.Join("..", ".."))
 	manifestPath := filepath.Join(root, "dots.yaml")
 
@@ -808,22 +808,48 @@ func TestRepositoryManifestDesktopProfileIncludesDarwinCodexBarDependency(t *tes
 		t.Fatalf("LoadFile(%q) error = %v", manifestPath, err)
 	}
 
-	tag, ok := got.Tags["codexbar"]
-	if !ok {
-		t.Fatal("repository manifest missing codexbar tag")
+	capabilityTags := []string{"ghostty", "warp", "zed"}
+	for _, name := range capabilityTags {
+		tag, ok := got.Tags[name]
+		if !ok {
+			t.Errorf("repository manifest missing atomic Desktop Tag %q", name)
+			continue
+		}
+		if tag.Kind != "surface" || tag.Status != "current" || strings.TrimSpace(tag.Description) == "" {
+			t.Errorf("Tag %q = %#v, want described current surface", name, tag)
+		}
 	}
-	if tag.Kind != "surface" || tag.Status != "current" {
-		t.Fatalf("codexbar tag = %#v, want current surface tag", tag)
+
+	legacy := got.Tags["desktop"]
+	if legacy.Kind != "compatibility" || legacy.Status != "legacy" || !reflect.DeepEqual([]string(legacy.ReplacedBy), capabilityTags) {
+		t.Fatalf("desktop Tag = %#v, want ordered compatibility alias for %#v", legacy, capabilityTags)
 	}
 
 	selection, err := manifest.ResolveSelection(*got, []string{"desktop"}, nil)
 	if err != nil {
 		t.Fatalf("ResolveSelection(desktop) error = %v", err)
 	}
-	if want := []string{"desktop", "codexbar"}; !reflect.DeepEqual(selection.Tags, want) {
+	if want := []string{"ghostty", "warp", "zed", "codexbar"}; !reflect.DeepEqual(selection.Tags, want) {
 		t.Fatalf("desktop selection tags = %#v, want %#v", selection.Tags, want)
 	}
+	legacySelection, err := manifest.ResolveSelection(*got, nil, []string{"desktop"})
+	if err != nil {
+		t.Fatalf("ResolveSelection(--tag desktop) error = %v", err)
+	}
+	if !reflect.DeepEqual(legacySelection.Tags, capabilityTags) {
+		t.Fatalf("legacy desktop selection tags = %#v, want %#v", legacySelection.Tags, capabilityTags)
+	}
 
+	for _, name := range capabilityTags {
+		if dep := findDependency(selectedsurface.Evaluate(*got, []string{name}, "linux").Dependencies, "Desktop Nerd Font"); dep == nil {
+			t.Errorf("Tag %q missing shared Desktop Nerd Font Dependency", name)
+		}
+	}
+
+	tag, ok := got.Tags["codexbar"]
+	if !ok || tag.Kind != "surface" || tag.Status != "current" {
+		t.Fatalf("codexbar tag = %#v, present=%v, want current surface tag", tag, ok)
+	}
 	darwin := selectedsurface.Evaluate(*got, []string{"codexbar"}, "darwin")
 	if len(darwin.Dependencies) != 1 {
 		t.Fatalf("Darwin codexbar dependencies = %#v, want one dependency", darwin.Dependencies)
@@ -839,7 +865,7 @@ func TestRepositoryManifestDesktopProfileIncludesDarwinCodexBarDependency(t *tes
 	}
 }
 
-func TestRepositoryManifestDefinesNativeAgentCLIBaseline(t *testing.T) {
+func TestRepositoryManifestDeclaresAtomicAgentCapabilities(t *testing.T) {
 	root := filepath.Clean(filepath.Join("..", ".."))
 	manifestPath := filepath.Join(root, "dots.yaml")
 
@@ -848,50 +874,54 @@ func TestRepositoryManifestDefinesNativeAgentCLIBaseline(t *testing.T) {
 		t.Fatalf("LoadFile(%q) error = %v", manifestPath, err)
 	}
 
-	sets := make(map[string]*manifest.DependencySet)
-	for i := range got.Dependencies {
-		candidate := &got.Dependencies[i]
-		for _, tag := range candidate.Tags {
-			sets[tag] = candidate
+	capabilityTags := []string{"codex", "claude", "opencode", "antigravity", "copilot"}
+	for _, name := range capabilityTags {
+		tag, ok := got.Tags[name]
+		if !ok {
+			t.Errorf("repository manifest missing atomic Agent Tag %q", name)
+			continue
+		}
+		if tag.Kind != "surface" || tag.Status != "current" || strings.TrimSpace(tag.Description) == "" {
+			t.Errorf("Tag %q = %#v, want described current surface", name, tag)
 		}
 	}
-	agents := sets["agents"]
-	if agents == nil {
-		t.Fatal("repository manifest missing agents dependency set")
+	legacy := got.Tags["agents"]
+	if legacy.Kind != "compatibility" || legacy.Status != "legacy" || !reflect.DeepEqual([]string(legacy.ReplacedBy), capabilityTags) {
+		t.Fatalf("agents Tag = %#v, want ordered compatibility alias for %#v", legacy, capabilityTags)
 	}
-	if !sameStrings(agents.OS, []string{"darwin", "linux"}) {
-		t.Fatalf("agents dependency set OS = %#v, want [darwin linux]", agents.OS)
+	if profile := got.Profiles["agents"]; !reflect.DeepEqual(profile.Tags, capabilityTags) {
+		t.Fatalf("agents Profile Tags = %#v, want %#v", profile.Tags, capabilityTags)
 	}
 
 	wantAgents := map[string]struct {
+		tag     string
 		command string
 		recipe  string
 	}{
-		"Codex":       {command: "codex", recipe: "codex"},
-		"Claude Code": {command: "claude", recipe: "claude"},
-		"OpenCode":    {command: "opencode", recipe: "opencode"},
-		"Antigravity": {command: "agy", recipe: "antigravity"},
-		"Copilot CLI": {command: "copilot", recipe: "copilot"},
-		"jq":          {command: "jq"},
+		"Codex":       {tag: "codex", command: "codex", recipe: "codex"},
+		"Claude Code": {tag: "claude", command: "claude", recipe: "claude"},
+		"OpenCode":    {tag: "opencode", command: "opencode", recipe: "opencode"},
+		"Antigravity": {tag: "antigravity", command: "agy", recipe: "antigravity"},
+		"Copilot CLI": {tag: "copilot", command: "copilot", recipe: "copilot"},
 	}
 	for name, want := range wantAgents {
-		dep := findDependency(agents.Dependencies, name)
+		surface := selectedsurface.Evaluate(*got, []string{want.tag}, "linux")
+		dep := findDependency(surface.Dependencies, name)
 		if dep == nil {
-			t.Errorf("agents dependency set missing %s: %#v", name, agents.Dependencies)
+			t.Errorf("Tag %q missing %s Dependency: %#v", want.tag, name, surface.Dependencies)
 			continue
 		}
 		if dep.Command != want.command {
-			t.Errorf("agents dependency %s command = %q, want %q", name, dep.Command, want.command)
-		}
-		if want.recipe == "" {
-			continue
+			t.Errorf("Tag %q dependency %s command = %q, want %q", want.tag, name, dep.Command, want.command)
 		}
 		if dep.RollingUserLocal == nil || dep.RollingUserLocal.Recipe != want.recipe {
-			t.Errorf("agents dependency %s rolling provider = %#v, want recipe %q", name, dep.RollingUserLocal, want.recipe)
+			t.Errorf("Tag %q dependency %s rolling provider = %#v, want recipe %q", want.tag, name, dep.RollingUserLocal, want.recipe)
 		}
 	}
-	if dep := findDependency(agents.Dependencies, "GitHub CLI"); dep != nil {
-		t.Errorf("agents dependency set includes GitHub CLI: %#v", *dep)
+	for _, name := range []string{"claude", "copilot"} {
+		if dep := findDependency(selectedsurface.Evaluate(*got, []string{name}, "linux").Dependencies, "jq"); dep == nil {
+			t.Errorf("Tag %q missing shared jq Dependency", name)
+		}
 	}
 
 	githubCLI := findDependency(selectedsurface.Evaluate(*got, []string{"gh"}, "linux").Dependencies, "GitHub CLI")
@@ -909,16 +939,16 @@ func TestRepositoryManifestDefinesNativeAgentCLIBaseline(t *testing.T) {
 	if opencodeEntry == nil {
 		t.Fatal("agents profile missing native OpenCode Managed Entry")
 	}
-	if opencodeEntry.Source != "configs/opencode/opencode.json" || opencodeEntry.Ownership != "json-subset" || !sameStrings(opencodeEntry.Tags, []string{"agents"}) {
-		t.Errorf("OpenCode Managed Entry = %#v, want agents-tagged configs/opencode/opencode.json with JSON Subset Ownership", *opencodeEntry)
+	if opencodeEntry.Source != "configs/opencode/opencode.json" || opencodeEntry.Ownership != "json-subset" || !sameStrings(opencodeEntry.Tags, []string{"opencode"}) {
+		t.Errorf("OpenCode Managed Entry = %#v, want opencode-tagged configs/opencode/opencode.json with JSON Subset Ownership", *opencodeEntry)
 	}
 
 	zedSettings := findEntry(got.Entries, "~/.config/zed/settings.json")
 	if zedSettings == nil {
 		t.Fatal("desktop profile missing Zed settings Managed Entry")
 	}
-	if zedSettings.Source != "configs/zed/settings.json" || zedSettings.Strategy != "copy" || zedSettings.Ownership != "jsonc-subset" {
-		t.Errorf("Zed settings Managed Entry = %#v, want copy with JSONC Subset Ownership", *zedSettings)
+	if zedSettings.Source != "configs/zed/settings.json" || zedSettings.Strategy != "copy" || zedSettings.Ownership != "jsonc-subset" || !sameStrings(zedSettings.Tags, []string{"zed"}) {
+		t.Errorf("Zed settings Managed Entry = %#v, want zed-tagged copy with JSONC Subset Ownership", *zedSettings)
 	}
 
 	selected, err := provision.Select(*got, provision.Options{Profile: "agents", OS: "darwin"})
@@ -928,6 +958,67 @@ func TestRepositoryManifestDefinesNativeAgentCLIBaseline(t *testing.T) {
 	if len(selected) != 0 {
 		t.Errorf("agents selected legacy Provisioners = %#v, want none", selected)
 	}
+
+	wantWorkstation := append(append(append([]string(nil), got.Profiles["core"].Tags...), got.Profiles["desktop"].Tags[:3]...), capabilityTags...)
+	if profile := got.Profiles["workstation"]; !reflect.DeepEqual(profile.Tags, wantWorkstation) {
+		t.Fatalf("workstation Profile Tags = %#v, want core + Ghostty/Warp/Zed + Agent capability Tags %#v", profile.Tags, wantWorkstation)
+	}
+
+	for i, set := range got.Dependencies {
+		if hasString(set.Tags, "desktop") || hasString(set.Tags, "agents") {
+			t.Errorf("dependencies[%d] still selects a legacy broad Tag: %#v", i, set.Tags)
+		}
+	}
+	for i, entry := range got.Entries {
+		if hasString(entry.Tags, "desktop") || hasString(entry.Tags, "agents") {
+			t.Errorf("entries[%d] %q still selects a legacy broad Tag: %#v", i, entry.Target, entry.Tags)
+		}
+	}
+	for i, provisioner := range got.Provisioners {
+		if hasString(provisioner.Tags, "desktop") || hasString(provisioner.Tags, "agents") {
+			t.Errorf("provisioners[%d] %q still selects a legacy broad Tag: %#v", i, provisioner.Tool, provisioner.Tags)
+		}
+	}
+}
+
+func TestRepositoryAtomicAgentCompositionAndCodexSourceOverride(t *testing.T) {
+	got, err := manifest.LoadFile(filepath.Join("..", "..", "dots.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		tags    []string
+		target  string
+		sources []string
+	}{
+		{name: "OpenCode baseline plus web subset", tags: []string{"opencode", "web"}, target: "~/.config/opencode/opencode.json", sources: []string{"configs/opencode/opencode.json", "configs/opencode/mcp.json"}},
+		{name: "Antigravity baseline plus mobile subset", tags: []string{"antigravity", "mobile"}, target: "~/.gemini/antigravity-cli/settings.json", sources: []string{"configs/antigravity/settings.json", "configs/antigravity/mobile-mcp-settings.json"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var sources []string
+			for _, entry := range selectedsurface.Evaluate(*got, tt.tags, "linux").Entries {
+				if entry.Entry.Target == tt.target {
+					sources = append(sources, entry.Source)
+				}
+			}
+			if !reflect.DeepEqual(sources, tt.sources) {
+				t.Fatalf("selected sources for %q = %#v, want %#v", tt.target, sources, tt.sources)
+			}
+		})
+	}
+
+	for _, entry := range selectedsurface.Evaluate(*got, []string{"codex", "codegraph"}, "linux").Entries {
+		if entry.Entry.Target == "~/.codex/config.toml" {
+			if entry.Source != "configs/codex/config-codegraph.toml" || entry.OverrideTag != "codegraph" {
+				t.Fatalf("Codex selected entry = %#v, want codegraph source override", entry)
+			}
+			return
+		}
+	}
+	t.Fatal("Codex and codegraph Tags did not select the Codex Managed Entry")
 }
 
 func TestRepositoryManifestLinuxHomebrewReviewBoundary(t *testing.T) {
@@ -3578,7 +3669,8 @@ func TestRepositoryManifestDeclaresAtomicCoreCapabilitySelection(t *testing.T) {
 	if profile := got.Profiles["core"]; !reflect.DeepEqual(profile.Tags, wantTags) {
 		t.Fatalf("core Profile Tags = %#v, want %#v", profile.Tags, wantTags)
 	}
-	wantWorkstation := append(append([]string(nil), wantTags...), "desktop", "agents")
+	wantWorkstation := append(append([]string(nil), wantTags...),
+		"ghostty", "warp", "zed", "codex", "claude", "opencode", "antigravity", "copilot")
 	if profile := got.Profiles["workstation"]; !reflect.DeepEqual(profile.Tags, wantWorkstation) {
 		t.Fatalf("workstation Profile Tags = %#v, want %#v", profile.Tags, wantWorkstation)
 	}

--- a/internal/selectedsurface/selectedsurface_test.go
+++ b/internal/selectedsurface/selectedsurface_test.go
@@ -150,7 +150,7 @@ func TestRepositoryProfilesMatchEquivalentExplicitTagsAcrossSupportedOS(t *testi
 	}
 }
 
-func TestRepositoryAtomicCoreTagsSelectOnlyTheirCapabilities(t *testing.T) {
+func TestRepositoryAtomicCapabilityTagsSelectOnlyTheirCapabilities(t *testing.T) {
 	m, err := manifest.LoadFile(filepath.Join("..", "..", "dots.yaml"))
 	if err != nil {
 		t.Fatal(err)
@@ -190,6 +190,14 @@ func TestRepositoryAtomicCoreTagsSelectOnlyTheirCapabilities(t *testing.T) {
 		{tag: "fd", osName: "linux", dependencies: []string{"fd"}},
 		{tag: "gh", osName: "linux", dependencies: []string{"GitHub CLI"}},
 		{tag: "jq", osName: "linux", dependencies: []string{"jq"}},
+		{tag: "ghostty", osName: "linux", entries: []string{"~/.config/ghostty/config.ghostty"}, dependencies: []string{"Desktop Nerd Font", "ghostty"}},
+		{tag: "warp", osName: "linux", entries: []string{"~/.config/warp-terminal/settings.toml", "~/.config/warp-terminal/keybindings.yaml"}, dependencies: []string{"Desktop Nerd Font", "Warp"}},
+		{tag: "zed", osName: "linux", entries: []string{"~/.config/zed/settings.json", "~/.config/zed/keymap.json", "~/.config/zed/themes/catppuccin-blue.json"}, dependencies: []string{"Desktop Nerd Font", "zed"}},
+		{tag: "codex", osName: "linux", entries: []string{"~/.codex/config.toml"}, dependencies: []string{"Codex"}},
+		{tag: "claude", osName: "linux", entries: []string{"~/.claude/settings.json", "~/.claude/statusline-command.sh"}, dependencies: []string{"Claude Code", "jq"}},
+		{tag: "opencode", osName: "linux", entries: []string{"~/.config/opencode/opencode.json"}, dependencies: []string{"OpenCode"}},
+		{tag: "antigravity", osName: "linux", entries: []string{"~/.gemini/antigravity-cli/settings.json"}, dependencies: []string{"Antigravity"}},
+		{tag: "copilot", osName: "linux", entries: []string{"~/.copilot/settings.json", "~/.copilot/statusline-command.sh"}, dependencies: []string{"Copilot CLI", "jq"}},
 	}
 
 	for _, tt := range tests {
@@ -203,6 +211,78 @@ func TestRepositoryAtomicCoreTagsSelectOnlyTheirCapabilities(t *testing.T) {
 			}
 			if got := provisionerTools(surface.Provisioners); !reflect.DeepEqual(got, nonNil(tt.provisioners)) {
 				t.Errorf("Provisioners = %#v, want %#v", got, nonNil(tt.provisioners))
+			}
+		})
+	}
+}
+
+func TestRepositoryDesktopAndAgentProfilesPreservePreAtomizationSurfaces(t *testing.T) {
+	m, err := manifest.LoadFile(filepath.Join("..", "..", "dots.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		profile      string
+		osName       string
+		entries      []string
+		dependencies []string
+	}{
+		{
+			profile: "desktop",
+			osName:  "darwin",
+			entries: []string{
+				"~/.config/ghostty/config.ghostty", "~/.warp/settings.toml", "~/.warp/keybindings.yaml",
+				"~/.config/zed/settings.json", "~/.config/zed/keymap.json", "~/.config/zed/themes/catppuccin-blue.json",
+			},
+			dependencies: []string{"Desktop Nerd Font", "CodexBar", "ghostty", "zed"},
+		},
+		{
+			profile: "desktop",
+			osName:  "linux",
+			entries: []string{
+				"~/.config/ghostty/config.ghostty", "~/.config/warp-terminal/settings.toml", "~/.config/warp-terminal/keybindings.yaml",
+				"~/.config/zed/settings.json", "~/.config/zed/keymap.json", "~/.config/zed/themes/catppuccin-blue.json",
+			},
+			dependencies: []string{"Desktop Nerd Font", "ghostty", "Warp", "zed"},
+		},
+		{
+			profile: "agents",
+			osName:  "darwin",
+			entries: []string{
+				"~/.claude/settings.json", "~/.claude/statusline-command.sh", "~/.codex/config.toml",
+				"~/.copilot/settings.json", "~/.copilot/statusline-command.sh", "~/.gemini/antigravity-cli/settings.json",
+				"~/.config/opencode/opencode.json",
+			},
+			dependencies: []string{"Codex", "Claude Code", "OpenCode", "Antigravity", "Copilot CLI", "jq"},
+		},
+		{
+			profile: "agents",
+			osName:  "linux",
+			entries: []string{
+				"~/.claude/settings.json", "~/.claude/statusline-command.sh", "~/.codex/config.toml",
+				"~/.copilot/settings.json", "~/.copilot/statusline-command.sh", "~/.gemini/antigravity-cli/settings.json",
+				"~/.config/opencode/opencode.json",
+			},
+			dependencies: []string{"Codex", "Claude Code", "OpenCode", "Antigravity", "Copilot CLI", "jq"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.profile+"/"+tt.osName, func(t *testing.T) {
+			selection, err := manifest.ResolveReadOnlySelection(*m, []string{tt.profile}, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			surface := selectedsurface.Evaluate(*m, selection.Tags, tt.osName)
+			if got := selectedTargets(surface.Entries); !reflect.DeepEqual(got, tt.entries) {
+				t.Errorf("Managed Entries changed from the pre-atomization surface\ngot:  %#v\nwant: %#v", got, tt.entries)
+			}
+			if got := dependencyNames(surface.Dependencies); !reflect.DeepEqual(got, tt.dependencies) {
+				t.Errorf("Dependencies changed from the pre-atomization surface\ngot:  %#v\nwant: %#v", got, tt.dependencies)
+			}
+			if got := provisionerTools(surface.Provisioners); len(got) != 0 {
+				t.Errorf("Provisioners changed from the pre-atomization surface: %#v", got)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #462

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [x] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Atomizes Desktop into `ghostty`, `warp`, and `zed`, while keeping `codexbar` Profile-only and preserving Workstation behavior.
- Atomizes the Agent CLI Baseline into `codex`, `claude`, `opencode`, `antigravity`, and `copilot`, with shared internal Dependencies.
- Preserves legacy aliases, composed JSON targets, Codex source overrides, generated catalog documentation, and sandboxed Profile/Tag parity.

## Changes

| File | Change |
|------|--------|
| `dots.yaml` | Declares atomic capabilities, Profile presets, hidden legacy replacements, shared Dependency Sets, and atomic Managed Entry ownership. |
| `internal/manifest`, `internal/selectedsurface`, `internal/cli` tests | Covers atomic surfaces, legacy expansion, prior Profile parity, composed targets, source overrides, and isolated Tag-only installs. |
| `CONTEXT.md`, ADR and user/config docs | Records the domain model and refreshes catalog, ownership, and retirement-evidence documentation. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go build ./...`
- [x] Built-binary `manifest validate --file dots.yaml`
- [x] Built-binary sandboxed catalog, plan, and install scenarios with explicit temporary roots

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked one issue with an admitted Delivery Contract using `Closes #462`.
- [x] Added exactly one `type:*` label.
- [x] Delivery Evidence records the Contract Source snapshot, Acceptance coverage, and Independent review.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

### Delivery Contract snapshot

- Contract Source: composed delivery ticket.
- Ticket body: node `I_kwDOSzLlmM8AAAABNwYwSQ`; https://github.com/yersonargotev/dots/issues/462; updated `2026-08-21T20:57:58Z`; SHA-256 `c47963b096b5b6caac97b258c854b870074228f19015edddba398d0200363be2`.
- Parent specification body: node `I_kwDOSzLlmM8AAAABNwWsDA`; https://github.com/yersonargotev/dots/issues/458; updated `2026-08-21T20:58:58Z`; SHA-256 `aec4b86128a4cfec51290b7917a4757a7f16cc1557466e7d8478ca41495f5f0d`.
- Category/readiness: `enhancement`; only triage state `ready-for-agent`.
- Native relationships: parent #458 OPEN (`2026-08-21T20:58:58Z`); no sub-issues; blocked by #461 CLOSED (`2026-08-21T22:56:03Z`); blocking #463 OPEN (`2026-08-21T20:58:01Z`).
- Snapshot revalidated before code mutation and PR creation; no later comments.

### Acceptance coverage

- Desktop capabilities and shared font selection: `dots.yaml`, `TestRepositoryManifestDeclaresAtomicDesktopCapabilities`, and atomic surface cases.
- Agent capabilities, CLI requirements, Managed Configuration, and shared `jq`: `TestRepositoryManifestDeclaresAtomicAgentCapabilities` and atomic surface cases.
- Desktop, Agents, and Workstation preservation including CodexBar exclusion: static pre-atomization surface tests plus Darwin/Linux Profile-versus-Tag parity.
- Hidden one-to-many legacy aliases: manifest contract tests and built-binary catalog detail checks.
- OpenCode/Antigravity composed targets and Codex override: `TestRepositoryAtomicAgentCompositionAndCodexSourceOverride` plus built-binary Install Plans.
- Representative Tag-only installs: sandboxed `ghostty` and `codex` Temporary Home tests and manual runs.
- Catalog/domain documentation: generated catalog check, CONTEXT/ADR updates, and atomic Managed Entry ownership table.

### Automated validation

Passed on head `6b2f325a6f69f7a8f704fccc41bbd858e3d809e2`:

- `gofmt -l .` — no output.
- `go vet ./...` — passed.
- `go build ./...` — passed.
- `go test ./...` — passed.
- `go generate ./internal/catalog` and generated-doc test — passed.
- `git diff --check` — passed.

### Manual verification

One temporary binary built with `go build -o <tmp>/dots ./cmd/dots` was used for all final scenarios:

- `<tmp>/dots manifest validate --file dots.yaml` — exit 0, valid.
- `catalog profile desktop|agents --os darwin|linux --output json` — expected Tag lists and unchanged entry/dependency surfaces.
- `catalog tag desktop|agents --all --os all --output json` — legacy, hidden replacements normalized in declared order.
- `install --yes --skip-deps --tag ghostty|codex --home <tmp> --source-root "$PWD" --state-root <tmp> --output json` — exit 0; only the selected Managed Configuration installed; inherited HOME remained empty.
- `plan --tag codex --tag codegraph ... --output json` — Codex resolved to `configs/codex/config-codegraph.toml`.
- `plan --tag opencode --tag web ...` and `plan --tag antigravity --tag mobile ...` — each composed action retained both expected source contributions.
- Documentation checks confirmed atomic ownership rows and unambiguous retirement-evidence wording.

### Independent review

Reviewed stable range `origin/main...6b2f325a6f69f7a8f704fccc41bbd858e3d809e2` after all fixes:

- Spec: pass; 0 actionable findings, 0 observations.
- Standards: pass; 0 actionable findings, 0 observations.
<!-- delivery-issue:evidence:end -->