### PR TITLE
feat(state): record contribution ownership evidence

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -149,7 +149,7 @@ The current alignment between a workstation and the repository-owned Source of T
 _Avoid_: health, sync state, installed state
 
 **Installation Metadata**:
-The state file stored under `~/.local/state/dots/installed.json` that records what the Dotfiles CLI installed, including Managed Entries, Provisioners, strategies, hashes, timestamps, optional structured-ownership or seeded-baseline evidence, and an optional Installed Selection. It lets the CLI detect Drift, reconcile or remove only proven contributions for copied subset-owned targets, and advance Seeded Runtime State without conflating it with dots' own state root, while preserving machine-level selection intent separately from historical inventory.
+The state file stored under `~/.local/state/dots/installed.json` that records what the Dotfiles CLI installed, including Managed Entries, Provisioners, strategies, hashes, timestamps, ordered per-contribution Source of Truth identity, selector Tags and mode-specific ownership evidence, target-wide compatibility projections, and an optional Installed Selection. It lets the CLI detect Drift, reconcile or remove only proven contributions for copied subset-owned targets, and advance Seeded Runtime State without conflating it with dots' own state root, while preserving machine-level selection intent separately from historical inventory. Historical records without per-contribution evidence remain readable and explicitly unattributed; loading alone never upgrades them.
 _Avoid_: install log, state file, tracking file
 
 **Installed Selection**:

--- a/docs/agents/output-contract.md
+++ b/docs/agents/output-contract.md
@@ -38,7 +38,7 @@ state.
 
 ```json
 {
-  "schema_version": "8",
+  "schema_version": "9",
   "command": "doctor",
   "status": "ok",
   "data": { "...": "command-specific report" }
@@ -59,7 +59,7 @@ Schema version `3` introduced this partial-error report allowance:
 
 ```json
 {
-  "schema_version": "8",
+  "schema_version": "9",
   "command": "doctor",
   "status": "error",
   "error": "read manifest: open dots.yaml: no such file or directory"
@@ -145,6 +145,18 @@ prose the text surface prints:
   diagnostic, so an absent Installed Selection or partial Profile coverage
   remains `status: "ok"`; use `status` or `doctor` when an agent needs
   drift/dependency findings.
+- Each `data.managed_entries` item identifies whether its Source of Truth
+  evidence is `recorded-contribution` or `legacy-unattributed` in
+  `attribution`. Attributed items expose their exact `ownership` mode, a
+  non-sensitive `ownership_evidence` discriminator (`source-identity`,
+  `source-hash`, `owned-json`, `owned-jsonc`, `owned-toml`,
+  `owned-marked-block`, `seeded-baseline`, or `missing` for an incomplete
+  attributed record), and selector Tags with
+  `tags_source: "recorded-contribution"`. Legacy items use
+  `ownership_evidence: "legacy-target-wide"`; dots may still report their
+  historical target-level Tags, but does not claim per-contribution
+  attribution. Raw owned content and seeded baselines are never included in
+  installed output.
 - For Installation Metadata v1/v2 without an Installed Selection, `installed`
   may add `data.selection_migration` alongside (never inside) the historical
   inventory. It contains stable arrays `profiles`, `extra_tags`,
@@ -218,6 +230,10 @@ prose the text surface prints:
 - Schema version `8` changes Install Catalog `replaced_by` values from one Tag
   string to an ordered array of current replacement Tags and adds optional
   `tag_migrations` evidence to selection reports.
+- Schema version `9` adds mandatory Managed Entry `attribution` and
+  `ownership_evidence` fields to `installed`, plus optional `ownership`, so
+  agents can distinguish exact per-contribution evidence from historical
+  target-wide inventory without receiving raw configuration bytes.
 - Plan actions and Status Managed Entry items may add the optional reason
   `source-override-not-selected` and a deterministic `matching_tags` array when
   a conflicting target exactly matches one or more alternate sources whose

--- a/internal/cli/agent_baseline_test.go
+++ b/internal/cli/agent_baseline_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/yersonargotev/dots/internal/cli"
+	"github.com/yersonargotev/dots/internal/state"
 )
 
 func TestAgentsProfileInstallsNativeBaselineWithoutAuthorizingHistoricalCleanup(t *testing.T) {
@@ -137,6 +138,26 @@ Keep this unmarked user-owned content.
 	}
 	if _, err := os.Stat(filepath.Join(home, ".config", "opencode-dots.json")); !os.IsNotExist(err) {
 		t.Errorf("agents + web left obsolete standalone OpenCode overlay; stat error = %v", err)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load OpenCode contribution metadata: %v", err)
+	}
+	opencodeRecord, ok := meta.FindByTarget(opencodeTarget)
+	if !ok || len(opencodeRecord.Contributions) != 2 {
+		t.Fatalf("OpenCode metadata = %+v, want two attributed contributions", opencodeRecord)
+	}
+	for i, want := range []struct {
+		source string
+		tag    string
+	}{
+		{source: "configs/opencode/opencode.json", tag: "opencode"},
+		{source: "configs/opencode/mcp.json", tag: "opencode-chrome-devtools"},
+	} {
+		contribution := opencodeRecord.Contributions[i]
+		if contribution.Source != want.source || len(contribution.SelectorTags) != 1 || contribution.SelectorTags[0] != want.tag || contribution.Ownership != "json-subset" {
+			t.Fatalf("OpenCode contribution[%d] = %+v, want %s selected by %s", i, contribution, want.source, want.tag)
+		}
 	}
 
 	gotAuth, err := os.ReadFile(auth)

--- a/internal/cli/antigravity_config_test.go
+++ b/internal/cli/antigravity_config_test.go
@@ -58,6 +58,21 @@ func TestWorkstationAndMobileComposeAntigravitySettingsInSandbox(t *testing.T) {
 	if !reflect.DeepEqual(rec.SourceList(), wantSources) {
 		t.Fatalf("metadata sources = %#v, want %#v", rec.SourceList(), wantSources)
 	}
+	if len(rec.Contributions) != 2 {
+		t.Fatalf("metadata contributions = %+v, want two attributed sources", rec.Contributions)
+	}
+	for i, want := range []struct {
+		source string
+		tag    string
+	}{
+		{source: "configs/antigravity/settings.json", tag: "antigravity"},
+		{source: "configs/antigravity/mobile-mcp-settings.json", tag: "antigravity-dart-mcp"},
+	} {
+		contribution := rec.Contributions[i]
+		if contribution.Source != want.source || !reflect.DeepEqual(contribution.SelectorTags, []string{want.tag}) || contribution.Ownership != "json-subset" {
+			t.Fatalf("metadata contribution[%d] = %+v, want %s selected by %s", i, contribution, want.source, want.tag)
+		}
+	}
 	if meta.InstalledSelection == nil || !reflect.DeepEqual(meta.InstalledSelection.Profiles, []string{"workstation", "mobile"}) {
 		t.Fatalf("installed selection = %+v, want workstation + mobile", meta.InstalledSelection)
 	}

--- a/internal/cli/installed.go
+++ b/internal/cli/installed.go
@@ -134,6 +134,8 @@ func renderInstalled(w io.Writer, report inst.Report) {
 		fmt.Fprintf(w, "Managed Entries (%d)\n", len(report.ManagedEntries))
 		for _, entry := range report.ManagedEntries {
 			fmt.Fprintf(w, "  %-8s %s -> %s\n", entry.Strategy, entry.Source, entry.Target)
+			fmt.Fprintf(w, "    attribution: %s\n", entry.Attribution)
+			fmt.Fprintf(w, "    ownership: %s (%s)\n", renderValueOrUnknown(entry.Ownership), entry.OwnershipEvidence)
 			fmt.Fprintf(w, "    tags: %s (%s)\n", renderListOrUnknown(entry.Tags), entry.TagsSource)
 			fmt.Fprintf(w, "    profiles: %s (%s)\n", renderListOrUnknown(entry.Profiles), entry.ProfilesSource)
 			if entry.InstalledAt != "" {

--- a/internal/cli/installed_test.go
+++ b/internal/cli/installed_test.go
@@ -51,6 +51,78 @@ func TestInstalledJSONEnvelope(t *testing.T) {
 	}
 }
 
+func TestInstalledTextAndJSONExplainContributionAttributionWithoutRawEvidence(t *testing.T) {
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	sourceRoot := t.TempDir()
+	writeCLISource(t, sourceRoot, "configs/shared.json", "{\"portable-secret-value\":true}\n")
+	writeCLISource(t, sourceRoot, "configs/legacy", "legacy\n")
+	manifestPath := writeCLIManifest(t, home, `version: 1
+profiles:
+  default:
+    tags: [shared, legacy]
+entries:
+  - source: configs/shared.json
+    target: ~/.config/shared.json
+    strategy: copy
+    ownership: json-subset
+    tags: [shared]
+  - source: configs/legacy
+    target: ~/.legacy
+    strategy: copy
+    tags: [legacy]
+`)
+	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, Entries: []state.Record{
+		{
+			Target: filepath.Join(home, ".config", "shared.json"), Source: "configs/shared.json", Strategy: "copy", Ownership: "json-subset",
+			Contributions: []state.Contribution{{
+				Source: "configs/shared.json", SelectorTags: []string{"shared"}, Ownership: "json-subset", EvidenceRecorded: true, Hash: "source-hash", OwnedContent: []byte(`{"portable-secret-value":true}`),
+			}},
+		},
+		{Target: filepath.Join(home, ".legacy"), Source: "configs/legacy", Strategy: "copy", Ownership: "whole", Hash: "legacy-hash", Tags: []string{"legacy"}},
+	}}); err != nil {
+		t.Fatalf("save metadata: %v", err)
+	}
+
+	run := func(args ...string) string {
+		t.Helper()
+		var out, errOut bytes.Buffer
+		code := cli.Run(args, &out, &errOut)
+		if code != 0 {
+			t.Fatalf("exit code = %d, want 0\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
+		}
+		return out.String()
+	}
+	common := []string{"--file", manifestPath, "--source-root", sourceRoot, "--home", home, "--state-root", stateRoot}
+	textOutput := run(append([]string{"installed"}, common...)...)
+	for _, want := range []string{
+		"attribution: recorded-contribution",
+		"ownership: json-subset (owned-json)",
+		"attribution: legacy-unattributed",
+		"ownership: whole (legacy-target-wide)",
+	} {
+		if !strings.Contains(textOutput, want) {
+			t.Fatalf("installed text missing %q:\n%s", want, textOutput)
+		}
+	}
+
+	jsonOutput := run(append([]string{"installed", "--output", "json"}, common...)...)
+	for _, want := range []string{
+		`"attribution": "recorded-contribution"`,
+		`"ownership_evidence": "owned-json"`,
+		`"tags_source": "recorded-contribution"`,
+		`"attribution": "legacy-unattributed"`,
+		`"ownership_evidence": "legacy-target-wide"`,
+	} {
+		if !strings.Contains(jsonOutput, want) {
+			t.Fatalf("installed JSON missing %s:\n%s", want, jsonOutput)
+		}
+	}
+	if strings.Contains(jsonOutput, "owned_content") || strings.Contains(jsonOutput, "portable-secret-value") {
+		t.Fatalf("installed JSON exposed raw ownership evidence:\n%s", jsonOutput)
+	}
+}
+
 func TestInstalledJSONMatchesXDGStateEntryWithCompleteCoverage(t *testing.T) {
 	home := t.TempDir()
 	stateRoot := t.TempDir()

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -22,7 +22,7 @@ const (
 // binary. Renaming, removing, or repurposing a field in any command's JSON
 // `data` is a breaking change to the Agent Output Contract and must bump this
 // value.
-const schemaVersion = "8"
+const schemaVersion = "9"
 
 // Envelope statuses. They mirror the semantic exit codes: ok->0, findings->2,
 // error->1.

--- a/internal/cli/output_golden_test.go
+++ b/internal/cli/output_golden_test.go
@@ -131,7 +131,7 @@ func TestEnvelopeGolden(t *testing.T) {
 						ResolvedTags: []string{"core", "agents", "work"},
 						Provenance:   state.Provenance{SourceRoot: "/src/dots", SourceRevision: "abc123", DotsVersion: "v0.test", RecordedAt: "2026-07-08T12:00:00Z"},
 					},
-					ManagedEntries: []inst.ManagedEntry{{Source: "configs/zsh/zshrc", Target: "/home/user/.zshrc", Strategy: "symlink", InstalledAt: "2026-07-08T12:00:00Z", Tags: []string{"core"}, TagsSource: "recorded", Profiles: []string{"core"}, ProfilesSource: "recorded", ManifestMatched: true}},
+					ManagedEntries: []inst.ManagedEntry{{Source: "configs/zsh/zshrc", Target: "/home/user/.zshrc", Strategy: "symlink", Attribution: "legacy-unattributed", OwnershipEvidence: "legacy-target-wide", InstalledAt: "2026-07-08T12:00:00Z", Tags: []string{"core"}, TagsSource: "recorded", Profiles: []string{"core"}, ProfilesSource: "recorded", ManifestMatched: true}},
 					Tags:           []string{"core"},
 					Profiles:       []inst.ProfileCoverage{{Name: "core", Source: "recorded+inferred", State: inst.CoverageComplete, CoveredTags: []string{"core"}, CoveredEntries: 1, TotalEntries: 1}},
 					Provisioners:   []inst.ProvisionerRun{{Tool: "claude", Executable: "claude", Args: []string{"plugin", "marketplace", "add", "example/tools"}, Status: "provisioned", LastRunAt: "2026-07-08T12:00:00Z", Profile: "core", Profiles: []string{"core"}, ProfilesSource: "recorded", Tags: []string{"core"}, TagsSource: "recorded", ManifestMatched: true}},

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -86,8 +86,8 @@ func decodeEnvelope(t *testing.T, out string) testEnvelope {
 	if err := json.Unmarshal([]byte(out), &env); err != nil {
 		t.Fatalf("stdout is not a JSON envelope: %v\noutput:\n%s", err, out)
 	}
-	if env.SchemaVersion != "8" {
-		t.Fatalf("schema_version = %q, want \"8\"", env.SchemaVersion)
+	if env.SchemaVersion != "9" {
+		t.Fatalf("schema_version = %q, want \"9\"", env.SchemaVersion)
 	}
 	if env.Command != "status" {
 		t.Fatalf("command = %q, want \"status\"", env.Command)
@@ -101,8 +101,8 @@ func decodeEnvelopeForCommand(t *testing.T, out string, command string) testEnve
 	if err := json.Unmarshal([]byte(out), &env); err != nil {
 		t.Fatalf("stdout is not a JSON envelope: %v\noutput:\n%s", err, out)
 	}
-	if env.SchemaVersion != "8" {
-		t.Fatalf("schema_version = %q, want \"8\"", env.SchemaVersion)
+	if env.SchemaVersion != "9" {
+		t.Fatalf("schema_version = %q, want \"9\"", env.SchemaVersion)
 	}
 	if env.Command != command {
 		t.Fatalf("command = %q, want %q", env.Command, command)

--- a/internal/cli/testdata/envelope_catalog_compare.golden
+++ b/internal/cli/testdata/envelope_catalog_compare.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "8",
+  "schema_version": "9",
   "command": "catalog compare",
   "status": "ok",
   "data": {

--- a/internal/cli/testdata/envelope_catalog_tag.golden
+++ b/internal/cli/testdata/envelope_catalog_tag.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "8",
+  "schema_version": "9",
   "command": "catalog tag",
   "status": "ok",
   "data": {

--- a/internal/cli/testdata/envelope_catalog_why.golden
+++ b/internal/cli/testdata/envelope_catalog_why.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "8",
+  "schema_version": "9",
   "command": "catalog why",
   "status": "ok",
   "data": {

--- a/internal/cli/testdata/envelope_deps_check.golden
+++ b/internal/cli/testdata/envelope_deps_check.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "8",
+  "schema_version": "9",
   "command": "deps check",
   "status": "findings",
   "data": {

--- a/internal/cli/testdata/envelope_deps_plan.golden
+++ b/internal/cli/testdata/envelope_deps_plan.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "8",
+  "schema_version": "9",
   "command": "deps plan",
   "status": "findings",
   "data": {

--- a/internal/cli/testdata/envelope_doctor.golden
+++ b/internal/cli/testdata/envelope_doctor.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "8",
+  "schema_version": "9",
   "command": "doctor",
   "status": "findings",
   "data": {

--- a/internal/cli/testdata/envelope_install.golden
+++ b/internal/cli/testdata/envelope_install.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "8",
+  "schema_version": "9",
   "command": "install",
   "status": "ok",
   "data": {

--- a/internal/cli/testdata/envelope_installed.golden
+++ b/internal/cli/testdata/envelope_installed.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "8",
+  "schema_version": "9",
   "command": "installed",
   "status": "ok",
   "data": {
@@ -38,6 +38,8 @@
         "source": "configs/zsh/zshrc",
         "target": "/home/user/.zshrc",
         "strategy": "symlink",
+        "attribution": "legacy-unattributed",
+        "ownership_evidence": "legacy-target-wide",
         "installed_at": "2026-07-08T12:00:00Z",
         "tags": [
           "core"

--- a/internal/cli/testdata/envelope_legacy_tag_migration_required.golden
+++ b/internal/cli/testdata/envelope_legacy_tag_migration_required.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "8",
+  "schema_version": "9",
   "command": "update",
   "status": "error",
   "data": {

--- a/internal/cli/testdata/envelope_plan.golden
+++ b/internal/cli/testdata/envelope_plan.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "8",
+  "schema_version": "9",
   "command": "plan",
   "status": "findings",
   "data": {

--- a/internal/cli/testdata/envelope_selection_migration_required.golden
+++ b/internal/cli/testdata/envelope_selection_migration_required.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "8",
+  "schema_version": "9",
   "command": "status",
   "status": "error",
   "data": {

--- a/internal/cli/testdata/envelope_status.golden
+++ b/internal/cli/testdata/envelope_status.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "8",
+  "schema_version": "9",
   "command": "status",
   "status": "findings",
   "data": {

--- a/internal/cli/testdata/envelope_uninstall.golden
+++ b/internal/cli/testdata/envelope_uninstall.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "8",
+  "schema_version": "9",
   "command": "uninstall",
   "status": "ok",
   "data": {

--- a/internal/cli/testdata/envelope_update.golden
+++ b/internal/cli/testdata/envelope_update.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "8",
+  "schema_version": "9",
   "command": "update",
   "status": "ok",
   "data": {

--- a/internal/cli/testdata/envelope_update_selection_error.golden
+++ b/internal/cli/testdata/envelope_update_selection_error.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "8",
+  "schema_version": "9",
   "command": "update",
   "status": "error",
   "data": {

--- a/internal/cli/testdata/envelope_upgrade.golden
+++ b/internal/cli/testdata/envelope_upgrade.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "8",
+  "schema_version": "9",
   "command": "upgrade",
   "status": "ok",
   "data": {

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -120,54 +120,23 @@ func recordMetadata(p plan.Plan, resolvedSources [][]string, opts Options) error
 		if recordedOwnership == "" {
 			recordedOwnership = "whole"
 		}
-		if action.Strategy != "symlink" {
-			if len(action.Sources) > 0 {
-				hash = state.HashBytes(action.Content)
-				if action.Ownership == "json-subset" {
-					ownedContent = append([]byte(nil), action.Content...)
-				}
-			} else {
-				var err error
-				hash, err = state.HashFile(resolvedSources[i][0])
-				if err != nil {
-					return err
-				}
-				if action.Ownership == "json-subset" {
-					ownedContent, err = os.ReadFile(resolvedSources[i][0])
-					if err != nil {
-						return fmt.Errorf("read owned JSON contribution %s: %w", resolvedSources[i][0], err)
-					}
-				} else if action.Ownership == "jsonc-subset" {
-					rawContent, readErr := os.ReadFile(resolvedSources[i][0])
-					if readErr != nil {
-						return fmt.Errorf("read owned JSONC contribution %s: %w", resolvedSources[i][0], readErr)
-					}
-					ownedContent, err = configsubset.CanonicalJSONC(rawContent)
-					if err != nil {
-						return fmt.Errorf("canonicalize owned JSONC contribution %s: %w", resolvedSources[i][0], err)
-					}
-				} else if action.Ownership == "toml-subset" {
-					ownedBytes, err = os.ReadFile(resolvedSources[i][0])
-					if err != nil {
-						return fmt.Errorf("read owned TOML contribution %s: %w", resolvedSources[i][0], err)
-					}
-				} else if action.Ownership == "seeded" {
-					if action.Migration != nil && action.Migration.RecordedBaseline != nil {
-						seededBaseline = append([]byte(nil), action.Migration.RecordedBaseline...)
-					} else {
-						seededBaseline, err = os.ReadFile(resolvedSources[i][0])
-						if err != nil {
-							return fmt.Errorf("read seeded baseline %s: %w", resolvedSources[i][0], err)
-						}
-					}
-				} else if action.Ownership == "marked-block" {
-					ownedBytes, err = os.ReadFile(resolvedSources[i][0])
-					if err != nil {
-						return fmt.Errorf("read owned marked block %s: %w", resolvedSources[i][0], err)
-					}
-				}
+		contributions, err := recordContributions(action, resolvedSources[i], recordedOwnership)
+		if err != nil {
+			return err
+		}
+		targetWide, err := targetWideEvidence(action, resolvedSources[i], contributions, recordedOwnership)
+		if err != nil {
+			return err
+		}
+		if len(contributions) > 0 {
+			if err := validateRecordedConvergence(action, resolvedSources[i], targetWide, contributions); err != nil {
+				return err
 			}
 		}
+		hash = targetWide.Hash
+		ownedContent = targetWide.OwnedContent
+		ownedBytes = targetWide.OwnedBytes
+		seededBaseline = targetWide.SeededBaseline
 		upsertRecord(&meta, state.Record{
 			Target:         action.Target,
 			Source:         action.Source,
@@ -177,6 +146,7 @@ func recordMetadata(p plan.Plan, resolvedSources [][]string, opts Options) error
 			OwnedContent:   ownedContent,
 			OwnedBytes:     ownedBytes,
 			SeededBaseline: seededBaseline,
+			Contributions:  contributions,
 			Hash:           hash,
 			InstalledAt:    now,
 			Profiles:       append([]string(nil), p.Profiles...),
@@ -191,6 +161,153 @@ func recordMetadata(p plan.Plan, resolvedSources [][]string, opts Options) error
 	}
 
 	return state.Save(path, meta)
+}
+
+func recordContributions(action plan.Action, resolvedSources []string, ownership string) ([]state.Contribution, error) {
+	planned := action.Contributions
+	if len(planned) == 0 {
+		return nil, nil
+	}
+	if len(planned) != len(resolvedSources) {
+		return nil, fmt.Errorf("record contribution evidence for %s: %d contributions for %d resolved sources", action.Target, len(planned), len(resolvedSources))
+	}
+
+	contributions := make([]state.Contribution, 0, len(planned))
+	for i, contribution := range planned {
+		recorded, err := captureContributionEvidence(action, contribution, resolvedSources[i], ownership)
+		if err != nil {
+			return nil, err
+		}
+		contributions = append(contributions, recorded)
+	}
+	return contributions, nil
+}
+
+func captureContributionEvidence(action plan.Action, contribution plan.Contribution, resolvedSource, ownership string) (state.Contribution, error) {
+	recorded := state.Contribution{
+		Source:           contribution.Source,
+		SelectorTags:     append([]string(nil), contribution.SelectorTags...),
+		Ownership:        ownership,
+		EvidenceRecorded: true,
+	}
+	if action.Strategy == "symlink" {
+		return recorded, nil
+	}
+
+	raw, err := os.ReadFile(resolvedSource)
+	if err != nil {
+		return state.Contribution{}, fmt.Errorf("read %s contribution %s: %w", ownership, resolvedSource, err)
+	}
+	recorded.Hash = state.HashBytes(raw)
+	switch ownership {
+	case "json-subset":
+		recorded.OwnedContent = append([]byte{}, raw...)
+	case "jsonc-subset":
+		recorded.OwnedContent, err = configsubset.CanonicalJSONC(raw)
+		if err != nil {
+			return state.Contribution{}, fmt.Errorf("canonicalize owned jsonc contribution %s: %w", resolvedSource, err)
+		}
+	case "toml-subset", "marked-block":
+		recorded.OwnedBytes = append([]byte{}, raw...)
+	case "seeded":
+		if action.Migration != nil && action.Migration.RecordedBaseline != nil {
+			recorded.SeededBaseline = append([]byte{}, action.Migration.RecordedBaseline...)
+		} else {
+			recorded.SeededBaseline = append([]byte{}, raw...)
+		}
+	}
+	return recorded, nil
+}
+
+func targetWideEvidence(action plan.Action, resolvedSources []string, contributions []state.Contribution, ownership string) (state.Contribution, error) {
+	if len(contributions) == 0 {
+		return captureContributionEvidence(action, plan.Contribution{Source: action.Source}, resolvedSources[0], ownership)
+	}
+	if len(contributions) == 1 {
+		return contributions[0], nil
+	}
+	if ownership != "json-subset" {
+		return state.Contribution{}, fmt.Errorf("compose target-wide evidence for %s: unsupported ownership %s", action.Target, ownership)
+	}
+
+	composed := append([]byte(nil), contributions[0].OwnedContent...)
+	var err error
+	for _, contribution := range contributions[1:] {
+		composed, err = configsubset.MergeJSON(composed, contribution.OwnedContent)
+		if err != nil {
+			return state.Contribution{}, fmt.Errorf("compose target-wide evidence for %s: %w", action.Target, err)
+		}
+	}
+	return state.Contribution{
+		Ownership:        ownership,
+		EvidenceRecorded: true,
+		Hash:             state.HashBytes(composed),
+		OwnedContent:     composed,
+	}, nil
+}
+
+func validateRecordedConvergence(action plan.Action, resolvedSources []string, targetWide state.Contribution, contributions []state.Contribution) error {
+	if action.Strategy == "symlink" {
+		if len(contributions) != 1 {
+			return fmt.Errorf("managed target %s no longer converged: symlink has %d contributions", action.Target, len(contributions))
+		}
+		info, err := os.Lstat(action.Target)
+		if err != nil {
+			return fmt.Errorf("inspect converged symlink %s: %w", action.Target, err)
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			return fmt.Errorf("managed target %s no longer converged: expected symlink", action.Target)
+		}
+		destination, err := os.Readlink(action.Target)
+		if err != nil {
+			return fmt.Errorf("read converged symlink %s: %w", action.Target, err)
+		}
+		if filepath.Clean(destination) != filepath.Clean(resolvedSources[0]) {
+			return fmt.Errorf("managed target %s no longer converged: symlink destination changed", action.Target)
+		}
+		return nil
+	}
+
+	live, err := os.ReadFile(action.Target)
+	if err != nil {
+		return fmt.Errorf("read converged target %s: %w", action.Target, err)
+	}
+	converged := false
+	switch targetWide.Ownership {
+	case "whole":
+		converged = state.HashBytes(live) == targetWide.Hash
+	case "json-subset":
+		relation, analyzeErr := configsubset.AnalyzeJSON(live, targetWide.OwnedContent)
+		if analyzeErr != nil {
+			return fmt.Errorf("validate converged json target %s: %w", action.Target, analyzeErr)
+		}
+		converged = relation.Contains
+	case "jsonc-subset":
+		relation, analyzeErr := configsubset.AnalyzeJSONC(live, targetWide.OwnedContent)
+		if analyzeErr != nil {
+			return fmt.Errorf("validate converged jsonc target %s: %w", action.Target, analyzeErr)
+		}
+		converged = relation.Contains
+	case "toml-subset":
+		relation, analyzeErr := configsubset.AnalyzeTOML(live, targetWide.OwnedBytes)
+		if analyzeErr != nil {
+			return fmt.Errorf("validate converged toml target %s: %w", action.Target, analyzeErr)
+		}
+		converged = relation.Contains
+	case "marked-block":
+		reconciliation := textblock.ReconcileOwned(live, targetWide.OwnedBytes, targetWide.OwnedBytes, textblock.DotsManagedMarkers())
+		converged = reconciliation.Compatible && !reconciliation.Changed
+	case "seeded":
+		if action.Migration != nil {
+			converged = bytes.Equal(live, action.Migration.FinalContent)
+		} else {
+			converged = bytes.Equal(live, targetWide.SeededBaseline)
+		}
+	}
+	if !converged {
+		return fmt.Errorf("managed target %s no longer converged; contribution evidence was not recorded", action.Target)
+	}
+	return nil
 }
 
 func upsertRecord(meta *state.Metadata, rec state.Record) {
@@ -244,6 +361,16 @@ func validatePlan(p plan.Plan, opts Options) ([][]string, error) {
 			declaredResolved = action.ResolvedSources
 			if action.Strategy != "copy" || action.Ownership != "json-subset" || len(sources) < 2 {
 				return nil, fmt.Errorf("composed target %s requires at least two copy/json-subset sources", action.Target)
+			}
+		}
+		if len(action.Contributions) > 0 {
+			if len(action.Contributions) != len(sources) {
+				return nil, fmt.Errorf("install plan has %d contributions for %d sources on %s", len(action.Contributions), len(sources), action.Target)
+			}
+			for j, contribution := range action.Contributions {
+				if contribution.Source != sources[j] {
+					return nil, fmt.Errorf("install plan contribution source %q does not match source %q on %s", contribution.Source, sources[j], action.Target)
+				}
 			}
 		}
 		for j, sourceName := range sources {

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -71,6 +71,35 @@ func TestApplyComposedJSONSubsetCreatesAndUpdatesOneSharedTarget(t *testing.T) {
 	if rec.Hash != targetHash {
 		t.Fatalf("metadata hash = %q, want composed target hash %q", rec.Hash, targetHash)
 	}
+	if len(rec.Contributions) != 2 {
+		t.Fatalf("metadata contributions = %+v, want two attributed sources", rec.Contributions)
+	}
+	for i, want := range []struct {
+		source string
+		tag    string
+		owned  string
+	}{
+		{source: "configs/base.json", tag: "base", owned: `{"editor":{"theme":"dark"},"servers":["one"]}`},
+		{source: "configs/mobile.json", tag: "mobile", owned: `{"mobile":true,"servers":["two"]}`},
+	} {
+		contribution := rec.Contributions[i]
+		if contribution.Source != want.source ||
+			!reflect.DeepEqual(contribution.SelectorTags, []string{want.tag}) ||
+			contribution.Ownership != "json-subset" ||
+			contribution.Hash != state.HashBytes([]byte(want.owned)) {
+			t.Fatalf("metadata contribution[%d] = %+v, want source %q selected by %q with exact JSON evidence", i, contribution, want.source, want.tag)
+		}
+		var gotOwned, wantOwned any
+		if err := json.Unmarshal(contribution.OwnedContent, &gotOwned); err != nil {
+			t.Fatalf("decode contribution[%d] owned content: %v", i, err)
+		}
+		if err := json.Unmarshal([]byte(want.owned), &wantOwned); err != nil {
+			t.Fatalf("decode wanted contribution[%d] owned content: %v", i, err)
+		}
+		if !reflect.DeepEqual(gotOwned, wantOwned) {
+			t.Fatalf("metadata contribution[%d] owned content = %v, want %v", i, gotOwned, wantOwned)
+		}
+	}
 
 	if err := os.WriteFile(target, []byte(`{"editor":{"theme":"dark"},"servers":["one"],"userOnly":"keep"}`), 0o640); err != nil {
 		t.Fatalf("write trusted target: %v", err)
@@ -119,6 +148,306 @@ func TestApplyComposedJSONSubsetCreatesAndUpdatesOneSharedTarget(t *testing.T) {
 	}
 	if shared == nil || shared.Status != plan.UninstallRemove || shared.Ownership != "json-subset" {
 		t.Fatalf("shared uninstall action = %+v, want partial removal that preserves target-only state", shared)
+	}
+}
+
+func TestApplyRecordsModeSpecificContributionEvidence(t *testing.T) {
+	tests := []struct {
+		name      string
+		strategy  string
+		ownership string
+		content   string
+		assert    func(*testing.T, state.Contribution, []byte)
+	}{
+		{
+			name: "whole copy", strategy: "copy", content: "whole\n",
+			assert: func(t *testing.T, got state.Contribution, content []byte) {
+				t.Helper()
+				if got.Hash != state.HashBytes(content) || len(got.OwnedContent) != 0 || len(got.OwnedBytes) != 0 || len(got.SeededBaseline) != 0 {
+					t.Fatalf("whole-copy evidence = %+v, want source hash only", got)
+				}
+			},
+		},
+		{
+			name: "whole symlink", strategy: "symlink", content: "linked\n",
+			assert: func(t *testing.T, got state.Contribution, _ []byte) {
+				t.Helper()
+				if got.Hash != "" || len(got.OwnedContent) != 0 || len(got.OwnedBytes) != 0 || len(got.SeededBaseline) != 0 {
+					t.Fatalf("whole-symlink evidence = %+v, want Source of Truth identity only", got)
+				}
+			},
+		},
+		{
+			name: "json subset", strategy: "copy", ownership: "json-subset", content: `{"owned":true}`,
+			assert: func(t *testing.T, got state.Contribution, _ []byte) {
+				t.Helper()
+				if !json.Valid(got.OwnedContent) {
+					t.Fatalf("json-subset evidence = %+v, want owned JSON", got)
+				}
+			},
+		},
+		{
+			name: "jsonc subset", strategy: "copy", ownership: "jsonc-subset", content: "{\n  // portable\n  \"owned\": true,\n}\n",
+			assert: func(t *testing.T, got state.Contribution, _ []byte) {
+				t.Helper()
+				if !json.Valid(got.OwnedContent) || strings.Contains(string(got.OwnedContent), "portable") {
+					t.Fatalf("jsonc-subset evidence = %+v, want canonical semantic JSON", got)
+				}
+			},
+		},
+		{
+			name: "toml subset", strategy: "copy", ownership: "toml-subset", content: "owned = true\n",
+			assert: func(t *testing.T, got state.Contribution, content []byte) {
+				t.Helper()
+				if !reflect.DeepEqual(got.OwnedBytes, content) {
+					t.Fatalf("toml-subset evidence = %q, want %q", got.OwnedBytes, content)
+				}
+			},
+		},
+		{
+			name: "empty toml subset", strategy: "copy", ownership: "toml-subset", content: "",
+			assert: func(t *testing.T, got state.Contribution, _ []byte) {
+				t.Helper()
+				if !got.EvidenceRecorded || len(got.OwnedBytes) != 0 {
+					t.Fatalf("empty toml-subset evidence = %+v, want recorded empty bytes", got)
+				}
+			},
+		},
+		{
+			name: "marked block", strategy: "copy", ownership: "marked-block", content: "# >>> dots managed block >>>\nsource portable\n# <<< dots managed block <<<\n",
+			assert: func(t *testing.T, got state.Contribution, content []byte) {
+				t.Helper()
+				if !reflect.DeepEqual(got.OwnedBytes, content) {
+					t.Fatalf("marked-block evidence = %q, want %q", got.OwnedBytes, content)
+				}
+			},
+		},
+		{
+			name: "seeded runtime state", strategy: "copy", ownership: "seeded", content: "seeded baseline\n",
+			assert: func(t *testing.T, got state.Contribution, content []byte) {
+				t.Helper()
+				if !reflect.DeepEqual(got.SeededBaseline, content) {
+					t.Fatalf("seeded evidence = %q, want %q", got.SeededBaseline, content)
+				}
+			},
+		},
+		{
+			name: "empty seeded runtime state", strategy: "copy", ownership: "seeded", content: "",
+			assert: func(t *testing.T, got state.Contribution, _ []byte) {
+				t.Helper()
+				if !got.EvidenceRecorded || len(got.SeededBaseline) != 0 {
+					t.Fatalf("empty seeded evidence = %+v, want recorded empty baseline", got)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sourceRoot := t.TempDir()
+			home := t.TempDir()
+			stateRoot := filepath.Join(home, ".local", "state", "dots")
+			rel := filepath.Join("configs", strings.ReplaceAll(tt.name, " ", "-"))
+			source := filepath.Join(sourceRoot, rel)
+			if err := os.MkdirAll(filepath.Dir(source), 0o755); err != nil {
+				t.Fatalf("mkdir source: %v", err)
+			}
+			content := []byte(tt.content)
+			if err := os.WriteFile(source, content, 0o600); err != nil {
+				t.Fatalf("write source: %v", err)
+			}
+			m := manifest.Manifest{
+				Version:  1,
+				Profiles: map[string]manifest.Profile{"default": {Tags: []string{"capability"}}},
+				Entries: []manifest.Entry{{
+					Source: rel, Target: "~/.config/" + strings.ReplaceAll(tt.name, " ", "-"),
+					Strategy: tt.strategy, Ownership: tt.ownership, Tags: []string{"capability"},
+				}},
+			}
+			p, err := plan.Build(m, plan.Options{Profile: "default", OS: "linux", SourceRoot: sourceRoot, Home: home})
+			if err != nil {
+				t.Fatalf("Build() error = %v", err)
+			}
+			if err := install.Apply(p, install.Options{SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot}); err != nil {
+				t.Fatalf("Apply() error = %v", err)
+			}
+			meta, err := state.Load(state.Path(stateRoot))
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if len(meta.Entries) != 1 || len(meta.Entries[0].Contributions) != 1 {
+				t.Fatalf("metadata = %+v, want one target with one contribution", meta)
+			}
+			contribution := meta.Entries[0].Contributions[0]
+			wantOwnership := tt.ownership
+			if wantOwnership == "" {
+				wantOwnership = "whole"
+			}
+			if contribution.Source != rel || !reflect.DeepEqual(contribution.SelectorTags, []string{"capability"}) || contribution.Ownership != wantOwnership || !contribution.EvidenceRecorded {
+				t.Fatalf("contribution identity = %+v, want %q selected by capability with %q ownership", contribution, rel, wantOwnership)
+			}
+			tt.assert(t, contribution, content)
+		})
+	}
+}
+
+func TestApplyContributionEvidencePreservesUnrelatedInventoryAndInstalledSelection(t *testing.T) {
+	sourceRoot := t.TempDir()
+	home := t.TempDir()
+	stateRoot := filepath.Join(home, ".local", "state", "dots")
+	source := filepath.Join(sourceRoot, "configs", "new")
+	if err := os.MkdirAll(filepath.Dir(source), 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	if err := os.WriteFile(source, []byte("new\n"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	selection := &state.InstalledSelection{
+		Profiles: []string{"existing"}, ExtraTags: []string{"extra"}, ResolvedTags: []string{"existing", "extra"},
+		Provenance: state.Provenance{SourceRoot: "/previous", SourceRevision: "abc123", RecordedAt: "2026-08-21T00:00:00Z"},
+	}
+	unrelated := state.Record{Target: filepath.Join(home, ".unrelated"), Source: "configs/unrelated", Strategy: "copy", Ownership: "whole", Hash: "unchanged"}
+	provisioners := []state.ProvisionerRecord{{Profile: "existing", Tool: "codex", Executable: "codex", Args: []string{"mcp", "add"}, Status: "provisioned"}}
+	previous := state.Metadata{Version: 6, Entries: []state.Record{unrelated}, Provisioners: provisioners, InstalledSelection: selection}
+	if err := state.Save(state.Path(stateRoot), previous); err != nil {
+		t.Fatalf("save previous metadata: %v", err)
+	}
+	m := manifest.Manifest{
+		Version: 1, Profiles: map[string]manifest.Profile{"default": {Tags: []string{"new"}}},
+		Entries: []manifest.Entry{{Source: "configs/new", Target: "~/.new", Strategy: "copy", Tags: []string{"new"}}},
+	}
+	p, err := plan.Build(m, plan.Options{Profile: "default", OS: "linux", SourceRoot: sourceRoot, Home: home, Metadata: previous})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if err := install.Apply(p, install.Options{SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot}); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	got, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if got.Version != state.CurrentVersion || !reflect.DeepEqual(got.InstalledSelection, selection) || !reflect.DeepEqual(got.Provisioners, provisioners) {
+		t.Fatalf("metadata terminal state = %+v, want v%d with prior selection and Provisioners", got, state.CurrentVersion)
+	}
+	if kept, ok := got.FindByTarget(unrelated.Target); !ok || !reflect.DeepEqual(kept, unrelated) {
+		t.Fatalf("unrelated inventory = %+v, want preserved %+v", kept, unrelated)
+	}
+	newRecord, ok := got.FindByTarget(filepath.Join(home, ".new"))
+	if !ok || len(newRecord.Contributions) != 1 || !reflect.DeepEqual(newRecord.Contributions[0].SelectorTags, []string{"new"}) {
+		t.Fatalf("new record = %+v, want terminal contribution evidence", newRecord)
+	}
+}
+
+func TestApplyMetadataWriteFailurePreservesPreviousContributionEvidence(t *testing.T) {
+	sourceRoot := t.TempDir()
+	home := t.TempDir()
+	stateRoot := filepath.Join(home, ".local", "state", "dots")
+	source := filepath.Join(sourceRoot, "configs", "new")
+	if err := os.MkdirAll(filepath.Dir(source), 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	if err := os.WriteFile(source, []byte("new\n"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	previous := state.Metadata{Version: 6, Entries: []state.Record{{Target: filepath.Join(home, ".old"), Source: "configs/old", Strategy: "copy", Hash: "old"}}}
+	metadataPath := state.Path(stateRoot)
+	if err := state.Save(metadataPath, previous); err != nil {
+		t.Fatalf("save previous metadata: %v", err)
+	}
+	previousBytes, err := os.ReadFile(metadataPath)
+	if err != nil {
+		t.Fatalf("read previous metadata: %v", err)
+	}
+	m := manifest.Manifest{
+		Version: 1, Profiles: map[string]manifest.Profile{"default": {Tags: []string{"new"}}},
+		Entries: []manifest.Entry{{Source: "configs/new", Target: "~/.new", Strategy: "copy", Tags: []string{"new"}}},
+	}
+	p, err := plan.Build(m, plan.Options{Profile: "default", OS: "linux", SourceRoot: sourceRoot, Home: home, Metadata: previous})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if err := os.Chmod(stateRoot, 0o500); err != nil {
+		t.Fatalf("make state root read-only: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(stateRoot, 0o700) })
+
+	if err := install.Apply(p, install.Options{SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot}); err == nil {
+		t.Skip("filesystem permits metadata writes to a read-only state root")
+	}
+	unchanged, err := os.ReadFile(metadataPath)
+	if err != nil {
+		t.Fatalf("read metadata after failed write: %v", err)
+	}
+	if !reflect.DeepEqual(unchanged, previousBytes) {
+		t.Fatalf("metadata after failed write = %q, want previous bytes %q", unchanged, previousBytes)
+	}
+	got, err := state.Load(metadataPath)
+	if err != nil {
+		t.Fatalf("load metadata after failed write: %v", err)
+	}
+	if got.Version != 6 || len(got.Entries) != 1 || len(got.Entries[0].Contributions) != 0 {
+		t.Fatalf("metadata after failed write = %+v, want untouched previous evidence", got)
+	}
+}
+
+func TestApplyRejectsStaleUnchangedPlanWithoutRecordingContributionEvidence(t *testing.T) {
+	sourceRoot := t.TempDir()
+	home := t.TempDir()
+	stateRoot := filepath.Join(home, ".local", "state", "dots")
+	source := filepath.Join(sourceRoot, "configs", "shared.json")
+	if err := os.MkdirAll(filepath.Dir(source), 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	if err := os.WriteFile(source, []byte(`{"owned":"portable"}`), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	target := filepath.Join(home, ".config", "shared.json")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	if err := os.WriteFile(target, []byte(`{"owned":"portable","local":true}`), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	previous := state.Metadata{Version: 6, Entries: []state.Record{{
+		Target: target, Source: "configs/shared.json", Strategy: "copy", Ownership: "json-subset",
+		OwnedContent: []byte(`{"owned":"portable"}`),
+	}}}
+	metadataPath := state.Path(stateRoot)
+	if err := state.Save(metadataPath, previous); err != nil {
+		t.Fatalf("save previous metadata: %v", err)
+	}
+	previousBytes, err := os.ReadFile(metadataPath)
+	if err != nil {
+		t.Fatalf("read previous metadata: %v", err)
+	}
+	m := manifest.Manifest{
+		Version: 1, Profiles: map[string]manifest.Profile{"default": {Tags: []string{"shared"}}},
+		Entries: []manifest.Entry{{
+			Source: "configs/shared.json", Target: "~/.config/shared.json", Strategy: "copy", Ownership: "json-subset", Tags: []string{"shared"},
+		}},
+	}
+	p, err := plan.Build(m, plan.Options{Profile: "default", OS: "linux", SourceRoot: sourceRoot, Home: home, Metadata: previous})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if len(p.Actions) != 1 || p.Actions[0].Status != plan.StatusUnchanged {
+		t.Fatalf("plan = %+v, want one unchanged action", p)
+	}
+	if err := os.WriteFile(target, []byte(`{"owned":"drifted","local":true}`), 0o600); err != nil {
+		t.Fatalf("drift target after planning: %v", err)
+	}
+
+	if err := install.Apply(p, install.Options{SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot}); err == nil || !strings.Contains(err.Error(), "no longer converged") {
+		t.Fatalf("Apply() error = %v, want stale convergence rejection", err)
+	}
+	unchanged, err := os.ReadFile(metadataPath)
+	if err != nil {
+		t.Fatalf("read metadata after rejected apply: %v", err)
+	}
+	if !reflect.DeepEqual(unchanged, previousBytes) {
+		t.Fatalf("metadata after rejected apply = %q, want previous bytes %q", unchanged, previousBytes)
 	}
 }
 
@@ -918,6 +1247,37 @@ func TestApplyRejectsMissingSourceWithoutMutatingAnyAction(t *testing.T) {
 	}
 	if _, err := os.Lstat(wouldCreate); !os.IsNotExist(err) {
 		t.Fatalf("would-create target exists after rejected install; lstat err = %v", err)
+	}
+}
+
+func TestApplyRejectsMismatchedContributionAttributionBeforeMutation(t *testing.T) {
+	sourceRoot := t.TempDir()
+	home := t.TempDir()
+	stateRoot := filepath.Join(home, ".local", "state", "dots")
+	source := filepath.Join(sourceRoot, "configs", "safe")
+	if err := os.MkdirAll(filepath.Dir(source), 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	if err := os.WriteFile(source, []byte("safe\n"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	target := filepath.Join(home, ".config", "safe")
+	p := plan.Plan{Actions: []plan.Action{{
+		Source:        "configs/safe",
+		Contributions: []plan.Contribution{{Source: "configs/other", SelectorTags: []string{"safe"}}},
+		Target:        target,
+		Strategy:      "copy",
+		Status:        plan.StatusCreate,
+	}}}
+
+	if err := install.Apply(p, install.Options{SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot}); err == nil || !strings.Contains(err.Error(), "contribution source") {
+		t.Fatalf("Apply() error = %v, want contribution source mismatch", err)
+	}
+	if _, err := os.Lstat(target); !os.IsNotExist(err) {
+		t.Fatalf("mismatched attribution mutated target: %v", err)
+	}
+	if _, err := os.Lstat(state.Path(stateRoot)); !os.IsNotExist(err) {
+		t.Fatalf("mismatched attribution wrote metadata: %v", err)
 	}
 }
 

--- a/internal/install/issue396_herdr_test.go
+++ b/internal/install/issue396_herdr_test.go
@@ -104,6 +104,11 @@ func TestHerdrTOMLSubsetLifecycleMigratesAdaptiveConfigAndPreservesExternalConte
 	if !ok || rec.Source != "configs/herdr/config-adaptive.toml" || rec.Ownership != "toml-subset" || !bytes.Equal(rec.OwnedBytes, incomingAdaptiveBaseline) {
 		t.Fatalf("Herdr ownership record = %#v, want adaptive TOML contribution", rec)
 	}
+	if len(rec.Contributions) != 1 || rec.Contributions[0].Source != "configs/herdr/config-adaptive.toml" ||
+		!bytes.Equal(rec.Contributions[0].OwnedBytes, incomingAdaptiveBaseline) ||
+		len(rec.Contributions[0].SelectorTags) != 2 || rec.Contributions[0].SelectorTags[0] != "core" || rec.Contributions[0].SelectorTags[1] != "adaptive-theme" {
+		t.Fatalf("Herdr contribution attribution = %#v, want core + adaptive-theme exact TOML evidence", rec.Contributions)
+	}
 	report, err := status.Build(newManifest, meta, status.Options{Profile: "default", ExtraTags: []string{"adaptive-theme"}, OS: "darwin", SourceRoot: sourceRoot, Home: home})
 	if err != nil || len(report.Entries) != 1 || report.Entries[0].State != status.StateOK {
 		t.Fatalf("status after migration = (%#v, %v), want ok", report, err)

--- a/internal/installed/installed.go
+++ b/internal/installed/installed.go
@@ -31,16 +31,19 @@ type MetadataSummary struct {
 
 // ManagedEntry is one Managed Entry recorded in Installation Metadata.
 type ManagedEntry struct {
-	Source          string   `json:"source"`
-	Target          string   `json:"target"`
-	Strategy        string   `json:"strategy"`
-	Hash            string   `json:"hash,omitempty"`
-	InstalledAt     string   `json:"installed_at,omitempty"`
-	Tags            []string `json:"tags,omitempty"`
-	TagsSource      string   `json:"tags_source"`
-	Profiles        []string `json:"profiles,omitempty"`
-	ProfilesSource  string   `json:"profiles_source"`
-	ManifestMatched bool     `json:"manifest_matched"`
+	Source            string   `json:"source"`
+	Target            string   `json:"target"`
+	Strategy          string   `json:"strategy"`
+	Attribution       string   `json:"attribution"`
+	Ownership         string   `json:"ownership,omitempty"`
+	OwnershipEvidence string   `json:"ownership_evidence"`
+	Hash              string   `json:"hash,omitempty"`
+	InstalledAt       string   `json:"installed_at,omitempty"`
+	Tags              []string `json:"tags,omitempty"`
+	TagsSource        string   `json:"tags_source"`
+	Profiles          []string `json:"profiles,omitempty"`
+	ProfilesSource    string   `json:"profiles_source"`
+	ManifestMatched   bool     `json:"manifest_matched"`
 }
 
 // ProfileCoverage summarizes whether a Profile is explicit in metadata or can be
@@ -116,8 +119,10 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options) (Report, erro
 	legacyTagsInferred := false
 	legacyProfilesInferred := false
 	unmatchedEntries := false
+	missingContributionTags := false
 
-	for _, rec := range expandedRecords(meta.Entries) {
+	for _, expanded := range expandedRecords(meta.Entries) {
+		rec := expanded.Record
 		entry, matched, err := matchEntry(m, rec, opts)
 		if err != nil {
 			return Report{}, err
@@ -128,7 +133,14 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options) (Report, erro
 
 		tags := append([]string(nil), rec.Tags...)
 		tagsSource := "recorded"
-		if len(tags) == 0 && matched {
+		if expanded.Attributed {
+			tags = append([]string(nil), expanded.Contribution.SelectorTags...)
+			tagsSource = "recorded-contribution"
+			if len(tags) == 0 {
+				tagsSource = "unknown"
+				missingContributionTags = true
+			}
+		} else if len(tags) == 0 && matched {
 			tags = append([]string(nil), entry.Tags...)
 			tagsSource = "inferred-from-manifest"
 			legacyTagsInferred = true
@@ -151,17 +163,28 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options) (Report, erro
 			explicitProfiles.add(profile)
 		}
 
+		attribution := "legacy-unattributed"
+		ownership := rec.Ownership
+		ownershipEvidence := "legacy-target-wide"
+		if expanded.Attributed {
+			attribution = "recorded-contribution"
+			ownership = expanded.Contribution.Ownership
+			ownershipEvidence = describeContributionEvidence(rec.Strategy, expanded.Contribution)
+		}
 		report.ManagedEntries = append(report.ManagedEntries, ManagedEntry{
-			Source:          rec.Source,
-			Target:          rec.Target,
-			Strategy:        rec.Strategy,
-			Hash:            rec.Hash,
-			InstalledAt:     rec.InstalledAt,
-			Tags:            tags,
-			TagsSource:      tagsSource,
-			Profiles:        profiles,
-			ProfilesSource:  profilesSource,
-			ManifestMatched: matched,
+			Source:            rec.Source,
+			Target:            rec.Target,
+			Strategy:          rec.Strategy,
+			Attribution:       attribution,
+			Ownership:         ownership,
+			OwnershipEvidence: ownershipEvidence,
+			Hash:              rec.Hash,
+			InstalledAt:       rec.InstalledAt,
+			Tags:              tags,
+			TagsSource:        tagsSource,
+			Profiles:          profiles,
+			ProfilesSource:    profilesSource,
+			ManifestMatched:   matched,
 		})
 	}
 
@@ -224,28 +247,72 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options) (Report, erro
 	if unmatchedEntries {
 		report.Notes = append(report.Notes, "some installed entries no longer match the current manifest; their tags and profile coverage are unknown")
 	}
+	if missingContributionTags {
+		report.Notes = append(report.Notes, "some attributed contributions do not record selector Tags; their historical intent remains unknown")
+	}
 	if meta.Provenance.Empty() {
 		report.Notes = append(report.Notes, "metadata does not record Source of Truth provenance; run a future install/update to capture source revision and dots version")
 	}
 	return report, nil
 }
 
-func expandedRecords(records []state.Record) []state.Record {
-	expanded := make([]state.Record, 0, len(records))
+type expandedRecord struct {
+	Record       state.Record
+	Contribution state.Contribution
+	Attributed   bool
+}
+
+func expandedRecords(records []state.Record) []expandedRecord {
+	expanded := make([]expandedRecord, 0, len(records))
 	for _, rec := range records {
+		if len(rec.Contributions) > 0 {
+			for _, contribution := range rec.Contributions {
+				contributor := rec
+				contributor.Source = contribution.Source
+				contributor.Sources = nil
+				contributor.Contributions = nil
+				contributor.Hash = contribution.Hash
+				expanded = append(expanded, expandedRecord{Record: contributor, Contribution: contribution, Attributed: true})
+			}
+			continue
+		}
 		sources := rec.SourceList()
 		if len(sources) == 0 {
-			expanded = append(expanded, rec)
+			expanded = append(expanded, expandedRecord{Record: rec})
 			continue
 		}
 		for _, source := range sources {
 			contributor := rec
 			contributor.Source = source
 			contributor.Sources = nil
-			expanded = append(expanded, contributor)
+			expanded = append(expanded, expandedRecord{Record: contributor})
 		}
 	}
 	return expanded
+}
+
+func describeContributionEvidence(strategy string, contribution state.Contribution) string {
+	if !contribution.EvidenceRecorded {
+		return "missing"
+	}
+	switch contribution.Ownership {
+	case "json-subset":
+		return "owned-json"
+	case "jsonc-subset":
+		return "owned-jsonc"
+	case "toml-subset":
+		return "owned-toml"
+	case "marked-block":
+		return "owned-marked-block"
+	case "seeded":
+		return "seeded-baseline"
+	case "whole":
+		if strategy == "symlink" {
+			return "source-identity"
+		}
+		return "source-hash"
+	}
+	return "missing"
 }
 
 func matchEntry(m manifest.Manifest, rec state.Record, opts Options) (manifest.Entry, bool, error) {

--- a/internal/installed/installed_test.go
+++ b/internal/installed/installed_test.go
@@ -48,6 +48,84 @@ func TestBuildExposesEverySharedTargetContributor(t *testing.T) {
 	}
 }
 
+func TestBuildExplainsAttributedAndLegacyUnattributedOwnership(t *testing.T) {
+	home := t.TempDir()
+	sharedTarget := filepath.Join(home, ".config", "shared.json")
+	legacyTarget := filepath.Join(home, ".legacy")
+	m := manifest.Manifest{
+		Version: 1,
+		Entries: []manifest.Entry{
+			{Source: "configs/opencode.json", Target: "~/.config/shared.json", Strategy: "copy", Ownership: "json-subset", Tags: []string{"opencode"}},
+			{Source: "configs/antigravity.json", Target: "~/.config/shared.json", Strategy: "copy", Ownership: "json-subset", Tags: []string{"antigravity"}},
+			{Source: "configs/legacy", Target: "~/.legacy", Strategy: "copy", Tags: []string{"legacy"}},
+		},
+	}
+	meta := state.Metadata{Version: state.CurrentVersion, Entries: []state.Record{
+		{
+			Target: sharedTarget, Source: "configs/opencode.json", Sources: []string{"configs/opencode.json", "configs/antigravity.json"}, Strategy: "copy", Ownership: "json-subset",
+			Contributions: []state.Contribution{
+				{Source: "configs/opencode.json", SelectorTags: []string{"opencode"}, Ownership: "json-subset", EvidenceRecorded: true, Hash: "one", OwnedContent: []byte(`{"opencode":true}`)},
+				{Source: "configs/antigravity.json", SelectorTags: []string{"antigravity"}, Ownership: "json-subset", EvidenceRecorded: true, Hash: "two", OwnedContent: []byte(`{"antigravity":true}`)},
+			},
+		},
+		{Target: legacyTarget, Source: "configs/legacy", Strategy: "copy", Ownership: "whole", Hash: "legacy-hash", Tags: []string{"legacy"}},
+	}}
+
+	report, err := inst.Build(m, meta, inst.Options{StatePath: filepath.Join(home, "installed.json"), Home: home, OS: "linux"})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if report.InstalledSelection != nil {
+		t.Fatalf("InstalledSelection = %+v, want historical inventory to remain non-authoritative", report.InstalledSelection)
+	}
+	if len(report.ManagedEntries) != 3 {
+		t.Fatalf("ManagedEntries = %+v, want two attributed contributors and one legacy record", report.ManagedEntries)
+	}
+	for i, wantTag := range []string{"opencode", "antigravity"} {
+		entry := report.ManagedEntries[i]
+		if entry.Attribution != "recorded-contribution" || entry.Ownership != "json-subset" || entry.OwnershipEvidence != "owned-json" ||
+			!reflect.DeepEqual(entry.Tags, []string{wantTag}) || entry.TagsSource != "recorded-contribution" {
+			t.Fatalf("ManagedEntries[%d] = %+v, want attributed %s JSON contribution", i, entry, wantTag)
+		}
+	}
+	legacy := report.ManagedEntries[2]
+	if legacy.Attribution != "legacy-unattributed" || legacy.Ownership != "whole" || legacy.OwnershipEvidence != "legacy-target-wide" {
+		t.Fatalf("legacy Managed Entry = %+v, want explicit legacy-unattributed explanation", legacy)
+	}
+}
+
+func TestBuildReportsRecordedEmptyOwnershipEvidence(t *testing.T) {
+	home := t.TempDir()
+	tests := []struct {
+		ownership string
+		evidence  string
+	}{
+		{ownership: "toml-subset", evidence: "owned-toml"},
+		{ownership: "seeded", evidence: "seeded-baseline"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.ownership, func(t *testing.T) {
+			target := filepath.Join(home, tt.ownership)
+			m := manifest.Manifest{Version: 1, Entries: []manifest.Entry{{
+				Source: "configs/empty", Target: "~/" + tt.ownership, Strategy: "copy", Ownership: tt.ownership, Tags: []string{"empty"},
+			}}}
+			meta := state.Metadata{Version: state.CurrentVersion, Entries: []state.Record{{
+				Target: target, Source: "configs/empty", Strategy: "copy", Ownership: tt.ownership,
+				Contributions: []state.Contribution{{
+					Source: "configs/empty", SelectorTags: []string{"empty"}, Ownership: tt.ownership, EvidenceRecorded: true,
+				}},
+			}}}
+			report, err := inst.Build(m, meta, inst.Options{StatePath: filepath.Join(home, "installed.json"), Home: home, OS: "linux"})
+			if err != nil {
+				t.Fatalf("Build() error = %v", err)
+			}
+			if len(report.ManagedEntries) != 1 || report.ManagedEntries[0].OwnershipEvidence != tt.evidence {
+				t.Fatalf("ManagedEntries = %+v, want empty %s evidence reported as %s", report.ManagedEntries, tt.ownership, tt.evidence)
+			}
+		})
+	}
+}
+
 func TestBuildMatchesXDGStateTargetRoot(t *testing.T) {
 	home := t.TempDir()
 	xdgStateHome := filepath.Join(home, ".local", "state")

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -47,6 +47,10 @@ type Action struct {
 	// the portable, manifest-relative Source instead.
 	ResolvedSource  string   `json:"-"`
 	ResolvedSources []string `json:"-"`
+	// Contributions retains ordered Source of Truth attribution for metadata
+	// recording. It stays outside the Install Plan output because the stable
+	// public projection is exposed by dots installed after convergence.
+	Contributions []Contribution `json:"-"`
 	// Content is the conservatively composed baseline for a shared json-subset
 	// target. Apply writes or merges it once instead of mutating per contributor.
 	Content []byte `json:"-"`
@@ -68,6 +72,13 @@ type Action struct {
 	// action in the same plan. It lets apply validate a later child create
 	// without treating the pre-removal view as an unrelated conflict.
 	LegacyParent string `json:"-"`
+}
+
+// Contribution identifies one selected Source of Truth contribution and the
+// effective declarative Tags that selected its Managed Entry and source.
+type Contribution struct {
+	Source       string
+	SelectorTags []string
 }
 
 // LegacyMigration is provenance-backed content captured before the Installed
@@ -204,14 +215,18 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 		action := Action{
 			Source:         source,
 			ResolvedSource: sourceAbs,
-			Target:         target,
-			TargetRoot:     entry.TargetRoot,
-			Strategy:       entry.Strategy,
-			Status:         actionStatus,
-			Reason:         reason,
-			MatchingTags:   matchingTags,
-			Ownership:      entry.Ownership,
-			LegacyParent:   legacyParent,
+			Contributions: []Contribution{{
+				Source:       source,
+				SelectorTags: contributionSelectorTags(entry.Tags, tags, selected.OverrideTag),
+			}},
+			Target:       target,
+			TargetRoot:   entry.TargetRoot,
+			Strategy:     entry.Strategy,
+			Status:       actionStatus,
+			Reason:       reason,
+			MatchingTags: matchingTags,
+			Ownership:    entry.Ownership,
+			LegacyParent: legacyParent,
 		}
 		if actionStatus == StatusConflict || actionStatus == StatusCreate {
 			if migration, ok := opts.LegacyMigrations[target]; ok && ((migration.LegacyTarget == "" && actionStatus == StatusConflict) || (migration.LegacyTarget != "" && actionStatus == StatusCreate)) {
@@ -253,6 +268,7 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 			}
 			existing.Sources = append(existing.Sources, action.Source)
 			existing.ResolvedSources = append(existing.ResolvedSources, action.ResolvedSource)
+			existing.Contributions = append(existing.Contributions, action.Contributions...)
 			readSourcesByTarget[targetKey] = append(readSourcesByTarget[targetKey], readSourceAbs)
 			composed, err := configsubset.ComposeJSONFiles(readSourcesByTarget[targetKey])
 			if err != nil {
@@ -279,6 +295,25 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 	}
 
 	return plan, nil
+}
+
+func contributionSelectorTags(entryTags, selectedTags []string, overrideTag string) []string {
+	selectors := make([]string, 0, len(entryTags)+1)
+	for _, selectedTag := range selectedTags {
+		matches := selectedTag == overrideTag
+		if !matches {
+			for _, entryTag := range entryTags {
+				if selectedTag == entryTag {
+					matches = true
+					break
+				}
+			}
+		}
+		if matches {
+			selectors = append(selectors, selectedTag)
+		}
+	}
+	return selectors
 }
 
 type selectedManifestEntry struct {

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -99,6 +99,12 @@ func TestBuildComposesCompatibleJSONSubsetEntriesForSharedTarget(t *testing.T) {
 	if !reflect.DeepEqual(action.Sources, []string{"configs/base.json", "configs/mobile.json"}) {
 		t.Fatalf("Sources = %#v, want manifest-order contributors", action.Sources)
 	}
+	if got, want := action.Contributions, []plan.Contribution{
+		{Source: "configs/base.json", SelectorTags: []string{"base"}},
+		{Source: "configs/mobile.json", SelectorTags: []string{"mobile"}},
+	}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Contributions = %#v, want ordered attribution %#v", got, want)
+	}
 	if action.Status != plan.StatusCreate {
 		t.Fatalf("Status = %q, want %q", action.Status, plan.StatusCreate)
 	}
@@ -1151,6 +1157,9 @@ func TestBuildUsesSourceOverrideForSelectedExtraTag(t *testing.T) {
 	if got := withoutTag.Actions[0].Source; got != "default.conf" {
 		t.Fatalf("source without extra tag = %q, want default.conf", got)
 	}
+	if got, want := withoutTag.Actions[0].Contributions, []plan.Contribution{{Source: "default.conf", SelectorTags: []string{"core"}}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("contributions without extra tag = %#v, want %#v", got, want)
+	}
 
 	withTag, err := plan.Build(m, plan.Options{Profile: "default", ExtraTags: []string{"adaptive-theme"}, OS: "darwin", SourceRoot: sourceRoot, Home: home})
 	if err != nil {
@@ -1161,6 +1170,9 @@ func TestBuildUsesSourceOverrideForSelectedExtraTag(t *testing.T) {
 	}
 	if len(withTag.Actions) != 1 {
 		t.Fatalf("len(Actions) with source override = %d, want 1", len(withTag.Actions))
+	}
+	if got, want := withTag.Actions[0].Contributions, []plan.Contribution{{Source: "adaptive.conf", SelectorTags: []string{"core", "adaptive-theme"}}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("contributions with source override = %#v, want %#v", got, want)
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -18,7 +18,7 @@ import (
 )
 
 // CurrentVersion is the current Installation Metadata schema version.
-const CurrentVersion = 6
+const CurrentVersion = 7
 
 // Metadata is the machine-readable record of installed managed targets.
 type Metadata struct {
@@ -53,9 +53,10 @@ func (p Provenance) Empty() bool {
 
 // Record describes a single managed target the CLI installed. Version 4 records
 // explicit whole or partial Ownership; version 5 adds opaque seeded-baseline
-// evidence, and version 6 adds opaque byte contribution evidence for TOML
-// subset and marked-block ownership. An
-// empty Ownership is legacy and grants no force-removal authority.
+// evidence, version 6 adds opaque byte contribution evidence for TOML subset
+// and marked-block ownership, and version 7 attributes exact ownership evidence
+// to each Source of Truth contribution. An empty Ownership is legacy and grants
+// no force-removal authority.
 // Copy-like strategies may record a source content hash; symlink records leave
 // Hash empty because drift is detected from the link destination.
 type Record struct {
@@ -71,11 +72,29 @@ type Record struct {
 	// SeededBaseline is the exact opaque Source of Truth baseline last applied
 	// to Seeded Runtime State. []byte uses JSON base64 encoding, so the state
 	// itself need not be JSON.
-	SeededBaseline []byte   `json:"seeded_baseline,omitempty"`
-	Hash           string   `json:"hash"`
-	InstalledAt    string   `json:"installedAt"`
-	Profiles       []string `json:"profiles,omitempty"`
-	Tags           []string `json:"tags,omitempty"`
+	SeededBaseline []byte         `json:"seeded_baseline,omitempty"`
+	Contributions  []Contribution `json:"contributions,omitempty"`
+	Hash           string         `json:"hash"`
+	InstalledAt    string         `json:"installedAt"`
+	Profiles       []string       `json:"profiles,omitempty"`
+	Tags           []string       `json:"tags,omitempty"`
+}
+
+// Contribution records the exact ownership evidence attributable to one
+// selected Source of Truth contribution. SelectorTags identifies the selected
+// declarative Tags that caused this source to contribute. EvidenceRecorded
+// distinguishes exact empty evidence from an incomplete attributed record.
+// Records continue to retain target-wide compatibility fields for older
+// metadata consumers.
+type Contribution struct {
+	Source           string          `json:"source"`
+	SelectorTags     []string        `json:"selector_tags,omitempty"`
+	Ownership        string          `json:"ownership"`
+	EvidenceRecorded bool            `json:"evidence_recorded,omitempty"`
+	Hash             string          `json:"hash,omitempty"`
+	OwnedContent     json.RawMessage `json:"owned_content,omitempty"`
+	OwnedBytes       []byte          `json:"owned_bytes,omitempty"`
+	SeededBaseline   []byte          `json:"seeded_baseline,omitempty"`
 }
 
 // SourceList returns every Source of Truth contribution for the managed target.

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -157,6 +157,74 @@ func TestSaveThenLoadRoundTripsOpaqueSeededBaselineV5(t *testing.T) {
 	}
 }
 
+func TestSaveThenLoadRoundTripsOrderedContributionOwnershipV7(t *testing.T) {
+	path := state.Path(t.TempDir())
+	want := state.Metadata{
+		Version: state.CurrentVersion,
+		Entries: []state.Record{{
+			Target:       "/home/user/.config/shared.json",
+			Source:       "configs/opencode/settings.json",
+			Sources:      []string{"configs/opencode/settings.json", "configs/antigravity/settings.json"},
+			Strategy:     "copy",
+			Ownership:    "json-subset",
+			OwnedContent: []byte(`{"agents":{"antigravity":true,"opencode":true}}`),
+			Contributions: []state.Contribution{
+				{
+					Source:           "configs/opencode/settings.json",
+					SelectorTags:     []string{"opencode"},
+					Ownership:        "json-subset",
+					EvidenceRecorded: true,
+					Hash:             "opencode-hash",
+					OwnedContent:     []byte(`{"agents":{"opencode":true}}`),
+				},
+				{
+					Source:           "configs/antigravity/settings.json",
+					SelectorTags:     []string{"antigravity"},
+					Ownership:        "json-subset",
+					EvidenceRecorded: true,
+					Hash:             "antigravity-hash",
+					OwnedContent:     []byte(`{"agents":{"antigravity":true}}`),
+				},
+			},
+		}},
+	}
+
+	if err := state.Save(path, want); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	got, err := state.Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if got.Version != want.Version || len(got.Entries) != 1 {
+		t.Fatalf("Load() metadata = %+v, want one v%d record", got, want.Version)
+	}
+	gotRecord, wantRecord := got.Entries[0], want.Entries[0]
+	if gotRecord.Source != wantRecord.Source || !reflect.DeepEqual(gotRecord.Sources, wantRecord.Sources) || len(gotRecord.Contributions) != len(wantRecord.Contributions) {
+		t.Fatalf("Load() record = %+v, want ordered sources and contributions %+v", gotRecord, wantRecord)
+	}
+	for i := range wantRecord.Contributions {
+		gotContribution, wantContribution := gotRecord.Contributions[i], wantRecord.Contributions[i]
+		if gotContribution.Source != wantContribution.Source ||
+			!reflect.DeepEqual(gotContribution.SelectorTags, wantContribution.SelectorTags) ||
+			gotContribution.Ownership != wantContribution.Ownership ||
+			gotContribution.EvidenceRecorded != wantContribution.EvidenceRecorded ||
+			gotContribution.Hash != wantContribution.Hash {
+			t.Fatalf("Load() contribution[%d] = %+v, want %+v", i, gotContribution, wantContribution)
+		}
+		var gotOwned, wantOwned any
+		if err := json.Unmarshal(gotContribution.OwnedContent, &gotOwned); err != nil {
+			t.Fatalf("decode loaded contribution[%d]: %v", i, err)
+		}
+		if err := json.Unmarshal(wantContribution.OwnedContent, &wantOwned); err != nil {
+			t.Fatalf("decode wanted contribution[%d]: %v", i, err)
+		}
+		if !reflect.DeepEqual(gotOwned, wantOwned) {
+			t.Fatalf("Load() contribution[%d] owned content = %v, want %v", i, gotOwned, wantOwned)
+		}
+	}
+}
+
 func TestLoadLegacyRecordDoesNotGainPartialOwnershipEvidence(t *testing.T) {
 	path := state.Path(t.TempDir())
 	data := `{"version":3,"entries":[{"target":"/home/user/.config/shared.json","source":"configs/shared.json","strategy":"copy","hash":"abc","installedAt":"now"}]}`
@@ -169,6 +237,42 @@ func TestLoadLegacyRecordDoesNotGainPartialOwnershipEvidence(t *testing.T) {
 	}
 	if len(got.Entries) != 1 || got.Entries[0].Ownership != "" || len(got.Entries[0].OwnedContent) != 0 {
 		t.Fatalf("Load() legacy record = %+v, want no partial ownership evidence", got.Entries)
+	}
+	if len(got.Entries[0].Contributions) != 0 {
+		t.Fatalf("Load() legacy contributions = %+v, want none synthesized", got.Entries[0].Contributions)
+	}
+	unchanged, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read legacy metadata after Load(): %v", err)
+	}
+	if string(unchanged) != data {
+		t.Fatalf("Load() rewrote legacy metadata = %q, want %q", unchanged, data)
+	}
+}
+
+func TestLoadPreviousMetadataVersionsDoesNotRewriteOrAttribute(t *testing.T) {
+	for version := 1; version < state.CurrentVersion; version++ {
+		t.Run(fmt.Sprintf("v%d", version), func(t *testing.T) {
+			path := state.Path(t.TempDir())
+			data := []byte(fmt.Sprintf(`{"version":%d,"entries":[{"target":"/home/user/.config/app","source":"configs/app","strategy":"copy","hash":"abc","installedAt":"now"}]}`, version))
+			if err := os.WriteFile(path, data, 0o600); err != nil {
+				t.Fatalf("write previous metadata: %v", err)
+			}
+			got, err := state.Load(path)
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if got.Version != version || len(got.Entries) != 1 || len(got.Entries[0].Contributions) != 0 {
+				t.Fatalf("Load() metadata = %+v, want unchanged v%d record without attribution", got, version)
+			}
+			unchanged, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read previous metadata after Load(): %v", err)
+			}
+			if !reflect.DeepEqual(unchanged, data) {
+				t.Fatalf("Load() rewrote v%d metadata = %q, want %q", version, unchanged, data)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #464

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Records ordered Source of Truth attribution, selector Tags, and mode-specific evidence for every Managed Entry contribution.
- Preserves target-wide metadata behavior and explicitly reports contribution-backed versus legacy-unattributed inventory.
- Rejects stale terminal convergence before atomically committing stronger evidence.

## Changes

| File | Change |
|------|--------|
| `internal/state`, `internal/plan`, `internal/install` | Add metadata v7 contributions and capture validated per-mode evidence after convergence. |
| `internal/installed`, `internal/cli` | Expose safe attribution/evidence discriminators and bump the Agent Output Contract to schema 9. |
| focused tests and docs | Cover composition, compatibility, atomic failure, Drift, named configuration modes, and reporting. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go build ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml` (validated with the built binary and a sandbox manifest)
- [x] Sandboxed plan/install only: built `dots`, then used explicit temporary `--home`, `--source-root`, and `--state-root`.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root <tmp>`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked one issue with an admitted Delivery Contract using `Closes #464`.
- [x] Added exactly one `type:*` label.
- [x] Delivery Evidence records the Contract Source snapshot, Acceptance coverage, and Independent review.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

### Contract Source snapshot

- Kind: `composed-ticket`.
- Ticket body: issue node `I_kwDOSzLlmM8AAAABNwYzGw`, https://github.com/yersonargotev/dots/issues/464, `updatedAt: 2026-08-21T20:58:04Z`, 2,370 UTF-8 bytes, SHA-256 `105ccb0838f38cf302fd03473ca5e8b854835a8f9a75f57a81f6d54099635c90`.
- Parent body: issue node `I_kwDOSzLlmM8AAAABNwWsDA`, https://github.com/yersonargotev/dots/issues/458, `updatedAt: 2026-08-21T20:58:58Z`, 16,104 UTF-8 bytes, SHA-256 `aec4b86128a4cfec51290b7917a4757a7f16cc1557466e7d8478ca41495f5f0d`.
- Category/readiness: `enhancement`, `ready-for-agent`.
- Native relationships: parent #458 open; blocked by #460 closed; blocks #465 open; no sub-issues; no comments after snapshot.
- Revalidated immediately before PR creation with identical node IDs, timestamps, bodies, digests, labels, states, and relationships.

<details><summary>Complete ticket body snapshot — #464</summary>

### What to build

Record exact ownership evidence for every Source of Truth contribution to a Managed Entry target after successful convergence. Preserve backward-compatible metadata reads and target-level behavior while making shared contributions independently attributable for the later reconciliation specification.

### Current-state gap

Installation Metadata records all effective Tags against a target and stores composed subset ownership primarily as one aggregate. It cannot prove which declarative Tags selected each source contribution.

### Key interfaces

- Installation Metadata schema, loading, saving, compatibility, and installed reporting.
- Install Plan contribution composition and terminal metadata recording.
- Structured ownership evidence for whole, subset, marked-block, and seeded targets.

### Acceptance criteria

- [ ] A target record can carry ordered per-contribution Source identity, declarative selector Tags, and exact ownership evidence appropriate to its ownership mode.
- [ ] Composed targets retain separate contribution evidence rather than only an aggregate projection.
- [ ] Target-wide compatibility fields remain readable and deterministic where older metadata consumers require them.
- [ ] Previous metadata versions remain readable and are not upgraded by loading alone.
- [ ] Successful convergence records current contribution evidence atomically while preserving Installed Selection and unrelated inventory.
- [ ] Dry run, read-only commands, cancellation, Conflict, Drift, apply failure, and metadata-write failure never invent or partially commit stronger evidence.
- [ ] Existing whole-target uninstall and status behavior remains compatible.
- [ ] OpenCode/Antigravity-style shared JSON, source overrides, JSONC, TOML, marked blocks, and Seeded Runtime State have focused coverage.
- [ ] Human and JSON installed reporting can explain attributed and legacy-unattributed records without treating historical inventory as current intent.

### Non-goals

- Using contribution evidence to remove configuration.
- Redesigning Dependency Installation Metadata.
- Reversing Provisioners or external state.

### Validation notes

- Test backward-compatible schema round trips and atomic-write failures.
- Exercise composed targets only in temporary roots.
- Run focused state/install checks and the full CI-equivalent suite.

</details>

<details><summary>Complete parent body snapshot — #458</summary>

### Pre-flight checks

- [x] I searched existing issues and this is not a duplicate.
- [x] The scope clearly identifies independently reviewable slices.

### Desired outcome

Operators can select the smallest independently useful dotfiles capabilities directly by Tag while Profiles remain convenient, behavior-preserving presets. Existing broad Tag intent migrates safely, Tags alone form a valid installation selection, and Installation Metadata records enough contribution evidence for a later selective-reconciliation feature without removing configuration in this specification.

### Current-state gap

The current `core`, `desktop`, `agents`, `web`, and `mobile` Tags each select broad surfaces containing unrelated Managed Entries, Dependencies, and Provisioners. An operator who wants Zsh but not every core runtime, or Codex but not every Agent CLI, cannot state that intent. Although the domain treats explicit Tags as a complete selection route, mutating installation still requires a Profile for this repository manifest. Installation Metadata also records all effective Tags against a target rather than the Tags and Source of Truth contributions that selected it, which is insufficient evidence for future selective retirement of shared targets.

## Problem Statement

As a dots operator, I have to choose maintainer-authored Profiles or broad Tags even when I only want one tool or configuration capability. The selected intent is therefore coarser than the workstation I want, and future interactive management cannot honestly offer independent Tag checkboxes while one Tag still means an entire development baseline.

## Solution

Replace the broad selection Tags with atomic capability Tags: the smallest capabilities that make sense to install or stop managing independently. Preserve Profiles as ordered presets over those Tags and preserve each Profile's existing Darwin and Linux Selected Surface. Support Tag-only installation, declare one-to-many legacy replacements in the Install Manifest, normalize legacy intent into current Tags, and record per-contribution ownership evidence during successful convergence. Keep this specification non-destructive: no explicit or migrated Tag reduction removes Managed Configuration.

## User Stories

1. As a workstation operator, I want to select Zsh without selecting every core development tool, so that my workstation contains only the capabilities I want.
2. As a workstation operator, I want Git, Tmux, Neovim, Starship, Atuin, Zellij, and other tools to have independent Tags, so that each can be selected deliberately.
3. As a workstation operator, I want Node, Rust, Go, uv, pnpm, and Bun to be independent capabilities, so that language toolchains are not forced into one baseline.
4. As a workstation operator, I want fzf, zoxide, lazygit, eza, ripgrep, delta, fd, gh, and jq to be independently selectable, so that CLI utilities remain optional.
5. As a workstation operator, I want Zsh and Zim to be separate capabilities, so that I can use the shell without the framework.
6. As a workstation operator, I want each Agent CLI to be independently selectable, so that choosing Codex does not also choose Claude, OpenCode, Antigravity, and Copilot.
7. As a workstation operator, I want web skills and browser integrations separated by outcome and agent, so that unrelated Provisioners do not run.
8. As a workstation operator, I want mobile skills and Dart integrations separated by outcome and agent, so that unrelated mobile capabilities remain optional.
9. As a workstation operator, I want `adaptive-theme` and `codegraph` to remain global opt-ins, so that cross-cutting behavior does not create a Tag for every consumer combination.
10. As a workstation operator, I want shared helpers and prerequisites to remain implementation details, so that the catalog does not ask me to understand `theme.sh`, `curl`, `unzip`, `npx`, or a shared font.
11. As a workstation operator, I want the `core`, `desktop`, `agents`, `web`, `mobile`, and `workstation` Profiles to preserve their current effective surfaces, so that atomization does not install or omit capabilities unexpectedly.
12. As a workstation operator, I want `workstation` to continue excluding CodexBar, so that the refactor does not expand existing behavior.
13. As a workstation operator, I want to run `dots install --tag zsh` without a Profile, so that Profiles are presets rather than a technical prerequisite.
14. As a workstation operator, I want repeated explicit Tags to form one ordered, deduplicated complete selection, so that I can compose my workstation from capabilities.
15. As a workstation operator, I want old broad Tag selections translated into the equivalent atomic Tags, so that an upgrade does not discard my intent.
16. As a workstation operator, I want migration to show its delta and require confirmation, so that the stored intent does not change silently.
17. As a workstation operator, I want legacy Tag aliases to work for one release cycle with warnings, so that existing scripts have a bounded transition path.
18. As a workstation operator, I want newly recorded Installed Selection to contain only current atomic Tags, so that legacy aliases do not persist indefinitely.
19. As an automation author, I want the Install Catalog to hide legacy Tags by default and expose their replacements when requested, so that discovery recommends only current intent.
20. As an automation author, I want Profile and equivalent explicit Tag selections to produce the same Selected Surface on Darwin and Linux, so that provenance does not alter behavior.
21. As an automation author, I want text and JSON reports to explain legacy normalization deterministically, so that automation does not scrape warnings.
22. As a maintainer, I want each target's metadata to identify its actual Source of Truth contributions and selecting Tags, so that later reconciliation can reason from evidence rather than all effective Tags.
23. As a maintainer, I want composed JSON and other subset-owned targets to record contribution evidence separately, so that one capability can later be retired without claiming ownership of another.
24. As a maintainer, I want metadata enhancement to occur only after successful target convergence, so that Drift is never reclassified as proven ownership.
25. As a maintainer, I want historical metadata to remain readable, so that atomization does not strand existing installations.
26. As a maintainer, I want the domain glossary and ADR to explain why Tags are fine-grained while Profiles are broad presets, so that future manifest changes preserve the model.
27. As a release maintainer, I want legacy aliases removed through a separately visible follow-up after the announced transition, so that compatibility does not become permanent.

## Implementation Decisions

- A Tag is the smallest capability that makes sense to install or stop managing independently. It may select Managed Entries, Dependencies, Provisioners, or a coherent combination of them.
- Profile remains a pure ordered preset of Tags. Profiles do not own surface and do not contain other Profiles.
- The current capability catalog contains approximately fifty current Tags grouped conceptually as Core, Desktop, Agents, Web, Mobile, and Global.
- The Core preset contains `zsh`, `zimfw`, `git`, `starship`, `tmux`, `herdr`, `zellij`, `atuin`, `neovim`, `tuicr`, `bat`, `node`, `rust`, `go`, `uv`, `pnpm`, `bun`, `fzf`, `zoxide`, `lazygit`, `eza`, `ripgrep`, `delta`, `fd`, `gh`, and `jq`.
- The Desktop preset contains `ghostty`, `warp`, `zed`, and `codexbar`.
- The Agents preset contains `codex`, `claude`, `opencode`, `antigravity`, and `copilot`.
- The Web preset contains `playwright`, `frontend-design`, `vercel-web-skills`, `claude-chrome-devtools`, `codex-chrome-devtools`, and `opencode-chrome-devtools`.
- The Mobile preset contains `dart-skills`, `flutter-skills`, `android-skills`, `claude-dart-mcp`, `codex-dart-mcp`, `antigravity-dart-mcp`, and `vscode-mobile`.
- `adaptive-theme` and `codegraph` remain current global opt-ins. `codexbar` remains an independently selectable capability.
- Shared helpers and prerequisites are attached to every Selected Surface that needs them and deduplicated by the existing surface rules. They are not user-facing Tags unless they are independently useful capabilities.
- Each repository Profile preserves its current effective Darwin and Linux Selected Surface. In particular, `desktop` includes CodexBar while `workstation` preserves its current surface without CodexBar.
- Explicit Tags alone form a complete valid installation selection. The absence of both Profiles and Tags retains the existing safe selection-required behavior in non-interactive contexts.
- The Tag registry supports a legacy Tag declaring an ordered one-to-many replacement. The mapping is owned by the Install Manifest, not compiled names in Go.
- `core`, `desktop`, `agents`, `web`, and `mobile` remain hidden legacy aliases for one release cycle. Explicit use warns and normalizes before plan construction.
- Normalized current Tags, never legacy aliases, are persisted as explicit extra Tag intent after terminal success.
- Recorded legacy intent is presented as a migration candidate with a deterministic delta and requires interactive confirmation; non-interactive behavior returns structured remediation unless the caller supplies a complete current selection.
- Installed Selection derived from unchanged Profile names re-resolves through the new Profile definitions; the stored resolved Tag snapshot remains audit evidence.
- Installation Metadata advances backward-compatibly to record ownership per target contribution: Source identity, declarative selector Tags, and exact ownership evidence. Target-wide records may retain compatibility projections required by old readers.
- Metadata is enriched only during successful mutation after the target converges. Read-only commands, dry runs, failed installs, and ambiguous Drift never upgrade evidence.
- This specification records evidence needed by later reconciliation but never removes Managed Configuration, Dependencies, Provisioner effects, or user state.
- The existing Selected Surface module remains the cohesive pure evaluation seam. Manifest parsing, state persistence, filesystem mutation, and presentation remain adapters.
- The glossary updates Tag and Profile. A focused ADR records atomic capability Tags and behavior-preserving Profile presets.

## Testing Decisions

- The primary seam is observable command behavior and stable machine-readable output. Tests should prefer complete manifest/catalog/plan/install behavior over helper-level assertions.
- Repository Profile parity tests compare each Profile with its exact current Tag expansion on Darwin and Linux and prove that the resulting Selected Surfaces remain behaviorally equivalent to the pre-atomization manifest.
- A Temporary Home Test proves `dots install --tag zsh` succeeds without a Profile while omission of all selection in a non-interactive context fails before mutation.
- Catalog Golden Output Tests cover the current atomic Tag inventory, descriptions, grouping metadata where exposed, hidden legacy aliases, and ordered replacements.
- Selection tests cover one-to-many normalization, ordered deduplication, warnings, explicit and recorded migration, decline, dry run, structured non-interactive remediation, and persistence of current Tags only.
- Installation Metadata round-trip tests cover previous schema versions, per-contribution records, composed targets, compatibility projections, and atomic persistence.
- Target convergence tests prove that matching content can gain contribution evidence while Drift, Conflict, cancellation, or a metadata-write failure preserves prior evidence and Installed Selection.
- Shared-target tests use OpenCode and Antigravity-style composed JSON contributions to prove distinct Source and Tag attribution.
- Source-override tests prove `adaptive-theme` and `codegraph` still modify only applicable selected consumers.
- Dependency tests prove shared prerequisites remain selected when any consumer requires them and remain absent from the user-facing Tag catalog when they are not independent capabilities.
- Existing command envelope goldens, Selected Surface parity tests, migration tests, and Temporary Home Tests are the prior art.
- Full validation matches CI and includes manifest validation and generated catalog checks. Any filesystem behavior uses temporary home, source, and state roots and never the operator's real home.

## Out of Scope

- Interactive Tag selection or any new TUI screen.
- Selective retirement, uninstall, or reconciliation of no-longer-selected Managed Configuration.
- Removing Dependencies, reversing Provisioners, deleting runtime state, credentials, histories, or external configuration.
- Changing `dots uninstall`, which remains the global metadata-backed uninstall workflow.
- Automatically cleaning surfaces removed by Install Manifest evolution.
- Restoring Backup Sets during a selection change.
- Permanent compatibility aliases for the broad Tags.
- Changing the effective surface of any existing repository Profile.

## Further Notes

- This specification builds on the completed Installed Selection and pure Profile work in #339, #343, #427, and #428; it does not reopen their non-destructive evolution policy.
- The approximately fifty current Tags are intentionally numerous because Profiles carry convenience while Tags carry independent intent.
- The highest-value validation seam is Profile/explicit-Tag parity plus sandboxed command behavior; metadata unit tests are used only where the command seam cannot expose contribution evidence safely.
- Delivery should be sliced into dependency-ordered, independently green sub-issues. The parent becomes a Tracking Issue once those relationships are published and verified.

### Key interfaces

- Install Manifest Tag registry — current and legacy capability metadata plus ordered replacements.
- Install Manifest Profiles — ordered atomic Tag presets with preserved surfaces.
- Selection resolution — Profile and Tag-only intent, legacy normalization, and migration reporting.
- Install Catalog and stable output envelopes — discoverability and machine-readable migration evidence.
- Installation Metadata — backward-compatible per-contribution ownership evidence.

### Acceptance criteria

- [ ] The repository declares the approved atomic capability Tag catalog with descriptions and current lifecycle status.
- [ ] All repository Profiles preserve their current Darwin and Linux Selected Surfaces, including the existing CodexBar difference between `desktop` and `workstation`.
- [ ] Explicit Tags alone form a complete valid install selection.
- [ ] The Install Manifest supports ordered one-to-many legacy Tag replacements.
- [ ] Broad legacy Tags normalize for one release cycle, warn, remain hidden from normal catalog discovery, and are never persisted after successful migration.
- [ ] Recorded legacy extra Tag intent migrates only after confirmation and terminal success; failure or decline preserves the previous Installed Selection.
- [ ] Installation Metadata remains backward-compatible and can record exact selector and ownership evidence per target contribution.
- [ ] Metadata evidence is never upgraded by read-only, dry-run, Drifted, conflicted, failed, or canceled execution.
- [ ] No Managed Configuration, Dependency, Provisioner effect, or user state is removed by this specification.
- [ ] Glossary and ADR documentation record the approved domain model.
- [ ] Human and JSON output remain deterministic and documented.
- [ ] Focused validation and the full CI-equivalent suite pass using only sandboxed filesystem roots.

### Validation notes

- `gofmt -l .`
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- `go generate ./internal/catalog`
- `go run ./cmd/dots manifest validate --file dots.yaml`
- Use temporary `--home`, `--source-root`, and `--state-root` values for every mutating command test.

</details>

### Reviewed head

- `1da51c64c9003e6cff84f63c7001c408ece21384` against base `5d75d02ada3f8cc46101561a6d651a9f740236f7`.

### Acceptance coverage

| Criterion | Evidence |
|---|---|
| Ordered Source identity, selector Tags, exact per-mode evidence | `state.Contribution`, plan attribution, and mode table tests. |
| Separate composed evidence | Shared JSON unit test plus real OpenCode and Antigravity sandbox tests. |
| Target-wide compatibility | Aggregate compatibility fields remain populated; status and uninstall lifecycle tests pass. |
| Previous versions remain readable without load upgrade | v1-v6 no-rewrite/no-attribution tests and legacy reporting test. |
| Atomic successful convergence preserving selection/inventory | Single `state.Save`, preservation test, and terminal convergence validation. |
| No stronger evidence on non-convergence/failure | stale-unchanged Drift regression, plan rejection, metadata-write failure, existing cancel/conflict/apply-failure tests, and manual dry-run checksum. |
| Whole-target status/uninstall compatibility | Full suite plus shared-target uninstall assertion. |
| Named modes/integrations | OpenCode, Antigravity, source override, JSON/JSONC/TOML/marked-block/seeded focused coverage, including empty TOML/seeded evidence. |
| Human/JSON attribution without intent promotion | installed domain/CLI tests; raw evidence exclusion assertions; Installed Selection remains separate. |

### Automated validation

- PASS: `gofmt -l .` (no output).
- PASS: `go vet ./...`.
- PASS: `go build ./...`.
- PASS: `go test ./...`.
- PASS: focused state/plan/install/installed/CLI tests, including the stale-unchanged regression.

### Manual verification

- Built the exact HEAD with `go build -o <tmp>/dots ./cmd/dots`.
- In explicit temporary roots, installed two JSON-subset contributors to one target. Metadata v7 recorded both in manifest order with distinct selector Tags and `evidence_recorded: true`.
- `dots installed` human/JSON output reported `recorded-contribution` + `owned-json`; a separate v6 fixture reported `legacy-unattributed` + `legacy-target-wide`; raw owned bytes were absent.
- Metadata SHA-256 was identical before and after `dots install --dry-run`.

### Independent review

- Spec: PASS on corrected head; all nine acceptance areas covered, no missing, wrong, partial, or scope-creep findings.
- Standards: no hard violations. One non-blocking low judgement-call observation remains about ownership-mode switches; accepted because format algorithms are intentionally distinct and a registry refactor would expand this Delivery Unit.
- Initial review findings (stale unchanged attribution and empty evidence reporting) were fixed; all gates and both reviews were restarted.
<!-- delivery-issue:evidence:end -->
