### PR TITLE
fix(state): commit contribution evidence at terminal success

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -29,11 +29,13 @@ import (
 )
 
 var (
-	installHostOS                           = runtime.GOOS
-	installHostArch                         = runtime.GOARCH
-	packageManagerDetector                  = pkgmgr.Detector{}
-	packageManagerSetupRunner pkgmgr.Runner = pkgmgr.ExecRunner{}
-	recordInstalledSelection                = selection.Record
+	installHostOS                            = runtime.GOOS
+	installHostArch                          = runtime.GOARCH
+	packageManagerDetector                   = pkgmgr.Detector{}
+	packageManagerSetupRunner  pkgmgr.Runner = pkgmgr.ExecRunner{}
+	commitInstallationMetadata               = func(commit install.MetadataCommit, installed state.InstalledSelection) error {
+		return commit.Commit(&installed)
+	}
 )
 
 func newInstallCommand() *cobra.Command {
@@ -266,7 +268,7 @@ func newInstallCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			applied, err := resolveAndApply(cmd, p, paths, yes, noTUI, backupAndReplace)
+			applied, metadataCommit, err := resolveAndApply(cmd, p, paths, yes, noTUI, backupAndReplace)
 			if err != nil {
 				return err
 			}
@@ -293,7 +295,7 @@ func newInstallCommand() *cobra.Command {
 				return err
 			}
 			installedSelection.Provenance = state.CaptureProvenance(paths.SourceRoot, version.Value)
-			if err := recordInstalledSelection(state.Path(paths.StateRoot), installedSelection); err != nil {
+			if err := commitInstallationMetadata(metadataCommit, installedSelection); err != nil {
 				return err
 			}
 			if !wantsJSON(cmd) {
@@ -562,7 +564,7 @@ func selectedCodeGraphAgents(selected []manifest.Provisioner) []string {
 // the conservative --yes default) and applies it with Backup Set protection. It
 // is shared by install and update so post-update installation reuses identical
 // Conflict Resolution and filesystem machinery instead of reimplementing it.
-func resolveAndApply(cmd *cobra.Command, p plan.Plan, paths resolvedPaths, yes, noTUI, backupAndReplace bool) (bool, error) {
+func resolveAndApply(cmd *cobra.Command, p plan.Plan, paths resolvedPaths, yes, noTUI, backupAndReplace bool) (bool, install.MetadataCommit, error) {
 	var (
 		decisions map[string]install.ConflictDecision
 		err       error
@@ -576,20 +578,21 @@ func resolveAndApply(cmd *cobra.Command, p plan.Plan, paths resolvedPaths, yes, 
 	case noTUI:
 		decisions, err = promptConflictDecisions(cmd, p, paths.Home, paths.SourceRoot)
 		if err != nil {
-			return false, err
+			return false, install.MetadataCommit{}, err
 		}
 	default:
 		decisions, err = resolveConflictsTUI(cmd, p, paths.Home, paths.SourceRoot)
 		if errors.Is(err, tui.ErrCanceled) {
 			fmt.Fprintln(cmd.OutOrStdout(), "Conflict resolution canceled; no changes applied.")
-			return false, nil
+			return false, install.MetadataCommit{}, nil
 		}
 		if err != nil {
-			return false, err
+			return false, install.MetadataCommit{}, err
 		}
 	}
 
-	return true, install.Apply(p, install.Options{SourceRoot: paths.SourceRoot, Home: paths.Home, StateRoot: paths.StateRoot, ConflictDecisions: decisions})
+	commit, err := install.ApplyManagedEntries(p, install.Options{SourceRoot: paths.SourceRoot, Home: paths.Home, StateRoot: paths.StateRoot, ConflictDecisions: decisions})
+	return true, commit, err
 }
 
 func replaceAllConflictDecisions(p plan.Plan) map[string]install.ConflictDecision {

--- a/internal/cli/install_selection_internal_test.go
+++ b/internal/cli/install_selection_internal_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/yersonargotev/dots/internal/install"
 	"github.com/yersonargotev/dots/internal/state"
 )
 
@@ -51,11 +52,11 @@ entries:
 		t.Fatalf("seed metadata: %v", err)
 	}
 
-	originalRecord := recordInstalledSelection
-	recordInstalledSelection = func(string, state.InstalledSelection) error {
+	originalCommit := commitInstallationMetadata
+	commitInstallationMetadata = func(install.MetadataCommit, state.InstalledSelection) error {
 		return errors.New("injected Installed Selection commit failure")
 	}
-	t.Cleanup(func() { recordInstalledSelection = originalRecord })
+	t.Cleanup(func() { commitInstallationMetadata = originalCommit })
 
 	cmd := newInstallCommand()
 	var output bytes.Buffer
@@ -81,5 +82,8 @@ entries:
 	}
 	if meta.InstalledSelection == nil || !reflect.DeepEqual(*meta.InstalledSelection, previous) {
 		t.Fatalf("InstalledSelection = %#v, want previous %#v", meta.InstalledSelection, previous)
+	}
+	if len(meta.Entries) != 1 || len(meta.Entries[0].Contributions) != 0 {
+		t.Fatalf("Entries = %#v, want partial inventory without exact evidence", meta.Entries)
 	}
 }

--- a/internal/cli/install_selection_test.go
+++ b/internal/cli/install_selection_test.go
@@ -409,6 +409,9 @@ provisioners:
 	if len(meta.Entries) != 1 {
 		t.Fatalf("Entries = %#v, want partial Managed Entry inventory retained", meta.Entries)
 	}
+	if len(meta.Entries[0].Contributions) != 0 {
+		t.Fatalf("Contributions = %#v, want no exact evidence from failed install", meta.Entries[0].Contributions)
+	}
 	if len(meta.Provisioners) != 1 || meta.Provisioners[0].Status != "failed" {
 		t.Fatalf("Provisioners = %#v, want failed inventory retained", meta.Provisioners)
 	}
@@ -641,6 +644,9 @@ provisioners:
 	if len(meta.Provisioners) != 1 || meta.Provisioners[0].Status != "provisioned" {
 		t.Fatalf("Provisioners = %#v, want successful inventory before convergence failure", meta.Provisioners)
 	}
+	if len(meta.Entries) != 1 || len(meta.Entries[0].Contributions) != 0 {
+		t.Fatalf("Entries = %#v, want partial inventory without exact evidence", meta.Entries)
+	}
 }
 
 func TestInstallHistoricalRetirementFailurePreservesPreviousSelection(t *testing.T) {
@@ -697,6 +703,9 @@ entries:
 	}
 	if meta.InstalledSelection == nil || !reflect.DeepEqual(*meta.InstalledSelection, previous) {
 		t.Fatalf("InstalledSelection = %#v, want previous %#v", meta.InstalledSelection, previous)
+	}
+	if len(meta.Entries) != 1 || len(meta.Entries[0].Contributions) != 0 {
+		t.Fatalf("Entries = %#v, want partial inventory without exact evidence", meta.Entries)
 	}
 	got, err := os.ReadFile(instructions)
 	if err != nil || string(got) != malformed {

--- a/internal/cli/installed_test.go
+++ b/internal/cli/installed_test.go
@@ -123,6 +123,67 @@ entries:
 	}
 }
 
+func TestInstalledJSONKeepsRecordedTagProvenanceForIncompleteContribution(t *testing.T) {
+	home := t.TempDir()
+	stateRoot := t.TempDir()
+	sourceRoot := t.TempDir()
+	writeCLISource(t, sourceRoot, "configs/shared.json", "{\"portable-secret-value\":true}\n")
+	manifestPath := writeCLIManifest(t, home, `version: 1
+profiles:
+  default:
+    tags: [shared]
+entries:
+  - source: configs/shared.json
+    target: ~/.config/shared.json
+    strategy: copy
+    ownership: json-subset
+    tags: [shared]
+`)
+	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, Entries: []state.Record{{
+		Target: filepath.Join(home, ".config", "shared.json"), Source: "configs/shared.json", Strategy: "copy", Ownership: "json-subset",
+		Contributions: []state.Contribution{{
+			Source: "configs/shared.json", Ownership: "json-subset", OwnedContent: []byte(`{"portable-secret-value":true}`),
+		}},
+	}}}); err != nil {
+		t.Fatalf("save metadata: %v", err)
+	}
+
+	var out, errOut bytes.Buffer
+	code := cli.Run([]string{
+		"installed", "--output", "json", "--file", manifestPath,
+		"--source-root", sourceRoot, "--home", home, "--state-root", stateRoot,
+	}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
+	}
+	env := decodeEnvelopeForCommand(t, out.String(), "installed")
+	var report struct {
+		ManagedEntries []struct {
+			Attribution       string   `json:"attribution"`
+			OwnershipEvidence string   `json:"ownership_evidence"`
+			Tags              []string `json:"tags"`
+			TagsSource        string   `json:"tags_source"`
+		} `json:"managed_entries"`
+		Notes []string `json:"notes"`
+	}
+	if err := json.Unmarshal(env.Data, &report); err != nil {
+		t.Fatalf("decode installed report: %v\ndata:\n%s", err, env.Data)
+	}
+	if len(report.ManagedEntries) != 1 {
+		t.Fatalf("ManagedEntries = %+v, want one entry", report.ManagedEntries)
+	}
+	entry := report.ManagedEntries[0]
+	if entry.Attribution != "recorded-contribution" || entry.TagsSource != "recorded-contribution" || entry.OwnershipEvidence != "missing" || len(entry.Tags) != 0 {
+		t.Fatalf("ManagedEntry = %+v, want incomplete recorded-contribution provenance", entry)
+	}
+	if got := strings.Join(report.Notes, "\n"); !strings.Contains(got, "do not record selector Tags") {
+		t.Fatalf("Notes = %q, want missing selector Tags explanation", got)
+	}
+	if strings.Contains(out.String(), "owned_content") || strings.Contains(out.String(), "portable-secret-value") {
+		t.Fatalf("installed JSON exposed raw ownership evidence:\n%s", out.String())
+	}
+}
+
 func TestInstalledJSONMatchesXDGStateEntryWithCompleteCoverage(t *testing.T) {
 	home := t.TempDir()
 	stateRoot := t.TempDir()

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -310,7 +310,7 @@ func runUpdateWorkflow(cmd *cobra.Command, opts updateOptions, emit bool) (updat
 	if err != nil {
 		return updateReport{}, err
 	}
-	applied, err := resolveAndApply(cmd, p, paths, opts.yes, opts.noTUI, false)
+	applied, metadataCommit, err := resolveAndApply(cmd, p, paths, opts.yes, opts.noTUI, false)
 	if err != nil {
 		return updateReport{}, err
 	}
@@ -327,7 +327,7 @@ func runUpdateWorkflow(cmd *cobra.Command, opts updateOptions, emit bool) (updat
 			return updateReport{}, err
 		}
 		installedSelection := effective.InstalledSelection(state.CaptureProvenance(paths.SourceRoot, version.Value))
-		if err := recordInstalledSelection(state.Path(paths.StateRoot), installedSelection); err != nil {
+		if err := commitInstallationMetadata(metadataCommit, installedSelection); err != nil {
 			return updateReport{}, err
 		}
 		if !wantsJSON(cmd) {

--- a/internal/cli/update_selection_test.go
+++ b/internal/cli/update_selection_test.go
@@ -894,13 +894,19 @@ func TestUpdateProvisionerFailurePreservesPreviousInstalledSelection(t *testing.
 	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	previous := state.InstalledSelection{Profiles: []string{"core"}, ResolvedTags: []string{"core"}}
-	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, InstalledSelection: &previous}); err != nil {
-		t.Fatalf("save metadata: %v", err)
-	}
 	_, sourceRoot := newInstalledRepo(t, map[string]string{
 		"configs/git/gitconfig": "managed\n",
 		"dots.yaml":             updateProvisionerManifest,
 	})
+	previousEntries := []state.Record{{
+		Target: filepath.Join(home, ".gitconfig"), Source: "configs/git/gitconfig", Strategy: "copy", Ownership: "whole",
+		Contributions: []state.Contribution{{
+			Source: "configs/git/gitconfig", SelectorTags: []string{"core"}, Ownership: "whole", EvidenceRecorded: true, Hash: "previous-evidence",
+		}},
+	}}
+	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, Entries: previousEntries, InstalledSelection: &previous}); err != nil {
+		t.Fatalf("save metadata: %v", err)
+	}
 
 	cmd := cli.NewRootCommand()
 	var out bytes.Buffer
@@ -919,6 +925,9 @@ func TestUpdateProvisionerFailurePreservesPreviousInstalledSelection(t *testing.
 	}
 	if meta.InstalledSelection == nil || !reflect.DeepEqual(*meta.InstalledSelection, previous) {
 		t.Fatalf("InstalledSelection = %#v, want previous %#v", meta.InstalledSelection, previous)
+	}
+	if !reflect.DeepEqual(meta.Entries, previousEntries) {
+		t.Fatalf("Entries = %#v, want previous exact evidence %#v", meta.Entries, previousEntries)
 	}
 }
 

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/yersonargotev/dots/internal/backups"
 	"github.com/yersonargotev/dots/internal/configsubset"
+	"github.com/yersonargotev/dots/internal/ownershipevidence"
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/state"
 	"github.com/yersonargotev/dots/internal/textblock"
@@ -38,11 +39,41 @@ type Options struct {
 	ConflictDecisions map[string]ConflictDecision
 }
 
-// Apply performs safe filesystem changes described by an Install Plan.
+// MetadataCommit finalizes exact contribution evidence after every terminal
+// install step has succeeded. Its fields are intentionally opaque so callers
+// cannot commit evidence for a plan that was not applied and validated here.
+type MetadataCommit struct {
+	profiles []string
+	tags     []string
+	opts     Options
+	actions  []metadataAction
+}
+
+type metadataAction struct {
+	action          plan.Action
+	resolvedSources []string
+	stagedRecord    state.Record
+	recordsEvidence bool
+}
+
+// Apply performs safe filesystem changes described by an Install Plan and
+// immediately commits their metadata. Command workflows with later terminal
+// steps use ApplyManagedEntries and commit only after those steps succeed.
 func Apply(p plan.Plan, opts Options) error {
-	resolvedSources, err := validatePlan(p, opts)
+	commit, err := ApplyManagedEntries(p, opts)
 	if err != nil {
 		return err
+	}
+	return commit.Commit(nil)
+}
+
+// ApplyManagedEntries applies and validates Managed Entries while persisting
+// only compatibility inventory. Exact per-contribution evidence is kept out of
+// Installation Metadata until the returned commit reaches terminal success.
+func ApplyManagedEntries(p plan.Plan, opts Options) (MetadataCommit, error) {
+	resolvedSources, err := validatePlan(p, opts)
+	if err != nil {
+		return MetadataCommit{}, err
 	}
 
 	for i, action := range p.Actions {
@@ -52,15 +83,15 @@ func Apply(p plan.Plan, opts Options) error {
 			continue
 		case plan.StatusCreate:
 			if err := applyCreate(action, source); err != nil {
-				return err
+				return MetadataCommit{}, err
 			}
 		case plan.StatusUpdate:
 			if err := applyUpdate(action, source, opts); err != nil {
-				return err
+				return MetadataCommit{}, err
 			}
 		case plan.StatusMigrate:
 			if err := applyMigration(action, source, opts); err != nil {
-				return err
+				return MetadataCommit{}, err
 			}
 		case plan.StatusConflict:
 			switch conflictDecision(action, opts) {
@@ -70,88 +101,69 @@ func Apply(p plan.Plan, opts Options) error {
 				continue
 			case DecisionReplace:
 				if err := applyReplace(action, source, opts); err != nil {
-					return err
+					return MetadataCommit{}, err
 				}
 			case DecisionAdopt:
 				if err := applyAdopt(action, source, opts); err != nil {
-					return err
+					return MetadataCommit{}, err
 				}
 			}
 		}
 	}
 
-	return recordMetadata(p, resolvedSources, opts)
+	commit := newMetadataCommit(p, resolvedSources, opts)
+	if opts.StateRoot != "" {
+		if err := commit.captureStagedEvidence(); err != nil {
+			return MetadataCommit{}, err
+		}
+	}
+	if err := commit.recordPartialInventory(); err != nil {
+		return MetadataCommit{}, err
+	}
+	return commit, nil
 }
 
-// recordMetadata upserts Installation Metadata for every managed target the plan
-// installed or confirmed unchanged, so dots status has an authoritative record
-// of what dots owns. Copy-like records include a Source of Truth hash; symlink
-// records leave Hash empty because status compares the link destination.
-func recordMetadata(p plan.Plan, resolvedSources [][]string, opts Options) error {
-	if opts.StateRoot == "" {
+// Commit revalidates sources and live targets, then atomically records exact
+// contribution evidence and, when supplied, the authoritative selection.
+func (c MetadataCommit) Commit(installed *state.InstalledSelection) error {
+	if c.opts.StateRoot == "" {
 		return nil
 	}
+	if err := c.validateTerminalPaths(); err != nil {
+		return err
+	}
 
-	path := state.Path(opts.StateRoot)
+	path := state.Path(c.opts.StateRoot)
 	meta, err := state.Load(path)
 	if err != nil {
 		return err
 	}
 	meta.Version = state.CurrentVersion
-	meta.Provenance = state.CaptureProvenance(opts.SourceRoot, version.Value)
+	meta.Provenance = state.CaptureProvenance(c.opts.SourceRoot, version.Value)
 
 	now := time.Now().UTC().Format(time.RFC3339)
 	legacyTargets := map[string]struct{}{}
-	for i, action := range p.Actions {
-		if !recordsMetadata(action, conflictDecision(action, opts)) {
+	for _, stagedAction := range c.actions {
+		if !stagedAction.recordsEvidence {
 			continue
 		}
-		if action.Ownership == "seeded" && action.Reason == plan.ReasonSeededLocalEvolution {
-			// Preserve the baseline that originally seeded locally evolved state.
-			// Replacing it with the new Source of Truth baseline would destroy the
-			// evidence needed to recognize a later reset and advance safely.
-			continue
-		}
-		hash := ""
-		var ownedContent []byte
-		var ownedBytes []byte
-		var seededBaseline []byte
-		recordedOwnership := action.Ownership
-		if recordedOwnership == "" {
-			recordedOwnership = "whole"
-		}
-		contributions, err := recordContributions(action, resolvedSources[i], recordedOwnership)
+		action := stagedAction.action
+		staged, err := stagedAction.evidence()
 		if err != nil {
 			return err
 		}
-		targetWide, err := targetWideEvidence(action, resolvedSources[i], contributions, recordedOwnership)
+		current, err := buildMetadataRecord(c.profiles, c.tags, action, stagedAction.resolvedSources, staged.InstalledAt)
 		if err != nil {
 			return err
 		}
-		if len(contributions) > 0 {
-			if err := validateRecordedConvergence(action, resolvedSources[i], targetWide, contributions); err != nil {
-				return err
-			}
+		if !sameRecordEvidence(staged, current) {
+			return fmt.Errorf("source contribution evidence changed before terminal metadata commit for %s: %w", action.Target, ownershipevidence.ErrDrift)
 		}
-		hash = targetWide.Hash
-		ownedContent = targetWide.OwnedContent
-		ownedBytes = targetWide.OwnedBytes
-		seededBaseline = targetWide.SeededBaseline
-		upsertRecord(&meta, state.Record{
-			Target:         action.Target,
-			Source:         action.Source,
-			Sources:        append([]string(nil), action.Sources...),
-			Strategy:       action.Strategy,
-			Ownership:      recordedOwnership,
-			OwnedContent:   ownedContent,
-			OwnedBytes:     ownedBytes,
-			SeededBaseline: seededBaseline,
-			Contributions:  contributions,
-			Hash:           hash,
-			InstalledAt:    now,
-			Profiles:       append([]string(nil), p.Profiles...),
-			Tags:           append([]string(nil), p.Tags...),
-		})
+		if err := validateMetadataRecord(action, stagedAction.resolvedSources, staged); err != nil {
+			return fmt.Errorf("validate staged contribution evidence for %s: %w", action.Target, err)
+		}
+		staged.InstalledAt = now
+		upsertRecord(&meta, staged)
 		if action.Migration != nil && action.Migration.LegacyTarget != "" {
 			legacyTargets[action.Migration.LegacyTarget] = struct{}{}
 		}
@@ -159,153 +171,303 @@ func recordMetadata(p plan.Plan, resolvedSources [][]string, opts Options) error
 	for target := range legacyTargets {
 		meta = meta.Remove(target)
 	}
+	if installed != nil {
+		selection := *installed
+		meta.InstalledSelection = &selection
+	}
 
 	return state.Save(path, meta)
 }
 
-func recordContributions(action plan.Action, resolvedSources []string, ownership string) ([]state.Contribution, error) {
+func (c *MetadataCommit) captureStagedEvidence() error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	for i := range c.actions {
+		stagedAction := &c.actions[i]
+		if !stagedAction.recordsEvidence {
+			continue
+		}
+		record, err := buildMetadataRecord(c.profiles, c.tags, stagedAction.action, stagedAction.resolvedSources, now)
+		if err != nil {
+			return err
+		}
+		stagedAction.stagedRecord = record
+	}
+	return nil
+}
+
+// recordPartialInventory retains the existing rerunnable failed-install
+// inventory without replacing any previously committed exact evidence.
+func (c MetadataCommit) recordPartialInventory() error {
+	if c.opts.StateRoot == "" {
+		return nil
+	}
+	path := state.Path(c.opts.StateRoot)
+	meta, err := state.Load(path)
+	if err != nil {
+		return err
+	}
+	meta.Version = state.CurrentVersion
+	meta.Provenance = state.CaptureProvenance(c.opts.SourceRoot, version.Value)
+	for _, stagedAction := range c.actions {
+		if !stagedAction.recordsEvidence {
+			continue
+		}
+		action := stagedAction.action
+		if hasCommittedContributions(meta, action.Target) {
+			continue
+		}
+		record, err := stagedAction.evidence()
+		if err != nil {
+			return err
+		}
+		record.Contributions = nil
+		upsertRecord(&meta, record)
+	}
+	return state.Save(path, meta)
+}
+
+func (a metadataAction) evidence() (state.Record, error) {
+	if a.stagedRecord.Target == "" {
+		return state.Record{}, fmt.Errorf("terminal metadata commit has no staged evidence for %s", a.action.Target)
+	}
+	return a.stagedRecord, nil
+}
+
+func buildMetadataRecord(profiles, tags []string, action plan.Action, resolvedSources []string, installedAt string) (state.Record, error) {
+	mode := ownershipevidence.For(action.Strategy, action.Ownership)
+	contributions, projectionInputs, err := captureContributions(mode, action, resolvedSources)
+	if err != nil {
+		return state.Record{}, err
+	}
+	targetWide, err := mode.Project(action.Target, projectionInputs)
+	if err != nil {
+		return state.Record{}, err
+	}
+	err = validateProjectedEvidence(mode, action, resolvedSources, targetWide)
+	if err != nil {
+		return state.Record{}, fmt.Errorf("validate terminal contribution evidence for %s: %w", action.Target, err)
+	}
+	return state.Record{
+		Target:         action.Target,
+		Source:         action.Source,
+		Sources:        append([]string(nil), action.Sources...),
+		Strategy:       action.Strategy,
+		Ownership:      mode.Ownership(),
+		OwnedContent:   append([]byte(nil), targetWide.OwnedContent...),
+		OwnedBytes:     append([]byte(nil), targetWide.OwnedBytes...),
+		SeededBaseline: append([]byte(nil), targetWide.SeededBaseline...),
+		Contributions:  contributions,
+		Hash:           targetWide.Hash,
+		InstalledAt:    installedAt,
+		Profiles:       append([]string(nil), profiles...),
+		Tags:           append([]string(nil), tags...),
+	}, nil
+}
+
+func validateMetadataRecord(action plan.Action, resolvedSources []string, record state.Record) error {
+	mode := ownershipevidence.For(action.Strategy, record.Ownership)
+	return validateProjectedEvidence(mode, action, resolvedSources, state.Contribution{
+		Ownership:        record.Ownership,
+		EvidenceRecorded: true,
+		Hash:             record.Hash,
+		OwnedContent:     append([]byte(nil), record.OwnedContent...),
+		OwnedBytes:       append([]byte(nil), record.OwnedBytes...),
+		SeededBaseline:   append([]byte(nil), record.SeededBaseline...),
+	})
+}
+
+func validateProjectedEvidence(mode ownershipevidence.Mode, action plan.Action, resolvedSources []string, evidence state.Contribution) error {
+	if action.Migration != nil && mode.Ownership() == "seeded" {
+		return mode.Validate(action.Target, resolvedSources, evidence, action.Migration.FinalContent)
+	}
+	return mode.Validate(action.Target, resolvedSources, evidence)
+}
+
+func sameRecordEvidence(staged, current state.Record) bool {
+	if staged.Ownership != current.Ownership || staged.Hash != current.Hash ||
+		!bytes.Equal(staged.OwnedContent, current.OwnedContent) ||
+		!bytes.Equal(staged.OwnedBytes, current.OwnedBytes) ||
+		!bytes.Equal(staged.SeededBaseline, current.SeededBaseline) ||
+		len(staged.Contributions) != len(current.Contributions) {
+		return false
+	}
+	for i := range staged.Contributions {
+		if !sameContributionEvidence(staged.Contributions[i], current.Contributions[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func sameContributionEvidence(staged, current state.Contribution) bool {
+	if staged.Source != current.Source || staged.Ownership != current.Ownership ||
+		staged.EvidenceRecorded != current.EvidenceRecorded || staged.Hash != current.Hash ||
+		len(staged.SelectorTags) != len(current.SelectorTags) ||
+		!bytes.Equal(staged.OwnedContent, current.OwnedContent) ||
+		!bytes.Equal(staged.OwnedBytes, current.OwnedBytes) ||
+		!bytes.Equal(staged.SeededBaseline, current.SeededBaseline) {
+		return false
+	}
+	for i := range staged.SelectorTags {
+		if staged.SelectorTags[i] != current.SelectorTags[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func captureContributions(mode ownershipevidence.Mode, action plan.Action, resolvedSources []string) ([]state.Contribution, []state.Contribution, error) {
 	planned := action.Contributions
 	if len(planned) == 0 {
-		return nil, nil
+		if len(resolvedSources) != 1 {
+			return nil, nil, fmt.Errorf("record contribution evidence for %s: no contribution identities for %d resolved sources", action.Target, len(resolvedSources))
+		}
+		recorded, err := mode.Capture(action.Source, resolvedSources[0], nil, seededBaseline(action))
+		if err != nil {
+			return nil, nil, err
+		}
+		return nil, []state.Contribution{recorded}, nil
 	}
 	if len(planned) != len(resolvedSources) {
-		return nil, fmt.Errorf("record contribution evidence for %s: %d contributions for %d resolved sources", action.Target, len(planned), len(resolvedSources))
+		return nil, nil, fmt.Errorf("record contribution evidence for %s: %d contributions for %d resolved sources", action.Target, len(planned), len(resolvedSources))
 	}
 
 	contributions := make([]state.Contribution, 0, len(planned))
 	for i, contribution := range planned {
-		recorded, err := captureContributionEvidence(action, contribution, resolvedSources[i], ownership)
+		recorded, err := mode.Capture(contribution.Source, resolvedSources[i], contribution.SelectorTags, seededBaseline(action))
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		contributions = append(contributions, recorded)
 	}
-	return contributions, nil
+	return contributions, contributions, nil
 }
 
-func captureContributionEvidence(action plan.Action, contribution plan.Contribution, resolvedSource, ownership string) (state.Contribution, error) {
-	recorded := state.Contribution{
-		Source:           contribution.Source,
-		SelectorTags:     append([]string(nil), contribution.SelectorTags...),
-		Ownership:        ownership,
-		EvidenceRecorded: true,
+func seededBaseline(action plan.Action) []byte {
+	if action.Migration != nil && action.Migration.RecordedBaseline != nil {
+		return action.Migration.RecordedBaseline
 	}
-	if action.Strategy == "symlink" {
-		return recorded, nil
-	}
+	return nil
+}
 
-	raw, err := os.ReadFile(resolvedSource)
+func hasCommittedContributions(meta state.Metadata, target string) bool {
+	for _, record := range meta.Entries {
+		if record.Target == target {
+			return len(record.Contributions) > 0
+		}
+	}
+	return false
+}
+
+func newMetadataCommit(p plan.Plan, resolvedSources [][]string, opts Options) MetadataCommit {
+	commit := MetadataCommit{
+		profiles: append([]string(nil), p.Profiles...),
+		tags:     append([]string(nil), p.Tags...),
+		opts:     cloneOptions(opts),
+		actions:  make([]metadataAction, len(p.Actions)),
+	}
+	for i, action := range p.Actions {
+		commit.actions[i] = metadataAction{
+			action:          action,
+			resolvedSources: append([]string(nil), resolvedSources[i]...),
+			recordsEvidence: recordsContributionEvidence(action, conflictDecision(action, opts)),
+		}
+	}
+	return commit
+}
+
+func cloneOptions(opts Options) Options {
+	cloned := opts
+	if opts.ConflictDecisions != nil {
+		cloned.ConflictDecisions = make(map[string]ConflictDecision, len(opts.ConflictDecisions))
+		for target, decision := range opts.ConflictDecisions {
+			cloned.ConflictDecisions[target] = decision
+		}
+	}
+	return cloned
+}
+
+// validateTerminalPaths repeats the security boundary checks that can become
+// stale while Provisioners run. It intentionally does not repeat pre-apply
+// target-status checks, because successfully created targets now exist.
+func (c MetadataCommit) validateTerminalPaths() error {
+	home, err := cleanAbs(c.opts.Home)
 	if err != nil {
-		return state.Contribution{}, fmt.Errorf("read %s contribution %s: %w", ownership, resolvedSource, err)
+		return fmt.Errorf("resolve home: %w", err)
 	}
-	recorded.Hash = state.HashBytes(raw)
-	switch ownership {
-	case "json-subset":
-		recorded.OwnedContent = append([]byte{}, raw...)
-	case "jsonc-subset":
-		recorded.OwnedContent, err = configsubset.CanonicalJSONC(raw)
-		if err != nil {
-			return state.Contribution{}, fmt.Errorf("canonicalize owned jsonc contribution %s: %w", resolvedSource, err)
-		}
-	case "toml-subset", "marked-block":
-		recorded.OwnedBytes = append([]byte{}, raw...)
-	case "seeded":
-		if action.Migration != nil && action.Migration.RecordedBaseline != nil {
-			recorded.SeededBaseline = append([]byte{}, action.Migration.RecordedBaseline...)
-		} else {
-			recorded.SeededBaseline = append([]byte{}, raw...)
-		}
-	}
-	return recorded, nil
-}
-
-func targetWideEvidence(action plan.Action, resolvedSources []string, contributions []state.Contribution, ownership string) (state.Contribution, error) {
-	if len(contributions) == 0 {
-		return captureContributionEvidence(action, plan.Contribution{Source: action.Source}, resolvedSources[0], ownership)
-	}
-	if len(contributions) == 1 {
-		return contributions[0], nil
-	}
-	if ownership != "json-subset" {
-		return state.Contribution{}, fmt.Errorf("compose target-wide evidence for %s: unsupported ownership %s", action.Target, ownership)
-	}
-
-	composed := append([]byte(nil), contributions[0].OwnedContent...)
-	var err error
-	for _, contribution := range contributions[1:] {
-		composed, err = configsubset.MergeJSON(composed, contribution.OwnedContent)
-		if err != nil {
-			return state.Contribution{}, fmt.Errorf("compose target-wide evidence for %s: %w", action.Target, err)
-		}
-	}
-	return state.Contribution{
-		Ownership:        ownership,
-		EvidenceRecorded: true,
-		Hash:             state.HashBytes(composed),
-		OwnedContent:     composed,
-	}, nil
-}
-
-func validateRecordedConvergence(action plan.Action, resolvedSources []string, targetWide state.Contribution, contributions []state.Contribution) error {
-	if action.Strategy == "symlink" {
-		if len(contributions) != 1 {
-			return fmt.Errorf("managed target %s no longer converged: symlink has %d contributions", action.Target, len(contributions))
-		}
-		info, err := os.Lstat(action.Target)
-		if err != nil {
-			return fmt.Errorf("inspect converged symlink %s: %w", action.Target, err)
-		}
-		if info.Mode()&os.ModeSymlink == 0 {
-			return fmt.Errorf("managed target %s no longer converged: expected symlink", action.Target)
-		}
-		destination, err := os.Readlink(action.Target)
-		if err != nil {
-			return fmt.Errorf("read converged symlink %s: %w", action.Target, err)
-		}
-		if filepath.Clean(destination) != filepath.Clean(resolvedSources[0]) {
-			return fmt.Errorf("managed target %s no longer converged: symlink destination changed", action.Target)
-		}
-		return nil
-	}
-
-	live, err := os.ReadFile(action.Target)
+	sourceRoot, err := cleanAbs(c.opts.SourceRoot)
 	if err != nil {
-		return fmt.Errorf("read converged target %s: %w", action.Target, err)
+		return fmt.Errorf("resolve source root: %w", err)
 	}
-	converged := false
-	switch targetWide.Ownership {
-	case "whole":
-		converged = state.HashBytes(live) == targetWide.Hash
-	case "json-subset":
-		relation, analyzeErr := configsubset.AnalyzeJSON(live, targetWide.OwnedContent)
-		if analyzeErr != nil {
-			return fmt.Errorf("validate converged json target %s: %w", action.Target, analyzeErr)
-		}
-		converged = relation.Contains
-	case "jsonc-subset":
-		relation, analyzeErr := configsubset.AnalyzeJSONC(live, targetWide.OwnedContent)
-		if analyzeErr != nil {
-			return fmt.Errorf("validate converged jsonc target %s: %w", action.Target, analyzeErr)
-		}
-		converged = relation.Contains
-	case "toml-subset":
-		relation, analyzeErr := configsubset.AnalyzeTOML(live, targetWide.OwnedBytes)
-		if analyzeErr != nil {
-			return fmt.Errorf("validate converged toml target %s: %w", action.Target, analyzeErr)
-		}
-		converged = relation.Contains
-	case "marked-block":
-		reconciliation := textblock.ReconcileOwned(live, targetWide.OwnedBytes, targetWide.OwnedBytes, textblock.DotsManagedMarkers())
-		converged = reconciliation.Compatible && !reconciliation.Changed
-	case "seeded":
-		if action.Migration != nil {
-			converged = bytes.Equal(live, action.Migration.FinalContent)
-		} else {
-			converged = bytes.Equal(live, targetWide.SeededBaseline)
-		}
+	if err := validateStateRoot(c.opts.StateRoot, home); err != nil {
+		return err
 	}
-	if !converged {
-		return fmt.Errorf("managed target %s no longer converged; contribution evidence was not recorded", action.Target)
+
+	seenTargets := map[string]struct{}{}
+	for _, stagedAction := range c.actions {
+		if !stagedAction.recordsEvidence {
+			continue
+		}
+		action := stagedAction.action
+		if err := plan.ValidateResolvedTarget(action.Target, home); err != nil {
+			return err
+		}
+		targetKey, err := cleanAbs(action.Target)
+		if err != nil {
+			return fmt.Errorf("resolve target %s: %w", action.Target, err)
+		}
+		if _, exists := seenTargets[targetKey]; exists {
+			return fmt.Errorf("terminal metadata commit contains duplicate target %s", targetKey)
+		}
+		seenTargets[targetKey] = struct{}{}
+		if err := validateTargetParentInsideHome(action.Target, home); err != nil {
+			return err
+		}
+		if action.Strategy == "copy" {
+			if err := plan.ValidateFilePathInsideHomeNoSymlinkEscape(action.Target, home, "terminal managed target"); err != nil {
+				return err
+			}
+		}
+
+		sourceNames := []string{action.Source}
+		declaredResolved := []string{action.ResolvedSource}
+		if len(action.Sources) > 0 {
+			sourceNames = action.Sources
+			declaredResolved = action.ResolvedSources
+		}
+		if len(sourceNames) != len(stagedAction.resolvedSources) {
+			return fmt.Errorf("terminal metadata commit for %s has %d sources, want %d", action.Target, len(sourceNames), len(stagedAction.resolvedSources))
+		}
+		if len(action.Contributions) > 0 && len(action.Contributions) != len(sourceNames) {
+			return fmt.Errorf("terminal metadata commit has %d contributions for %d sources on %s", len(action.Contributions), len(sourceNames), action.Target)
+		}
+		for j, sourceName := range sourceNames {
+			source, err := plan.ResolveSource(sourceName, sourceRoot)
+			if err != nil {
+				return err
+			}
+			if source != stagedAction.resolvedSources[j] {
+				return fmt.Errorf("terminal source %q resolved to %q after applying from %q", sourceName, source, stagedAction.resolvedSources[j])
+			}
+			if j < len(declaredResolved) && declaredResolved[j] != "" && declaredResolved[j] != source {
+				return fmt.Errorf("install plan source %q resolved to %q, want %q", sourceName, declaredResolved[j], source)
+			}
+			if len(action.Contributions) > 0 && action.Contributions[j].Source != sourceName {
+				return fmt.Errorf("install plan contribution source %q does not match source %q on %s", action.Contributions[j].Source, sourceName, action.Target)
+			}
+			if err := validateSource(action.Strategy, source, sourceRoot); err != nil {
+				return err
+			}
+		}
+		if len(action.Sources) > 0 {
+			composed, err := configsubset.ComposeJSONFiles(stagedAction.resolvedSources)
+			if err != nil {
+				return fmt.Errorf("validate terminal composed target %s: %w", action.Target, err)
+			}
+			if !bytes.Equal(composed, action.Content) {
+				return fmt.Errorf("install plan composed content changed before terminal metadata commit for %s", action.Target)
+			}
+		}
 	}
 	return nil
 }
@@ -546,6 +708,16 @@ func recordsMetadata(action plan.Action, decision ConflictDecision) bool {
 		return true
 	}
 	return action.Status == plan.StatusConflict && (decision == DecisionReplace || decision == DecisionAdopt)
+}
+
+func recordsContributionEvidence(action plan.Action, decision ConflictDecision) bool {
+	if !recordsMetadata(action, decision) {
+		return false
+	}
+	// Preserve the baseline that originally seeded locally evolved state.
+	// Replacing it with the new Source of Truth baseline would destroy the
+	// evidence needed to recognize a later reset and advance safely.
+	return action.Ownership != "seeded" || action.Reason != plan.ReasonSeededLocalEvolution
 }
 
 func validateStateRoot(stateRoot, home string) error {

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -2,6 +2,7 @@ package install_test
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -11,6 +12,7 @@ import (
 	"github.com/yersonargotev/dots/internal/backups"
 	"github.com/yersonargotev/dots/internal/install"
 	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/ownershipevidence"
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/state"
 )
@@ -337,6 +339,167 @@ func TestApplyContributionEvidencePreservesUnrelatedInventoryAndInstalledSelecti
 	newRecord, ok := got.FindByTarget(filepath.Join(home, ".new"))
 	if !ok || len(newRecord.Contributions) != 1 || !reflect.DeepEqual(newRecord.Contributions[0].SelectorTags, []string{"new"}) {
 		t.Fatalf("new record = %+v, want terminal contribution evidence", newRecord)
+	}
+}
+
+func TestApplyManagedEntriesCommitsContributionEvidenceAndSelectionAtomically(t *testing.T) {
+	sourceRoot := t.TempDir()
+	home := t.TempDir()
+	stateRoot := filepath.Join(home, ".local", "state", "dots")
+	source := filepath.Join(sourceRoot, "configs", "new")
+	if err := os.MkdirAll(filepath.Dir(source), 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	if err := os.WriteFile(source, []byte("new\n"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	previousSelection := state.InstalledSelection{Profiles: []string{"previous"}, ResolvedTags: []string{"previous"}}
+	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, InstalledSelection: &previousSelection}); err != nil {
+		t.Fatalf("save previous metadata: %v", err)
+	}
+	m := manifest.Manifest{
+		Version: 1, Profiles: map[string]manifest.Profile{"default": {Tags: []string{"new"}}},
+		Entries: []manifest.Entry{{Source: "configs/new", Target: "~/.new", Strategy: "copy", Tags: []string{"new"}}},
+	}
+	p, err := plan.Build(m, plan.Options{Profile: "default", OS: "linux", SourceRoot: sourceRoot, Home: home})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	commit, err := install.ApplyManagedEntries(p, install.Options{SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot})
+	if err != nil {
+		t.Fatalf("ApplyManagedEntries() error = %v", err)
+	}
+
+	staged, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load staged metadata: %v", err)
+	}
+	if len(staged.Entries) != 1 || len(staged.Entries[0].Contributions) != 0 {
+		t.Fatalf("staged Entries = %+v, want compatibility inventory without exact evidence", staged.Entries)
+	}
+	if staged.InstalledSelection == nil || !reflect.DeepEqual(*staged.InstalledSelection, previousSelection) {
+		t.Fatalf("staged InstalledSelection = %+v, want previous %+v", staged.InstalledSelection, previousSelection)
+	}
+	provisioners := []state.ProvisionerRecord{{Tool: "codex", Executable: "codex", Status: "provisioned"}}
+	staged.Provisioners = provisioners
+	if err := state.Save(state.Path(stateRoot), staged); err != nil {
+		t.Fatalf("save terminal Provisioner inventory: %v", err)
+	}
+
+	installed := state.InstalledSelection{Profiles: []string{"default"}, ResolvedTags: []string{"new"}}
+	if err := commit.Commit(&installed); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	final, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load final metadata: %v", err)
+	}
+	if len(final.Entries) != 1 || len(final.Entries[0].Contributions) != 1 || !reflect.DeepEqual(final.Entries[0].Contributions[0].SelectorTags, []string{"new"}) {
+		t.Fatalf("final Entries = %+v, want exact selected contribution evidence", final.Entries)
+	}
+	if final.InstalledSelection == nil || !reflect.DeepEqual(*final.InstalledSelection, installed) {
+		t.Fatalf("final InstalledSelection = %+v, want %+v", final.InstalledSelection, installed)
+	}
+	if !reflect.DeepEqual(final.Provisioners, provisioners) {
+		t.Fatalf("final Provisioners = %+v, want preserved %+v", final.Provisioners, provisioners)
+	}
+}
+
+func TestMetadataCommitRejectsConcurrentDriftWithoutStrengtheningEvidence(t *testing.T) {
+	sourceRoot := t.TempDir()
+	home := t.TempDir()
+	stateRoot := filepath.Join(home, ".local", "state", "dots")
+	source := filepath.Join(sourceRoot, "configs", "new")
+	if err := os.MkdirAll(filepath.Dir(source), 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	if err := os.WriteFile(source, []byte("new\n"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	previousSelection := state.InstalledSelection{Profiles: []string{"previous"}, ResolvedTags: []string{"previous"}}
+	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, InstalledSelection: &previousSelection}); err != nil {
+		t.Fatalf("save previous metadata: %v", err)
+	}
+	m := manifest.Manifest{
+		Version: 1, Profiles: map[string]manifest.Profile{"default": {Tags: []string{"new"}}},
+		Entries: []manifest.Entry{{Source: "configs/new", Target: "~/.new", Strategy: "copy", Tags: []string{"new"}}},
+	}
+	p, err := plan.Build(m, plan.Options{Profile: "default", OS: "linux", SourceRoot: sourceRoot, Home: home})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	commit, err := install.ApplyManagedEntries(p, install.Options{SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot})
+	if err != nil {
+		t.Fatalf("ApplyManagedEntries() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".new"), []byte("concurrent drift\n"), 0o600); err != nil {
+		t.Fatalf("write concurrent Drift: %v", err)
+	}
+	installed := state.InstalledSelection{Profiles: []string{"default"}, ResolvedTags: []string{"new"}}
+	if err := commit.Commit(&installed); !errors.Is(err, ownershipevidence.ErrDrift) {
+		t.Fatalf("Commit() error = %v, want ErrDrift", err)
+	}
+
+	final, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load metadata after Drift: %v", err)
+	}
+	if len(final.Entries) != 1 || len(final.Entries[0].Contributions) != 0 {
+		t.Fatalf("Entries after Drift = %+v, want compatibility inventory without exact evidence", final.Entries)
+	}
+	if final.InstalledSelection == nil || !reflect.DeepEqual(*final.InstalledSelection, previousSelection) {
+		t.Fatalf("InstalledSelection after Drift = %+v, want previous %+v", final.InstalledSelection, previousSelection)
+	}
+}
+
+func TestMetadataCommitRejectsChangedSourceEvidenceEvenWhenTargetContainsIt(t *testing.T) {
+	sourceRoot := t.TempDir()
+	home := t.TempDir()
+	stateRoot := filepath.Join(home, ".local", "state", "dots")
+	source := filepath.Join(sourceRoot, "configs", "shared.json")
+	if err := os.MkdirAll(filepath.Dir(source), 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	if err := os.WriteFile(source, []byte(`{"owned":true,"retired":true}`), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	previousSelection := state.InstalledSelection{Profiles: []string{"previous"}, ResolvedTags: []string{"previous"}}
+	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, InstalledSelection: &previousSelection}); err != nil {
+		t.Fatalf("save previous metadata: %v", err)
+	}
+	m := manifest.Manifest{
+		Version: 1, Profiles: map[string]manifest.Profile{"default": {Tags: []string{"shared"}}},
+		Entries: []manifest.Entry{{
+			Source: "configs/shared.json", Target: "~/.config/shared.json", Strategy: "copy", Ownership: "json-subset", Tags: []string{"shared"},
+		}},
+	}
+	p, err := plan.Build(m, plan.Options{Profile: "default", OS: "linux", SourceRoot: sourceRoot, Home: home})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	commit, err := install.ApplyManagedEntries(p, install.Options{SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot})
+	if err != nil {
+		t.Fatalf("ApplyManagedEntries() error = %v", err)
+	}
+	// The live target still contains this reduced subset, but it is not the
+	// exact Source of Truth contribution that produced convergence.
+	if err := os.WriteFile(source, []byte(`{"owned":true}`), 0o600); err != nil {
+		t.Fatalf("change Source of Truth after staging: %v", err)
+	}
+	installed := state.InstalledSelection{Profiles: []string{"default"}, ResolvedTags: []string{"shared"}}
+	if err := commit.Commit(&installed); !errors.Is(err, ownershipevidence.ErrDrift) {
+		t.Fatalf("Commit() error = %v, want changed source ErrDrift", err)
+	}
+
+	final, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load metadata after source change: %v", err)
+	}
+	if len(final.Entries) != 1 || len(final.Entries[0].Contributions) != 0 {
+		t.Fatalf("Entries after source change = %+v, want compatibility inventory without exact evidence", final.Entries)
+	}
+	if final.InstalledSelection == nil || !reflect.DeepEqual(*final.InstalledSelection, previousSelection) {
+		t.Fatalf("InstalledSelection after source change = %+v, want previous %+v", final.InstalledSelection, previousSelection)
 	}
 }
 

--- a/internal/installed/installed.go
+++ b/internal/installed/installed.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/ownershipevidence"
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/provision"
 	"github.com/yersonargotev/dots/internal/selectedsurface"
@@ -137,7 +138,6 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options) (Report, erro
 			tags = append([]string(nil), expanded.Contribution.SelectorTags...)
 			tagsSource = "recorded-contribution"
 			if len(tags) == 0 {
-				tagsSource = "unknown"
 				missingContributionTags = true
 			}
 		} else if len(tags) == 0 && matched {
@@ -169,7 +169,7 @@ func Build(m manifest.Manifest, meta state.Metadata, opts Options) (Report, erro
 		if expanded.Attributed {
 			attribution = "recorded-contribution"
 			ownership = expanded.Contribution.Ownership
-			ownershipEvidence = describeContributionEvidence(rec.Strategy, expanded.Contribution)
+			ownershipEvidence = ownershipevidence.For(rec.Strategy, expanded.Contribution.Ownership).Discriminator(expanded.Contribution)
 		}
 		report.ManagedEntries = append(report.ManagedEntries, ManagedEntry{
 			Source:            rec.Source,
@@ -289,30 +289,6 @@ func expandedRecords(records []state.Record) []expandedRecord {
 		}
 	}
 	return expanded
-}
-
-func describeContributionEvidence(strategy string, contribution state.Contribution) string {
-	if !contribution.EvidenceRecorded {
-		return "missing"
-	}
-	switch contribution.Ownership {
-	case "json-subset":
-		return "owned-json"
-	case "jsonc-subset":
-		return "owned-jsonc"
-	case "toml-subset":
-		return "owned-toml"
-	case "marked-block":
-		return "owned-marked-block"
-	case "seeded":
-		return "seeded-baseline"
-	case "whole":
-		if strategy == "symlink" {
-			return "source-identity"
-		}
-		return "source-hash"
-	}
-	return "missing"
 }
 
 func matchEntry(m manifest.Manifest, rec state.Record, opts Options) (manifest.Entry, bool, error) {

--- a/internal/installed/installed_test.go
+++ b/internal/installed/installed_test.go
@@ -3,6 +3,7 @@ package installed_test
 import (
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	inst "github.com/yersonargotev/dots/internal/installed"
@@ -123,6 +124,35 @@ func TestBuildReportsRecordedEmptyOwnershipEvidence(t *testing.T) {
 				t.Fatalf("ManagedEntries = %+v, want empty %s evidence reported as %s", report.ManagedEntries, tt.ownership, tt.evidence)
 			}
 		})
+	}
+}
+
+func TestBuildKeepsRecordedContributionTagProvenanceWhenSelectorTagsAreMissing(t *testing.T) {
+	home := t.TempDir()
+	target := filepath.Join(home, ".config", "shared.json")
+	m := manifest.Manifest{Version: 1, Entries: []manifest.Entry{{
+		Source: "configs/shared.json", Target: "~/.config/shared.json", Strategy: "copy", Ownership: "json-subset", Tags: []string{"shared"},
+	}}}
+	meta := state.Metadata{Version: state.CurrentVersion, Entries: []state.Record{{
+		Target: target, Source: "configs/shared.json", Strategy: "copy", Ownership: "json-subset",
+		Contributions: []state.Contribution{{
+			Source: "configs/shared.json", Ownership: "json-subset",
+		}},
+	}}}
+
+	report, err := inst.Build(m, meta, inst.Options{StatePath: filepath.Join(home, "installed.json"), Home: home, OS: "linux"})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if len(report.ManagedEntries) != 1 {
+		t.Fatalf("ManagedEntries = %+v, want one attributed entry", report.ManagedEntries)
+	}
+	entry := report.ManagedEntries[0]
+	if entry.Attribution != "recorded-contribution" || entry.TagsSource != "recorded-contribution" || entry.OwnershipEvidence != "missing" || len(entry.Tags) != 0 {
+		t.Fatalf("ManagedEntry = %+v, want incomplete recorded-contribution provenance", entry)
+	}
+	if got := strings.Join(report.Notes, "\n"); !strings.Contains(got, "do not record selector Tags") {
+		t.Fatalf("Notes = %q, want missing selector Tags explanation", got)
 	}
 }
 

--- a/internal/ownershipevidence/evidence.go
+++ b/internal/ownershipevidence/evidence.go
@@ -1,0 +1,305 @@
+// Package ownershipevidence owns the mode-specific semantics for capturing,
+// projecting, validating, and describing exact contribution evidence.
+package ownershipevidence
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/yersonargotev/dots/internal/configsubset"
+	"github.com/yersonargotev/dots/internal/state"
+	"github.com/yersonargotev/dots/internal/textblock"
+)
+
+const (
+	DiscriminatorSourceIdentity   = "source-identity"
+	DiscriminatorSourceHash       = "source-hash"
+	DiscriminatorOwnedJSON        = "owned-json"
+	DiscriminatorOwnedJSONC       = "owned-jsonc"
+	DiscriminatorOwnedTOML        = "owned-toml"
+	DiscriminatorOwnedMarkedBlock = "owned-marked-block"
+	DiscriminatorSeededBaseline   = "seeded-baseline"
+	DiscriminatorMissing          = "missing"
+)
+
+// ErrDrift identifies a live target that no longer converges with captured
+// ownership evidence. Callers should use errors.Is rather than comparing the
+// returned error directly.
+var ErrDrift = errors.New("ownership evidence drift")
+
+// Mode is the concrete ownership behavior selected by an install strategy and
+// ownership declaration. Its zero value represents copy with Whole-Target
+// Ownership, matching the manifest default.
+type Mode struct {
+	strategy  string
+	ownership string
+}
+
+// For selects ownership behavior. An empty strategy defaults to copy so the
+// zero Mode remains useful, and empty ownership normalizes to whole.
+func For(strategy, ownership string) Mode {
+	if strategy == "" {
+		strategy = "copy"
+	}
+	if ownership == "" {
+		ownership = "whole"
+	}
+	return Mode{strategy: strategy, ownership: ownership}
+}
+
+// Ownership returns the normalized ownership name recorded in Installation
+// Metadata.
+func (m Mode) Ownership() string {
+	return m.normalized().ownership
+}
+
+// Capture records exact evidence for one Source of Truth contribution.
+// source is the manifest-relative identity and sourcePath is its already
+// validated, resolved filesystem path. A non-nil seededBaseline overrides the
+// source bytes for seeded evidence; an explicitly empty baseline is preserved.
+func (m Mode) Capture(source, sourcePath string, selectorTags []string, seededBaseline []byte) (state.Contribution, error) {
+	m = m.normalized()
+	if err := m.validate(); err != nil {
+		return state.Contribution{}, err
+	}
+
+	recorded := state.Contribution{
+		Source:           source,
+		SelectorTags:     append([]string(nil), selectorTags...),
+		Ownership:        m.ownership,
+		EvidenceRecorded: true,
+	}
+	if m.strategy == "symlink" {
+		return recorded, nil
+	}
+
+	raw, err := os.ReadFile(sourcePath)
+	if err != nil {
+		return state.Contribution{}, fmt.Errorf("read %s contribution %s: %w", m.ownership, sourcePath, err)
+	}
+	recorded.Hash = state.HashBytes(raw)
+
+	switch m.ownership {
+	case "whole":
+	case "json-subset":
+		recorded.OwnedContent = cloneBytes(raw)
+	case "jsonc-subset":
+		recorded.OwnedContent, err = configsubset.CanonicalJSONC(raw)
+		if err != nil {
+			return state.Contribution{}, fmt.Errorf("canonicalize owned jsonc contribution %s: %w", sourcePath, err)
+		}
+	case "toml-subset", "marked-block":
+		recorded.OwnedBytes = cloneBytes(raw)
+	case "seeded":
+		if seededBaseline != nil {
+			recorded.SeededBaseline = cloneBytes(seededBaseline)
+		} else {
+			recorded.SeededBaseline = cloneBytes(raw)
+		}
+	}
+	return recorded, nil
+}
+
+// Project derives target-wide compatibility evidence from exact contribution
+// evidence. One contribution projects directly. Multiple contributions are
+// supported only for copy/json-subset, where they are composed in order.
+func (m Mode) Project(target string, contributions []state.Contribution) (state.Contribution, error) {
+	m = m.normalized()
+	if err := m.validate(); err != nil {
+		return state.Contribution{}, err
+	}
+	if len(contributions) == 0 {
+		return state.Contribution{}, fmt.Errorf("project target-wide evidence for %s: no contributions", target)
+	}
+	for i, contribution := range contributions {
+		if !contribution.EvidenceRecorded {
+			return state.Contribution{}, fmt.Errorf("project target-wide evidence for %s: contribution %d has incomplete evidence", target, i)
+		}
+		if contribution.Ownership != m.ownership {
+			return state.Contribution{}, fmt.Errorf("project target-wide evidence for %s: contribution %d ownership %q does not match %q", target, i, contribution.Ownership, m.ownership)
+		}
+	}
+	if len(contributions) == 1 {
+		return cloneContribution(contributions[0]), nil
+	}
+	if m.strategy != "copy" || m.ownership != "json-subset" {
+		return state.Contribution{}, fmt.Errorf("project target-wide evidence for %s: multiple contributions require copy/json-subset ownership", target)
+	}
+
+	composed := append([]byte(nil), contributions[0].OwnedContent...)
+	for _, contribution := range contributions[1:] {
+		var err error
+		composed, err = configsubset.MergeJSON(composed, contribution.OwnedContent)
+		if err != nil {
+			return state.Contribution{}, fmt.Errorf("compose target-wide evidence for %s: %w", target, err)
+		}
+	}
+	return state.Contribution{
+		Ownership:        m.ownership,
+		EvidenceRecorded: true,
+		Hash:             state.HashBytes(composed),
+		OwnedContent:     composed,
+	}, nil
+}
+
+// Validate confirms that target still converges with evidence immediately
+// before evidence is committed. resolvedSources is used to verify symlink
+// identity. seededFinal accepts zero or one value: zero validates the recorded
+// baseline, while one validates migration final content, including empty
+// content. More than one final value is rejected.
+func (m Mode) Validate(target string, resolvedSources []string, evidence state.Contribution, seededFinal ...[]byte) error {
+	m = m.normalized()
+	if err := m.validate(); err != nil {
+		return err
+	}
+	if len(seededFinal) > 1 {
+		return fmt.Errorf("validate ownership evidence for %s: seeded final content accepts at most one value", target)
+	}
+	if len(seededFinal) == 1 && m.ownership != "seeded" {
+		return fmt.Errorf("validate ownership evidence for %s: final content requires seeded ownership", target)
+	}
+	if !evidence.EvidenceRecorded {
+		return fmt.Errorf("validate ownership evidence for %s: evidence is incomplete", target)
+	}
+	if evidence.Ownership != m.ownership {
+		return fmt.Errorf("validate ownership evidence for %s: ownership %q does not match %q", target, evidence.Ownership, m.ownership)
+	}
+
+	if m.strategy == "symlink" {
+		return m.validateSymlink(target, resolvedSources)
+	}
+
+	live, err := os.ReadFile(target)
+	if err != nil {
+		return fmt.Errorf("read converged target %s: %w", target, err)
+	}
+	converged := false
+	switch m.ownership {
+	case "whole":
+		converged = state.HashBytes(live) == evidence.Hash
+	case "json-subset":
+		relation, analyzeErr := configsubset.AnalyzeJSON(live, evidence.OwnedContent)
+		if analyzeErr != nil {
+			return fmt.Errorf("validate converged json target %s: %w", target, analyzeErr)
+		}
+		converged = relation.Contains
+	case "jsonc-subset":
+		relation, analyzeErr := configsubset.AnalyzeJSONC(live, evidence.OwnedContent)
+		if analyzeErr != nil {
+			return fmt.Errorf("validate converged jsonc target %s: %w", target, analyzeErr)
+		}
+		converged = relation.Contains
+	case "toml-subset":
+		relation, analyzeErr := configsubset.AnalyzeTOML(live, evidence.OwnedBytes)
+		if analyzeErr != nil {
+			return fmt.Errorf("validate converged toml target %s: %w", target, analyzeErr)
+		}
+		converged = relation.Contains
+	case "marked-block":
+		reconciliation := textblock.ReconcileOwned(live, evidence.OwnedBytes, evidence.OwnedBytes, textblock.DotsManagedMarkers())
+		converged = reconciliation.Compatible && !reconciliation.Changed
+	case "seeded":
+		want := evidence.SeededBaseline
+		if len(seededFinal) == 1 {
+			want = seededFinal[0]
+		}
+		converged = bytes.Equal(live, want)
+	}
+	if !converged {
+		return fmt.Errorf("managed target %s no longer converged: %w", target, ErrDrift)
+	}
+	return nil
+}
+
+// Discriminator returns the stable public name for the exact evidence kind.
+// Incomplete or unsupported evidence always reports missing.
+func (m Mode) Discriminator(evidence state.Contribution) string {
+	m = m.normalized()
+	if err := m.validate(); err != nil {
+		return DiscriminatorMissing
+	}
+	if !evidence.EvidenceRecorded || evidence.Ownership != m.ownership {
+		return DiscriminatorMissing
+	}
+	switch m.ownership {
+	case "json-subset":
+		return DiscriminatorOwnedJSON
+	case "jsonc-subset":
+		return DiscriminatorOwnedJSONC
+	case "toml-subset":
+		return DiscriminatorOwnedTOML
+	case "marked-block":
+		return DiscriminatorOwnedMarkedBlock
+	case "seeded":
+		return DiscriminatorSeededBaseline
+	case "whole":
+		if m.strategy == "symlink" {
+			return DiscriminatorSourceIdentity
+		}
+		if m.strategy == "copy" {
+			return DiscriminatorSourceHash
+		}
+	}
+	return DiscriminatorMissing
+}
+
+func (m Mode) normalized() Mode {
+	return For(m.strategy, m.ownership)
+}
+
+func (m Mode) validate() error {
+	switch m.strategy {
+	case "copy":
+		switch m.ownership {
+		case "whole", "json-subset", "jsonc-subset", "toml-subset", "marked-block", "seeded":
+			return nil
+		}
+	case "symlink":
+		if m.ownership == "whole" {
+			return nil
+		}
+	default:
+		return fmt.Errorf("ownership evidence strategy %q is not supported", m.strategy)
+	}
+	return fmt.Errorf("ownership evidence mode %s/%s is not supported", m.strategy, m.ownership)
+}
+
+func (m Mode) validateSymlink(target string, resolvedSources []string) error {
+	if len(resolvedSources) != 1 {
+		return fmt.Errorf("managed target %s no longer converged: symlink has %d sources: %w", target, len(resolvedSources), ErrDrift)
+	}
+	info, err := os.Lstat(target)
+	if err != nil {
+		return fmt.Errorf("inspect converged symlink %s: %w", target, err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		return fmt.Errorf("managed target %s no longer converged: expected symlink: %w", target, ErrDrift)
+	}
+	destination, err := os.Readlink(target)
+	if err != nil {
+		return fmt.Errorf("read converged symlink %s: %w", target, err)
+	}
+	if filepath.Clean(destination) != filepath.Clean(resolvedSources[0]) {
+		return fmt.Errorf("managed target %s no longer converged: symlink destination changed: %w", target, ErrDrift)
+	}
+	return nil
+}
+
+func cloneContribution(contribution state.Contribution) state.Contribution {
+	cloned := contribution
+	cloned.SelectorTags = append([]string(nil), contribution.SelectorTags...)
+	cloned.OwnedContent = append([]byte(nil), contribution.OwnedContent...)
+	cloned.OwnedBytes = append([]byte(nil), contribution.OwnedBytes...)
+	cloned.SeededBaseline = cloneBytes(contribution.SeededBaseline)
+	return cloned
+}
+
+func cloneBytes(value []byte) []byte {
+	if value == nil {
+		return nil
+	}
+	return append([]byte{}, value...)
+}

--- a/internal/ownershipevidence/evidence_test.go
+++ b/internal/ownershipevidence/evidence_test.go
@@ -1,0 +1,288 @@
+package ownershipevidence_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/ownershipevidence"
+	"github.com/yersonargotev/dots/internal/state"
+)
+
+func TestCaptureAndDiscriminatorByMode(t *testing.T) {
+	t.Parallel()
+
+	marked := []byte("# >>> dots managed block >>>\nmanaged\n# <<< dots managed block <<<\n")
+	tests := []struct {
+		name           string
+		strategy       string
+		ownership      string
+		content        []byte
+		baseline       []byte
+		wantEvidence   string
+		wantOwned      []byte
+		wantOwnedBytes []byte
+		wantBaseline   []byte
+		wantHash       bool
+	}{
+		{name: "implicit whole copy", strategy: "copy", content: []byte("copy\n"), wantEvidence: ownershipevidence.DiscriminatorSourceHash, wantHash: true},
+		{name: "implicit whole symlink", strategy: "symlink", content: []byte("not read"), wantEvidence: ownershipevidence.DiscriminatorSourceIdentity},
+		{name: "json subset", strategy: "copy", ownership: "json-subset", content: []byte(`{"owned":true}`), wantEvidence: ownershipevidence.DiscriminatorOwnedJSON, wantOwned: []byte(`{"owned":true}`), wantHash: true},
+		{name: "jsonc canonical", strategy: "copy", ownership: "jsonc-subset", content: []byte("{\n  // note\n  \"owned\": true,\n}\n"), wantEvidence: ownershipevidence.DiscriminatorOwnedJSONC, wantOwned: []byte("{\n  \"owned\": true\n}\n"), wantHash: true},
+		{name: "empty exact toml", strategy: "copy", ownership: "toml-subset", content: []byte{}, wantEvidence: ownershipevidence.DiscriminatorOwnedTOML, wantOwnedBytes: []byte{}, wantHash: true},
+		{name: "marked block", strategy: "copy", ownership: "marked-block", content: marked, wantEvidence: ownershipevidence.DiscriminatorOwnedMarkedBlock, wantOwnedBytes: marked, wantHash: true},
+		{name: "seeded recorded baseline", strategy: "copy", ownership: "seeded", content: []byte("current source\n"), baseline: []byte("recorded baseline\n"), wantEvidence: ownershipevidence.DiscriminatorSeededBaseline, wantBaseline: []byte("recorded baseline\n"), wantHash: true},
+		{name: "seeded explicit empty baseline", strategy: "copy", ownership: "seeded", content: []byte("current source\n"), baseline: []byte{}, wantEvidence: ownershipevidence.DiscriminatorSeededBaseline, wantBaseline: []byte{}, wantHash: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			path := filepath.Join(dir, "source")
+			if tt.strategy != "symlink" {
+				if err := os.WriteFile(path, tt.content, 0o600); err != nil {
+					t.Fatalf("write source: %v", err)
+				}
+			}
+
+			mode := ownershipevidence.For(tt.strategy, tt.ownership)
+			got, err := mode.Capture("configs/source", path, []string{"core"}, tt.baseline)
+			if err != nil {
+				t.Fatalf("Capture() error = %v", err)
+			}
+			if got.Source != "configs/source" || !reflect.DeepEqual(got.SelectorTags, []string{"core"}) || got.Ownership != mode.Ownership() || !got.EvidenceRecorded {
+				t.Fatalf("Capture() identity = %#v", got)
+			}
+			if (got.Hash != "") != tt.wantHash {
+				t.Errorf("Capture().Hash presence = %v, want %v", got.Hash != "", tt.wantHash)
+			}
+			if !reflect.DeepEqual([]byte(got.OwnedContent), tt.wantOwned) {
+				t.Errorf("Capture().OwnedContent = %q, want %q", got.OwnedContent, tt.wantOwned)
+			}
+			if !reflect.DeepEqual(got.OwnedBytes, tt.wantOwnedBytes) {
+				t.Errorf("Capture().OwnedBytes = %q, want %q", got.OwnedBytes, tt.wantOwnedBytes)
+			}
+			if !reflect.DeepEqual(got.SeededBaseline, tt.wantBaseline) {
+				t.Errorf("Capture().SeededBaseline = %#v, want %#v", got.SeededBaseline, tt.wantBaseline)
+			}
+			if got := mode.Discriminator(got); got != tt.wantEvidence {
+				t.Errorf("Discriminator() = %q, want %q", got, tt.wantEvidence)
+			}
+		})
+	}
+}
+
+func TestDiscriminatorReportsMissingEvidence(t *testing.T) {
+	t.Parallel()
+
+	mode := ownershipevidence.For("copy", "json-subset")
+	if got := mode.Discriminator(state.Contribution{Ownership: "json-subset"}); got != ownershipevidence.DiscriminatorMissing {
+		t.Fatalf("Discriminator(incomplete) = %q, want missing", got)
+	}
+	if got := mode.Discriminator(state.Contribution{Ownership: "whole", EvidenceRecorded: true}); got != ownershipevidence.DiscriminatorMissing {
+		t.Fatalf("Discriminator(mismatched) = %q, want missing", got)
+	}
+}
+
+func TestProjectComposesMultipleJSONContributions(t *testing.T) {
+	t.Parallel()
+
+	mode := ownershipevidence.For("copy", "json-subset")
+	contributions := []state.Contribution{
+		{Source: "base.json", Ownership: "json-subset", EvidenceRecorded: true, OwnedContent: []byte(`{"base":{"one":true}}`)},
+		{Source: "mobile.json", Ownership: "json-subset", EvidenceRecorded: true, OwnedContent: []byte(`{"mobile":true,"base":{"two":true}}`)},
+	}
+	got, err := mode.Project("/home/test/shared.json", contributions)
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	want := "{\n  \"base\": {\n    \"one\": true,\n    \"two\": true\n  },\n  \"mobile\": true\n}\n"
+	if string(got.OwnedContent) != want || got.Hash != state.HashBytes([]byte(want)) || !got.EvidenceRecorded || got.Ownership != "json-subset" {
+		t.Fatalf("Project() = %#v, want composed JSON and its hash", got)
+	}
+
+	got.OwnedContent[0] = '['
+	if contributions[0].OwnedContent[0] != '{' {
+		t.Fatal("Project() aliased contribution evidence")
+	}
+}
+
+func TestProjectRejectsInvalidComposition(t *testing.T) {
+	t.Parallel()
+
+	jsonMode := ownershipevidence.For("copy", "json-subset")
+	tests := []struct {
+		name          string
+		mode          ownershipevidence.Mode
+		contributions []state.Contribution
+		want          string
+	}{
+		{name: "empty", mode: jsonMode, want: "no contributions"},
+		{name: "incomplete", mode: jsonMode, contributions: []state.Contribution{{Ownership: "json-subset"}}, want: "incomplete evidence"},
+		{name: "mismatched ownership", mode: jsonMode, contributions: []state.Contribution{{Ownership: "whole", EvidenceRecorded: true}}, want: "does not match"},
+		{name: "multiple toml", mode: ownershipevidence.For("copy", "toml-subset"), contributions: []state.Contribution{{Ownership: "toml-subset", EvidenceRecorded: true}, {Ownership: "toml-subset", EvidenceRecorded: true}}, want: "require copy/json-subset"},
+		{name: "incompatible json", mode: jsonMode, contributions: []state.Contribution{{Ownership: "json-subset", EvidenceRecorded: true, OwnedContent: []byte(`{"value":1}`)}, {Ownership: "json-subset", EvidenceRecorded: true, OwnedContent: []byte(`{"value":2}`)}}, want: "cannot be merged safely"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := tt.mode.Project("/target", tt.contributions)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Project() error = %v, want containing %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateConvergenceAndDriftByCopyMode(t *testing.T) {
+	t.Parallel()
+
+	marked := "# >>> dots managed block >>>\nmanaged\n# <<< dots managed block <<<\n"
+	tests := []struct {
+		name        string
+		ownership   string
+		source      string
+		live        string
+		drift       string
+		baseline    []byte
+		seededFinal []byte
+	}{
+		{name: "whole", source: "exact\n", live: "exact\n", drift: "changed\n"},
+		{name: "json subset", ownership: "json-subset", source: `{"owned":true}`, live: `{"owned":true,"external":1}`, drift: `{"owned":false,"external":1}`},
+		{name: "jsonc subset", ownership: "jsonc-subset", source: "{\n// owned\n\"owned\": true,\n}", live: "{\n// kept\n\"owned\": true,\n\"external\": 1,\n}", drift: `{"owned":false}`},
+		{name: "toml subset", ownership: "toml-subset", source: "[owned]\nvalue = true\n", live: "external = 1\n[owned]\nvalue = true\n", drift: "[owned]\nvalue = false\n"},
+		{name: "marked block", ownership: "marked-block", source: marked, live: "# external\n" + marked, drift: strings.Replace(marked, "managed", "changed", 1)},
+		{name: "seeded baseline", ownership: "seeded", source: "baseline\n", live: "baseline\n", drift: "evolved\n"},
+		{name: "seeded migration final", ownership: "seeded", source: "current\n", live: "final\n", drift: "other\n", baseline: []byte("baseline\n"), seededFinal: []byte("final\n")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			source := filepath.Join(dir, "source")
+			target := filepath.Join(dir, "target")
+			if err := os.WriteFile(source, []byte(tt.source), 0o600); err != nil {
+				t.Fatalf("write source: %v", err)
+			}
+			if err := os.WriteFile(target, []byte(tt.live), 0o600); err != nil {
+				t.Fatalf("write target: %v", err)
+			}
+			mode := ownershipevidence.For("copy", tt.ownership)
+			evidence, err := mode.Capture("source", source, nil, tt.baseline)
+			if err != nil {
+				t.Fatalf("Capture() error = %v", err)
+			}
+			var validateErr error
+			if tt.seededFinal != nil {
+				validateErr = mode.Validate(target, []string{source}, evidence, tt.seededFinal)
+			} else {
+				validateErr = mode.Validate(target, []string{source}, evidence)
+			}
+			if validateErr != nil {
+				t.Fatalf("Validate(converged) error = %v", validateErr)
+			}
+
+			if err := os.WriteFile(target, []byte(tt.drift), 0o600); err != nil {
+				t.Fatalf("write drift: %v", err)
+			}
+			if tt.seededFinal != nil {
+				validateErr = mode.Validate(target, []string{source}, evidence, tt.seededFinal)
+			} else {
+				validateErr = mode.Validate(target, []string{source}, evidence)
+			}
+			if !errors.Is(validateErr, ownershipevidence.ErrDrift) {
+				t.Fatalf("Validate(drift) error = %v, want ErrDrift", validateErr)
+			}
+		})
+	}
+}
+
+func TestValidateSeededExplicitEmptyFinal(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source")
+	target := filepath.Join(dir, "target")
+	if err := os.WriteFile(source, []byte("source"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := os.WriteFile(target, nil, 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	mode := ownershipevidence.For("copy", "seeded")
+	evidence, err := mode.Capture("source", source, nil, []byte("baseline"))
+	if err != nil {
+		t.Fatalf("Capture() error = %v", err)
+	}
+	if err := mode.Validate(target, []string{source}, evidence, []byte{}); err != nil {
+		t.Fatalf("Validate(explicit empty final) error = %v", err)
+	}
+	if err := mode.Validate(target, []string{source}, evidence, []byte{}, []byte{}); err == nil || !strings.Contains(err.Error(), "at most one") {
+		t.Fatalf("Validate(multiple final content) error = %v", err)
+	}
+}
+
+func TestValidateSymlinkIdentityAndDestinationDrift(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source")
+	other := filepath.Join(dir, "other")
+	target := filepath.Join(dir, "target")
+	if err := os.WriteFile(source, []byte("source"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := os.WriteFile(other, []byte("other"), 0o600); err != nil {
+		t.Fatalf("write other: %v", err)
+	}
+	if err := os.Symlink(source, target); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+	mode := ownershipevidence.For("symlink", "")
+	evidence, err := mode.Capture("source", source, nil, nil)
+	if err != nil {
+		t.Fatalf("Capture() error = %v", err)
+	}
+	if err := mode.Validate(target, []string{source}, evidence); err != nil {
+		t.Fatalf("Validate(converged symlink) error = %v", err)
+	}
+	if err := os.Remove(target); err != nil {
+		t.Fatalf("remove symlink: %v", err)
+	}
+	if err := os.Symlink(other, target); err != nil {
+		t.Fatalf("replace symlink: %v", err)
+	}
+	if err := mode.Validate(target, []string{source}, evidence); !errors.Is(err, ownershipevidence.ErrDrift) || !strings.Contains(err.Error(), "destination changed") {
+		t.Fatalf("Validate(changed destination) error = %v, want destination ErrDrift", err)
+	}
+	if err := mode.Validate(target, []string{source, other}, evidence); !errors.Is(err, ownershipevidence.ErrDrift) {
+		t.Fatalf("Validate(multiple sources) error = %v, want ErrDrift", err)
+	}
+}
+
+func TestUnsupportedModesFailClosed(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source")
+	if err := os.WriteFile(source, []byte("source"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	for _, mode := range []ownershipevidence.Mode{
+		ownershipevidence.For("template", "whole"),
+		ownershipevidence.For("symlink", "json-subset"),
+		ownershipevidence.For("copy", "future-mode"),
+	} {
+		if _, err := mode.Capture("source", source, nil, nil); err == nil {
+			t.Fatalf("Capture() unsupported mode error = nil")
+		}
+		if got := mode.Discriminator(state.Contribution{Ownership: mode.Ownership(), EvidenceRecorded: true}); got != ownershipevidence.DiscriminatorMissing {
+			t.Fatalf("Discriminator(unsupported) = %q, want missing", got)
+		}
+	}
+}


### PR DESCRIPTION
Closes #475
Refs #458

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Defers exact per-contribution ownership evidence until install/update terminal success.
- Commits `Contributions` and the authoritative `InstalledSelection` together after source and target revalidation.
- Keeps incomplete attributed JSON output contractually consistent without exposing raw evidence.

## Changes

| File | Change |
|------|--------|
| `internal/install` | Adds an opaque terminal metadata commit, staged evidence, final source/target validation, atomic selection persistence, and failure regressions. |
| `internal/ownershipevidence` | Centralizes capture, compatibility projection, convergence validation, and public evidence discrimination for every ownership mode. |
| `internal/cli` | Runs Provisioners and retirement before the terminal metadata commit for install/update and covers all terminal failure paths. |
| `internal/installed` | Preserves `tags_source: "recorded-contribution"` for incomplete attribution and delegates safe evidence discrimination. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go build ./...`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] `go generate ./internal/catalog`
- [x] Sandboxed plan: `go run ./cmd/dots plan --file dots.yaml --profile core --source-root "$PWD" --home <tmp>`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked one issue with an admitted Delivery Contract using `Closes #475`.
- [x] Added exactly one `type:*` label.
- [x] Delivery Evidence records the Contract Source snapshot, Acceptance coverage, and Independent review.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed. Existing docs already specified terminal-only evidence and required no content change.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

## Delivery Evidence

### Contract Source

- Delivery Unit #475: node `I_kwDOSzLlmM8AAAABNxuurw`, updated `2026-08-22T01:52:33Z`, SHA-256 `4aeeebd83bc1f336caaccb35ec3eca97668b99dcab0ea180309e9758f642ed49`.
- Native parent #458: node `I_kwDOSzLlmM8AAAABNwWsDA`, updated `2026-08-21T20:58:58Z`, SHA-256 `aec4b86128a4cfec51290b7917a4757a7f16cc1557466e7d8478ca41495f5f0d`.
- Relationships: parent #458 open; no sub-issues, blockers, blocking issues, or comments. Labels: `bug`, `ready-for-agent`.
- Revalidated immediately before PR creation with no differences.

### Acceptance coverage

- Provisioner failures for install/update preserve prior selection/evidence and retain only compatible partial inventory.
- Post-Provisioner convergence, retirement, and terminal persistence failures cannot publish new exact evidence.
- Successful finalization writes exact selector evidence and Installed Selection in one `state.Save`.
- Concurrent target Drift and Source of Truth evidence changes fail closed with prior metadata intact.
- All ownership modes share one cohesive module and retain compatibility projections.
- Incomplete attributed JSON keeps recorded Tag provenance, reports missing evidence, and exposes no raw content.

### Automated validation

- `gofmt -l .` — no output.
- `go vet ./...` — passed.
- `go build ./...` — passed.
- `go test ./...` — passed.
- `go generate ./internal/catalog` — clean.
- Manifest validation and sandboxed core plan — passed.

### Manual validation

- Built one temporary real `dots` binary.
- Successful sandboxed `install --tag zsh --skip-deps`: three Managed Entries, one exact contribution each, authoritative `zsh` selection, and safe installed JSON.
- Failing sandboxed `install --tag codex --tag claude-chrome-devtools --skip-deps` with a failing `claude` stub: exit 1, failed Provisioner history retained, partial entries retained, no Installed Selection, and zero exact Contributions.

### Independent review

- Standards: 0 findings — PASS.
- Spec (#475 composed with #458): 0 findings — PASS.
