### PR TITLE
feat(cli): add manifest-backed selection completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ state:
 
 ```bash
 dots catalog profiles
+dots catalog tags
+dots catalog tag zsh
 dots catalog map workstation
 dots catalog why workstation atuin
 dots catalog compare core workstation

--- a/internal/cli/deps.go
+++ b/internal/cli/deps.go
@@ -35,10 +35,11 @@ func newDepsCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "deps",
 		Short: "Inspect external tool Dependencies declared by managed entries",
-		Long:  "deps reports which external Dependencies a profile needs, offers OS-aware installation guidance, and can execute missing install actions with explicit confirmation.",
+		Long:  "deps reports which external Dependencies a complete Profile/Tag selection needs, offers OS-aware installation guidance, and can execute missing install actions with explicit confirmation.",
 	}
-	cmd.PersistentFlags().StringArrayVarP(&profiles, "profile", "p", nil, "profile to inspect")
-	cmd.PersistentFlags().StringArrayVar(&extraTags, "tag", nil, "include an additional manifest tag; repeat to include multiple tags")
+	cmd.PersistentFlags().StringArrayVarP(&profiles, "profile", "p", nil, selectionProfileHelp)
+	cmd.PersistentFlags().StringArrayVar(&extraTags, "tag", nil, selectionTagHelp)
+	registerSelectionFlagCompletion(cmd)
 	cmd.AddCommand(newDepsCheckCommand(&profiles, &extraTags))
 	cmd.AddCommand(newDepsPlanCommand(&profiles, &extraTags))
 	cmd.AddCommand(newDepsInstallCommand(&profiles, &extraTags))
@@ -103,7 +104,7 @@ func newDepsPlanCommand(profiles *[]string, extraTags *[]string) *cobra.Command 
 	cmd := &cobra.Command{
 		Use:   "plan",
 		Short: "Show OS-aware installation guidance for missing Dependencies",
-		Long:  "plan produces advisory installation guidance for the Dependencies a profile needs but the workstation is missing. It never installs packages.",
+		Long:  "plan produces advisory installation guidance for the Dependencies a complete Profile/Tag selection needs but the workstation is missing. It never installs packages.",
 		// Domain errors (e.g. unknown profile or tier) are user-facing messages,
 		// not misuse of the command, so do not dump the usage block on failure.
 		SilenceUsage: true,

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -83,10 +83,11 @@ func newDoctorCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&file, "file", "f", "dots.yaml", "manifest file to inspect")
-	cmd.Flags().StringArrayVarP(&profiles, "profile", "p", nil, "profile to inspect")
-	cmd.Flags().StringArrayVar(&extraTags, "tag", nil, "include an additional manifest tag; repeat to include multiple tags")
+	cmd.Flags().StringArrayVarP(&profiles, "profile", "p", nil, selectionProfileHelp)
+	cmd.Flags().StringArrayVar(&extraTags, "tag", nil, selectionTagHelp)
 	cmd.Flags().StringVar(&sourceRoot, "source-root", "", "installed repository root (default ~/.local/share/dots)")
 	cmd.Flags().StringVar(&home, "home", "", "target home directory to inspect (default: the current user's home); use a sandbox path to inspect without touching real config")
 	cmd.Flags().StringVar(&stateRoot, "state-root", "", "state directory for Installation Metadata (default ~/.local/state/dots)")
+	registerSelectionFlagCompletion(cmd)
 	return cmd
 }

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -309,8 +309,8 @@ func newInstallCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&file, "file", "f", "dots.yaml", "manifest file to install")
-	cmd.Flags().StringArrayVarP(&profiles, "profile", "p", nil, "profile to install")
-	cmd.Flags().StringArrayVar(&extraTags, "tag", nil, "include an additional manifest tag; repeat to include multiple tags")
+	cmd.Flags().StringArrayVarP(&profiles, "profile", "p", nil, selectionProfileHelp)
+	cmd.Flags().StringArrayVar(&extraTags, "tag", nil, selectionTagHelp)
 	cmd.Flags().StringVar(&sourceRoot, "source-root", "", "installed repository root (default ~/.local/share/dots)")
 	cmd.Flags().StringVar(&home, "home", "", "target home directory to install into (default: the current user's home); use a sandbox path to avoid touching real config")
 	cmd.Flags().StringVar(&stateRoot, "state-root", "", "state directory for Installation Metadata (default ~/.local/state/dots)")
@@ -320,6 +320,7 @@ func newInstallCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&skipDeps, "skip-deps", false, "skip dependency provisioning before applying managed configuration")
 	cmd.Flags().BoolVar(&backupAndReplace, "backup-and-replace", false, "with --yes, replace every conflict after creating Backup Sets")
 	cmd.Flags().BoolVar(&ackSelection, "acknowledge-selection-change", false, "with --yes, acknowledge removal of previously selected Profiles or extra Tags")
+	registerSelectionFlagCompletion(cmd)
 	return cmd
 }
 

--- a/internal/cli/plan.go
+++ b/internal/cli/plan.go
@@ -21,7 +21,7 @@ func newPlanCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "plan",
 		Short: "Preview the changes dots would apply (dry run)",
-		Long:  "plan computes the Install Plan for a profile against the current workstation state without modifying any files.",
+		Long:  "plan computes the Install Plan for the complete Profile/Tag selection against the current workstation state without modifying any files.",
 		// Domain errors (e.g. unknown profile) are user-facing messages, not
 		// misuse of the command, so do not dump the usage block on failure.
 		SilenceUsage: true,
@@ -75,10 +75,11 @@ func newPlanCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&file, "file", "f", "dots.yaml", "manifest file to plan")
-	cmd.Flags().StringArrayVarP(&profiles, "profile", "p", nil, "profile to plan")
-	cmd.Flags().StringArrayVar(&extraTags, "tag", nil, "include an additional manifest tag; repeat to include multiple tags")
+	cmd.Flags().StringArrayVarP(&profiles, "profile", "p", nil, selectionProfileHelp)
+	cmd.Flags().StringArrayVar(&extraTags, "tag", nil, selectionTagHelp)
 	cmd.Flags().StringVar(&sourceRoot, "source-root", "", "installed repository root (default ~/.local/share/dots)")
 	cmd.Flags().StringVar(&home, "home", "", "target home directory to plan against (default: the current user's home); use a sandbox path to preview without touching real config")
 	cmd.Flags().StringVar(&stateRoot, "state-root", "", "state directory for Installation Metadata (default ~/.local/state/dots)")
+	registerSelectionFlagCompletion(cmd)
 	return cmd
 }

--- a/internal/cli/selection_completion.go
+++ b/internal/cli/selection_completion.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/yersonargotev/dots/internal/completion"
+)
+
+const (
+	selectionProfileHelp = "select an ordered Profile preset; repeat to compose presets; any explicit Profile/Tag request is the complete selection and is not merged with Installed Selection"
+	selectionTagHelp     = "select an independently meaningful Tag capability; repeat to compose a complete selection without a Profile; any explicit Profile/Tag request is the complete selection and is not merged with Installed Selection"
+)
+
+func registerSelectionFlagCompletion(cmd *cobra.Command) {
+	_ = cmd.RegisterFlagCompletionFunc("profile", completeSelectionFlag(completion.Profile))
+	_ = cmd.RegisterFlagCompletionFunc("tag", completeSelectionFlag(completion.Tag))
+}
+
+func completeSelectionFlag(kind completion.Kind) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		path, err := selectionCompletionManifestPath(cmd)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		values, err := completion.Complete(path, kind, toComplete)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		return values, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// selectionCompletionManifestPath mirrors command manifest resolution without
+// preparing or refreshing the Installed Repository.
+func selectionCompletionManifestPath(cmd *cobra.Command) (string, error) {
+	fileFlag := cmd.Flag("file")
+	if fileFlag == nil {
+		return "", fmt.Errorf("completion command %q has no --file flag", cmd.CommandPath())
+	}
+	file := fileFlag.Value.String()
+	if fileFlag.Changed {
+		return file, nil
+	}
+
+	sourceRoot := stringFlagValue(cmd, "source-root")
+	if sourceRoot == "" {
+		home := stringFlagValue(cmd, "home")
+		if home == "" {
+			resolvedHome, err := os.UserHomeDir()
+			if err != nil {
+				return "", err
+			}
+			home = resolvedHome
+		}
+		sourceRoot = defaultSourceRoot(home)
+	}
+	return filepath.Join(sourceRoot, file), nil
+}
+
+func stringFlagValue(cmd *cobra.Command, name string) string {
+	flag := cmd.Flag(name)
+	if flag == nil {
+		return ""
+	}
+	return flag.Value.String()
+}

--- a/internal/cli/selection_completion_test.go
+++ b/internal/cli/selection_completion_test.go
@@ -1,0 +1,193 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSelectionFlagCompletionCoversEveryPublicCommand(t *testing.T) {
+	manifestPath := writeSelectionCompletionManifest(t, t.TempDir())
+	commands := [][]string{
+		{"install"},
+		{"plan"},
+		{"status"},
+		{"doctor"},
+		{"deps", "check"},
+		{"deps", "plan"},
+		{"deps", "install"},
+		{"update"},
+		{"upgrade"},
+	}
+
+	for _, command := range commands {
+		name := strings.Join(command, " ")
+		t.Run(name+" profile", func(t *testing.T) {
+			args := append(append([]string{}, command...), "--file", manifestPath, "--profile", "w")
+			out, errOut := runCompletion(t, args...)
+			assertCompletion(t, out, errOut, []string{"workstation\tComplete workstation preset"}, []string{"legacy"})
+		})
+		t.Run(name+" tag", func(t *testing.T) {
+			args := append(append([]string{}, command...), "--file", manifestPath, "--tag", "z")
+			out, errOut := runCompletion(t, args...)
+			assertCompletion(t, out, errOut, []string{"zed\tZed editor", "zsh\tZ shell"}, []string{"legacy"})
+		})
+	}
+}
+
+func TestSelectionFlagCompletionUsesEffectiveSourceRoot(t *testing.T) {
+	sourceRoot := t.TempDir()
+	writeSelectionCompletionManifest(t, sourceRoot)
+
+	out, errOut := runCompletion(t, "plan", "--source-root", sourceRoot, "--tag", "z")
+	assertCompletion(t, out, errOut, []string{"zed\tZed editor", "zsh\tZ shell"}, []string{"core", "legacy"})
+}
+
+func TestSelectionFlagCompletionFailsQuietlyWithoutMutation(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := filepath.Join(home, "missing-repository")
+
+	out, errOut := runCompletion(t, "install", "--home", home, "--source-root", sourceRoot, "--tag", "")
+	if strings.TrimSpace(out) != ":4" {
+		t.Fatalf("completion output = %q, want only NoFileComp directive", out)
+	}
+	if strings.Contains(errOut, "manifest") || strings.Contains(errOut, "repository") {
+		t.Fatalf("completion printed ordinary error: %s", errOut)
+	}
+	if _, err := os.Stat(sourceRoot); !os.IsNotExist(err) {
+		t.Fatalf("completion mutated source root: stat error = %v", err)
+	}
+}
+
+func TestSelectionFlagCompletionFailsQuietlyForInvalidManifest(t *testing.T) {
+	manifestPath := filepath.Join(t.TempDir(), "invalid.yaml")
+	if err := os.WriteFile(manifestPath, []byte("version: ["), 0o600); err != nil {
+		t.Fatalf("write invalid manifest: %v", err)
+	}
+
+	out, errOut := runCompletion(t, "plan", "--file", manifestPath, "--tag", "")
+	if strings.TrimSpace(out) != ":4" {
+		t.Fatalf("completion output = %q, want only NoFileComp directive", out)
+	}
+	if strings.Contains(errOut, "manifest") || strings.Contains(errOut, "yaml") {
+		t.Fatalf("completion printed ordinary error: %s", errOut)
+	}
+}
+
+func TestSelectionHelpIsConsistentAcrossPublicCommands(t *testing.T) {
+	commands := [][]string{
+		{"install"},
+		{"plan"},
+		{"status"},
+		{"doctor"},
+		{"deps", "check"},
+		{"deps", "plan"},
+		{"deps", "install"},
+		{"update"},
+		{"upgrade"},
+	}
+
+	root := NewRootCommand()
+	for _, path := range commands {
+		cmd, _, err := root.Find(path)
+		if err != nil {
+			t.Fatalf("find %q: %v", strings.Join(path, " "), err)
+		}
+		if flag := cmd.Flag("profile"); flag == nil || flag.Usage != selectionProfileHelp {
+			t.Errorf("%s --profile help = %#v", strings.Join(path, " "), flag)
+		}
+		if flag := cmd.Flag("tag"); flag == nil || flag.Usage != selectionTagHelp {
+			t.Errorf("%s --tag help = %#v", strings.Join(path, " "), flag)
+		}
+	}
+}
+
+func TestSelectionCommandDescriptionsDoNotRequireAProfile(t *testing.T) {
+	root := NewRootCommand()
+	commands := [][]string{{"plan"}, {"deps"}, {"deps", "plan"}}
+	for _, path := range commands {
+		cmd, _, err := root.Find(path)
+		if err != nil {
+			t.Fatalf("find %q: %v", strings.Join(path, " "), err)
+		}
+		if !strings.Contains(cmd.Long, "complete Profile/Tag selection") {
+			t.Errorf("%s Long description does not describe complete Profile/Tag selection: %q", strings.Join(path, " "), cmd.Long)
+		}
+		if strings.Contains(strings.ToLower(cmd.Long), "a profile") {
+			t.Errorf("%s Long description still requires a Profile: %q", strings.Join(path, " "), cmd.Long)
+		}
+	}
+}
+
+func runCompletion(t *testing.T, args ...string) (string, string) {
+	t.Helper()
+	root := NewRootCommand()
+	var out, errOut bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&errOut)
+	root.SetArgs(append([]string{"__complete"}, args...))
+	if err := root.Execute(); err != nil {
+		t.Fatalf("completion Execute() error = %v\nstderr:\n%s", err, errOut.String())
+	}
+	return out.String(), errOut.String()
+}
+
+func assertCompletion(t *testing.T, out, errOut string, want, avoid []string) {
+	t.Helper()
+	if !strings.HasSuffix(strings.TrimSpace(out), ":4") {
+		t.Fatalf("completion output missing NoFileComp directive:\n%s", out)
+	}
+	for _, value := range want {
+		if !strings.Contains(out, value+"\n") {
+			t.Errorf("completion output missing %q:\n%s", value, out)
+		}
+	}
+	for _, value := range avoid {
+		if strings.Contains(out, value) {
+			t.Errorf("completion output unexpectedly contains %q:\n%s", value, out)
+		}
+	}
+	if strings.Contains(errOut, "Error:") {
+		t.Errorf("completion printed ordinary error:\n%s", errOut)
+	}
+}
+
+func writeSelectionCompletionManifest(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "dots.yaml")
+	contents := `version: 1
+tags:
+  zsh:
+    description: Z shell
+    kind: surface
+    status: current
+  legacy:
+    description: Legacy alias
+    kind: compatibility
+    status: legacy
+    replaced_by: [zsh]
+  zed:
+    description: Zed editor
+    kind: surface
+    status: current
+profiles:
+  workstation:
+    description: Complete workstation preset
+    tags: [zsh, zed]
+  legacy:
+    description: Legacy preset
+    status: legacy
+    tags: [legacy]
+entries:
+  - source: zshrc
+    target: ~/.zshrc
+    strategy: copy
+    tags: [zsh]
+`
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write completion manifest: %v", err)
+	}
+	return path
+}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -98,10 +98,11 @@ func newStatusCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&file, "file", "f", "dots.yaml", "manifest file to evaluate")
-	cmd.Flags().StringArrayVarP(&profiles, "profile", "p", nil, "profile to evaluate")
-	cmd.Flags().StringArrayVar(&extraTags, "tag", nil, "include an additional manifest tag; repeat to include multiple tags")
+	cmd.Flags().StringArrayVarP(&profiles, "profile", "p", nil, selectionProfileHelp)
+	cmd.Flags().StringArrayVar(&extraTags, "tag", nil, selectionTagHelp)
 	cmd.Flags().StringVar(&sourceRoot, "source-root", "", "installed repository root (default ~/.local/share/dots)")
 	cmd.Flags().StringVar(&home, "home", "", "target home directory to evaluate (default: the current user's home); use a sandbox path to inspect without touching real config")
 	cmd.Flags().StringVar(&stateRoot, "state-root", "", "state directory for Installation Metadata (default ~/.local/state/dots)")
+	registerSelectionFlagCompletion(cmd)
 	return cmd
 }

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -70,8 +70,8 @@ func newUpdateCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&file, "file", "f", "dots.yaml", "manifest file to install after updating")
-	cmd.Flags().StringArrayVarP(&profiles, "profile", "p", nil, "profile to install after updating")
-	cmd.Flags().StringArrayVar(&extraTags, "tag", nil, "include an additional manifest tag; repeat to include multiple tags")
+	cmd.Flags().StringArrayVarP(&profiles, "profile", "p", nil, selectionProfileHelp)
+	cmd.Flags().StringArrayVar(&extraTags, "tag", nil, selectionTagHelp)
 	cmd.Flags().StringVar(&sourceRoot, "source-root", "", "installed repository root to update (default ~/.local/share/dots)")
 	cmd.Flags().StringVar(&home, "home", "", "target home directory to install into (default: the current user's home); use a sandbox path to avoid touching real config")
 	cmd.Flags().StringVar(&stateRoot, "state-root", "", "state directory for Installation Metadata and Backup Sets (default ~/.local/state/dots)")
@@ -79,6 +79,7 @@ func newUpdateCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&yes, "yes", false, "apply safe install actions without prompting; conflicts default to skip")
 	cmd.Flags().BoolVar(&noTUI, "no-tui", false, "use text prompts instead of the interactive TUI for conflict resolution")
 	cmd.Flags().BoolVar(&ackSelection, "acknowledge-selection-change", false, "with --yes, acknowledge removal of previously selected Profiles or extra Tags")
+	registerSelectionFlagCompletion(cmd)
 	return cmd
 }
 

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -139,8 +139,8 @@ func newUpgradeCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&file, "file", "f", "dots.yaml", "manifest file to install after upgrading")
-	cmd.Flags().StringArrayVarP(&profiles, "profile", "p", nil, "profile to install after upgrading")
-	cmd.Flags().StringArrayVar(&extraTags, "tag", nil, "include an additional manifest tag; repeat to include multiple tags")
+	cmd.Flags().StringArrayVarP(&profiles, "profile", "p", nil, selectionProfileHelp)
+	cmd.Flags().StringArrayVar(&extraTags, "tag", nil, selectionTagHelp)
 	cmd.Flags().StringVar(&sourceRoot, "source-root", "", "installed repository root to update (default ~/.local/share/dots)")
 	cmd.Flags().StringVar(&home, "home", "", "target home directory to install into (default: the current user's home); use a sandbox path to avoid touching real config")
 	cmd.Flags().StringVar(&stateRoot, "state-root", "", "state directory for Installation Metadata and Backup Sets (default ~/.local/state/dots)")
@@ -170,6 +170,7 @@ func newUpgradeCommand() *cobra.Command {
 	_ = cmd.Flags().MarkHidden("selection-source")
 	_ = cmd.Flags().MarkHidden("selection-profile")
 	_ = cmd.Flags().MarkHidden("selection-tag")
+	registerSelectionFlagCompletion(cmd)
 	return cmd
 }
 

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -1,0 +1,62 @@
+// Package completion builds deterministic, manifest-backed completion values.
+// It reads only the supplied Install Manifest and never inspects workstation or
+// Installation Metadata state.
+package completion
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/yersonargotev/dots/internal/catalog"
+	"github.com/yersonargotev/dots/internal/manifest"
+)
+
+// Kind selects the manifest declaration completed by Complete.
+type Kind uint8
+
+const (
+	Profile Kind = iota
+	Tag
+)
+
+// Complete loads one Install Manifest and returns current declarations whose
+// names match prefix. Values are sorted and carry Cobra-compatible descriptions.
+func Complete(path string, kind Kind, prefix string) ([]string, error) {
+	m, err := manifest.LoadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	report, err := catalog.Build(*m, catalog.Options{OS: "all"})
+	if err != nil {
+		return nil, err
+	}
+
+	switch kind {
+	case Profile:
+		values := make([]string, 0, len(report.Profiles))
+		for _, profile := range report.Profiles {
+			if strings.HasPrefix(profile.Name, prefix) {
+				values = append(values, annotate(profile.Name, profile.Description))
+			}
+		}
+		return values, nil
+	case Tag:
+		values := make([]string, 0, len(report.Tags))
+		for _, tag := range report.Tags {
+			if strings.HasPrefix(tag.Name, prefix) {
+				values = append(values, annotate(tag.Name, tag.Description))
+			}
+		}
+		return values, nil
+	default:
+		return nil, fmt.Errorf("unsupported completion kind %d", kind)
+	}
+}
+
+func annotate(name, description string) string {
+	if strings.TrimSpace(description) == "" {
+		return name
+	}
+	return name + "\t" + description
+}

--- a/internal/completion/completion_test.go
+++ b/internal/completion/completion_test.go
@@ -1,0 +1,91 @@
+package completion
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestCompleteReturnsCurrentAnnotatedValuesInDeterministicOrder(t *testing.T) {
+	path := writeManifest(t)
+
+	tests := []struct {
+		name   string
+		kind   Kind
+		prefix string
+		want   []string
+	}{
+		{
+			name:   "profiles",
+			kind:   Profile,
+			prefix: "",
+			want:   []string{"core\tCore preset", "workstation\tComplete workstation preset"},
+		},
+		{
+			name:   "tags with prefix",
+			kind:   Tag,
+			prefix: "z",
+			want:   []string{"zed\tZed editor", "zsh\tZ shell"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Complete(path, tt.kind, tt.prefix)
+			if err != nil {
+				t.Fatalf("Complete() error = %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("Complete() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompleteReturnsManifestErrors(t *testing.T) {
+	if _, err := Complete(filepath.Join(t.TempDir(), "missing.yaml"), Tag, ""); err == nil {
+		t.Fatal("Complete() error = nil, want missing manifest error")
+	}
+}
+
+func writeManifest(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "dots.yaml")
+	contents := `version: 1
+tags:
+  zsh:
+    description: Z shell
+    kind: surface
+    status: current
+  legacy:
+    description: Legacy alias
+    kind: compatibility
+    status: legacy
+    replaced_by: [zsh]
+  zed:
+    description: Zed editor
+    kind: surface
+    status: current
+profiles:
+  workstation:
+    description: Complete workstation preset
+    tags: [zsh, zed]
+  legacy:
+    description: Legacy preset
+    status: legacy
+    tags: [legacy]
+  core:
+    description: Core preset
+    tags: [zsh]
+entries:
+  - source: zshrc
+    target: ~/.zshrc
+    strategy: copy
+    tags: [zsh]
+`
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	return path
+}


### PR DESCRIPTION
Closes #479

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Make Profile presets and complete Tag-only selection explicit across every public selection-aware help surface.
- Add one read-only manifest-backed completion module for current Profile and Tag flag values.
- Preserve legacy input and Catalog behavior while keeping compatibility Tags out of normal selection completion.

## Changes

| File | Change |
|------|--------|
| `internal/completion/*` | Load the selected Install Manifest and return deterministic, current-only, annotated completion candidates. |
| `internal/cli/selection_completion*` | Adapt effective command paths and quiet failures to Cobra flag completion, with command-wide coverage. |
| `internal/cli/{install,plan,status,doctor,deps,update,upgrade}.go` | Use consistent selection help and register completion for local and inherited flags. |
| `README.md` | Add current Tag inventory and Tag detail examples to the Catalog quickstart. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan is not applicable: completion reads only an explicit Install Manifest and never evaluates targets or Installation Metadata.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] CLI verification used only repository or temporary manifest paths; no home/config target behavior was invoked.

## Contributor Checklist

- [x] Linked the admitted Delivery Contract to its single issue.
- [x] Added exactly one `type:*` label.
- [x] Delivery Evidence records the Contract Source snapshot, Acceptance coverage, and Independent review.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated README guidance for the changed discovery surface.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

### Contract Source snapshot

- Kind: standalone issue body.
- Source body: node `I_kwDOSzLlmM8AAAABN0aV1A`; https://github.com/yersonargotev/dots/issues/479; updated `2026-08-22T14:22:50Z`; SHA-256 `ba58e4ec5d1b6c239763f92f83f2c381aed34acc8809172aee5b7d50a4ae0f14`.
- Category/readiness: `enhancement`; `ready-for-agent` as the only triage-state label.
- Native relationships: parent none; sub-issues none; blocked-by none; blocking none.
- Revalidated unchanged before code mutation and before PR creation; no later comments were present.

### Acceptance coverage

- Shared help constants describe repeatable ordered Profile presets, independently meaningful repeatable Tags, complete Tag-only selections, and explicit selection replacement rather than Installed Selection merging. `plan` and `deps` no longer imply a Profile is required.
- `internal/completion` loads one manifest, uses the current-only Catalog view, preserves deterministic order, filters by prefix, and adds Cobra `name\tdescription` annotations.
- Flag completion is registered for `install`, `plan`, `status`, `doctor`, `deps check`, `deps plan`, `deps install`, `update`, and `upgrade`; `deps` coverage exercises inherited persistent flags.
- Effective explicit `--file`, explicit `--source-root`, and default/home-derived Installed Repository paths are resolved without repository preparation or refresh.
- Unit and CLI tests cover current/legacy filtering, custom temporary manifests, missing and invalid sources, quiet `NoFileComp` failures, and absence of source-root mutation.
- README now demonstrates `dots catalog tags` and `dots catalog tag zsh`.
- Selection normalization, Selected Surface, JSON schemas, exit codes, Installed Selection, legacy migration, and Catalog positional completion were not changed; the full suite remains green.

### Automated validation

- `go test ./internal/completion -count=1` — pass.
- `go test ./internal/cli -run 'Help|Completion|Catalog|Description' -count=1` — pass.
- `gofmt -l .` — pass, no output.
- `go vet ./...` — pass.
- `go build ./...` — pass.
- `go test ./...` — pass.
- `go run ./cmd/dots manifest validate --file dots.yaml` — pass, `manifest is valid`.

### Manual verification

Built `/tmp/dots-issue-479-manual.2b2ZGT/dots` with `go build -o <binary> ./cmd/dots` and used that same binary throughout.

- `dots __complete plan --file dots.yaml --tag z` — exit 0; returned `zed`, `zellij`, `zimfw`, `zoxide`, and `zsh`, each with its manifest description, followed by directive `:4` (`NoFileComp`).
- `dots __complete install --file dots.yaml --profile w` — exit 0; returned current `web` and `workstation` Profiles with descriptions, followed by `:4`.
- `dots __complete plan --source-root <temporary-custom-root> --tag c` and `--profile d` — exit 0; returned only the custom manifest's `core` Tag and `default` Profile respectively, followed by `:4`; repository declarations did not leak.
- `dots __complete plan --file <missing> --tag z` — exit 0; returned no candidates and only `:4`, with no ordinary command error.
- `dots plan --help` and `dots deps plan --help` — exit 0; showed the complete Profile/Tag selection description and shared Profile/Tag flag guidance; the stale `additional manifest tag` wording was absent.
- `dots catalog tag core --file dots.yaml --os all` — exit 0; legacy direct detail and ordered replacements remained available.
- `dots manifest validate --file dots.yaml` — exit 0; `manifest is valid`.

No real home, state, package-manager, dependency probe, repository refresh, or network operation was used.

### Independent review

- Reviewed commit: `790a64781384ba9d2b8fb8f1443cd92ece1b9576` against `origin/main` (`164b196ffca703b5d3976eb58f3a5908151ec6d1`).
- Spec: 0 actionable findings; all requirements, acceptance criteria, and non-goals satisfied.
- Standards: 0 actionable findings. One non-blocking observation noted the established small repetition of flag registration across Cobra adapters; no follow-up is required for this scope.
<!-- delivery-issue:evidence:end -->
