### PR TITLE
feat(selection): preview reconciliation plans

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -160,6 +160,14 @@ _Avoid_: inferred selection, installed profile, tag inventory
 A complete explicit Profile/Tag request on a mutating command that differs from the authoritative Installed Selection. Its delta reports added and removed Profiles, explicit extra Tags, effective Tags, Managed Entries, Dependencies, and Provisioners before mutation. Removing a recorded Profile or explicit extra Tag is a reduction that requires distinct interactive confirmation or, in Confirmed Install mode, `--acknowledge-selection-change` in addition to `--yes`.
 _Avoid_: implicit selection update, selection merge, automatic retirement
 
+**Selection Reconciliation Plan**:
+A deterministic, read-only comparison between an authoritative previous selection and a complete explicitly requested selection that classifies how their Selected Surfaces and proven installed contributions would coexist, change, or stop being managed. It previews additions, preservation, safe reconciliation, potential retirement, blocks, and Retained External State without changing the filesystem or Installation Metadata.
+_Avoid_: selection delta, retirement plan, implicit cleanup
+
+**Retained External State**:
+The installed effect of a removed Dependency or Provisioner selection that dots reports but deliberately leaves unchanged because reversing external tools or provisioned behavior is outside Managed Entry retirement. It is selection residue, not a dots-owned Managed Entry eligible for removal.
+_Avoid_: orphaned dependency, automatic uninstall, leftover file
+
 **Selection Migration Candidate**:
 A non-authoritative selection proposed for Installation Metadata v1 or v2 from historical Managed Entry and Provisioner records plus current Install Manifest, target, and Source of Truth evidence. It reports ordered Profiles, explicit extra Tags, effective Tags, confidence, and ambiguity reasons. Only an unambiguous candidate can become an Installed Selection, and only after interactive operator confirmation and terminal success; ambiguous or absent evidence requires an explicit selection.
 _Avoid_: inferred selection, migrated selection, implicit default

--- a/docs/adr/0019-selection-reconciliation-plan.md
+++ b/docs/adr/0019-selection-reconciliation-plan.md
@@ -37,6 +37,8 @@ selecting Tags are removed, the plan reports the selection reduction and a
 executables, receipts, and provisioned effects. A Dependency-only or
 Provisioner-only reduction therefore has no Managed Entry removal. Reversing a
 Dependency or Provisioner remains a separate, explicitly authorized concern.
+Distinct Provisioner effects are compared by exact rendered command identity,
+not only by tool name; reports expose a digest rather than raw command arguments.
 
 Install Manifest evolution is also report-only: a changed manifest may explain
 how the current surface differs, but it never supplies the operator intent

--- a/docs/adr/0019-selection-reconciliation-plan.md
+++ b/docs/adr/0019-selection-reconciliation-plan.md
@@ -1,0 +1,62 @@
+# Plan explicit selection reconciliation from proven contributions
+
+An explicit complete Profile or Tag request may select a different surface from
+the authoritative Installed Selection. A simple selection delta cannot say
+whether a removed Managed Entry contribution can be retired safely, whether a
+shared target must be reconciled, or whether current workstation state makes
+ownership ambiguous. We therefore produce one deterministic, read-only
+Selection Reconciliation Plan from the previous and requested intent, both
+Selected Surfaces, per-contribution Installation Metadata, and inspected target
+state. `dots plan` and `dots install --dry-run` expose the same report and
+ordering; the install dry run embeds that report in its Install Plan rather than
+recomputing a second interpretation.
+
+The plan is driven by the difference between the authoritative previous
+Selected Surface and a complete explicitly requested Selected Surface. Each
+contribution is classified as `create`, `update`, `preserve`, `reconcile`,
+`remove`, `retain`, `blocked`, or `retained-external-state`. Actions and reasons
+have deterministic ordering so text and JSON describe the same semantics.
+Creation and update describe requested contributions, preservation describes
+shared or already aligned contributions, reconciliation describes a safe
+ownership-aware change to a co-owned target, removal requires exact evidence
+that dots can subtract the retired contribution, retention preserves state that
+must not be removed, and blocking records insufficient or contradictory proof.
+
+Whole-target ownership and partial ownership fail closed in different ways. A
+whole-target contribution with Drift or lost ownership is a finding and cannot
+be retired safely. A subset-owned contribution is removable or reconcilable
+only when its ordered per-contribution Installation Metadata and the live target
+prove exactly what dots owns; missing, legacy target-wide, overlapping, or
+otherwise inconclusive evidence is reported as ambiguous partial ownership.
+This distinction lets an operator choose remediation without interpreting every
+unsafe case as generic Drift.
+
+Dependencies and Provisioners are outside Managed Entry ownership. When their
+selecting Tags are removed, the plan reports the selection reduction and a
+`retained-external-state` action, while preserving installed packages,
+executables, receipts, and provisioned effects. A Dependency-only or
+Provisioner-only reduction therefore has no Managed Entry removal. Reversing a
+Dependency or Provisioner remains a separate, explicitly authorized concern.
+
+Install Manifest evolution is also report-only: a changed manifest may explain
+how the current surface differs, but it never supplies the operator intent
+needed to retire a previously selected contribution. This slice performs no
+filesystem removal, reconciliation, retirement, dependency reversal,
+Provisioner reversal, or Installation Metadata update. A later mutating design
+must define separate authorization and last-moment safety checks rather than
+turning these preview actions into implicit cleanup.
+
+**Considered options**: Extending the forward-only Install Plan without a
+selection comparison was rejected because it cannot represent removed or
+shared contributions. Treating the Uninstall Plan as the inverse was rejected
+because uninstall operates on global recorded ownership rather than a mixed
+previous/requested selection. Inferring retirement from Install Manifest
+evolution was rejected because repository changes are not operator
+authorization to remove workstation state.
+
+**Consequences**: Machine consumers receive one stable reconciliation report
+through both planning commands, and read-only planning treats unsafe ownership
+findings as divergence. Install dry-run remains a successful action preview
+while carrying the identical findings. No action in this report promises that a
+future mutating command can apply it without revalidating ownership and target
+state.

--- a/docs/agents/output-contract.md
+++ b/docs/agents/output-contract.md
@@ -38,7 +38,7 @@ state.
 
 ```json
 {
-  "schema_version": "9",
+  "schema_version": "10",
   "command": "doctor",
   "status": "ok",
   "data": { "...": "command-specific report" }
@@ -59,7 +59,7 @@ Schema version `3` introduced this partial-error report allowance:
 
 ```json
 {
-  "schema_version": "9",
+  "schema_version": "10",
   "command": "doctor",
   "status": "error",
   "error": "read manifest: open dots.yaml: no such file or directory"
@@ -85,6 +85,14 @@ The `2` findings code applies only to read-only diagnostic commands such as
 `0`/`1` even when their JSON payload includes a plan or preview. Reserving `1`
 for real failures means existing `|| handle-error` scripts never confuse a
 divergent-but-healthy run with a broken one.
+
+For a Selection Reconciliation Plan, read-only `dots plan` returns
+`status: "findings"` and exit `2` when the report contains a blocked action,
+whole-target Drift, lost whole-target ownership, or ambiguous partial ownership.
+The same report embedded by `dots install --dry-run` remains an action preview:
+it returns `status: "ok"` and exit `0` unless planning itself fails. Callers
+must inspect the embedded reconciliation report when they need its finding
+semantics; the action-command exit code does not erase or reclassify them.
 
 ```bash
 dots status --output json
@@ -234,6 +242,18 @@ prose the text surface prints:
   `ownership_evidence` fields to `installed`, plus optional `ownership`, so
   agents can distinguish exact per-contribution evidence from historical
   target-wide inventory without receiving raw configuration bytes.
+- Schema version `10` adds the Selection Reconciliation Plan under
+  `plan`'s `data.selection_reconciliation`. The same report is embedded under
+  `install --dry-run`'s `data.plan.selection_reconciliation`; both surfaces
+  preserve identical semantic actions, reasons, and deterministic ordering.
+  Reconciliation actions are `create`, `update`, `preserve`, `reconcile`,
+  `remove`, `retain`, `blocked`, and `retained-external-state`. Reasons
+  distinguish whole-target Drift, lost whole-target ownership, and ambiguous
+  partial ownership rather than collapsing them into one unsafe-removal state.
+  Dependency and Provisioner reductions use `retained-external-state` because
+  this report never removes or reverses their installed effects. Install
+  Manifest evolution is report-only and does not authorize retirement or
+  Installation Metadata mutation.
 - Plan actions and Status Managed Entry items may add the optional reason
   `source-override-not-selected` and a deterministic `matching_tags` array when
   a conflicting target exactly matches one or more alternate sources whose

--- a/docs/agents/output-contract.md
+++ b/docs/agents/output-contract.md
@@ -254,6 +254,9 @@ prose the text surface prints:
   this report never removes or reverses their installed effects. Install
   Manifest evolution is report-only and does not authorize retirement or
   Installation Metadata mutation.
+  Provisioner actions include a non-sensitive `identity` digest of the exact
+  rendered command so separate effects from the same tool remain distinguishable
+  without exposing command arguments.
 - Plan actions and Status Managed Entry items may add the optional reason
   `source-override-not-selected` and a deterministic `matching_tags` array when
   a conflicting target exactly matches one or more alternate sources whose

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -172,7 +172,7 @@ func newInstallCommand() *cobra.Command {
 					return err
 				}
 				p.Selection = &effective.Report
-				p.SelectionReconciliation, err = buildSelectionReconciliation(*m, meta, effective, p, hostOS, paths, prep.SourceReadRoot)
+				p.SelectionReconciliation, err = buildSelectionReconciliation(*m, meta, effective, p, hostOS, paths, prep.SourceReadRoot, len(profiles) > 0 || len(extraTags) > 0)
 				if err != nil {
 					return err
 				}

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -172,6 +172,10 @@ func newInstallCommand() *cobra.Command {
 					return err
 				}
 				p.Selection = &effective.Report
+				p.SelectionReconciliation, err = buildSelectionReconciliation(*m, meta, effective, p, hostOS, paths, prep.SourceReadRoot)
+				if err != nil {
+					return err
+				}
 				if wantsJSON(cmd) {
 					return emitOK(cmd, installReport{RepositoryRefresh: prep.Refresh, DryRun: true, Selection: effective.Report, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan})
 				}

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -22,7 +22,7 @@ const (
 // binary. Renaming, removing, or repurposing a field in any command's JSON
 // `data` is a breaking change to the Agent Output Contract and must bump this
 // value.
-const schemaVersion = "9"
+const schemaVersion = "10"
 
 // Envelope statuses. They mirror the semantic exit codes: ok->0, findings->2,
 // error->1.

--- a/internal/cli/output_golden_test.go
+++ b/internal/cli/output_golden_test.go
@@ -90,6 +90,7 @@ func TestEnvelopeGolden(t *testing.T) {
 			{Scope: selectionreconciliation.ScopeSelection, Outcome: selectionreconciliation.OutcomeRemove, PreviousSources: []string{}, CurrentSources: []string{}, Names: []string{"adaptive-theme"}},
 			{Scope: selectionreconciliation.ScopeManagedEntry, Outcome: selectionreconciliation.OutcomeBlocked, Reason: selectionreconciliation.ReasonAmbiguousPartialOwnership, DeclarativeTarget: "~/.config/app/settings.json", ResolvedTarget: "/home/user/.config/app/settings.json", PreviousSources: []string{"configs/app/adaptive.json"}, CurrentSources: []string{"configs/app/base.json"}, Names: []string{}},
 			{Scope: selectionreconciliation.ScopeDependency, Outcome: selectionreconciliation.OutcomeRetainedExternalState, PreviousSources: []string{}, CurrentSources: []string{}, Names: []string{"theme-helper"}},
+			{Scope: selectionreconciliation.ScopeProvisioner, Outcome: selectionreconciliation.OutcomeRetainedExternalState, PreviousSources: []string{}, CurrentSources: []string{}, Names: []string{"claude"}, Identity: "sha256:1111111111111111111111111111111111111111111111111111111111111111"},
 		},
 	}
 	tests := []struct {

--- a/internal/cli/output_golden_test.go
+++ b/internal/cli/output_golden_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/yersonargotev/dots/internal/provision"
 	"github.com/yersonargotev/dots/internal/selection"
 	"github.com/yersonargotev/dots/internal/selectionmigration"
+	"github.com/yersonargotev/dots/internal/selectionreconciliation"
 	"github.com/yersonargotev/dots/internal/state"
 	"github.com/yersonargotev/dots/internal/status"
 	"github.com/yersonargotev/dots/internal/uninstall"
@@ -81,6 +82,15 @@ func TestEnvelopeGolden(t *testing.T) {
 		},
 		MissingProfiles: []string{},
 		StaleExtraTags:  []string{"retired"},
+	}
+	reconciliationReport := &selectionreconciliation.Report{
+		PreviousIntent:  selectionreconciliation.Intent{Authority: selectionreconciliation.AuthorityRecorded, Profiles: []string{"core"}, ExtraTags: []string{"adaptive-theme"}, ResolvedTags: []string{"core", "adaptive-theme"}},
+		RequestedIntent: selectionreconciliation.Intent{Authority: selectionreconciliation.AuthorityExplicitRequest, Profiles: []string{"core"}, ExtraTags: []string{}, ResolvedTags: []string{"core"}},
+		Actions: []selectionreconciliation.Action{
+			{Scope: selectionreconciliation.ScopeSelection, Outcome: selectionreconciliation.OutcomeRemove, PreviousSources: []string{}, CurrentSources: []string{}, Names: []string{"adaptive-theme"}},
+			{Scope: selectionreconciliation.ScopeManagedEntry, Outcome: selectionreconciliation.OutcomeBlocked, Reason: selectionreconciliation.ReasonAmbiguousPartialOwnership, DeclarativeTarget: "~/.config/app/settings.json", ResolvedTarget: "/home/user/.config/app/settings.json", PreviousSources: []string{"configs/app/adaptive.json"}, CurrentSources: []string{"configs/app/base.json"}, Names: []string{}},
+			{Scope: selectionreconciliation.ScopeDependency, Outcome: selectionreconciliation.OutcomeRetainedExternalState, PreviousSources: []string{}, CurrentSources: []string{}, Names: []string{"theme-helper"}},
+		},
 	}
 	tests := []struct {
 		name   string
@@ -190,7 +200,7 @@ func TestEnvelopeGolden(t *testing.T) {
 				Status:        statusFindings,
 				Data: plan.Plan{Profile: "default", Selection: &selection.Report{
 					Source: selection.SourceExplicit, Profiles: []string{"default"}, ExtraTags: []string{"work"}, EffectiveTags: []string{"core", "work"},
-				}, Actions: []plan.Action{
+				}, SelectionReconciliation: reconciliationReport, Actions: []plan.Action{
 					{Source: "configs/zsh/zshrc", ResolvedSource: "/abs/machine/local/path/MUST/NOT/APPEAR", Target: "/home/user/.zshrc", Strategy: "symlink", Status: plan.StatusCreate},
 					{Source: "configs/nvim/lazy-lock.json", ResolvedSource: "/abs/MUST/NOT/APPEAR", Target: "/home/user/.local/state/nvim/lazy-lock.json", TargetRoot: "xdg-state", Strategy: "copy", Status: plan.StatusUnchanged, Reason: plan.ReasonSeededLocalEvolution},
 					{Source: "configs/app/settings.json", ResolvedSource: "/abs/MUST/NOT/APPEAR", Target: "/home/user/.config/app/settings.json", Strategy: "copy", Status: plan.StatusMigrate, Migration: &plan.LegacyMigration{CapturedContent: []byte("MUST NOT APPEAR")}},
@@ -320,7 +330,7 @@ func TestEnvelopeGolden(t *testing.T) {
 						Preview: &installPreview,
 						Result:  &installResult,
 					},
-					Plan: plan.Plan{Profile: "default", Selection: &installSelection, Actions: []plan.Action{
+					Plan: plan.Plan{Profile: "default", Selection: &installSelection, SelectionReconciliation: reconciliationReport, Actions: []plan.Action{
 						{Source: "configs/zsh/zshrc", Target: "/home/user/.zshrc", Strategy: "symlink", Status: plan.StatusCreate},
 					}},
 					Provisioners: provision.Plan{Profile: "default", Steps: []provision.Step{

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -86,8 +86,8 @@ func decodeEnvelope(t *testing.T, out string) testEnvelope {
 	if err := json.Unmarshal([]byte(out), &env); err != nil {
 		t.Fatalf("stdout is not a JSON envelope: %v\noutput:\n%s", err, out)
 	}
-	if env.SchemaVersion != "9" {
-		t.Fatalf("schema_version = %q, want \"9\"", env.SchemaVersion)
+	if env.SchemaVersion != "10" {
+		t.Fatalf("schema_version = %q, want \"10\"", env.SchemaVersion)
 	}
 	if env.Command != "status" {
 		t.Fatalf("command = %q, want \"status\"", env.Command)
@@ -101,8 +101,8 @@ func decodeEnvelopeForCommand(t *testing.T, out string, command string) testEnve
 	if err := json.Unmarshal([]byte(out), &env); err != nil {
 		t.Fatalf("stdout is not a JSON envelope: %v\noutput:\n%s", err, out)
 	}
-	if env.SchemaVersion != "9" {
-		t.Fatalf("schema_version = %q, want \"9\"", env.SchemaVersion)
+	if env.SchemaVersion != "10" {
+		t.Fatalf("schema_version = %q, want \"10\"", env.SchemaVersion)
 	}
 	if env.Command != command {
 		t.Fatalf("command = %q, want %q", env.Command, command)

--- a/internal/cli/plan.go
+++ b/internal/cli/plan.go
@@ -66,6 +66,10 @@ func newPlanCommand() *cobra.Command {
 				return err
 			}
 			p.Selection = &effective.Report
+			p.SelectionReconciliation, err = buildSelectionReconciliation(*m, meta, effective, p, runtime.GOOS, paths, paths.SourceRoot)
+			if err != nil {
+				return err
+			}
 
 			return renderOrEmit(cmd, p, func() error {
 				renderPlan(cmd.OutOrStdout(), p)

--- a/internal/cli/plan.go
+++ b/internal/cli/plan.go
@@ -66,7 +66,7 @@ func newPlanCommand() *cobra.Command {
 				return err
 			}
 			p.Selection = &effective.Report
-			p.SelectionReconciliation, err = buildSelectionReconciliation(*m, meta, effective, p, runtime.GOOS, paths, paths.SourceRoot)
+			p.SelectionReconciliation, err = buildSelectionReconciliation(*m, meta, effective, p, runtime.GOOS, paths, paths.SourceRoot, len(profiles) > 0 || len(extraTags) > 0)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -72,6 +72,9 @@ func renderSelectionReconciliation(w io.Writer, report *selectionreconciliation.
 		if action.Scope == selectionreconciliation.ScopeManagedEntry {
 			subject = action.ResolvedTarget
 		}
+		if action.Identity != "" {
+			subject += " [" + action.Identity + "]"
+		}
 		fmt.Fprintf(w, "  %-24s %-14s %s", action.Outcome, action.Scope, subject)
 		if action.Reason != "" {
 			fmt.Fprintf(w, " [reason=%s]", action.Reason)

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -8,6 +8,7 @@ import (
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/selection"
+	"github.com/yersonargotev/dots/internal/selectionreconciliation"
 )
 
 // renderPlan writes a human-readable, deterministic preview of an Install Plan.
@@ -18,6 +19,7 @@ func renderPlan(w io.Writer, p plan.Plan) {
 
 	if len(p.Actions) == 0 {
 		fmt.Fprintln(w, "Nothing to do.")
+		renderSelectionReconciliation(w, p.SelectionReconciliation)
 		return
 	}
 
@@ -56,6 +58,25 @@ func renderPlan(w io.Writer, p plan.Plan) {
 	}
 	if counts.conflict > 0 {
 		renderConflictResolutionGuidance(w)
+	}
+	renderSelectionReconciliation(w, p.SelectionReconciliation)
+}
+
+func renderSelectionReconciliation(w io.Writer, report *selectionreconciliation.Report) {
+	if report == nil {
+		return
+	}
+	fmt.Fprintln(w, "\nSelection reconciliation:")
+	for _, action := range report.Actions {
+		subject := strings.Join(action.Names, ", ")
+		if action.Scope == selectionreconciliation.ScopeManagedEntry {
+			subject = action.ResolvedTarget
+		}
+		fmt.Fprintf(w, "  %-24s %-14s %s", action.Outcome, action.Scope, subject)
+		if action.Reason != "" {
+			fmt.Fprintf(w, " [reason=%s]", action.Reason)
+		}
+		fmt.Fprintln(w)
 	}
 }
 

--- a/internal/cli/render_golden_test.go
+++ b/internal/cli/render_golden_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/selection"
+	"github.com/yersonargotev/dots/internal/selectionreconciliation"
 )
 
 var update = flag.Bool("update", false, "update golden files")
@@ -23,6 +24,10 @@ func TestRenderPlanGolden(t *testing.T) {
 			name: "all statuses",
 			plan: plan.Plan{
 				Profile: "work",
+				SelectionReconciliation: &selectionreconciliation.Report{Actions: []selectionreconciliation.Action{
+					{Scope: selectionreconciliation.ScopeSelection, Outcome: selectionreconciliation.OutcomeRemove, PreviousSources: []string{}, CurrentSources: []string{}, Names: []string{"adaptive-theme"}},
+					{Scope: selectionreconciliation.ScopeManagedEntry, Outcome: selectionreconciliation.OutcomeBlocked, Reason: selectionreconciliation.ReasonWholeTargetDrift, ResolvedTarget: "/home/user/.config/app/settings.json", PreviousSources: []string{"configs/app/settings.json"}, CurrentSources: []string{}, Names: []string{}},
+				}},
 				Actions: []plan.Action{
 					{Source: "configs/zsh/zshrc", Target: "/home/user/.zshrc", Strategy: "symlink", Status: plan.StatusCreate},
 					{Source: "configs/nvim/lazy-lock.json", Target: "/home/user/.local/state/nvim/lazy-lock.json", TargetRoot: "xdg-state", Strategy: "copy", Status: plan.StatusUnchanged, Reason: plan.ReasonSeededLocalEvolution},

--- a/internal/cli/selection_reconciliation.go
+++ b/internal/cli/selection_reconciliation.go
@@ -1,0 +1,269 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/plan"
+	"github.com/yersonargotev/dots/internal/selectedsurface"
+	"github.com/yersonargotev/dots/internal/selection"
+	"github.com/yersonargotev/dots/internal/selectionreconciliation"
+	"github.com/yersonargotev/dots/internal/state"
+)
+
+func buildSelectionReconciliation(m manifest.Manifest, meta state.Metadata, effective selection.Effective, installPlan plan.Plan, hostOS string, paths resolvedPaths, sourceReadRoot string) (*selectionreconciliation.Report, error) {
+	installed := meta.InstalledSelection
+	if installed == nil {
+		return nil, nil
+	}
+	if sourceReadRoot == "" {
+		sourceReadRoot = paths.SourceRoot
+	}
+
+	previousSurface := selectedsurface.Evaluate(m, installed.ResolvedTags, hostOS)
+	currentSurface := selectedsurface.Evaluate(m, effective.Selection.Tags, hostOS)
+	evidence, err := inspectSelectionReconciliation(previousSurface, currentSurface, installPlan, paths, sourceReadRoot)
+	if err != nil {
+		return nil, fmt.Errorf("inspect selection reconciliation: %w", err)
+	}
+
+	authority := selectionreconciliation.AuthorityManifestEvolution
+	if effective.Report.Source == selection.SourceExplicit {
+		authority = selectionreconciliation.AuthorityExplicitRequest
+	}
+	report, err := selectionreconciliation.Build(selectionreconciliation.Input{
+		PreviousIntent: selectionreconciliation.Intent{
+			Authority:    selectionreconciliation.AuthorityRecorded,
+			Profiles:     append([]string(nil), installed.Profiles...),
+			ExtraTags:    append([]string(nil), installed.ExtraTags...),
+			ResolvedTags: append([]string(nil), installed.ResolvedTags...),
+		},
+		RequestedIntent: selectionreconciliation.Intent{
+			Authority:    authority,
+			Profiles:     append([]string(nil), effective.Profiles...),
+			ExtraTags:    append([]string(nil), effective.ExtraTags...),
+			ResolvedTags: append([]string(nil), effective.Selection.Tags...),
+		},
+		PreviousSurface: previousSurface,
+		CurrentSurface:  currentSurface,
+		Metadata:        meta,
+		Evidence:        evidence,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &report, nil
+}
+
+func inspectSelectionReconciliation(previous, current selectedsurface.Surface, installPlan plan.Plan, paths resolvedPaths, sourceReadRoot string) (evidence selectionreconciliation.Evidence, err error) {
+	paths.Home, err = filepath.Abs(paths.Home)
+	if err != nil {
+		return selectionreconciliation.Evidence{}, fmt.Errorf("resolve reconciliation home: %w", err)
+	}
+	paths.SourceRoot, err = filepath.Abs(paths.SourceRoot)
+	if err != nil {
+		return selectionreconciliation.Evidence{}, fmt.Errorf("resolve reconciliation source root: %w", err)
+	}
+	sourceReadRoot, err = filepath.Abs(sourceReadRoot)
+	if err != nil {
+		return selectionreconciliation.Evidence{}, fmt.Errorf("resolve reconciliation source read root: %w", err)
+	}
+	homeRoot, err := os.OpenRoot(paths.Home)
+	if err != nil {
+		return selectionreconciliation.Evidence{}, fmt.Errorf("open target home root: %w", err)
+	}
+	defer func() {
+		if closeErr := homeRoot.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("close target home root: %w", closeErr))
+		}
+	}()
+	sourceRoot, err := os.OpenRoot(sourceReadRoot)
+	if err != nil {
+		return selectionreconciliation.Evidence{}, fmt.Errorf("open source read root: %w", err)
+	}
+	defer func() {
+		if closeErr := sourceRoot.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("close source read root: %w", closeErr))
+		}
+	}()
+
+	evidence = selectionreconciliation.Evidence{
+		Targets: make([]selectionreconciliation.TargetEvidence, 0),
+		Sources: make([]selectionreconciliation.SourceEvidence, 0),
+	}
+	entries := orderedReconciliationEntries(current.Entries, previous.Entries)
+	seenTargets := make(map[string]bool)
+	seenSources := make(map[string]bool)
+	for _, selected := range entries {
+		declarativeTarget := selected.Entry.Target
+		if !seenTargets[declarativeTarget] {
+			target, inspectErr := inspectReconciliationTarget(selected.Entry, declarativeTarget, installPlan, paths, homeRoot)
+			if inspectErr != nil {
+				return selectionreconciliation.Evidence{}, inspectErr
+			}
+			evidence.Targets = append(evidence.Targets, target)
+			seenTargets[declarativeTarget] = true
+		}
+
+		sourceKey := declarativeTarget + "\x00" + selected.Source
+		if seenSources[sourceKey] {
+			continue
+		}
+		source, inspectErr := inspectReconciliationSource(declarativeTarget, selected.Source, paths.SourceRoot, sourceReadRoot, sourceRoot)
+		if inspectErr != nil {
+			return selectionreconciliation.Evidence{}, inspectErr
+		}
+		evidence.Sources = append(evidence.Sources, source)
+		seenSources[sourceKey] = true
+	}
+	return evidence, nil
+}
+
+func orderedReconciliationEntries(groups ...[]selectedsurface.SelectedEntry) []selectedsurface.SelectedEntry {
+	result := make([]selectedsurface.SelectedEntry, 0)
+	for _, entries := range groups {
+		result = append(result, entries...)
+	}
+	return result
+}
+
+func inspectReconciliationTarget(entry manifest.Entry, declarativeTarget string, installPlan plan.Plan, paths resolvedPaths, root *os.Root) (selectionreconciliation.TargetEvidence, error) {
+	resolved, err := plan.ResolveEntryTarget(entry, paths.Home, paths.XDGStateHome)
+	if err != nil {
+		return selectionreconciliation.TargetEvidence{}, fmt.Errorf("resolve reconciliation target %s: %w", declarativeTarget, err)
+	}
+	evidence := selectionreconciliation.TargetEvidence{
+		DeclarativeTarget: declarativeTarget,
+		ResolvedTarget:    resolved,
+		ForwardStatus:     reconciliationForwardStatus(installPlan, resolved),
+	}
+	if err := plan.ValidateResolvedTarget(resolved, paths.Home); err != nil {
+		evidence.Exists = true
+		evidence.Kind = selectionreconciliation.TargetKindOther
+		return evidence, nil
+	}
+	if err := plan.ValidateTargetParentInsideHome(resolved, paths.Home); err != nil {
+		evidence.Exists = true
+		evidence.Kind = selectionreconciliation.TargetKindOther
+		return evidence, nil
+	}
+	relative, err := filepath.Rel(paths.Home, resolved)
+	if err != nil || !filepath.IsLocal(relative) {
+		evidence.Exists = true
+		evidence.Kind = selectionreconciliation.TargetKindOther
+		return evidence, nil
+	}
+	info, err := root.Lstat(relative)
+	if errors.Is(err, os.ErrNotExist) {
+		return evidence, nil
+	}
+	if err != nil {
+		evidence.Exists = true
+		evidence.Kind = selectionreconciliation.TargetKindOther
+		return evidence, nil
+	}
+	evidence.Exists = true
+	switch {
+	case info.Mode()&os.ModeSymlink != 0:
+		evidence.Kind = selectionreconciliation.TargetKindSymlink
+		destination, readErr := os.Readlink(resolved)
+		if readErr != nil {
+			evidence.Kind = selectionreconciliation.TargetKindOther
+			return evidence, nil
+		}
+		if current, statErr := root.Lstat(relative); statErr != nil || current.Mode()&os.ModeSymlink == 0 {
+			evidence.Kind = selectionreconciliation.TargetKindOther
+			return evidence, nil
+		}
+		if err := plan.ValidateTargetParentInsideHome(resolved, paths.Home); err != nil {
+			evidence.Kind = selectionreconciliation.TargetKindOther
+			return evidence, nil
+		}
+		evidence.LinkDestination = destination
+	case info.Mode().IsRegular():
+		evidence.Kind = selectionreconciliation.TargetKindRegular
+		content, readErr := readReconciliationRootFile(root, relative)
+		if readErr != nil {
+			evidence.Kind = selectionreconciliation.TargetKindOther
+			return evidence, nil
+		}
+		evidence.Content = content
+	default:
+		evidence.Kind = selectionreconciliation.TargetKindOther
+	}
+	return evidence, nil
+}
+
+func inspectReconciliationSource(declarativeTarget, source, canonicalRoot, readRoot string, root *os.Root) (selectionreconciliation.SourceEvidence, error) {
+	canonical, err := plan.ResolveSource(source, canonicalRoot)
+	if err != nil {
+		return selectionreconciliation.SourceEvidence{}, fmt.Errorf("resolve canonical reconciliation source %s: %w", source, err)
+	}
+	inspected, err := plan.ResolveSource(source, readRoot)
+	if err != nil {
+		return selectionreconciliation.SourceEvidence{}, fmt.Errorf("resolve reconciliation source %s: %w", source, err)
+	}
+	evidence := selectionreconciliation.SourceEvidence{
+		DeclarativeTarget: declarativeTarget,
+		Source:            source,
+		ResolvedSource:    canonical,
+	}
+	if err := plan.ValidateResolvedSource(inspected, readRoot); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return evidence, nil
+		}
+		return evidence, nil
+	}
+	relative, err := filepath.Rel(readRoot, inspected)
+	if err != nil || !filepath.IsLocal(relative) {
+		return evidence, nil
+	}
+	content, err := readReconciliationRootFile(root, relative)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return evidence, nil
+		}
+		return evidence, nil
+	}
+	evidence.Exists = true
+	evidence.Content = content
+	return evidence, nil
+}
+
+func readReconciliationRootFile(root *os.Root, name string) (content []byte, err error) {
+	file, err := root.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("close reconciliation file %s: %w", name, closeErr))
+		}
+	}()
+	return io.ReadAll(file)
+}
+
+func reconciliationForwardStatus(installPlan plan.Plan, target string) selectionreconciliation.ForwardStatus {
+	for _, action := range installPlan.Actions {
+		if action.Target != target {
+			continue
+		}
+		switch action.Status {
+		case plan.StatusCreate:
+			return selectionreconciliation.ForwardCreate
+		case plan.StatusUpdate, plan.StatusMigrate:
+			return selectionreconciliation.ForwardUpdate
+		case plan.StatusUnchanged:
+			return selectionreconciliation.ForwardUnchanged
+		case plan.StatusConflict:
+			return selectionreconciliation.ForwardConflict
+		case plan.StatusMissingSource:
+			return selectionreconciliation.ForwardMissingSource
+		}
+	}
+	return ""
+}

--- a/internal/cli/selection_reconciliation.go
+++ b/internal/cli/selection_reconciliation.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/plan"
@@ -15,7 +16,7 @@ import (
 	"github.com/yersonargotev/dots/internal/state"
 )
 
-func buildSelectionReconciliation(m manifest.Manifest, meta state.Metadata, effective selection.Effective, installPlan plan.Plan, hostOS string, paths resolvedPaths, sourceReadRoot string) (*selectionreconciliation.Report, error) {
+func buildSelectionReconciliation(m manifest.Manifest, meta state.Metadata, effective selection.Effective, installPlan plan.Plan, hostOS string, paths resolvedPaths, sourceReadRoot string, explicitIntent bool) (*selectionreconciliation.Report, error) {
 	installed := meta.InstalledSelection
 	if installed == nil {
 		return nil, nil
@@ -26,13 +27,20 @@ func buildSelectionReconciliation(m manifest.Manifest, meta state.Metadata, effe
 
 	previousSurface := selectedsurface.Evaluate(m, installed.ResolvedTags, hostOS)
 	currentSurface := selectedsurface.Evaluate(m, effective.Selection.Tags, hostOS)
+	previousSurface, manifestEvolutionTargets := supplementRecordedManagedEntries(previousSurface, currentSurface, meta, *installed, paths)
 	evidence, err := inspectSelectionReconciliation(previousSurface, currentSurface, installPlan, paths, sourceReadRoot)
 	if err != nil {
 		return nil, fmt.Errorf("inspect selection reconciliation: %w", err)
 	}
 
+	for index := range evidence.Targets {
+		if manifestEvolutionTargets[evidence.Targets[index].DeclarativeTarget] {
+			evidence.Targets[index].RetirementAuthority = selectionreconciliation.AuthorityManifestEvolution
+		}
+	}
+
 	authority := selectionreconciliation.AuthorityManifestEvolution
-	if effective.Report.Source == selection.SourceExplicit {
+	if explicitIntent && effective.Report.Source == selection.SourceExplicit && installedIntentDiffers(*installed, effective) {
 		authority = selectionreconciliation.AuthorityExplicitRequest
 	}
 	report, err := selectionreconciliation.Build(selectionreconciliation.Input{
@@ -57,6 +65,100 @@ func buildSelectionReconciliation(m manifest.Manifest, meta state.Metadata, effe
 		return nil, err
 	}
 	return &report, nil
+}
+
+func installedIntentDiffers(installed state.InstalledSelection, effective selection.Effective) bool {
+	return !slices.Equal(installed.Profiles, effective.Profiles) || !slices.Equal(installed.ExtraTags, effective.ExtraTags)
+}
+
+func supplementRecordedManagedEntries(previous, current selectedsurface.Surface, meta state.Metadata, installed state.InstalledSelection, paths resolvedPaths) (selectedsurface.Surface, map[string]bool) {
+	type targetIdentity struct {
+		declarative string
+		entry       manifest.Entry
+	}
+
+	identities := make(map[string]targetIdentity)
+	seen := make(map[string]bool)
+	for _, selected := range orderedReconciliationEntries(previous.Entries, current.Entries) {
+		resolved, err := plan.ResolveEntryTarget(selected.Entry, paths.Home, paths.XDGStateHome)
+		if err != nil {
+			continue
+		}
+		resolved = filepath.Clean(resolved)
+		if _, exists := identities[resolved]; !exists {
+			identities[resolved] = targetIdentity{declarative: selected.Entry.Target, entry: selected.Entry}
+		}
+		seen[resolved+"\x00"+selected.Source] = true
+	}
+
+	manifestEvolutionTargets := make(map[string]bool)
+	for _, record := range meta.Entries {
+		resolved := filepath.Clean(record.Target)
+		if err := plan.ValidateResolvedTarget(resolved, paths.Home); err != nil {
+			continue
+		}
+		identity, ok := identities[resolved]
+		if !ok {
+			declarative, declarativeOK := homeRelativeTarget(resolved, paths.Home)
+			if !declarativeOK {
+				continue
+			}
+			identity = targetIdentity{
+				declarative: declarative,
+				entry: manifest.Entry{
+					Target:    declarative,
+					Strategy:  record.Strategy,
+					Ownership: record.Ownership,
+				},
+			}
+		}
+
+		appendContribution := func(source, ownership string, selectorTags []string) {
+			key := resolved + "\x00" + source
+			if source == "" || seen[key] || !sharesSelectionTag(selectorTags, installed.ResolvedTags) {
+				return
+			}
+			entry := identity.entry
+			entry.Source = source
+			entry.Strategy = record.Strategy
+			entry.Ownership = ownership
+			entry.Tags = append([]string(nil), selectorTags...)
+			previous.Entries = append(previous.Entries, selectedsurface.SelectedEntry{Entry: entry, Source: source})
+			seen[key] = true
+			manifestEvolutionTargets[identity.declarative] = true
+		}
+
+		if len(record.Contributions) > 0 {
+			for _, contribution := range record.Contributions {
+				appendContribution(contribution.Source, contribution.Ownership, contribution.SelectorTags)
+			}
+			continue
+		}
+		for _, source := range record.SourceList() {
+			appendContribution(source, record.Ownership, record.Tags)
+		}
+	}
+	return previous, manifestEvolutionTargets
+}
+
+func homeRelativeTarget(target, home string) (string, bool) {
+	relative, err := filepath.Rel(home, target)
+	if err != nil || !filepath.IsLocal(relative) {
+		return "", false
+	}
+	if relative == "." {
+		return "~", true
+	}
+	return "~/" + filepath.ToSlash(relative), true
+}
+
+func sharesSelectionTag(left, right []string) bool {
+	for _, leftTag := range left {
+		if slices.Contains(right, leftTag) {
+			return true
+		}
+	}
+	return false
 }
 
 func inspectSelectionReconciliation(previous, current selectedsurface.Surface, installPlan plan.Plan, paths resolvedPaths, sourceReadRoot string) (evidence selectionreconciliation.Evidence, err error) {

--- a/internal/cli/selection_reconciliation.go
+++ b/internal/cli/selection_reconciliation.go
@@ -27,7 +27,7 @@ func buildSelectionReconciliation(m manifest.Manifest, meta state.Metadata, effe
 
 	previousSurface := selectedsurface.Evaluate(m, installed.ResolvedTags, hostOS)
 	currentSurface := selectedsurface.Evaluate(m, effective.Selection.Tags, hostOS)
-	previousSurface, manifestEvolutionTargets := supplementRecordedManagedEntries(previousSurface, currentSurface, meta, *installed, paths)
+	previousSurface, manifestEvolutionTargets := supplementRecordedSurface(previousSurface, currentSurface, meta, *installed, paths)
 	evidence, err := inspectSelectionReconciliation(previousSurface, currentSurface, installPlan, paths, sourceReadRoot)
 	if err != nil {
 		return nil, fmt.Errorf("inspect selection reconciliation: %w", err)
@@ -71,7 +71,7 @@ func installedIntentDiffers(installed state.InstalledSelection, effective select
 	return !slices.Equal(installed.Profiles, effective.Profiles) || !slices.Equal(installed.ExtraTags, effective.ExtraTags)
 }
 
-func supplementRecordedManagedEntries(previous, current selectedsurface.Surface, meta state.Metadata, installed state.InstalledSelection, paths resolvedPaths) (selectedsurface.Surface, map[string]bool) {
+func supplementRecordedSurface(previous, current selectedsurface.Surface, meta state.Metadata, installed state.InstalledSelection, paths resolvedPaths) (selectedsurface.Surface, map[string]bool) {
 	type targetIdentity struct {
 		declarative string
 		entry       manifest.Entry
@@ -138,7 +138,38 @@ func supplementRecordedManagedEntries(previous, current selectedsurface.Surface,
 			appendContribution(source, record.Ownership, record.Tags)
 		}
 	}
+
+	seenProvisioners := make(map[string]bool)
+	for _, provisioner := range append(append([]manifest.Provisioner(nil), previous.Provisioners...), current.Provisioners...) {
+		seenProvisioners[provisioner.Tool] = true
+	}
+	for _, record := range meta.Provisioners {
+		if record.Tool == "" || seenProvisioners[record.Tool] || !recordedProvisionerSelected(record, installed) {
+			continue
+		}
+		previous.Provisioners = append(previous.Provisioners, manifest.Provisioner{
+			Tool: record.Tool,
+			Tags: append([]string(nil), record.Tags...),
+		})
+		seenProvisioners[record.Tool] = true
+	}
 	return previous, manifestEvolutionTargets
+}
+
+func recordedProvisionerSelected(record state.ProvisionerRecord, installed state.InstalledSelection) bool {
+	if sharesSelectionTag(record.Tags, installed.ResolvedTags) {
+		return true
+	}
+	profiles := record.Profiles
+	if len(profiles) == 0 && record.Profile != "" {
+		profiles = []string{record.Profile}
+	}
+	for _, profile := range profiles {
+		if slices.Contains(installed.Profiles, profile) {
+			return true
+		}
+	}
+	return false
 }
 
 func homeRelativeTarget(target, home string) (string, bool) {

--- a/internal/cli/selection_reconciliation.go
+++ b/internal/cli/selection_reconciliation.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/plan"
+	"github.com/yersonargotev/dots/internal/provision"
 	"github.com/yersonargotev/dots/internal/selectedsurface"
 	"github.com/yersonargotev/dots/internal/selection"
 	"github.com/yersonargotev/dots/internal/selectionreconciliation"
@@ -38,6 +39,8 @@ func buildSelectionReconciliation(m manifest.Manifest, meta state.Metadata, effe
 			evidence.Targets[index].RetirementAuthority = selectionreconciliation.AuthorityManifestEvolution
 		}
 	}
+	evidence.PreviousProvisioners = reconciliationProvisionerEvidence(previousSurface.Provisioners, meta.Provisioners, installed)
+	evidence.CurrentProvisioners = reconciliationProvisionerEvidence(currentSurface.Provisioners, nil, nil)
 
 	authority := selectionreconciliation.AuthorityManifestEvolution
 	if explicitIntent && effective.Report.Source == selection.SourceExplicit && installedIntentDiffers(*installed, effective) {
@@ -139,21 +142,33 @@ func supplementRecordedSurface(previous, current selectedsurface.Surface, meta s
 		}
 	}
 
-	seenProvisioners := make(map[string]bool)
-	for _, provisioner := range append(append([]manifest.Provisioner(nil), previous.Provisioners...), current.Provisioners...) {
-		seenProvisioners[provisioner.Tool] = true
+	return previous, manifestEvolutionTargets
+}
+
+func reconciliationProvisionerEvidence(declarations []manifest.Provisioner, records []state.ProvisionerRecord, installed *state.InstalledSelection) []selectionreconciliation.ProvisionerEvidence {
+	result := make([]selectionreconciliation.ProvisionerEvidence, 0, len(declarations)+len(records))
+	seen := make(map[string]bool)
+	appendEvidence := func(item selectionreconciliation.ProvisionerEvidence) {
+		if item.Identity == "" || seen[item.Identity] {
+			return
+		}
+		seen[item.Identity] = true
+		result = append(result, item)
 	}
-	for _, record := range meta.Provisioners {
-		if record.Tool == "" || seenProvisioners[record.Tool] || !recordedProvisionerSelected(record, installed) {
+	for _, declaration := range declarations {
+		executable, args := provision.RenderCommand(declaration)
+		appendEvidence(selectionreconciliation.NewProvisionerEvidence(declaration.Tool, executable, args))
+	}
+	if installed == nil {
+		return result
+	}
+	for _, record := range records {
+		if !recordedProvisionerSelected(record, *installed) {
 			continue
 		}
-		previous.Provisioners = append(previous.Provisioners, manifest.Provisioner{
-			Tool: record.Tool,
-			Tags: append([]string(nil), record.Tags...),
-		})
-		seenProvisioners[record.Tool] = true
+		appendEvidence(selectionreconciliation.NewProvisionerEvidence(record.Tool, record.Executable, record.Args))
 	}
-	return previous, manifestEvolutionTargets
+	return result
 }
 
 func recordedProvisionerSelected(record state.ProvisionerRecord, installed state.InstalledSelection) bool {

--- a/internal/cli/selection_reconciliation_test.go
+++ b/internal/cli/selection_reconciliation_test.go
@@ -1,0 +1,362 @@
+package cli_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/cli"
+	"github.com/yersonargotev/dots/internal/state"
+)
+
+func TestSelectionReconciliationPlanAndInstallDryRunJSONParity(t *testing.T) {
+	fixture := newSelectionReconciliationFixture(t, false)
+	targetBefore := mustReadSelectionFile(t, fixture.retiredTarget)
+	metadataBefore := mustReadSelectionFile(t, state.Path(fixture.stateRoot))
+
+	plan := runSelectionReconciliationJSON(t, cli.ExitOK, append([]string{"plan"}, fixture.args...)...)
+	install := runSelectionReconciliationJSON(t, cli.ExitOK, append([]string{"install", "--dry-run", "--skip-deps"}, fixture.args...)...)
+
+	planReconciliation := jsonPathSelection(t, plan, "data", "selection_reconciliation")
+	installReconciliation := jsonPathSelection(t, install, "data", "plan", "selection_reconciliation")
+	planActions := jsonPathSelection(t, planReconciliation, "actions")
+	installActions := jsonPathSelection(t, installReconciliation, "actions")
+	if !reflect.DeepEqual(planActions, installActions) {
+		t.Fatalf("reconciliation actions differ\nplan: %#v\ninstall --dry-run: %#v", planActions, installActions)
+	}
+	assertSelectionAction(t, planActions, "selection", "remove", "retired")
+	assertSelectionAction(t, planActions, "managed-entry", "remove", fixture.retiredTarget)
+	if got := mustReadSelectionFile(t, fixture.retiredTarget); !bytes.Equal(got, targetBefore) {
+		t.Fatalf("planning mutated target: got %q, want %q", got, targetBefore)
+	}
+	if got := mustReadSelectionFile(t, state.Path(fixture.stateRoot)); !bytes.Equal(got, metadataBefore) {
+		t.Fatalf("planning mutated Installation Metadata\ngot: %s\nwant: %s", got, metadataBefore)
+	}
+}
+
+func TestSelectionReconciliationTextSurfacesUseIdenticalActionOrder(t *testing.T) {
+	fixture := newSelectionReconciliationFixture(t, false)
+	plan := runSelectionReconciliationText(t, cli.ExitOK, append([]string{"plan"}, fixture.args...)...)
+	install := runSelectionReconciliationText(t, cli.ExitOK, append([]string{"install", "--dry-run", "--skip-deps"}, fixture.args...)...)
+
+	planLines := reconciliationActionLines(plan)
+	installLines := reconciliationActionLines(install)
+	if len(planLines) == 0 {
+		t.Fatalf("plan text has no deterministic reconciliation action lines:\n%s", plan)
+	}
+	want := []string{
+		fmt.Sprintf("  %-24s %-14s %s", "remove", "selection", "full, retired"),
+		fmt.Sprintf("  %-24s %-14s %s", "create", "selection", "reduced"),
+		fmt.Sprintf("  %-24s %-14s %s", "create", "managed-entry", filepath.Join(fixture.root, "home", ".config", "kept.conf")),
+		fmt.Sprintf("  %-24s %-14s %s", "remove", "managed-entry", fixture.retiredTarget),
+	}
+	if !reflect.DeepEqual(planLines, want) {
+		t.Fatalf("plan reconciliation lines = %#v, want %#v\noutput:\n%s", planLines, want, plan)
+	}
+	if !reflect.DeepEqual(planLines, installLines) {
+		t.Fatalf("reconciliation text action order differs\nplan: %#v\ninstall --dry-run: %#v\n\nplan output:\n%s\ninstall output:\n%s", planLines, installLines, plan, install)
+	}
+}
+
+func TestSelectionReconciliationRetainsDependencyAndProvisionerExternalState(t *testing.T) {
+	fixture := newSelectionReconciliationFixture(t, true)
+	plan := runSelectionReconciliationJSON(t, cli.ExitOK, append([]string{"plan"}, fixture.args...)...)
+	actions := jsonPathSelection(t, plan, "data", "selection_reconciliation", "actions")
+
+	assertSelectionAction(t, actions, "dependency", "retained-external-state", "retired-tool")
+	assertSelectionAction(t, actions, "provisioner", "retained-external-state", "claude")
+	for _, raw := range actions.([]any) {
+		action := raw.(map[string]any)
+		if action["scope"] == "managed-entry" && action["outcome"] == "remove" {
+			t.Fatalf("external-only reduction reported Managed Entry removal: %#v", action)
+		}
+	}
+}
+
+func TestSelectionReconciliationManifestEvolutionNeverAuthorizesRetirement(t *testing.T) {
+	fixture := newSelectionReconciliationFixture(t, false)
+	manifestPath := fixture.args[3]
+	manifest, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest = bytes.Replace(manifest, []byte("  full:\n    tags: [kept, retired]"), []byte("  full:\n    tags: [kept]"), 1)
+	if err := os.WriteFile(manifestPath, manifest, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	plan := runSelectionReconciliationJSON(t, cli.ExitOK, append([]string{"plan"}, fixture.args[2:]...)...)
+	actions := jsonPathSelection(t, plan, "data", "selection_reconciliation", "actions")
+	assertSelectionAction(t, actions, "managed-entry", "retain", "manifest-evolution-report-only")
+	for _, raw := range actions.([]any) {
+		action := raw.(map[string]any)
+		if action["scope"] == "managed-entry" && action["outcome"] == "remove" {
+			t.Fatalf("manifest evolution authorized removal: %#v", action)
+		}
+	}
+}
+
+func TestSelectionReconciliationParentSymlinkEscapeIsBlockedWithoutReadingTarget(t *testing.T) {
+	fixture := newSelectionReconciliationFixture(t, false)
+	external := filepath.Join(fixture.root, "external")
+	if err := os.MkdirAll(external, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const secret = "must-not-be-read-across-parent-symlink"
+	if err := os.WriteFile(filepath.Join(external, "retired.conf"), []byte(secret), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(external, "kept.conf"), []byte(secret), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(fixture.retiredTarget); err != nil {
+		t.Fatal(err)
+	}
+	parent := filepath.Dir(fixture.retiredTarget)
+	if err := os.Remove(parent); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, parent); err != nil {
+		t.Fatal(err)
+	}
+
+	planOut := runSelectionReconciliationJSONBytes(t, cli.ExitFindings, append([]string{"plan"}, fixture.args...)...)
+	installOut := runSelectionReconciliationJSONBytes(t, cli.ExitOK, append([]string{"install", "--dry-run", "--skip-deps"}, fixture.args...)...)
+	for name, output := range map[string][]byte{"plan": planOut, "install --dry-run": installOut} {
+		if bytes.Contains(output, []byte(secret)) {
+			t.Fatalf("%s exposed content read through parent symlink: %s", name, output)
+		}
+		var envelope map[string]any
+		if err := json.Unmarshal(output, &envelope); err != nil {
+			t.Fatalf("decode %s JSON: %v\n%s", name, err, output)
+		}
+		actions := envelope["data"].(map[string]any)
+		if name == "install --dry-run" {
+			actions = actions["plan"].(map[string]any)
+		}
+		assertSelectionAction(t, actions["selection_reconciliation"].(map[string]any)["actions"], "managed-entry", "blocked", "lost-ownership")
+	}
+}
+
+type selectionReconciliationFixture struct {
+	root, stateRoot, retiredTarget string
+	args                           []string
+}
+
+func newSelectionReconciliationFixture(t *testing.T, externalOnly bool) selectionReconciliationFixture {
+	t.Helper()
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	sourceRoot := filepath.Join(root, "source")
+	stateRoot := filepath.Join(root, "state")
+	for _, dir := range []string{home, sourceRoot, stateRoot, filepath.Join(home, ".config")} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("HOME", filepath.Join(root, "unused-real-home"))
+
+	retiredTarget := filepath.Join(home, ".config", "retired.conf")
+	retiredContent := []byte("retired managed content\n")
+	writeSelectionSource(t, sourceRoot, "configs/kept.conf", "kept managed content\n")
+	if !externalOnly {
+		writeSelectionSource(t, sourceRoot, "configs/retired.conf", string(retiredContent))
+		if err := os.WriteFile(retiredTarget, retiredContent, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	manifest := `version: 1
+tags:
+  kept:
+    description: retained surface
+    kind: surface
+    status: current
+  retired:
+    description: retired surface
+    kind: surface
+    status: current
+profiles:
+  full:
+    tags: [kept, retired]
+  reduced:
+    tags: [kept]
+`
+	if externalOnly {
+		manifest += `entries:
+  - source: configs/kept.conf
+    target: ~/.config/kept.conf
+    strategy: copy
+    tags: [kept]
+dependencies:
+  - tags: [retired]
+    dependencies:
+      - name: retired-tool
+provisioners:
+  - tool: claude
+    tags: [retired]
+    spec:
+      marketplace: example/tools
+    dependencies:
+      - name: claude
+`
+	} else {
+		manifest += `entries:
+  - source: configs/kept.conf
+    target: ~/.config/kept.conf
+    strategy: copy
+    tags: [kept]
+  - source: configs/retired.conf
+    target: ~/.config/retired.conf
+    strategy: copy
+    tags: [retired]
+`
+	}
+	manifestPath := filepath.Join(sourceRoot, "dots.yaml")
+	if err := os.WriteFile(manifestPath, []byte(manifest), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	metadata := state.Metadata{
+		Version: state.CurrentVersion,
+		InstalledSelection: &state.InstalledSelection{
+			Profiles: []string{"full"}, ResolvedTags: []string{"kept", "retired"},
+			Provenance: state.Provenance{SourceRoot: sourceRoot, RecordedAt: "2026-08-22T00:00:00Z"},
+		},
+	}
+	if !externalOnly {
+		metadata.Entries = []state.Record{{
+			Target: retiredTarget, Source: "configs/retired.conf", Strategy: "copy", Ownership: "whole",
+			Hash: state.HashBytes(retiredContent), InstalledAt: "2026-08-22T00:00:00Z", Tags: []string{"retired"},
+			Contributions: []state.Contribution{{
+				Source: "configs/retired.conf", SelectorTags: []string{"retired"}, Ownership: "whole",
+				EvidenceRecorded: true, Hash: state.HashBytes(retiredContent),
+			}},
+		}}
+	}
+	if err := state.Save(state.Path(stateRoot), metadata); err != nil {
+		t.Fatal(err)
+	}
+	return selectionReconciliationFixture{
+		root: root, stateRoot: stateRoot, retiredTarget: retiredTarget,
+		args: []string{"--profile", "reduced", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot},
+	}
+}
+
+func runSelectionReconciliationJSON(t *testing.T, want int, args ...string) map[string]any {
+	t.Helper()
+	var envelope map[string]any
+	out := runSelectionReconciliationJSONBytes(t, want, append(args, "--output", "json")...)
+	if err := json.Unmarshal(out, &envelope); err != nil {
+		t.Fatalf("decode JSON: %v\n%s", err, out)
+	}
+	if envelope["schema_version"] != "10" {
+		t.Fatalf("schema_version = %#v, want 10", envelope["schema_version"])
+	}
+	return envelope
+}
+
+func runSelectionReconciliationJSONBytes(t *testing.T, want int, args ...string) []byte {
+	t.Helper()
+	if !containsSelectionArg(args, "--output") {
+		args = append(args, "--output", "json")
+	}
+	var stdout, stderr bytes.Buffer
+	code := cli.Run(args, &stdout, &stderr)
+	if code != want {
+		t.Fatalf("cli.Run(%v) code = %d, want %d\nstdout:\n%s\nstderr:\n%s", args, code, want, stdout.String(), stderr.String())
+	}
+	return stdout.Bytes()
+}
+
+func runSelectionReconciliationText(t *testing.T, want int, args ...string) string {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	code := cli.Run(args, &stdout, &stderr)
+	if code != want {
+		t.Fatalf("cli.Run(%v) code = %d, want %d\nstdout:\n%s\nstderr:\n%s", args, code, want, stdout.String(), stderr.String())
+	}
+	return stdout.String()
+}
+
+func jsonPathSelection(t *testing.T, value any, path ...string) any {
+	t.Helper()
+	current := value
+	for _, key := range path {
+		object, ok := current.(map[string]any)
+		if !ok {
+			t.Fatalf("JSON path %v: %#v is not an object", path, current)
+		}
+		current, ok = object[key]
+		if !ok {
+			t.Fatalf("JSON path %v: missing %q in %#v", path, key, object)
+		}
+	}
+	return current
+}
+
+func assertSelectionAction(t *testing.T, raw any, scope, outcome, evidence string) {
+	t.Helper()
+	for _, item := range raw.([]any) {
+		action := item.(map[string]any)
+		encoded, _ := json.Marshal(action)
+		if action["scope"] == scope && action["outcome"] == outcome && strings.Contains(string(encoded), evidence) {
+			return
+		}
+	}
+	t.Fatalf("missing %s/%s action containing %q in %#v", scope, outcome, evidence, raw)
+}
+
+func reconciliationActionLines(output string) []string {
+	var lines []string
+	inBlock := false
+	for _, line := range strings.Split(output, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "Selection reconciliation:" {
+			inBlock = true
+			continue
+		}
+		if !inBlock {
+			continue
+		}
+		if trimmed == "" {
+			break
+		}
+		lines = append(lines, line)
+	}
+	return lines
+}
+
+func writeSelectionSource(t *testing.T, root, rel, content string) {
+	t.Helper()
+	path := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustReadSelectionFile(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func containsSelectionArg(args []string, needle string) bool {
+	for _, arg := range args {
+		if arg == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/selection_reconciliation_test.go
+++ b/internal/cli/selection_reconciliation_test.go
@@ -78,6 +78,42 @@ func TestSelectionReconciliationRetainsDependencyAndProvisionerExternalState(t *
 	}
 }
 
+func TestSelectionReconciliationRetainsProvisionerRemovedFromManifest(t *testing.T) {
+	fixture := newSelectionReconciliationFixture(t, true)
+	manifestPath := fixture.args[3]
+	manifest, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	provisioners := bytes.Index(manifest, []byte("provisioners:\n"))
+	if provisioners < 0 {
+		t.Fatal("fixture manifest has no provisioners block")
+	}
+	if err := os.WriteFile(manifestPath, manifest[:provisioners], 0o600); err != nil {
+		t.Fatal(err)
+	}
+	metadataPath := state.Path(fixture.stateRoot)
+	metadata, err := state.Load(metadataPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	metadata.Provisioners = []state.ProvisionerRecord{{
+		Profiles: []string{"full"}, Tags: []string{"retired"}, Tool: "claude", Status: "provisioned",
+	}}
+	if err := state.Save(metadataPath, metadata); err != nil {
+		t.Fatal(err)
+	}
+
+	plan := runSelectionReconciliationJSON(t, cli.ExitOK, append([]string{"plan"}, fixture.args...)...)
+	install := runSelectionReconciliationJSON(t, cli.ExitOK, append([]string{"install", "--dry-run", "--skip-deps"}, fixture.args...)...)
+	planActions := jsonPathSelection(t, plan, "data", "selection_reconciliation", "actions")
+	installActions := jsonPathSelection(t, install, "data", "plan", "selection_reconciliation", "actions")
+	assertSelectionAction(t, planActions, "provisioner", "retained-external-state", "claude")
+	if !reflect.DeepEqual(planActions, installActions) {
+		t.Fatalf("manifest evolution actions differ\nplan: %#v\ninstall --dry-run: %#v", planActions, installActions)
+	}
+}
+
 func TestSelectionReconciliationManifestEvolutionNeverAuthorizesRetirement(t *testing.T) {
 	fixture := newSelectionReconciliationFixture(t, false)
 	manifestPath := fixture.args[3]

--- a/internal/cli/selection_reconciliation_test.go
+++ b/internal/cli/selection_reconciliation_test.go
@@ -89,7 +89,13 @@ func TestSelectionReconciliationRetainsProvisionerRemovedFromManifest(t *testing
 	if provisioners < 0 {
 		t.Fatal("fixture manifest has no provisioners block")
 	}
-	if err := os.WriteFile(manifestPath, manifest[:provisioners], 0o600); err != nil {
+	manifest = append(manifest[:provisioners], []byte(`provisioners:
+  - tool: claude
+    tags: [kept]
+    spec:
+      marketplace: retained/tools
+`)...)
+	if err := os.WriteFile(manifestPath, manifest, 0o600); err != nil {
 		t.Fatal(err)
 	}
 	metadataPath := state.Path(fixture.stateRoot)
@@ -97,9 +103,16 @@ func TestSelectionReconciliationRetainsProvisionerRemovedFromManifest(t *testing
 	if err != nil {
 		t.Fatal(err)
 	}
-	metadata.Provisioners = []state.ProvisionerRecord{{
-		Profiles: []string{"full"}, Tags: []string{"retired"}, Tool: "claude", Status: "provisioned",
-	}}
+	metadata.Provisioners = []state.ProvisionerRecord{
+		{
+			Profiles: []string{"full"}, Tags: []string{"retired"}, Tool: "claude", Executable: "claude",
+			Args: []string{"plugin", "marketplace", "add", "removed/tools"}, Status: "provisioned",
+		},
+		{
+			Profiles: []string{"full"}, Tags: []string{"kept"}, Tool: "claude", Executable: "claude",
+			Args: []string{"plugin", "marketplace", "add", "retained/tools"}, Status: "provisioned",
+		},
+	}
 	if err := state.Save(metadataPath, metadata); err != nil {
 		t.Fatal(err)
 	}
@@ -109,8 +122,33 @@ func TestSelectionReconciliationRetainsProvisionerRemovedFromManifest(t *testing
 	planActions := jsonPathSelection(t, plan, "data", "selection_reconciliation", "actions")
 	installActions := jsonPathSelection(t, install, "data", "plan", "selection_reconciliation", "actions")
 	assertSelectionAction(t, planActions, "provisioner", "retained-external-state", "claude")
+	provisionerRetirements := 0
+	provisionerIdentity := ""
+	for _, raw := range planActions.([]any) {
+		action := raw.(map[string]any)
+		if action["scope"] == "provisioner" && action["outcome"] == "retained-external-state" {
+			provisionerRetirements++
+			provisionerIdentity = action["identity"].(string)
+			if !strings.HasPrefix(provisionerIdentity, "sha256:") {
+				t.Fatalf("Provisioner identity = %#v, want non-sensitive digest", action["identity"])
+			}
+		}
+	}
+	if provisionerRetirements != 1 {
+		t.Fatalf("Provisioner retirements = %d, want 1 in %#v", provisionerRetirements, planActions)
+	}
 	if !reflect.DeepEqual(planActions, installActions) {
 		t.Fatalf("manifest evolution actions differ\nplan: %#v\ninstall --dry-run: %#v", planActions, installActions)
+	}
+	planText := runSelectionReconciliationText(t, cli.ExitOK, append([]string{"plan"}, fixture.args...)...)
+	installText := runSelectionReconciliationText(t, cli.ExitOK, append([]string{"install", "--dry-run", "--skip-deps"}, fixture.args...)...)
+	planLines := reconciliationActionLines(planText)
+	installLines := reconciliationActionLines(installText)
+	if !reflect.DeepEqual(planLines, installLines) {
+		t.Fatalf("manifest evolution text actions differ\nplan: %#v\ninstall --dry-run: %#v", planLines, installLines)
+	}
+	if !strings.Contains(strings.Join(planLines, "\n"), "claude ["+provisionerIdentity+"]") {
+		t.Fatalf("text output omits Provisioner identity %q:\n%s", provisionerIdentity, planText)
 	}
 }
 

--- a/internal/cli/selection_reconciliation_test.go
+++ b/internal/cli/selection_reconciliation_test.go
@@ -101,6 +101,53 @@ func TestSelectionReconciliationManifestEvolutionNeverAuthorizesRetirement(t *te
 	}
 }
 
+func TestSelectionReconciliationExplicitUnchangedIntentDoesNotAuthorizeManifestEvolution(t *testing.T) {
+	fixture := newSelectionReconciliationFixture(t, false)
+	manifestPath := fixture.args[3]
+	manifest, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest = bytes.Replace(manifest, []byte("  full:\n    tags: [kept, retired]"), []byte("  full:\n    tags: [kept]"), 1)
+	if err := os.WriteFile(manifestPath, manifest, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	args := append([]string(nil), fixture.args...)
+	args[1] = "full"
+	plan := runSelectionReconciliationJSON(t, cli.ExitOK, append([]string{"plan"}, args...)...)
+	actions := jsonPathSelection(t, plan, "data", "selection_reconciliation", "actions")
+	assertSelectionAction(t, actions, "managed-entry", "retain", "manifest-evolution-report-only")
+	for _, raw := range actions.([]any) {
+		action := raw.(map[string]any)
+		if action["scope"] == "managed-entry" && action["outcome"] == "remove" {
+			t.Fatalf("unchanged explicit intent authorized manifest retirement: %#v", action)
+		}
+	}
+}
+
+func TestSelectionReconciliationReportsManifestRemovedRecordedEntry(t *testing.T) {
+	fixture := newSelectionReconciliationFixture(t, false)
+	manifestPath := fixture.args[3]
+	manifest, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest = bytes.Replace(manifest, []byte(`  - source: configs/retired.conf
+    target: ~/.config/retired.conf
+    strategy: copy
+    tags: [retired]
+`), nil, 1)
+	if err := os.WriteFile(manifestPath, manifest, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	plan := runSelectionReconciliationJSON(t, cli.ExitOK, append([]string{"plan"}, fixture.args[2:]...)...)
+	actions := jsonPathSelection(t, plan, "data", "selection_reconciliation", "actions")
+	assertSelectionAction(t, actions, "managed-entry", "retain", fixture.retiredTarget)
+	assertSelectionAction(t, actions, "managed-entry", "retain", "manifest-evolution-report-only")
+}
+
 func TestSelectionReconciliationParentSymlinkEscapeIsBlockedWithoutReadingTarget(t *testing.T) {
 	fixture := newSelectionReconciliationFixture(t, false)
 	external := filepath.Join(fixture.root, "external")

--- a/internal/cli/testdata/envelope_catalog_compare.golden
+++ b/internal/cli/testdata/envelope_catalog_compare.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "9",
+  "schema_version": "10",
   "command": "catalog compare",
   "status": "ok",
   "data": {

--- a/internal/cli/testdata/envelope_catalog_tag.golden
+++ b/internal/cli/testdata/envelope_catalog_tag.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "9",
+  "schema_version": "10",
   "command": "catalog tag",
   "status": "ok",
   "data": {

--- a/internal/cli/testdata/envelope_catalog_why.golden
+++ b/internal/cli/testdata/envelope_catalog_why.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "9",
+  "schema_version": "10",
   "command": "catalog why",
   "status": "ok",
   "data": {

--- a/internal/cli/testdata/envelope_deps_check.golden
+++ b/internal/cli/testdata/envelope_deps_check.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "9",
+  "schema_version": "10",
   "command": "deps check",
   "status": "findings",
   "data": {

--- a/internal/cli/testdata/envelope_deps_plan.golden
+++ b/internal/cli/testdata/envelope_deps_plan.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "9",
+  "schema_version": "10",
   "command": "deps plan",
   "status": "findings",
   "data": {

--- a/internal/cli/testdata/envelope_doctor.golden
+++ b/internal/cli/testdata/envelope_doctor.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "9",
+  "schema_version": "10",
   "command": "doctor",
   "status": "findings",
   "data": {

--- a/internal/cli/testdata/envelope_install.golden
+++ b/internal/cli/testdata/envelope_install.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "9",
+  "schema_version": "10",
   "command": "install",
   "status": "ok",
   "data": {
@@ -231,6 +231,65 @@
           "acknowledgement_required": true,
           "acknowledgement_accepted": true
         }
+      },
+      "selection_reconciliation": {
+        "previous_intent": {
+          "authority": "recorded",
+          "profiles": [
+            "core"
+          ],
+          "extra_tags": [
+            "adaptive-theme"
+          ],
+          "resolved_tags": [
+            "core",
+            "adaptive-theme"
+          ]
+        },
+        "requested_intent": {
+          "authority": "explicit-request",
+          "profiles": [
+            "core"
+          ],
+          "extra_tags": [],
+          "resolved_tags": [
+            "core"
+          ]
+        },
+        "actions": [
+          {
+            "scope": "selection",
+            "outcome": "remove",
+            "previous_sources": [],
+            "current_sources": [],
+            "names": [
+              "adaptive-theme"
+            ]
+          },
+          {
+            "scope": "managed-entry",
+            "outcome": "blocked",
+            "reason": "ambiguous-partial-ownership",
+            "declarative_target": "~/.config/app/settings.json",
+            "resolved_target": "/home/user/.config/app/settings.json",
+            "previous_sources": [
+              "configs/app/adaptive.json"
+            ],
+            "current_sources": [
+              "configs/app/base.json"
+            ],
+            "names": []
+          },
+          {
+            "scope": "dependency",
+            "outcome": "retained-external-state",
+            "previous_sources": [],
+            "current_sources": [],
+            "names": [
+              "theme-helper"
+            ]
+          }
+        ]
       },
       "actions": [
         {

--- a/internal/cli/testdata/envelope_install.golden
+++ b/internal/cli/testdata/envelope_install.golden
@@ -288,6 +288,16 @@
             "names": [
               "theme-helper"
             ]
+          },
+          {
+            "scope": "provisioner",
+            "outcome": "retained-external-state",
+            "previous_sources": [],
+            "current_sources": [],
+            "names": [
+              "claude"
+            ],
+            "identity": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
           }
         ]
       },

--- a/internal/cli/testdata/envelope_installed.golden
+++ b/internal/cli/testdata/envelope_installed.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "9",
+  "schema_version": "10",
   "command": "installed",
   "status": "ok",
   "data": {

--- a/internal/cli/testdata/envelope_legacy_tag_migration_required.golden
+++ b/internal/cli/testdata/envelope_legacy_tag_migration_required.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "9",
+  "schema_version": "10",
   "command": "update",
   "status": "error",
   "data": {

--- a/internal/cli/testdata/envelope_plan.golden
+++ b/internal/cli/testdata/envelope_plan.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "9",
+  "schema_version": "10",
   "command": "plan",
   "status": "findings",
   "data": {
@@ -15,6 +15,65 @@
       "effective_tags": [
         "core",
         "work"
+      ]
+    },
+    "selection_reconciliation": {
+      "previous_intent": {
+        "authority": "recorded",
+        "profiles": [
+          "core"
+        ],
+        "extra_tags": [
+          "adaptive-theme"
+        ],
+        "resolved_tags": [
+          "core",
+          "adaptive-theme"
+        ]
+      },
+      "requested_intent": {
+        "authority": "explicit-request",
+        "profiles": [
+          "core"
+        ],
+        "extra_tags": [],
+        "resolved_tags": [
+          "core"
+        ]
+      },
+      "actions": [
+        {
+          "scope": "selection",
+          "outcome": "remove",
+          "previous_sources": [],
+          "current_sources": [],
+          "names": [
+            "adaptive-theme"
+          ]
+        },
+        {
+          "scope": "managed-entry",
+          "outcome": "blocked",
+          "reason": "ambiguous-partial-ownership",
+          "declarative_target": "~/.config/app/settings.json",
+          "resolved_target": "/home/user/.config/app/settings.json",
+          "previous_sources": [
+            "configs/app/adaptive.json"
+          ],
+          "current_sources": [
+            "configs/app/base.json"
+          ],
+          "names": []
+        },
+        {
+          "scope": "dependency",
+          "outcome": "retained-external-state",
+          "previous_sources": [],
+          "current_sources": [],
+          "names": [
+            "theme-helper"
+          ]
+        }
       ]
     },
     "actions": [

--- a/internal/cli/testdata/envelope_plan.golden
+++ b/internal/cli/testdata/envelope_plan.golden
@@ -73,6 +73,16 @@
           "names": [
             "theme-helper"
           ]
+        },
+        {
+          "scope": "provisioner",
+          "outcome": "retained-external-state",
+          "previous_sources": [],
+          "current_sources": [],
+          "names": [
+            "claude"
+          ],
+          "identity": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
         }
       ]
     },

--- a/internal/cli/testdata/envelope_selection_migration_required.golden
+++ b/internal/cli/testdata/envelope_selection_migration_required.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "9",
+  "schema_version": "10",
   "command": "status",
   "status": "error",
   "data": {

--- a/internal/cli/testdata/envelope_status.golden
+++ b/internal/cli/testdata/envelope_status.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "9",
+  "schema_version": "10",
   "command": "status",
   "status": "findings",
   "data": {

--- a/internal/cli/testdata/envelope_uninstall.golden
+++ b/internal/cli/testdata/envelope_uninstall.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "9",
+  "schema_version": "10",
   "command": "uninstall",
   "status": "ok",
   "data": {

--- a/internal/cli/testdata/envelope_update.golden
+++ b/internal/cli/testdata/envelope_update.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "9",
+  "schema_version": "10",
   "command": "update",
   "status": "ok",
   "data": {

--- a/internal/cli/testdata/envelope_update_selection_error.golden
+++ b/internal/cli/testdata/envelope_update_selection_error.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "9",
+  "schema_version": "10",
   "command": "update",
   "status": "error",
   "data": {

--- a/internal/cli/testdata/envelope_upgrade.golden
+++ b/internal/cli/testdata/envelope_upgrade.golden
@@ -1,5 +1,5 @@
 {
-  "schema_version": "9",
+  "schema_version": "10",
   "command": "upgrade",
   "status": "ok",
   "data": {

--- a/internal/cli/testdata/plan_all_statuses.golden
+++ b/internal/cli/testdata/plan_all_statuses.golden
@@ -18,3 +18,7 @@ Conflict guidance:
   - adopt is only for supported regular-file conflicts; it copies local file content into the Source of Truth after you choose it.
   - diff previews target versus source before you decide.
   Non-interactive install/update keeps conflicts skipped by default.
+
+Selection reconciliation:
+  remove                   selection      adaptive-theme
+  blocked                  managed-entry  /home/user/.config/app/settings.json [reason=whole-target-drift]

--- a/internal/plan/findings_test.go
+++ b/internal/plan/findings_test.go
@@ -1,6 +1,10 @@
 package plan
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/selectionreconciliation"
+)
 
 func TestPlanHasFindings(t *testing.T) {
 	cases := []struct {
@@ -28,5 +32,16 @@ func TestPlanHasFindings(t *testing.T) {
 func TestPlanHasFindingsEmpty(t *testing.T) {
 	if (Plan{}).HasFindings() {
 		t.Fatal("an empty plan must not report findings")
+	}
+}
+
+func TestPlanHasFindingsIncludesSelectionReconciliation(t *testing.T) {
+	clean := &selectionreconciliation.Report{Actions: []selectionreconciliation.Action{{Outcome: selectionreconciliation.OutcomeRetainedExternalState}}}
+	if (Plan{SelectionReconciliation: clean}).HasFindings() {
+		t.Fatal("Retained External State must not be a finding")
+	}
+	blocked := &selectionreconciliation.Report{Actions: []selectionreconciliation.Action{{Outcome: selectionreconciliation.OutcomeBlocked}}}
+	if !(Plan{SelectionReconciliation: blocked}).HasFindings() {
+		t.Fatal("blocked reconciliation action must be a finding")
 	}
 }

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -15,6 +15,7 @@ import (
 	"github.com/yersonargotev/dots/internal/seededstate"
 	"github.com/yersonargotev/dots/internal/selectedsurface"
 	"github.com/yersonargotev/dots/internal/selection"
+	"github.com/yersonargotev/dots/internal/selectionreconciliation"
 	"github.com/yersonargotev/dots/internal/state"
 	"github.com/yersonargotev/dots/internal/textblock"
 )
@@ -100,17 +101,21 @@ type LegacyMigration struct {
 
 // Plan is the preview of changes the installer would apply for a Profile.
 type Plan struct {
-	Profile   string            `json:"profile,omitempty"`
-	Profiles  []string          `json:"profiles,omitempty"`
-	Tags      []string          `json:"tags,omitempty"`
-	Selection *selection.Report `json:"selection,omitempty"`
-	Actions   []Action          `json:"actions"`
+	Profile                 string                          `json:"profile,omitempty"`
+	Profiles                []string                        `json:"profiles,omitempty"`
+	Tags                    []string                        `json:"tags,omitempty"`
+	Selection               *selection.Report               `json:"selection,omitempty"`
+	SelectionReconciliation *selectionreconciliation.Report `json:"selection_reconciliation,omitempty"`
+	Actions                 []Action                        `json:"actions"`
 }
 
 // HasFindings reports whether the Install Plan contains an action the caller
 // must act on before a clean apply: an unresolved Conflict, or a missing source
 // the manifest declares but the Installed Repository does not provide.
 func (p Plan) HasFindings() bool {
+	if p.SelectionReconciliation != nil && p.SelectionReconciliation.HasFindings() {
+		return true
+	}
 	for _, a := range p.Actions {
 		switch a.Status {
 		case StatusConflict, StatusMissingSource:
@@ -163,6 +168,7 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 	plan := Plan{Profile: resolved.Profile, Profiles: resolved.Profiles, Tags: resolved.Tags}
 	actionByTarget := map[string]int{}
 	readSourcesByTarget := map[string][]string{}
+	unsafeTargetByTarget := map[string]bool{}
 	scheduledLegacyParents := map[string]struct{}{}
 	for _, selected := range selectedEntries(m, tags, opts.OS) {
 		entry := selected.Entry
@@ -181,9 +187,13 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 			return Plan{}, err
 		}
 		entry.Source = source
-		actionStatus, err := status(entry, target, readSourceAbs, readRoot, sourceAbs, opts.Metadata, defaultSource)
-		if err != nil {
-			return Plan{}, err
+		unsafeTargetParent := ValidateTargetParentInsideHome(target, opts.Home) != nil
+		actionStatus := StatusConflict
+		if !unsafeTargetParent {
+			actionStatus, err = status(entry, target, readSourceAbs, readRoot, sourceAbs, opts.Metadata, defaultSource)
+			if err != nil {
+				return Plan{}, err
+			}
 		}
 		legacyParent := ""
 		if actionStatus == StatusConflict {
@@ -203,7 +213,7 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 			}
 		}
 		var matchingTags []string
-		if actionStatus == StatusConflict {
+		if actionStatus == StatusConflict && !unsafeTargetParent {
 			matchingTags, err = matchingUnselectedSourceOverrideTags(entry, tags, target, readRoot, opts.SourceRoot)
 			if err != nil {
 				return Plan{}, err
@@ -228,7 +238,7 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 			Ownership:    entry.Ownership,
 			LegacyParent: legacyParent,
 		}
-		if actionStatus == StatusConflict || actionStatus == StatusCreate {
+		if !unsafeTargetParent && (actionStatus == StatusConflict || actionStatus == StatusCreate) {
 			if migration, ok := opts.LegacyMigrations[target]; ok && ((migration.LegacyTarget == "" && actionStatus == StatusConflict) || (migration.LegacyTarget != "" && actionStatus == StatusCreate)) {
 				planned, compatible, migrateErr := planLegacyMigration(entry, readSourceAbs, migration)
 				if migrateErr != nil {
@@ -281,15 +291,20 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 			if rec, ok := opts.Metadata.FindByTarget(existing.Target); ok && rec.Ownership == "json-subset" && len(rec.OwnedContent) > 0 {
 				existing.PreviousContent = append([]byte(nil), rec.OwnedContent...)
 			}
-			existing.Status, err = composedJSONStatus(*existing, opts.Metadata)
-			if err != nil {
-				return Plan{}, err
+			if unsafeTargetByTarget[targetKey] || unsafeTargetParent {
+				existing.Status = StatusConflict
+			} else {
+				existing.Status, err = composedJSONStatus(*existing, opts.Metadata)
+				if err != nil {
+					return Plan{}, err
+				}
 			}
 			existing.Reason = ""
 			existing.MatchingTags = nil
 			continue
 		}
 		actionByTarget[targetKey] = len(plan.Actions)
+		unsafeTargetByTarget[targetKey] = unsafeTargetParent
 		readSourcesByTarget[targetKey] = []string{readSourceAbs}
 		plan.Actions = append(plan.Actions, action)
 	}

--- a/internal/selectionreconciliation/reconciliation.go
+++ b/internal/selectionreconciliation/reconciliation.go
@@ -734,6 +734,9 @@ func recordHasExactContributions(record state.Record, sources []string, strategy
 	if len(sources) == 0 || record.Strategy != strategy || record.Ownership != ownership || len(record.Contributions) != len(sources) {
 		return false
 	}
+	if len(sources) > 1 && ownership != "json-subset" {
+		return false
+	}
 	for index, source := range sources {
 		contribution := record.Contributions[index]
 		if contribution.Source != source || !contribution.EvidenceRecorded || contribution.Ownership != ownership {

--- a/internal/selectionreconciliation/reconciliation.go
+++ b/internal/selectionreconciliation/reconciliation.go
@@ -5,11 +5,14 @@ package selectionreconciliation
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/yersonargotev/dots/internal/configsubset"
 	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/provision"
 	"github.com/yersonargotev/dots/internal/seededstate"
 	"github.com/yersonargotev/dots/internal/selectedsurface"
 	"github.com/yersonargotev/dots/internal/state"
@@ -121,8 +124,24 @@ type SourceEvidence struct {
 // Evidence contains complete, ordered inspection snapshots. Slices are treated
 // as immutable and result values never alias their byte storage.
 type Evidence struct {
-	Targets []TargetEvidence
-	Sources []SourceEvidence
+	Targets              []TargetEvidence
+	Sources              []SourceEvidence
+	PreviousProvisioners []ProvisionerEvidence
+	CurrentProvisioners  []ProvisionerEvidence
+}
+
+// ProvisionerEvidence identifies one external Provisioner effect by its exact
+// rendered command while keeping command details out of the public report.
+type ProvisionerEvidence struct {
+	Identity string
+	Name     string
+}
+
+// NewProvisionerEvidence builds a stable identity from the exact command that
+// a manifest declaration or Installation Metadata receipt represents.
+func NewProvisionerEvidence(tool, executable string, args []string) ProvisionerEvidence {
+	parts := append([]string{tool, executable}, args...)
+	return ProvisionerEvidence{Identity: strings.Join(parts, "\x00"), Name: tool}
 }
 
 // Input is the complete pure seam for building a reconciliation report.
@@ -147,6 +166,7 @@ type Action struct {
 	PreviousSources   []string `json:"previous_sources"`
 	CurrentSources    []string `json:"current_sources"`
 	Names             []string `json:"names"`
+	Identity          string   `json:"identity,omitempty"`
 }
 
 // Report is a deterministic Selection Reconciliation Plan.
@@ -223,7 +243,7 @@ func Build(input Input) (Report, error) {
 		report.Actions = append(report.Actions, action)
 	}
 
-	report.Actions = append(report.Actions, externalActions(input.PreviousSurface, input.CurrentSurface)...)
+	report.Actions = append(report.Actions, externalActions(input.PreviousSurface, input.CurrentSurface, input.Evidence)...)
 	return report, nil
 }
 
@@ -242,7 +262,7 @@ func selectionActions(previous, current Intent) []Action {
 	return actions
 }
 
-func externalActions(previous, current selectedsurface.Surface) []Action {
+func externalActions(previous, current selectedsurface.Surface, evidence Evidence) []Action {
 	actions := make([]Action, 0)
 	previousDependencies := dependencyNames(previous.Dependencies)
 	currentDependencies := dependencyNames(current.Dependencies)
@@ -252,15 +272,70 @@ func externalActions(previous, current selectedsurface.Surface) []Action {
 	for _, name := range difference(previousDependencies, currentDependencies) {
 		actions = append(actions, newNamedAction(ScopeDependency, OutcomeRetainedExternalState, []string{name}))
 	}
-	previousProvisioners := provisionerNames(previous.Provisioners)
-	currentProvisioners := provisionerNames(current.Provisioners)
-	for _, name := range difference(currentProvisioners, previousProvisioners) {
-		actions = append(actions, newNamedAction(ScopeProvisioner, OutcomeCreate, []string{name}))
+	previousProvisioners := evidence.PreviousProvisioners
+	if previousProvisioners == nil {
+		previousProvisioners = surfaceProvisionerEvidence(previous.Provisioners)
 	}
-	for _, name := range difference(previousProvisioners, currentProvisioners) {
-		actions = append(actions, newNamedAction(ScopeProvisioner, OutcomeRetainedExternalState, []string{name}))
+	currentProvisioners := evidence.CurrentProvisioners
+	if currentProvisioners == nil {
+		currentProvisioners = surfaceProvisionerEvidence(current.Provisioners)
+	}
+	actions = append(actions, provisionerActions(previousProvisioners, currentProvisioners)...)
+	return actions
+}
+
+func provisionerActions(previous, current []ProvisionerEvidence) []Action {
+	previous = orderedUniqueProvisioners(previous)
+	current = orderedUniqueProvisioners(current)
+	previousIDs := make(map[string]bool, len(previous))
+	currentIDs := make(map[string]bool, len(current))
+	for _, item := range previous {
+		previousIDs[item.Identity] = true
+	}
+	for _, item := range current {
+		currentIDs[item.Identity] = true
+	}
+	actions := make([]Action, 0)
+	for _, item := range current {
+		if !previousIDs[item.Identity] {
+			actions = append(actions, newProvisionerAction(OutcomeCreate, item))
+		}
+	}
+	for _, item := range previous {
+		if !currentIDs[item.Identity] {
+			actions = append(actions, newProvisionerAction(OutcomeRetainedExternalState, item))
+		}
 	}
 	return actions
+}
+
+func surfaceProvisionerEvidence(provisioners []manifest.Provisioner) []ProvisionerEvidence {
+	result := make([]ProvisionerEvidence, 0, len(provisioners))
+	for _, item := range provisioners {
+		executable, args := provision.RenderCommand(item)
+		result = append(result, NewProvisionerEvidence(item.Tool, executable, args))
+	}
+	return result
+}
+
+func orderedUniqueProvisioners(items []ProvisionerEvidence) []ProvisionerEvidence {
+	result := make([]ProvisionerEvidence, 0, len(items))
+	seen := make(map[string]bool, len(items))
+	for _, item := range items {
+		if item.Identity == "" || seen[item.Identity] {
+			continue
+		}
+		seen[item.Identity] = true
+		result = append(result, item)
+	}
+	return result
+}
+
+func newProvisionerAction(outcome Outcome, item ProvisionerEvidence) Action {
+	action := newNamedAction(ScopeProvisioner, outcome, []string{item.Name})
+	digest := sha256.Sum256([]byte(item.Identity))
+	action.Identity = fmt.Sprintf("sha256:%x", digest)
+	return action
 }
 
 func buildTargetAction(previous, current targetGroup, input Input) (Action, error) {
@@ -786,14 +861,6 @@ func dependencyNames(dependencies []manifest.Dependency) []string {
 	result := make([]string, 0, len(dependencies))
 	for _, dependency := range dependencies {
 		result = append(result, dependency.Name)
-	}
-	return orderedUnique(result)
-}
-
-func provisionerNames(provisioners []manifest.Provisioner) []string {
-	result := make([]string, 0, len(provisioners))
-	for _, provisioner := range provisioners {
-		result = append(result, provisioner.Tool)
 	}
 	return orderedUnique(result)
 }

--- a/internal/selectionreconciliation/reconciliation.go
+++ b/internal/selectionreconciliation/reconciliation.go
@@ -1,0 +1,864 @@
+// Package selectionreconciliation builds a deterministic, read-only Selection
+// Reconciliation Plan from already resolved selection and inspection evidence.
+// It never reads or writes the filesystem or mutates Installation Metadata.
+package selectionreconciliation
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	"github.com/yersonargotev/dots/internal/configsubset"
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/seededstate"
+	"github.com/yersonargotev/dots/internal/selectedsurface"
+	"github.com/yersonargotev/dots/internal/state"
+	"github.com/yersonargotev/dots/internal/textblock"
+)
+
+// Authority identifies whether the requested intent may authorize retirement.
+type Authority string
+
+const (
+	AuthorityRecorded          Authority = "recorded"
+	AuthorityExplicitRequest   Authority = "explicit-request"
+	AuthorityManifestEvolution Authority = "manifest-evolution"
+)
+
+var errMissingSourceEvidence = errors.New("source evidence is missing")
+
+// Intent is a detached selection intent and its resolved Tag snapshot.
+type Intent struct {
+	Authority    Authority `json:"authority"`
+	Profiles     []string  `json:"profiles"`
+	ExtraTags    []string  `json:"extra_tags"`
+	ResolvedTags []string  `json:"resolved_tags"`
+}
+
+// Outcome is the stable result of one reconciliation action.
+type Outcome string
+
+const (
+	OutcomeCreate                Outcome = "create"
+	OutcomeUpdate                Outcome = "update"
+	OutcomePreserve              Outcome = "preserve"
+	OutcomeReconcile             Outcome = "reconcile"
+	OutcomeRemove                Outcome = "remove"
+	OutcomeRetain                Outcome = "retain"
+	OutcomeBlocked               Outcome = "blocked"
+	OutcomeRetainedExternalState Outcome = "retained-external-state"
+)
+
+// Scope identifies the kind of selected surface item described by an action.
+type Scope string
+
+const (
+	ScopeSelection    Scope = "selection"
+	ScopeManagedEntry Scope = "managed-entry"
+	ScopeDependency   Scope = "dependency"
+	ScopeProvisioner  Scope = "provisioner"
+)
+
+const (
+	ReasonWholeTargetDrift          = "whole-target-drift"
+	ReasonLostOwnership             = "lost-ownership"
+	ReasonAmbiguousPartialOwnership = "ambiguous-partial-ownership"
+	ReasonMissingSource             = "missing-source"
+	ReasonManifestEvolution         = "manifest-evolution-report-only"
+	ReasonLocalEvolution            = "seeded-local-evolution"
+)
+
+// TargetKind is the inspected filesystem object kind. The adapter supplies it;
+// Build does not perform any filesystem inspection.
+type TargetKind string
+
+const (
+	TargetKindRegular TargetKind = "regular"
+	TargetKindSymlink TargetKind = "symlink"
+	TargetKindOther   TargetKind = "other"
+)
+
+// ForwardStatus is the adapter's portable projection of the existing Install
+// Plan classification. Supplying it lets Build reuse template rendering and
+// ordinary forward-install decisions instead of reproducing them.
+type ForwardStatus string
+
+const (
+	ForwardCreate        ForwardStatus = "create"
+	ForwardUpdate        ForwardStatus = "update"
+	ForwardUnchanged     ForwardStatus = "unchanged"
+	ForwardConflict      ForwardStatus = "conflict"
+	ForwardMissingSource ForwardStatus = "missing-source"
+)
+
+// TargetEvidence is an immutable snapshot prepared by the filesystem adapter.
+// DeclarativeTarget joins it to Selected Surface order. ResolvedTarget joins it
+// to Installation Metadata and is also carried into the resulting action.
+type TargetEvidence struct {
+	DeclarativeTarget string
+	ResolvedTarget    string
+	Exists            bool
+	Kind              TargetKind
+	Content           []byte
+	LinkDestination   string
+	ForwardStatus     ForwardStatus
+	ForwardReason     string
+}
+
+// SourceEvidence is an immutable snapshot of the selected source contribution.
+// Content is the final desired contribution (rendered already, when needed).
+type SourceEvidence struct {
+	DeclarativeTarget string
+	Source            string
+	ResolvedSource    string
+	Exists            bool
+	Content           []byte
+}
+
+// Evidence contains complete, ordered inspection snapshots. Slices are treated
+// as immutable and result values never alias their byte storage.
+type Evidence struct {
+	Targets []TargetEvidence
+	Sources []SourceEvidence
+}
+
+// Input is the complete pure seam for building a reconciliation report.
+type Input struct {
+	PreviousIntent  Intent
+	RequestedIntent Intent
+	PreviousSurface selectedsurface.Surface
+	CurrentSurface  selectedsurface.Surface
+	Metadata        state.Metadata
+	Evidence        Evidence
+}
+
+// Action describes one semantic outcome. Arrays are always non-nil so JSON is
+// stable. Managed Entry actions carry target and source fields; selection and
+// external-state actions carry Names.
+type Action struct {
+	Scope             Scope    `json:"scope"`
+	Outcome           Outcome  `json:"outcome"`
+	Reason            string   `json:"reason,omitempty"`
+	DeclarativeTarget string   `json:"declarative_target,omitempty"`
+	ResolvedTarget    string   `json:"resolved_target,omitempty"`
+	PreviousSources   []string `json:"previous_sources"`
+	CurrentSources    []string `json:"current_sources"`
+	Names             []string `json:"names"`
+}
+
+// Report is a deterministic Selection Reconciliation Plan.
+type Report struct {
+	PreviousIntent  Intent   `json:"previous_intent"`
+	RequestedIntent Intent   `json:"requested_intent"`
+	Actions         []Action `json:"actions"`
+}
+
+// HasFindings reports whether any action is blocked. Retained External State is
+// intentionally informational and does not by itself become a finding.
+func (r Report) HasFindings() bool {
+	for _, action := range r.Actions {
+		if action.Outcome == OutcomeBlocked {
+			return true
+		}
+	}
+	return false
+}
+
+type targetGroup struct {
+	target  string
+	entries []selectedsurface.SelectedEntry
+}
+
+// Build computes a Selection Reconciliation Plan without mutating any input.
+func Build(input Input) (Report, error) {
+	if input.RequestedIntent.Authority != AuthorityExplicitRequest && input.RequestedIntent.Authority != AuthorityManifestEvolution {
+		return Report{}, fmt.Errorf("build selection reconciliation: requested authority %q is invalid", input.RequestedIntent.Authority)
+	}
+	if input.PreviousIntent.Authority != AuthorityRecorded {
+		return Report{}, fmt.Errorf("build selection reconciliation: previous authority %q is invalid", input.PreviousIntent.Authority)
+	}
+
+	report := Report{
+		PreviousIntent:  cloneIntent(input.PreviousIntent),
+		RequestedIntent: cloneIntent(input.RequestedIntent),
+		Actions:         make([]Action, 0),
+	}
+	report.Actions = append(report.Actions, selectionActions(input.PreviousIntent, input.RequestedIntent)...)
+
+	previousGroups, err := groupTargets(input.PreviousSurface.Entries)
+	if err != nil {
+		return Report{}, fmt.Errorf("build selection reconciliation: group previous surface: %w", err)
+	}
+	currentGroups, err := groupTargets(input.CurrentSurface.Entries)
+	if err != nil {
+		return Report{}, fmt.Errorf("build selection reconciliation: group current surface: %w", err)
+	}
+
+	previousByTarget := make(map[string]targetGroup, len(previousGroups))
+	currentByTarget := make(map[string]targetGroup, len(currentGroups))
+	for _, group := range previousGroups {
+		previousByTarget[group.target] = group
+	}
+	for _, group := range currentGroups {
+		currentByTarget[group.target] = group
+	}
+	for _, current := range currentGroups {
+		action, buildErr := buildTargetAction(previousByTarget[current.target], current, input)
+		if buildErr != nil {
+			return Report{}, fmt.Errorf("build selection reconciliation for target %s: %w", current.target, buildErr)
+		}
+		report.Actions = append(report.Actions, action)
+	}
+	for _, previous := range previousGroups {
+		if _, retained := currentByTarget[previous.target]; retained {
+			continue
+		}
+		action, buildErr := buildTargetAction(previous, targetGroup{}, input)
+		if buildErr != nil {
+			return Report{}, fmt.Errorf("build selection reconciliation for target %s: %w", previous.target, buildErr)
+		}
+		report.Actions = append(report.Actions, action)
+	}
+
+	report.Actions = append(report.Actions, externalActions(input.PreviousSurface, input.CurrentSurface)...)
+	return report, nil
+}
+
+func selectionActions(previous, current Intent) []Action {
+	actions := make([]Action, 0, 2)
+	removed := append(difference(previous.Profiles, current.Profiles), difference(previous.ExtraTags, current.ExtraTags)...)
+	removed = append(removed, difference(previous.ResolvedTags, current.ResolvedTags)...)
+	if len(removed) > 0 {
+		actions = append(actions, newNamedAction(ScopeSelection, OutcomeRemove, orderedUnique(removed)))
+	}
+	added := append(difference(current.Profiles, previous.Profiles), difference(current.ExtraTags, previous.ExtraTags)...)
+	added = append(added, difference(current.ResolvedTags, previous.ResolvedTags)...)
+	if len(added) > 0 {
+		actions = append(actions, newNamedAction(ScopeSelection, OutcomeCreate, orderedUnique(added)))
+	}
+	return actions
+}
+
+func externalActions(previous, current selectedsurface.Surface) []Action {
+	actions := make([]Action, 0)
+	previousDependencies := dependencyNames(previous.Dependencies)
+	currentDependencies := dependencyNames(current.Dependencies)
+	for _, name := range difference(currentDependencies, previousDependencies) {
+		actions = append(actions, newNamedAction(ScopeDependency, OutcomeCreate, []string{name}))
+	}
+	for _, name := range difference(previousDependencies, currentDependencies) {
+		actions = append(actions, newNamedAction(ScopeDependency, OutcomeRetainedExternalState, []string{name}))
+	}
+	previousProvisioners := provisionerNames(previous.Provisioners)
+	currentProvisioners := provisionerNames(current.Provisioners)
+	for _, name := range difference(currentProvisioners, previousProvisioners) {
+		actions = append(actions, newNamedAction(ScopeProvisioner, OutcomeCreate, []string{name}))
+	}
+	for _, name := range difference(previousProvisioners, currentProvisioners) {
+		actions = append(actions, newNamedAction(ScopeProvisioner, OutcomeRetainedExternalState, []string{name}))
+	}
+	return actions
+}
+
+func buildTargetAction(previous, current targetGroup, input Input) (Action, error) {
+	declarativeTarget := current.target
+	if declarativeTarget == "" {
+		declarativeTarget = previous.target
+	}
+	action := Action{
+		Scope:             ScopeManagedEntry,
+		DeclarativeTarget: declarativeTarget,
+		PreviousSources:   groupSources(previous),
+		CurrentSources:    groupSources(current),
+		Names:             make([]string, 0),
+	}
+	target, ok := findTargetEvidence(input.Evidence.Targets, declarativeTarget)
+	if !ok {
+		return Action{}, fmt.Errorf("target evidence is required")
+	}
+	action.ResolvedTarget = target.ResolvedTarget
+
+	active := current
+	if active.target == "" {
+		active = previous
+	}
+	strategy, ownership, err := groupMode(active)
+	if err != nil {
+		return Action{}, err
+	}
+	if previous.target != "" {
+		previousStrategy, previousOwnership, previousErr := groupMode(previous)
+		if previousErr != nil {
+			return Action{}, previousErr
+		}
+		if current.target != "" && (previousStrategy != strategy || normalizedOwnership(previousOwnership) != normalizedOwnership(ownership)) {
+			return blocked(action, ReasonAmbiguousPartialOwnership), nil
+		}
+	}
+	ownership = normalizedOwnership(ownership)
+
+	record, recorded := findRecord(input.Metadata.Entries, target.ResolvedTarget)
+	if current.target == "" && input.RequestedIntent.Authority == AuthorityManifestEvolution {
+		action.Outcome = OutcomeRetain
+		action.Reason = ReasonManifestEvolution
+		return action, nil
+	}
+	if current.target != "" && hasRetiredSources(previous, current) && input.RequestedIntent.Authority == AuthorityManifestEvolution {
+		action.Outcome = OutcomeRetain
+		action.Reason = ReasonManifestEvolution
+		return action, nil
+	}
+	if current.target != "" && !hasRetiredSources(previous, current) && target.ForwardStatus != "" {
+		return classifyForward(action, ownership, target.ForwardStatus, target.ForwardReason), nil
+	}
+
+	currentContent, currentSources, err := composeGroup(current, ownership, input.Evidence.Sources)
+	if err != nil {
+		if missingSource(err) {
+			return blocked(action, ReasonMissingSource), nil
+		}
+		return Action{}, err
+	}
+	if current.target != "" && !target.Exists {
+		action.Outcome = OutcomeCreate
+		return action, nil
+	}
+	if !target.Exists {
+		return blocked(action, ReasonLostOwnership), nil
+	}
+
+	if strategy == "symlink" {
+		return classifySymlink(action, previous, current, target, currentSources, record, recorded, input.Evidence.Sources), nil
+	}
+	if target.Kind != TargetKindRegular {
+		return blocked(action, ReasonLostOwnership), nil
+	}
+	if ownership == "whole" {
+		return classifyWhole(action, current, target.Content, currentContent, record, recorded), nil
+	}
+	if ownership == "seeded" {
+		return classifySeeded(action, current, target.Content, currentContent, record, recorded), nil
+	}
+	return classifyPartial(action, previous, current, ownership, target.Content, currentContent, record, recorded)
+}
+
+func classifySymlink(action Action, previous, current targetGroup, target TargetEvidence, currentSources []SourceEvidence, record state.Record, recorded bool, evidence []SourceEvidence) Action {
+	if target.Kind != TargetKindSymlink {
+		return blocked(action, ReasonLostOwnership)
+	}
+	if current.target == "" {
+		if !recorded || target.LinkDestination == "" || !recordHasExactSource(record, action.PreviousSources) {
+			return blocked(action, ReasonLostOwnership)
+		}
+		if len(action.PreviousSources) != 1 || !record.HasSource(action.PreviousSources[0]) ||
+			target.LinkDestination != resolvedSource(evidence, previous.target, action.PreviousSources[0]) {
+			return blocked(action, ReasonLostOwnership)
+		}
+		action.Outcome = OutcomeRemove
+		return action
+	}
+	if len(currentSources) != 1 {
+		return blocked(action, ReasonLostOwnership)
+	}
+	if target.LinkDestination == currentSources[0].ResolvedSource {
+		action.Outcome = OutcomePreserve
+		return action
+	}
+	if recorded && previous.target != "" && recordHasExactSource(record, action.PreviousSources) {
+		if len(action.PreviousSources) != 1 || target.LinkDestination != resolvedSource(evidence, previous.target, action.PreviousSources[0]) {
+			return blocked(action, ReasonLostOwnership)
+		}
+		action.Outcome = OutcomeUpdate
+		return action
+	}
+	return blocked(action, ReasonLostOwnership)
+}
+
+func classifyWhole(action Action, current targetGroup, live, desired []byte, record state.Record, recorded bool) Action {
+	if current.target != "" && bytes.Equal(live, desired) {
+		action.Outcome = OutcomePreserve
+		return action
+	}
+	if !recorded {
+		return blocked(action, ReasonLostOwnership)
+	}
+	if record.Hash == "" || state.HashBytes(live) != record.Hash {
+		return blocked(action, ReasonWholeTargetDrift)
+	}
+	if current.target == "" {
+		action.Outcome = OutcomeRemove
+	} else {
+		action.Outcome = OutcomeUpdate
+	}
+	return action
+}
+
+func classifySeeded(action Action, current targetGroup, live, desired []byte, record state.Record, recorded bool) Action {
+	if current.target == "" {
+		action.Outcome = OutcomeRetain
+		return action
+	}
+	if !recorded {
+		if bytes.Equal(live, desired) {
+			action.Outcome = OutcomePreserve
+			return action
+		}
+		return blocked(action, ReasonLostOwnership)
+	}
+	previous, ok := exactSeededBaseline(record, action.PreviousSources)
+	if !ok {
+		return blocked(action, ReasonAmbiguousPartialOwnership)
+	}
+	result := seededstate.Reconcile(live, previous, desired)
+	switch result.Classification {
+	case seededstate.AlignedCurrent:
+		action.Outcome = OutcomePreserve
+	case seededstate.AdvanceBaseline:
+		action.Outcome = OutcomeUpdate
+	default:
+		action.Outcome = OutcomeRetain
+		action.Reason = ReasonLocalEvolution
+	}
+	return action
+}
+
+func classifyPartial(action Action, previous, current targetGroup, ownership string, live, desired []byte, record state.Record, recorded bool) (Action, error) {
+	if previous.target == "" {
+		outcome, err := analyzePartialAddition(ownership, live, desired)
+		if err != nil {
+			return Action{}, fmt.Errorf("analyze new partial contribution: %w", err)
+		}
+		if outcome == OutcomeBlocked {
+			return blocked(action, ReasonAmbiguousPartialOwnership), nil
+		}
+		action.Outcome = outcome
+		return action, nil
+	}
+	if !recorded {
+		return blocked(action, ReasonAmbiguousPartialOwnership), nil
+	}
+	previousOwned, ok, err := exactPreviousContent(previous, ownership, record)
+	if err != nil {
+		return Action{}, fmt.Errorf("compose exact previous contribution: %w", err)
+	}
+	if !ok {
+		return blocked(action, ReasonAmbiguousPartialOwnership), nil
+	}
+
+	if current.target == "" {
+		changed, empty, compatible, removeErr := removePartial(ownership, live, previousOwned)
+		if removeErr != nil {
+			return Action{}, fmt.Errorf("analyze partial retirement: %w", removeErr)
+		}
+		if !compatible {
+			return blocked(action, ReasonAmbiguousPartialOwnership), nil
+		}
+		if !changed {
+			action.Outcome = OutcomePreserve
+		} else if empty {
+			action.Outcome = OutcomeRemove
+		} else {
+			action.Outcome = OutcomeRetain
+		}
+		return action, nil
+	}
+
+	changed, compatible, reconcileErr := reconcilePartial(ownership, live, previousOwned, desired)
+	if reconcileErr != nil {
+		return Action{}, fmt.Errorf("reconcile partial contribution: %w", reconcileErr)
+	}
+	if !compatible {
+		return blocked(action, ReasonAmbiguousPartialOwnership), nil
+	}
+	if changed {
+		action.Outcome = OutcomeReconcile
+	} else {
+		action.Outcome = OutcomePreserve
+	}
+	return action, nil
+}
+
+func analyzePartialAddition(ownership string, live, desired []byte) (Outcome, error) {
+	switch ownership {
+	case "json-subset":
+		relation, err := configsubset.AnalyzeJSON(live, desired)
+		return relationOutcome(relation), err
+	case "jsonc-subset":
+		relation, err := configsubset.AnalyzeJSONC(live, desired)
+		return relationOutcome(relation), err
+	case "toml-subset":
+		relation, err := configsubset.AnalyzeTOML(live, desired)
+		return relationOutcome(relation), err
+	case "marked-block":
+		reconciliation := textblock.ReconcileOwned(live, desired, desired, textblock.DotsManagedMarkers())
+		if reconciliation.Compatible && !reconciliation.Changed {
+			return OutcomePreserve, nil
+		}
+		return OutcomeBlocked, nil
+	default:
+		return "", fmt.Errorf("partial ownership %q is not supported", ownership)
+	}
+}
+
+func relationOutcome(relation configsubset.JSONFileRelation) Outcome {
+	if relation.Contains {
+		return OutcomePreserve
+	}
+	if relation.Mergeable {
+		return OutcomeReconcile
+	}
+	return OutcomeBlocked
+}
+
+func reconcilePartial(ownership string, live, previous, current []byte) (bool, bool, error) {
+	switch ownership {
+	case "json-subset":
+		result, err := configsubset.ReconcileJSON(live, previous, current)
+		return result.Changed, result.Compatible, err
+	case "jsonc-subset":
+		result, err := configsubset.ReconcileJSONC(live, previous, current)
+		return result.Changed, result.Compatible, err
+	case "toml-subset":
+		result, err := configsubset.ReconcileTOML(live, previous, current)
+		return result.Changed, result.Compatible, err
+	case "marked-block":
+		result := textblock.ReconcileOwned(live, previous, current, textblock.DotsManagedMarkers())
+		return result.Changed, result.Compatible, nil
+	default:
+		return false, false, fmt.Errorf("partial ownership %q is not supported", ownership)
+	}
+}
+
+func removePartial(ownership string, live, owned []byte) (bool, bool, bool, error) {
+	switch ownership {
+	case "json-subset":
+		_, changed, empty, compatible, err := configsubset.RemoveJSON(live, owned)
+		return changed, empty, compatible, err
+	case "jsonc-subset":
+		_, changed, empty, compatible, err := configsubset.RemoveJSONC(live, owned)
+		return changed, empty, compatible, err
+	case "toml-subset":
+		_, changed, empty, compatible, err := configsubset.RemoveTOML(live, owned)
+		return changed, empty, compatible, err
+	case "marked-block":
+		_, changed, empty, compatible := textblock.RemoveOwned(live, owned, textblock.DotsManagedMarkers())
+		return changed, empty, compatible, nil
+	default:
+		return false, false, false, fmt.Errorf("partial ownership %q is not supported", ownership)
+	}
+}
+
+func exactPreviousContent(group targetGroup, ownership string, record state.Record) ([]byte, bool, error) {
+	contributions := make([][]byte, 0, len(group.entries))
+	seen := make(map[string]bool)
+	for _, entry := range group.entries {
+		if seen[entry.Source] {
+			continue
+		}
+		seen[entry.Source] = true
+		contribution, ok := exactContribution(record.Contributions, entry.Source, ownership)
+		if !ok {
+			return nil, false, nil
+		}
+		switch ownership {
+		case "json-subset", "jsonc-subset":
+			contributions = append(contributions, cloneBytes(contribution.OwnedContent))
+		case "toml-subset", "marked-block":
+			contributions = append(contributions, cloneBytes(contribution.OwnedBytes))
+		default:
+			return nil, false, fmt.Errorf("partial ownership %q is not supported", ownership)
+		}
+	}
+	return composeContents(ownership, contributions)
+}
+
+func composeGroup(group targetGroup, ownership string, evidence []SourceEvidence) ([]byte, []SourceEvidence, error) {
+	if group.target == "" {
+		return nil, make([]SourceEvidence, 0), nil
+	}
+	contents := make([][]byte, 0, len(group.entries))
+	selected := make([]SourceEvidence, 0, len(group.entries))
+	seen := make(map[string]bool)
+	for _, entry := range group.entries {
+		if seen[entry.Source] {
+			continue
+		}
+		seen[entry.Source] = true
+		source, ok := findSourceEvidence(evidence, group.target, entry.Source)
+		if !ok || !source.Exists {
+			return nil, nil, fmt.Errorf("source evidence for %s: %w", entry.Source, errMissingSourceEvidence)
+		}
+		selected = append(selected, cloneSourceEvidence(source))
+		contents = append(contents, cloneBytes(source.Content))
+	}
+	if ownership == "whole" || ownership == "seeded" {
+		if len(contents) != 1 {
+			return nil, nil, fmt.Errorf("ownership %s requires exactly one source", ownership)
+		}
+		return contents[0], selected, nil
+	}
+	content, ok, err := composeContents(ownership, contents)
+	if !ok {
+		return nil, nil, fmt.Errorf("compose %s contribution: exact content is unavailable", ownership)
+	}
+	return content, selected, err
+}
+
+func composeContents(ownership string, contents [][]byte) ([]byte, bool, error) {
+	if len(contents) == 0 {
+		return nil, false, nil
+	}
+	if len(contents) == 1 {
+		return cloneBytes(contents[0]), true, nil
+	}
+	if ownership != "json-subset" {
+		return nil, false, fmt.Errorf("multiple contributions require json-subset ownership")
+	}
+	composed := cloneBytes(contents[0])
+	for _, content := range contents[1:] {
+		var err error
+		composed, err = configsubset.MergeJSON(composed, content)
+		if err != nil {
+			return nil, false, fmt.Errorf("merge contribution: %w", err)
+		}
+	}
+	return composed, true, nil
+}
+
+func groupTargets(entries []selectedsurface.SelectedEntry) ([]targetGroup, error) {
+	groups := make([]targetGroup, 0)
+	indexes := make(map[string]int)
+	for _, entry := range entries {
+		if entry.Entry.Target == "" {
+			return nil, fmt.Errorf("managed entry target is empty")
+		}
+		if index, ok := indexes[entry.Entry.Target]; ok {
+			groups[index].entries = append(groups[index].entries, entry)
+			continue
+		}
+		indexes[entry.Entry.Target] = len(groups)
+		groups = append(groups, targetGroup{target: entry.Entry.Target, entries: []selectedsurface.SelectedEntry{entry}})
+	}
+	return groups, nil
+}
+
+func groupMode(group targetGroup) (string, string, error) {
+	if len(group.entries) == 0 {
+		return "", "", fmt.Errorf("managed target has no selected entries")
+	}
+	strategy := group.entries[0].Entry.Strategy
+	ownership := normalizedOwnership(group.entries[0].Entry.Ownership)
+	for _, entry := range group.entries[1:] {
+		if entry.Entry.Strategy != strategy || normalizedOwnership(entry.Entry.Ownership) != ownership {
+			return "", "", fmt.Errorf("shared target has incompatible strategy or ownership")
+		}
+	}
+	return strategy, ownership, nil
+}
+
+func groupSources(group targetGroup) []string {
+	result := make([]string, 0, len(group.entries))
+	seen := make(map[string]bool)
+	for _, entry := range group.entries {
+		if !seen[entry.Source] {
+			seen[entry.Source] = true
+			result = append(result, entry.Source)
+		}
+	}
+	return result
+}
+
+func hasRetiredSources(previous, current targetGroup) bool {
+	if previous.target == "" {
+		return false
+	}
+	return len(difference(groupSources(previous), groupSources(current))) > 0
+}
+
+func classifyForward(action Action, ownership string, status ForwardStatus, reason string) Action {
+	switch status {
+	case ForwardCreate:
+		action.Outcome = OutcomeCreate
+	case ForwardUpdate:
+		if ownership == "json-subset" || ownership == "jsonc-subset" || ownership == "toml-subset" || ownership == "marked-block" {
+			action.Outcome = OutcomeReconcile
+		} else {
+			action.Outcome = OutcomeUpdate
+		}
+	case ForwardUnchanged:
+		action.Outcome = OutcomePreserve
+	case ForwardConflict:
+		switch reason {
+		case ReasonWholeTargetDrift, ReasonLostOwnership, ReasonAmbiguousPartialOwnership:
+			return blocked(action, reason)
+		default:
+			return blocked(action, ReasonLostOwnership)
+		}
+	case ForwardMissingSource:
+		return blocked(action, ReasonMissingSource)
+	default:
+		return blocked(action, ReasonLostOwnership)
+	}
+	return action
+}
+
+func exactContribution(contributions []state.Contribution, source, ownership string) (state.Contribution, bool) {
+	for _, contribution := range contributions {
+		if contribution.Source == source && contribution.EvidenceRecorded && normalizedOwnership(contribution.Ownership) == ownership {
+			return contribution, true
+		}
+	}
+	return state.Contribution{}, false
+}
+
+func exactSeededBaseline(record state.Record, sources []string) ([]byte, bool) {
+	if len(sources) != 1 {
+		return nil, false
+	}
+	contribution, ok := exactContribution(record.Contributions, sources[0], "seeded")
+	if !ok {
+		return nil, false
+	}
+	return cloneBytes(contribution.SeededBaseline), true
+}
+
+func recordHasExactSource(record state.Record, sources []string) bool {
+	for _, source := range sources {
+		found := false
+		for _, contribution := range record.Contributions {
+			if contribution.Source == source && contribution.EvidenceRecorded {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return len(sources) > 0
+}
+
+func findTargetEvidence(evidence []TargetEvidence, target string) (TargetEvidence, bool) {
+	for _, candidate := range evidence {
+		if candidate.DeclarativeTarget == target {
+			candidate.Content = cloneBytes(candidate.Content)
+			return candidate, true
+		}
+	}
+	return TargetEvidence{}, false
+}
+
+func findSourceEvidence(evidence []SourceEvidence, target, source string) (SourceEvidence, bool) {
+	for _, candidate := range evidence {
+		if candidate.DeclarativeTarget == target && candidate.Source == source {
+			return candidate, true
+		}
+	}
+	return SourceEvidence{}, false
+}
+
+func resolvedSource(evidence []SourceEvidence, target, source string) string {
+	resolved, ok := findSourceEvidence(evidence, target, source)
+	if !ok {
+		return ""
+	}
+	return resolved.ResolvedSource
+}
+
+func findRecord(records []state.Record, target string) (state.Record, bool) {
+	for _, record := range records {
+		if record.Target == target {
+			return record, true
+		}
+	}
+	return state.Record{}, false
+}
+
+func dependencyNames(dependencies []manifest.Dependency) []string {
+	result := make([]string, 0, len(dependencies))
+	for _, dependency := range dependencies {
+		result = append(result, dependency.Name)
+	}
+	return orderedUnique(result)
+}
+
+func provisionerNames(provisioners []manifest.Provisioner) []string {
+	result := make([]string, 0, len(provisioners))
+	for _, provisioner := range provisioners {
+		result = append(result, provisioner.Tool)
+	}
+	return orderedUnique(result)
+}
+
+func difference(left, right []string) []string {
+	excluded := make(map[string]bool, len(right))
+	for _, value := range right {
+		excluded[value] = true
+	}
+	result := make([]string, 0)
+	for _, value := range left {
+		if !excluded[value] {
+			result = append(result, value)
+		}
+	}
+	return result
+}
+
+func orderedUnique(values []string) []string {
+	result := make([]string, 0, len(values))
+	seen := make(map[string]bool, len(values))
+	for _, value := range values {
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		result = append(result, value)
+	}
+	return result
+}
+
+func newNamedAction(scope Scope, outcome Outcome, names []string) Action {
+	return Action{
+		Scope:           scope,
+		Outcome:         outcome,
+		PreviousSources: make([]string, 0),
+		CurrentSources:  make([]string, 0),
+		Names:           append(make([]string, 0, len(names)), names...),
+	}
+}
+
+func blocked(action Action, reason string) Action {
+	action.Outcome = OutcomeBlocked
+	action.Reason = reason
+	return action
+}
+
+func normalizedOwnership(ownership string) string {
+	if ownership == "" {
+		return "whole"
+	}
+	return ownership
+}
+
+func missingSource(err error) bool {
+	return errors.Is(err, errMissingSourceEvidence)
+}
+
+func cloneIntent(intent Intent) Intent {
+	intent.Profiles = append(make([]string, 0, len(intent.Profiles)), intent.Profiles...)
+	intent.ExtraTags = append(make([]string, 0, len(intent.ExtraTags)), intent.ExtraTags...)
+	intent.ResolvedTags = append(make([]string, 0, len(intent.ResolvedTags)), intent.ResolvedTags...)
+	return intent
+}
+
+func cloneSourceEvidence(source SourceEvidence) SourceEvidence {
+	source.Content = cloneBytes(source.Content)
+	return source
+}
+
+func cloneBytes(value []byte) []byte {
+	if value == nil {
+		return nil
+	}
+	return append([]byte(nil), value...)
+}

--- a/internal/selectionreconciliation/reconciliation.go
+++ b/internal/selectionreconciliation/reconciliation.go
@@ -97,12 +97,15 @@ const (
 type TargetEvidence struct {
 	DeclarativeTarget string
 	ResolvedTarget    string
-	Exists            bool
-	Kind              TargetKind
-	Content           []byte
-	LinkDestination   string
-	ForwardStatus     ForwardStatus
-	ForwardReason     string
+	// RetirementAuthority overrides the requested intent for contributions
+	// reconstructed only from Installation Metadata after manifest evolution.
+	RetirementAuthority Authority
+	Exists              bool
+	Kind                TargetKind
+	Content             []byte
+	LinkDestination     string
+	ForwardStatus       ForwardStatus
+	ForwardReason       string
 }
 
 // SourceEvidence is an immutable snapshot of the selected source contribution.
@@ -298,12 +301,16 @@ func buildTargetAction(previous, current targetGroup, input Input) (Action, erro
 	ownership = normalizedOwnership(ownership)
 
 	record, recorded := findRecord(input.Metadata.Entries, target.ResolvedTarget)
-	if current.target == "" && input.RequestedIntent.Authority == AuthorityManifestEvolution {
+	retirementAuthority := input.RequestedIntent.Authority
+	if target.RetirementAuthority != "" {
+		retirementAuthority = target.RetirementAuthority
+	}
+	if current.target == "" && retirementAuthority == AuthorityManifestEvolution {
 		action.Outcome = OutcomeRetain
 		action.Reason = ReasonManifestEvolution
 		return action, nil
 	}
-	if current.target != "" && hasRetiredSources(previous, current) && input.RequestedIntent.Authority == AuthorityManifestEvolution {
+	if current.target != "" && hasRetiredSources(previous, current) && retirementAuthority == AuthorityManifestEvolution {
 		action.Outcome = OutcomeRetain
 		action.Reason = ReasonManifestEvolution
 		return action, nil
@@ -334,10 +341,10 @@ func buildTargetAction(previous, current targetGroup, input Input) (Action, erro
 		return blocked(action, ReasonLostOwnership), nil
 	}
 	if ownership == "whole" {
-		return classifyWhole(action, current, target.Content, currentContent, record, recorded), nil
+		return classifyWhole(action, previous, current, target.Content, currentContent, record, recorded), nil
 	}
 	if ownership == "seeded" {
-		return classifySeeded(action, current, target.Content, currentContent, record, recorded), nil
+		return classifySeeded(action, previous, current, target.Content, currentContent, record, recorded), nil
 	}
 	return classifyPartial(action, previous, current, ownership, target.Content, currentContent, record, recorded)
 }
@@ -347,10 +354,10 @@ func classifySymlink(action Action, previous, current targetGroup, target Target
 		return blocked(action, ReasonLostOwnership)
 	}
 	if current.target == "" {
-		if !recorded || target.LinkDestination == "" || !recordHasExactSource(record, action.PreviousSources) {
+		if !recorded || target.LinkDestination == "" || !recordHasExactContributions(record, action.PreviousSources, "symlink", "whole") {
 			return blocked(action, ReasonLostOwnership)
 		}
-		if len(action.PreviousSources) != 1 || !record.HasSource(action.PreviousSources[0]) ||
+		if len(action.PreviousSources) != 1 ||
 			target.LinkDestination != resolvedSource(evidence, previous.target, action.PreviousSources[0]) {
 			return blocked(action, ReasonLostOwnership)
 		}
@@ -364,7 +371,7 @@ func classifySymlink(action Action, previous, current targetGroup, target Target
 		action.Outcome = OutcomePreserve
 		return action
 	}
-	if recorded && previous.target != "" && recordHasExactSource(record, action.PreviousSources) {
+	if recorded && previous.target != "" && recordHasExactContributions(record, action.PreviousSources, "symlink", "whole") {
 		if len(action.PreviousSources) != 1 || target.LinkDestination != resolvedSource(evidence, previous.target, action.PreviousSources[0]) {
 			return blocked(action, ReasonLostOwnership)
 		}
@@ -374,15 +381,16 @@ func classifySymlink(action Action, previous, current targetGroup, target Target
 	return blocked(action, ReasonLostOwnership)
 }
 
-func classifyWhole(action Action, current targetGroup, live, desired []byte, record state.Record, recorded bool) Action {
+func classifyWhole(action Action, previous, current targetGroup, live, desired []byte, record state.Record, recorded bool) Action {
 	if current.target != "" && bytes.Equal(live, desired) {
 		action.Outcome = OutcomePreserve
 		return action
 	}
-	if !recorded {
+	if !recorded || previous.target == "" || !recordHasExactContributions(record, action.PreviousSources, previous.entries[0].Entry.Strategy, "whole") {
 		return blocked(action, ReasonLostOwnership)
 	}
-	if record.Hash == "" || state.HashBytes(live) != record.Hash {
+	contribution, _ := exactContribution(record.Contributions, action.PreviousSources[0], "whole")
+	if contribution.Hash == "" || state.HashBytes(live) != contribution.Hash {
 		return blocked(action, ReasonWholeTargetDrift)
 	}
 	if current.target == "" {
@@ -393,23 +401,23 @@ func classifyWhole(action Action, current targetGroup, live, desired []byte, rec
 	return action
 }
 
-func classifySeeded(action Action, current targetGroup, live, desired []byte, record state.Record, recorded bool) Action {
+func classifySeeded(action Action, previous, current targetGroup, live, desired []byte, record state.Record, recorded bool) Action {
 	if current.target == "" {
 		action.Outcome = OutcomeRetain
 		return action
 	}
-	if !recorded {
+	if !recorded || previous.target == "" || !recordHasExactContributions(record, action.PreviousSources, previous.entries[0].Entry.Strategy, "seeded") {
 		if bytes.Equal(live, desired) {
 			action.Outcome = OutcomePreserve
 			return action
 		}
 		return blocked(action, ReasonLostOwnership)
 	}
-	previous, ok := exactSeededBaseline(record, action.PreviousSources)
+	previousBaseline, ok := exactSeededBaseline(record, action.PreviousSources)
 	if !ok {
 		return blocked(action, ReasonAmbiguousPartialOwnership)
 	}
-	result := seededstate.Reconcile(live, previous, desired)
+	result := seededstate.Reconcile(live, previousBaseline, desired)
 	switch result.Classification {
 	case seededstate.AlignedCurrent:
 		action.Outcome = OutcomePreserve
@@ -434,7 +442,7 @@ func classifyPartial(action Action, previous, current targetGroup, ownership str
 		action.Outcome = outcome
 		return action, nil
 	}
-	if !recorded {
+	if !recorded || !recordHasExactContributions(record, action.PreviousSources, previous.entries[0].Entry.Strategy, ownership) {
 		return blocked(action, ReasonAmbiguousPartialOwnership), nil
 	}
 	previousOwned, ok, err := exactPreviousContent(previous, ownership, record)
@@ -722,20 +730,17 @@ func exactSeededBaseline(record state.Record, sources []string) ([]byte, bool) {
 	return cloneBytes(contribution.SeededBaseline), true
 }
 
-func recordHasExactSource(record state.Record, sources []string) bool {
-	for _, source := range sources {
-		found := false
-		for _, contribution := range record.Contributions {
-			if contribution.Source == source && contribution.EvidenceRecorded {
-				found = true
-				break
-			}
-		}
-		if !found {
+func recordHasExactContributions(record state.Record, sources []string, strategy, ownership string) bool {
+	if len(sources) == 0 || record.Strategy != strategy || record.Ownership != ownership || len(record.Contributions) != len(sources) {
+		return false
+	}
+	for index, source := range sources {
+		contribution := record.Contributions[index]
+		if contribution.Source != source || !contribution.EvidenceRecorded || contribution.Ownership != ownership {
 			return false
 		}
 	}
-	return len(sources) > 0
+	return true
 }
 
 func findTargetEvidence(evidence []TargetEvidence, target string) (TargetEvidence, bool) {

--- a/internal/selectionreconciliation/reconciliation_test.go
+++ b/internal/selectionreconciliation/reconciliation_test.go
@@ -348,6 +348,26 @@ func TestBuildDependencyAndProvisionerOnlyReductionRetainsExternalState(t *testi
 	}
 }
 
+func TestBuildDistinguishesProvisionerEffectsWithTheSameTool(t *testing.T) {
+	removed := NewProvisionerEvidence("claude", "claude", []string{"plugin", "install", "removed"})
+	retained := NewProvisionerEvidence("claude", "claude", []string{"mcp", "add", "retained"})
+	input := baseInput(nil, nil)
+	input.Evidence.PreviousProvisioners = []ProvisionerEvidence{removed, retained}
+	input.Evidence.CurrentProvisioners = []ProvisionerEvidence{retained}
+
+	report, err := Build(input)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if len(report.Actions) != 1 {
+		t.Fatalf("Actions = %#v, want one removed Provisioner effect", report.Actions)
+	}
+	got := report.Actions[0]
+	if got.Scope != ScopeProvisioner || got.Outcome != OutcomeRetainedExternalState || !reflect.DeepEqual(got.Names, []string{"claude"}) || got.Identity == "" {
+		t.Fatalf("Action = %#v, want one identified retained external Provisioner effect", got)
+	}
+}
+
 func TestBuildReturnsDetachedStableArrays(t *testing.T) {
 	input := baseInput(nil, nil)
 	input.PreviousIntent.Profiles = []string{"old"}

--- a/internal/selectionreconciliation/reconciliation_test.go
+++ b/internal/selectionreconciliation/reconciliation_test.go
@@ -136,6 +136,31 @@ func TestBuildRequiresExactWholeTargetContributionEvidence(t *testing.T) {
 	}
 }
 
+func TestBuildBlocksMultipleWholeTargetContributions(t *testing.T) {
+	previous := []selectedsurface.SelectedEntry{
+		selectedEntry("first", "~/.target", "copy", "whole"),
+		selectedEntry("second", "~/.target", "copy", "whole"),
+	}
+	input := baseInput(previous, nil, TargetEvidence{
+		DeclarativeTarget: "~/.target", ResolvedTarget: "/home/test/.target",
+		Exists: true, Kind: TargetKindRegular, Content: []byte("first\n"),
+	})
+	input.Metadata.Entries = []state.Record{{
+		Target: "/home/test/.target", Strategy: "copy", Ownership: "whole",
+		Contributions: []state.Contribution{
+			{Source: "first", Ownership: "whole", EvidenceRecorded: true, Hash: state.HashBytes([]byte("first\n"))},
+			{Source: "second", Ownership: "whole", EvidenceRecorded: true, Hash: state.HashBytes([]byte("second\n"))},
+		},
+	}}
+	report, err := Build(input)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if got := report.Actions[0]; got.Outcome != OutcomeBlocked || got.Reason != ReasonLostOwnership {
+		t.Fatalf("Action = %#v, want lost ownership block", got)
+	}
+}
+
 func TestBuildRequiresExactSymlinkContributionSet(t *testing.T) {
 	previous := selectedEntry("source", "~/.target", "symlink", "whole")
 	input := baseInput([]selectedsurface.SelectedEntry{previous}, nil, TargetEvidence{

--- a/internal/selectionreconciliation/reconciliation_test.go
+++ b/internal/selectionreconciliation/reconciliation_test.go
@@ -72,9 +72,14 @@ func TestBuildClassifiesWholeTargetReplacementFromRecordedEvidence(t *testing.T)
 				Content:           test.live,
 			})
 			input.Metadata.Entries = []state.Record{{
-				Target: "/home/test/.target",
-				Source: "old",
-				Hash:   state.HashBytes([]byte("old\n")),
+				Target:    "/home/test/.target",
+				Source:    "old",
+				Strategy:  "copy",
+				Ownership: "whole",
+				Hash:      state.HashBytes([]byte("old\n")),
+				Contributions: []state.Contribution{{
+					Source: "old", Ownership: "whole", EvidenceRecorded: true, Hash: state.HashBytes([]byte("old\n")),
+				}},
 			}}
 			input.Evidence.Sources = []SourceEvidence{{
 				DeclarativeTarget: "~/.target", Source: "new", Exists: true, Content: []byte("new\n"),
@@ -88,6 +93,71 @@ func TestBuildClassifiesWholeTargetReplacementFromRecordedEvidence(t *testing.T)
 				t.Fatalf("Action = %#v, want outcome %q reason %q", got, test.want, test.wantReason)
 			}
 		})
+	}
+}
+
+func TestBuildRequiresExactWholeTargetContributionEvidence(t *testing.T) {
+	previous := selectedEntry("old", "~/.target", "copy", "whole")
+	tests := []struct {
+		name   string
+		record state.Record
+	}{
+		{
+			name: "legacy target-wide hash",
+			record: state.Record{
+				Target: "/home/test/.target", Source: "old", Strategy: "copy", Ownership: "whole", Hash: state.HashBytes([]byte("old\n")),
+			},
+		},
+		{
+			name: "different attributed source",
+			record: state.Record{
+				Target: "/home/test/.target", Source: "other", Strategy: "copy", Ownership: "whole", Hash: state.HashBytes([]byte("old\n")),
+				Contributions: []state.Contribution{{
+					Source: "other", Ownership: "whole", EvidenceRecorded: true, Hash: state.HashBytes([]byte("old\n")),
+				}},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input := baseInput([]selectedsurface.SelectedEntry{previous}, nil, TargetEvidence{
+				DeclarativeTarget: "~/.target", ResolvedTarget: "/home/test/.target",
+				Exists: true, Kind: TargetKindRegular, Content: []byte("old\n"),
+			})
+			input.Metadata.Entries = []state.Record{test.record}
+			report, err := Build(input)
+			if err != nil {
+				t.Fatalf("Build() error = %v", err)
+			}
+			if got := report.Actions[0]; got.Outcome != OutcomeBlocked || got.Reason != ReasonLostOwnership {
+				t.Fatalf("Action = %#v, want lost ownership block", got)
+			}
+		})
+	}
+}
+
+func TestBuildRequiresExactSymlinkContributionSet(t *testing.T) {
+	previous := selectedEntry("source", "~/.target", "symlink", "whole")
+	input := baseInput([]selectedsurface.SelectedEntry{previous}, nil, TargetEvidence{
+		DeclarativeTarget: "~/.target", ResolvedTarget: "/home/test/.target",
+		Exists: true, Kind: TargetKindSymlink, LinkDestination: "/repo/source",
+	})
+	input.Evidence.Sources = []SourceEvidence{{
+		DeclarativeTarget: "~/.target", Source: "source", ResolvedSource: "/repo/source", Exists: true,
+	}}
+	input.Metadata.Entries = []state.Record{{
+		Target: "/home/test/.target", Strategy: "symlink", Ownership: "whole",
+		Contributions: []state.Contribution{
+			{Source: "source", Ownership: "whole", EvidenceRecorded: true},
+			{Source: "other", Ownership: "whole", EvidenceRecorded: true},
+		},
+	}}
+	report, err := Build(input)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if got := report.Actions[0]; got.Outcome != OutcomeBlocked || got.Reason != ReasonLostOwnership {
+		t.Fatalf("Action = %#v, want lost ownership block", got)
 	}
 }
 
@@ -111,13 +181,18 @@ func TestBuildReconcilesSharedJSONTargetInSelectedSurfaceOrder(t *testing.T) {
 	}}
 	input.Metadata.Entries = []state.Record{
 		{
-			Target: "/home/test/.shared.json",
+			Target: "/home/test/.shared.json", Strategy: "copy", Ownership: "json-subset",
 			Contributions: []state.Contribution{
 				{Source: "a.json", Ownership: "json-subset", EvidenceRecorded: true, OwnedContent: json.RawMessage(`{"a":1}`)},
 				{Source: "b.json", Ownership: "json-subset", EvidenceRecorded: true, OwnedContent: json.RawMessage(`{"b":2}`)},
 			},
 		},
-		{Target: "/home/test/.old", Source: "old", Hash: state.HashBytes([]byte("old"))},
+		{
+			Target: "/home/test/.old", Source: "old", Strategy: "copy", Ownership: "whole", Hash: state.HashBytes([]byte("old")),
+			Contributions: []state.Contribution{{
+				Source: "old", Ownership: "whole", EvidenceRecorded: true, Hash: state.HashBytes([]byte("old")),
+			}},
+		},
 	}
 
 	report, err := Build(input)
@@ -178,7 +253,7 @@ func TestBuildClassifiesExactPartialRetirement(t *testing.T) {
 				Exists: true, Kind: TargetKindRegular, Content: test.live,
 			})
 			input.Metadata.Entries = []state.Record{{
-				Target: "/home/test/.shared.json",
+				Target: "/home/test/.shared.json", Strategy: "copy", Ownership: "json-subset",
 				Contributions: []state.Contribution{{
 					Source: "a.json", Ownership: "json-subset", EvidenceRecorded: true, OwnedContent: json.RawMessage(`{"a":1}`),
 				}},

--- a/internal/selectionreconciliation/reconciliation_test.go
+++ b/internal/selectionreconciliation/reconciliation_test.go
@@ -1,0 +1,305 @@
+package selectionreconciliation
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/selectedsurface"
+	"github.com/yersonargotev/dots/internal/state"
+)
+
+func TestBuildReusesForwardClassification(t *testing.T) {
+	tests := []struct {
+		name       string
+		ownership  string
+		status     ForwardStatus
+		want       Outcome
+		wantReason string
+	}{
+		{name: "create", status: ForwardCreate, want: OutcomeCreate},
+		{name: "whole update", status: ForwardUpdate, want: OutcomeUpdate},
+		{name: "partial reconcile", ownership: "json-subset", status: ForwardUpdate, want: OutcomeReconcile},
+		{name: "preserve", status: ForwardUnchanged, want: OutcomePreserve},
+		{name: "conflict", status: ForwardConflict, want: OutcomeBlocked, wantReason: ReasonLostOwnership},
+		{name: "missing source", status: ForwardMissingSource, want: OutcomeBlocked, wantReason: ReasonMissingSource},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			entry := selectedEntry("source", "~/.target", "copy", test.ownership)
+			report, err := Build(baseInput(nil, []selectedsurface.SelectedEntry{entry}, TargetEvidence{
+				DeclarativeTarget: "~/.target",
+				ResolvedTarget:    "/home/test/.target",
+				ForwardStatus:     test.status,
+			}))
+			if err != nil {
+				t.Fatalf("Build() error = %v", err)
+			}
+			if len(report.Actions) != 1 {
+				t.Fatalf("Actions = %#v, want one", report.Actions)
+			}
+			if got := report.Actions[0]; got.Outcome != test.want || got.Reason != test.wantReason {
+				t.Fatalf("Action = %#v, want outcome %q reason %q", got, test.want, test.wantReason)
+			}
+			if got, want := report.HasFindings(), test.want == OutcomeBlocked; got != want {
+				t.Fatalf("HasFindings() = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestBuildClassifiesWholeTargetReplacementFromRecordedEvidence(t *testing.T) {
+	tests := []struct {
+		name       string
+		live       []byte
+		want       Outcome
+		wantReason string
+	}{
+		{name: "owned previous bytes update", live: []byte("old\n"), want: OutcomeUpdate},
+		{name: "drift blocks", live: []byte("external\n"), want: OutcomeBlocked, wantReason: ReasonWholeTargetDrift},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			previous := selectedEntry("old", "~/.target", "copy", "whole")
+			current := selectedEntry("new", "~/.target", "copy", "whole")
+			input := baseInput([]selectedsurface.SelectedEntry{previous}, []selectedsurface.SelectedEntry{current}, TargetEvidence{
+				DeclarativeTarget: "~/.target",
+				ResolvedTarget:    "/home/test/.target",
+				Exists:            true,
+				Kind:              TargetKindRegular,
+				Content:           test.live,
+			})
+			input.Metadata.Entries = []state.Record{{
+				Target: "/home/test/.target",
+				Source: "old",
+				Hash:   state.HashBytes([]byte("old\n")),
+			}}
+			input.Evidence.Sources = []SourceEvidence{{
+				DeclarativeTarget: "~/.target", Source: "new", Exists: true, Content: []byte("new\n"),
+			}}
+			report, err := Build(input)
+			if err != nil {
+				t.Fatalf("Build() error = %v", err)
+			}
+			got := report.Actions[0]
+			if got.Outcome != test.want || got.Reason != test.wantReason {
+				t.Fatalf("Action = %#v, want outcome %q reason %q", got, test.want, test.wantReason)
+			}
+		})
+	}
+}
+
+func TestBuildReconcilesSharedJSONTargetInSelectedSurfaceOrder(t *testing.T) {
+	previous := []selectedsurface.SelectedEntry{
+		selectedEntry("a.json", "~/.shared.json", "copy", "json-subset"),
+		selectedEntry("b.json", "~/.shared.json", "copy", "json-subset"),
+		selectedEntry("old", "~/.old", "copy", "whole"),
+	}
+	current := []selectedsurface.SelectedEntry{
+		selectedEntry("second", "~/.second", "copy", "whole"),
+		selectedEntry("b.json", "~/.shared.json", "copy", "json-subset"),
+	}
+	input := baseInput(previous, current,
+		TargetEvidence{DeclarativeTarget: "~/.second", ResolvedTarget: "/home/test/.second", ForwardStatus: ForwardCreate},
+		TargetEvidence{DeclarativeTarget: "~/.shared.json", ResolvedTarget: "/home/test/.shared.json", Exists: true, Kind: TargetKindRegular, Content: []byte(`{"a":1,"b":2,"external":true}`)},
+		TargetEvidence{DeclarativeTarget: "~/.old", ResolvedTarget: "/home/test/.old", Exists: true, Kind: TargetKindRegular, Content: []byte("old")},
+	)
+	input.Evidence.Sources = []SourceEvidence{{
+		DeclarativeTarget: "~/.shared.json", Source: "b.json", Exists: true, Content: []byte(`{"b":2}`),
+	}}
+	input.Metadata.Entries = []state.Record{
+		{
+			Target: "/home/test/.shared.json",
+			Contributions: []state.Contribution{
+				{Source: "a.json", Ownership: "json-subset", EvidenceRecorded: true, OwnedContent: json.RawMessage(`{"a":1}`)},
+				{Source: "b.json", Ownership: "json-subset", EvidenceRecorded: true, OwnedContent: json.RawMessage(`{"b":2}`)},
+			},
+		},
+		{Target: "/home/test/.old", Source: "old", Hash: state.HashBytes([]byte("old"))},
+	}
+
+	report, err := Build(input)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if got, want := managedTargets(report.Actions), []string{"~/.second", "~/.shared.json", "~/.old"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Managed Entry order = %#v, want %#v", got, want)
+	}
+	if got := report.Actions[1]; got.Outcome != OutcomeReconcile || !reflect.DeepEqual(got.PreviousSources, []string{"a.json", "b.json"}) || !reflect.DeepEqual(got.CurrentSources, []string{"b.json"}) {
+		t.Fatalf("shared target action = %#v", got)
+	}
+	if got := report.Actions[2].Outcome; got != OutcomeRemove {
+		t.Fatalf("retired whole target outcome = %q, want remove", got)
+	}
+}
+
+func TestBuildNeverUsesLegacyTargetWideProjectionForPartialRetirement(t *testing.T) {
+	previous := selectedEntry("a.json", "~/.shared.json", "copy", "json-subset")
+	input := baseInput([]selectedsurface.SelectedEntry{previous}, nil, TargetEvidence{
+		DeclarativeTarget: "~/.shared.json",
+		ResolvedTarget:    "/home/test/.shared.json",
+		Exists:            true,
+		Kind:              TargetKindRegular,
+		Content:           []byte(`{"a":1,"external":true}`),
+	})
+	input.Metadata.Entries = []state.Record{{
+		Target:       "/home/test/.shared.json",
+		Source:       "a.json",
+		Ownership:    "json-subset",
+		OwnedContent: json.RawMessage(`{"a":1}`),
+	}}
+
+	report, err := Build(input)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if got := report.Actions[0]; got.Outcome != OutcomeBlocked || got.Reason != ReasonAmbiguousPartialOwnership {
+		t.Fatalf("Action = %#v, want ambiguous partial ownership block", got)
+	}
+}
+
+func TestBuildClassifiesExactPartialRetirement(t *testing.T) {
+	tests := []struct {
+		name string
+		live []byte
+		want Outcome
+	}{
+		{name: "remove empty target", live: []byte(`{"a":1}`), want: OutcomeRemove},
+		{name: "retain external target bytes", live: []byte(`{"a":1,"external":true}`), want: OutcomeRetain},
+		{name: "changed owned value blocks", live: []byte(`{"a":2}`), want: OutcomeBlocked},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			previous := selectedEntry("a.json", "~/.shared.json", "copy", "json-subset")
+			input := baseInput([]selectedsurface.SelectedEntry{previous}, nil, TargetEvidence{
+				DeclarativeTarget: "~/.shared.json", ResolvedTarget: "/home/test/.shared.json",
+				Exists: true, Kind: TargetKindRegular, Content: test.live,
+			})
+			input.Metadata.Entries = []state.Record{{
+				Target: "/home/test/.shared.json",
+				Contributions: []state.Contribution{{
+					Source: "a.json", Ownership: "json-subset", EvidenceRecorded: true, OwnedContent: json.RawMessage(`{"a":1}`),
+				}},
+			}}
+			report, err := Build(input)
+			if err != nil {
+				t.Fatalf("Build() error = %v", err)
+			}
+			if got := report.Actions[0].Outcome; got != test.want {
+				t.Fatalf("Outcome = %q, want %q (action %#v)", got, test.want, report.Actions[0])
+			}
+			if test.want == OutcomeBlocked && report.Actions[0].Reason != ReasonAmbiguousPartialOwnership {
+				t.Fatalf("Reason = %q, want ambiguous partial ownership", report.Actions[0].Reason)
+			}
+		})
+	}
+}
+
+func TestBuildManifestEvolutionNeverAuthorizesRetirement(t *testing.T) {
+	previous := []selectedsurface.SelectedEntry{
+		selectedEntry("a.json", "~/.shared.json", "copy", "json-subset"),
+		selectedEntry("b.json", "~/.shared.json", "copy", "json-subset"),
+		selectedEntry("old", "~/.old", "copy", "whole"),
+	}
+	current := []selectedsurface.SelectedEntry{selectedEntry("b.json", "~/.shared.json", "copy", "json-subset")}
+	input := baseInput(previous, current,
+		TargetEvidence{DeclarativeTarget: "~/.shared.json", ResolvedTarget: "/home/test/.shared.json"},
+		TargetEvidence{DeclarativeTarget: "~/.old", ResolvedTarget: "/home/test/.old"},
+	)
+	input.RequestedIntent.Authority = AuthorityManifestEvolution
+
+	report, err := Build(input)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	for _, action := range report.Actions {
+		if action.Scope != ScopeManagedEntry {
+			continue
+		}
+		if action.Outcome != OutcomeRetain || action.Reason != ReasonManifestEvolution {
+			t.Fatalf("evolution action = %#v, want report-only retain", action)
+		}
+	}
+}
+
+func TestBuildDependencyAndProvisionerOnlyReductionRetainsExternalState(t *testing.T) {
+	input := baseInput(nil, nil)
+	input.PreviousIntent = Intent{Authority: AuthorityRecorded, ExtraTags: []string{"tools"}, ResolvedTags: []string{"tools"}}
+	input.RequestedIntent = Intent{Authority: AuthorityExplicitRequest, ExtraTags: []string{"core"}, ResolvedTags: []string{"core"}}
+	input.PreviousSurface.Dependencies = []manifest.Dependency{{Name: "ripgrep"}}
+	input.PreviousSurface.Provisioners = []manifest.Provisioner{{Tool: "codex"}}
+
+	report, err := Build(input)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if got, want := actionOutcomes(report.Actions), []Outcome{OutcomeRemove, OutcomeCreate, OutcomeRetainedExternalState, OutcomeRetainedExternalState}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("outcomes = %#v, want %#v", got, want)
+	}
+	for _, action := range report.Actions {
+		if action.Scope == ScopeManagedEntry {
+			t.Fatalf("unexpected Managed Entry action: %#v", action)
+		}
+	}
+	if report.HasFindings() {
+		t.Fatal("Retained External State must remain informational")
+	}
+}
+
+func TestBuildReturnsDetachedStableArrays(t *testing.T) {
+	input := baseInput(nil, nil)
+	input.PreviousIntent.Profiles = []string{"old"}
+	report, err := Build(input)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	input.PreviousIntent.Profiles[0] = "mutated"
+	if report.PreviousIntent.Profiles[0] != "old" {
+		t.Fatalf("report aliases input: %#v", report.PreviousIntent.Profiles)
+	}
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if string(data) == "" || report.Actions == nil || report.Actions[0].PreviousSources == nil || report.Actions[0].CurrentSources == nil || report.Actions[0].Names == nil {
+		t.Fatalf("report arrays are not stable: %s", data)
+	}
+}
+
+func baseInput(previous, current []selectedsurface.SelectedEntry, targets ...TargetEvidence) Input {
+	return Input{
+		PreviousIntent:  Intent{Authority: AuthorityRecorded},
+		RequestedIntent: Intent{Authority: AuthorityExplicitRequest},
+		PreviousSurface: selectedsurface.Surface{Entries: previous},
+		CurrentSurface:  selectedsurface.Surface{Entries: current},
+		Metadata:        state.Metadata{Version: state.CurrentVersion},
+		Evidence:        Evidence{Targets: targets, Sources: make([]SourceEvidence, 0)},
+	}
+}
+
+func selectedEntry(source, target, strategy, ownership string) selectedsurface.SelectedEntry {
+	return selectedsurface.SelectedEntry{
+		Entry:  manifest.Entry{Source: source, Target: target, Strategy: strategy, Ownership: ownership},
+		Source: source,
+	}
+}
+
+func managedTargets(actions []Action) []string {
+	result := make([]string, 0)
+	for _, action := range actions {
+		if action.Scope == ScopeManagedEntry {
+			result = append(result, action.DeclarativeTarget)
+		}
+	}
+	return result
+}
+
+func actionOutcomes(actions []Action) []Outcome {
+	result := make([]Outcome, 0, len(actions))
+	for _, action := range actions {
+		result = append(result, action.Outcome)
+	}
+	return result
+}


### PR DESCRIPTION
Closes #465

## PR Type

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds one pure, deterministic Selection Reconciliation Plan over recorded/requested intent, Selected Surfaces, v7 contribution evidence, and confined filesystem evidence.
- Exposes identical semantic actions through `dots plan` and `dots install --dry-run` in text and schema-v10 JSON without applying retirement.
- Documents the ownership boundary, manifest-evolution safety, Retained External State, and exact Provisioner-effect identity.

## Changes

| File | Change |
|------|--------|
| `internal/selectionreconciliation/` | Pure reconciliation classifier with exact ownership and external-state evidence. |
| `internal/cli/selection_reconciliation.go` | Confined filesystem/metadata adapter shared by plan and install dry-run. |
| `internal/plan/plan.go` | Optional reconciliation report plus fail-closed parent-symlink inspection. |
| `internal/cli/render.go` and output goldens | Stable text and schema-v10 JSON surfaces. |
| `CONTEXT.md`, `docs/adr/0019-selection-reconciliation-plan.md`, `docs/agents/output-contract.md` | Glossary, ADR, schema, ordering, and exit semantics. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile core --source-root "$PWD" --home <tmp> --state-root <tmp>`

Additional validation: `go build ./...`; focused reconciliation/CLI tests; `go test -race ./internal/selectionreconciliation ./internal/plan`; and `go test -race ./internal/cli -run TestSelectionReconciliation -count=1`.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked one issue with an admitted Delivery Contract using `Closes #465`.
- [x] Added exactly one `type:*` label.
- [x] Delivery Evidence records the Contract Source snapshot, Acceptance coverage, and Independent review.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

### Contract Source

Selected kind: composed delivery ticket #465 plus native parent specification #459.

- Ticket: node `I_kwDOSzLlmM8AAAABNwY0NA`; https://github.com/yersonargotev/dots/issues/465; `updatedAt=2026-08-21T20:58:07Z`; raw UTF-8 bytes `2416`; SHA-256 `a1683bece7347031b6b87a029f4fa67e359a2e3d62575f309951ae3e656dcd64`.
- Parent: node `I_kwDOSzLlmM8AAAABNwWsmQ`; https://github.com/yersonargotev/dots/issues/459; `updatedAt=2026-08-21T20:59:00Z`; raw UTF-8 bytes `19803`; SHA-256 `85febbb601376376f0b74c2b155d6556d1f63d209272fdc033a0b178169dc556`.
- Labels: category `enhancement`; triage `ready-for-agent`; no other triage label.
- Comments at snapshot/revalidation: none.
- Native parent: #459 OPEN (`updatedAt=2026-08-21T20:59:00Z`). No sub-issues.
- Native `blockedBy`: #463 CLOSED (`updatedAt=2026-08-22T00:17:27Z`), #464 CLOSED (`updatedAt=2026-08-22T01:17:41Z`).
- Native `blocking`: #466 OPEN (`updatedAt=2026-08-21T20:58:10Z`), #468 OPEN (`updatedAt=2026-08-21T20:58:16Z`).

<details><summary>Complete delivery ticket body (#465)</summary>

```markdown
### What to build

Introduce a deterministic, read-only Selection Reconciliation Plan that compares the authoritative previous selection with a requested complete selection using both Selected Surfaces, Installation Metadata, and current filesystem evidence. Expose the same semantic report through planning, install dry-run, text, and JSON without performing retirement.

### Current-state gap

The Install Plan describes forward application and the Uninstall Plan describes global removal. Neither represents a mixed explicit selection change with additions, shared contributions, safe retirements, blocks, and retained external state.

### Key interfaces

- Selection comparison and Selected Surface evaluation.
- Ownership-aware filesystem classification.
- `dots plan`, install dry-run, human rendering, and stable JSON envelopes.

### Acceptance criteria

- [ ] One pure report accepts previous intent, requested intent, previous/current Selected Surfaces, Installation Metadata, and inspected target state.
- [ ] The report deterministically classifies create, update, preserve, reconcile, remove, retain, blocked, and retained-external-state outcomes where applicable.
- [ ] Whole-target Drift/lost ownership and ambiguous partial ownership are distinguishable findings.
- [ ] Dependency-only and Provisioner-only Tag reductions report selection removal plus Retained External State and zero Managed Entry removals.
- [ ] `dots plan`, `dots install --dry-run`, human output, and JSON expose identical semantic actions and ordering.
- [ ] Explicit reductions are previewed; Install Manifest evolution remains report-only and never authorizes retirement.
- [ ] No filesystem or Installation Metadata mutation occurs in this slice.
- [ ] Stable JSON schema/version treatment and semantic exit behavior are documented and covered by goldens.
- [ ] The glossary defines Selection Reconciliation Plan and Retained External State, and an ADR records surface-difference planning with per-contribution evidence.

### Non-goals

- Applying removals or updating Installed Selection.
- Building a TUI selector.
- Removing Dependencies or reversing Provisioners.

### Validation notes

- Prefer command-level text/JSON parity tests over internal rendering assertions.
- Inspect files only inside temporary homes with parent-symlink confinement coverage.
- Run focused plan/output checks and the full CI-equivalent suite.

```
</details>

<details><summary>Complete parent specification body (#459)</summary>

```markdown
### Pre-flight checks

- [x] I searched existing issues and this is not a duplicate.
- [x] The scope clearly identifies independently reviewable slices.

### Desired outcome

Operators can open an interactive Tag selector, edit the complete machine selection, preview one deterministic reconciliation plan, and safely add or stop managing atomic capabilities. The same plan powers text, JSON, dry-run, and TUI behavior, and dots removes only Managed Configuration whose ownership it can prove while preserving all external state.

### Current-state gap

The existing TUI resolves installation Conflicts only. It cannot select Tags, inspect the Installed Selection, apply Profiles as presets, or explain current capability alignment. Explicit selection reductions update intent after acknowledgement but do not retire no-longer-selected Managed Configuration. The global Uninstall Plan acts on all recorded entries and cannot safely represent a partial desired-state transition, especially when multiple Tags contribute to one target.

## Problem Statement

As a dots operator, I cannot interactively see which atomic capabilities I selected, compare that intent with the workstation, or stop managing one capability without manually reconstructing a complete command. A checkbox interface would be misleading unless it is backed by a plan that understands shared targets, Drift, ownership evidence, retained external effects, and complete-selection safety.

## Solution

Add a Tag-selection TUI to interactive `dots install` and introduce a shared Selection Reconciliation Plan that compares the authoritative Installed Selection with a requested complete selection. The plan handles additions through existing installation behavior and classifies no-longer-selected Managed Configuration for safe removal, retention, or blocking. Profiles act only as presets; a confirmed edited selection persists as explicit Tags. Dependencies, Provisioner effects, Backup Sets, and user-owned state remain untouched and are reported as Retained External State.

## User Stories

1. As a workstation operator, I want `dots install` without selection flags to open a Tag selector in an interactive terminal, so that I do not need to memorize flags.
2. As a workstation operator, I want non-interactive, JSON, `--yes`, and text-prompt contexts to reject missing selection safely, so that automation never enters a TUI or clears intent accidentally.
3. As a workstation operator, I want to see all current atomic Tags grouped by Core, Desktop, Agents, Web, Mobile, and Global, so that a large catalog remains navigable.
4. As a workstation operator, I want to search Tags by name and description, so that I can find a capability quickly.
5. As a workstation operator, I want each Tag row to show a checkbox and observed status separately, so that desired intent is not confused with filesystem alignment.
6. As a workstation operator, I want a detail panel to show descriptions, Profiles, Managed Entries, Dependencies, Provisioners, and pending changes, so that I understand what a Tag means.
7. As a workstation operator using a narrow terminal, I want details in a separate view, so that the selector remains usable without compressed content.
8. As a workstation operator, I want Tags with no surface on my operating system shown as `not-applicable`, so that presets remain explainable without pretending they will mutate the machine.
9. As a workstation operator, I want existing Profiles available as select/deselect preset actions, so that common selections remain convenient.
10. As a workstation operator, I want Profile-derived intent expanded into editable Tags, so that I can remove one capability from a former preset.
11. As a workstation operator, I want a confirmed TUI edit persisted as explicit Tags rather than Profiles, so that no Profile silently re-adds a deselected capability.
12. As a workstation operator, I want checkbox edits to remain a draft until final confirmation, so that navigation never mutates files.
13. As a workstation operator, I want to review additions, updates, reconciliations, removals, retained targets, and external retained state in one plan, so that the complete effect is visible.
14. As a workstation operator, I want ordinary selection reductions confirmed separately from Conflict Resolution, so that omissions are not treated as routine installation.
15. As a workstation operator, I want clearing the entire selection to require typing `clear`, so that removing every managed capability cannot happen through one accidental keypress.
16. As an automation author, I want an empty non-interactive selection to require `--clear-selection`, `--yes`, and reduction acknowledgement, so that omitted flags never mean clear-all.
17. As a workstation operator, I want `dots install --dry-run` without selection flags to let me choose Tags and view the plan without applying it, so that I can explore safely.
18. As a workstation operator, I want canceling the selector, preview, reduction confirmation, or Conflict Resolution to leave files and metadata unchanged, so that abandonment is safe.
19. As a workstation operator, I want a selected Tag reported as `aligned`, `missing`, `drift`, or `conflict` from its actual components, so that I know what needs attention.
20. As a workstation operator, I want component-level explanations behind aggregate Tag status, so that a color or label never hides the cause.
21. As a workstation operator, I want deselecting a Tag to remove only Managed Configuration that dots can prove it owns, so that unrelated files are preserved.
22. As a workstation operator, I want a whole target with Drift or lost ownership preserved when its Tag is removed, so that dots can release management without destroying local work.
23. As a workstation operator, I want retirement of one contribution from a still-selected shared target blocked when attribution is ambiguous, so that another capability's configuration is never damaged.
24. As a workstation operator, I want shared JSON, JSONC, TOML, and marked-block contributions reconciled without reformatting unrelated content, so that co-owned files remain stable.
25. As a workstation operator, I want source overrides to return to their base source when an opt-in Tag is removed, so that the target is reconciled rather than deleted.
26. As a workstation operator, I want Seeded Runtime State preserved physically when its capability is removed, so that application-owned evolution is not lost.
27. As a workstation operator, I want Dependencies, installed binaries, Provisioner effects, credentials, histories, plugins, and runtime state preserved, so that stopping dots management is not mistaken for full application uninstall.
28. As a workstation operator, I want the plan and result to report Retained External State, so that I know what remains after a Tag leaves the selection.
29. As a workstation operator, I want Backup Sets preserved and not restored automatically, so that old configuration is not reintroduced silently.
30. As a workstation operator, I want additions and shared-target updates applied before safe retirements and the new Installed Selection committed only at terminal success, so that failed operations preserve authoritative intent.
31. As a workstation operator, I want rerunning after a partial failure to converge safely, so that recovery does not require manual metadata editing.
32. As a workstation operator, I want `dots uninstall` to remain a distinct global uninstall command, so that partial selection management has one clear path.
33. As a workstation operator, I want Install Manifest evolution to remain non-destructive unless I explicitly request a selection change, so that an upstream Profile edit cannot delete local configuration automatically.
34. As an automation author, I want `dots plan`, `dots install --dry-run`, text output, JSON output, and the TUI to consume the same reconciliation actions, so that every surface agrees.
35. As an automation author, I want semantic classifications and exit behavior in the stable JSON envelope, so that automation branches on contracts rather than prose.
36. As a maintainer, I want the reconciliation core independent of Bubble Tea, Cobra, and filesystem presentation, so that the TUI is an adapter over testable domain decisions.
37. As a maintainer, I want existing Conflict Resolution behavior reused after selection review, so that the feature does not create a second conflict engine.
38. As a maintainer, I want focused TUI Model Tests plus Temporary Home and Golden Output Tests, so that state transitions and real safety are both covered.
39. As a contributor, I want the glossary and ADR to define Selection Reconciliation Plan and Retained External State, so that future removal behavior preserves the approved boundary.

## Implementation Decisions

- This specification depends on the atomic capability catalog and per-contribution Installation Metadata delivered by the Atomic Capability Tags specification. It does not redefine that catalog.
- Interactive `dots install` with no explicit Profile or Tag opens the selector only when a suitable terminal is available.
- JSON output, Confirmed Install, `--no-tui`, and non-terminal execution never launch the selector and continue to require explicit intent or an explicit clear-selection request.
- The selector starts from the authoritative Installed Selection. Profile intent is resolved to effective current Tags for editing.
- Profiles appear as preset actions that select or deselect their ordered Tags. They do not remain authoritative after the operator edits and confirms the selection.
- A confirmed TUI selection records no Profiles and records all selected current Tags as explicit extra Tag intent.
- A checkbox represents desired selection only. Observed state is a separate aggregate with component-level evidence.
- Tag status includes `aligned`, `missing`, `drift`, `conflict`, `not-applicable`, and `external-state-retained` where applicable.
- The selector groups Tags by the existing conceptual Profiles, supports name/description search, and provides a detail view. A Tag has one primary visual group even if several Profiles include it.
- Tags without an applicable surface on the current operating system remain visible and selectable with `not-applicable` status.
- The TUI maintains an in-memory draft. Toggle actions never mutate filesystem or Installation Metadata.
- Selection Reconciliation Plan is one deterministic domain report comparing the previous and requested complete Selected Surfaces plus Installation Metadata and current filesystem evidence.
- The plan classifies actions such as create, update, preserve, reconcile contribution, remove, retain, blocked, and retained external state. Presentation adapters may rename headings but not recompute actions.
- `dots plan`, `dots install --dry-run`, install text/JSON output, and TUI preview consume the same report.
- An explicit selection reduction through `dots install` activates reconciliation after the existing separate reduction acknowledgement. `dots uninstall` does not gain Tag flags.
- Manifest-driven selection evolution remains report-only and does not activate selective retirement.
- A target that entirely leaves the desired surface is removed only when Installation Metadata and current inspection prove ownership. Drift or lost ownership causes preservation and release of dots management.
- A target still needed by selected capabilities is reconciled by contribution. Insufficient evidence blocks the operation before mutation rather than releasing the entire target.
- Structured ownership modes preserve target-only content and untouched formatting according to their existing contracts. Source override removal reconciles the selected base contribution.
- Seeded Runtime State is retained physically while dots removes only its ownership record when the capability leaves selection.
- Dependencies and Provisioner effects are never removed. Known residue is reported as Retained External State. User histories, credentials, plugins, caches, and application runtime state are never in removal authority.
- Backup Sets are preserved. Restoration remains an explicit global uninstall option and is not automatic during selection reconciliation.
- An ordinary reduction has its own confirmation step before existing Conflict Resolution. An empty desired selection requires typing `clear` interactively.
- Non-interactive empty selection requires `--clear-selection`, `--yes`, and the existing selection-change acknowledgement. Missing flags never imply empty intent.
- The complete plan is built and validated before mutation. Required Dependencies for additions are handled before filesystem retirement; selected Provisioners run before no-longer-selected Managed Configuration is retired.
- The requested Installed Selection is committed only after terminal success. Failure preserves the previous authoritative intent, and subsequent execution must converge safely from any already applied additions.
- The existing Bubble Tea stack is reused for presentation. The selection and reconciliation domain modules do not depend on Bubble Tea.
- The glossary adds Selection Reconciliation Plan and Retained External State and amends Tag/Profile semantics for interactive editing. A focused ADR records reconciliation by surface difference and per-contribution evidence.

## Testing Decisions

- The primary seam is public command behavior and stable JSON output for the complete reconciliation workflow. Domain package tests supplement only the pure planning states that are expensive to express through a terminal.
- Temporary Home Tests cover addition-only changes, mixed additions/removals, ordinary reductions, clear-all, cancellation, Conflict Resolution, failure before commit, safe rerun, and global uninstall separation.
- Golden Output Tests cover human and JSON reconciliation plans, retained external state, blocked shared contributions, Drifted whole-target preservation, empty selection, and reduction acknowledgement.
- TUI Model Tests exercise loading, grouping, search, preset toggles, checkbox intent, detail navigation, narrow layouts, plan transition, confirmation, clear typing, cancellation, and error states without visual snapshot brittleness.
- Plan parity tests feed the same inputs through `dots plan`, install dry run, JSON, and the TUI adapter and assert identical semantic actions.
- Shared-target tests cover removing only the Web contribution from an OpenCode target and only the Mobile contribution from an Antigravity target while preserving the selected Agent contribution.
- Structured ownership tests cover JSON, JSONC, TOML, marked blocks, whole-owned symlinks/copies, and Seeded Runtime State.
- Drift tests distinguish a whole retired target that is preserved and released from a shared target whose ambiguous partial retirement blocks before mutation.
- Source-override tests cover removing `adaptive-theme` while Herdr or Zellij remains selected and removing `codegraph` while Codex remains selected.
- Retained External State tests cover Dependency-only and Provisioner-only Tags, including a reduction that changes selection but removes zero Managed Entries.
- Platform tests cover Darwin/Linux applicability and `not-applicable` Tags without depending on the host's real applications.
- Non-interactive tests prove that `--yes` alone cannot approve a reduction or empty selection and that JSON never launches a TUI.
- Existing Conflict TUI tests, command envelope goldens, install/uninstall Temporary Home Tests, and structured ownership tests are prior art.
- Full validation matches CI. Every filesystem mutation test uses temporary home, source, and state roots with provisioner and package-manager executables stubbed so validation never touches the real home or network.

## Out of Scope

- Defining or migrating the atomic capability catalog; that belongs to the prerequisite specification.
- Uninstalling Dependencies or package-manager artifacts.
- Reversing Provisioners or deleting tool-owned regenerated content.
- Deleting credentials, histories, plugins, caches, application databases, or Seeded Runtime State.
- Automatically restoring Backup Sets during a selection change.
- Automatic retirement caused only by Install Manifest evolution.
- Adding Tag-scoped behavior to `dots uninstall`.
- Synchronizing Installed Selection across machines.
- A graphical user interface outside the terminal.
- Visual snapshot testing of every terminal rendering.

## Further Notes

- The feature deliberately treats stopping management and uninstalling external software as different operations.
- A Tag can be unselected while known external state remains. The UI and JSON must report that truth rather than presenting a false uninstalled state.
- The highest-value test seam is the shared reconciliation report observed through sandboxed commands; the Bubble Tea model is a presentation seam, not the authority for actions.
- Delivery should be sliced so the read-only plan lands before mutation and the CLI reconciliation lands before the TUI adapter.

### Key interfaces

- Interactive `dots install` entrypoint and non-interactive selection validation.
- Selection Reconciliation Plan — previous intent, requested intent, Selected Surfaces, ownership evidence, filesystem findings, and semantic actions.
- Installation mutation workflow — ordered additions, shared reconciliations, Provisioners, retirements, and terminal Installed Selection commit.
- Stable text and JSON output contracts — plan, result, blocks, and retained external state.
- Bubble Tea selection model — draft editing, presets, search, detail, preview, confirmations, and cancellation.

### Acceptance criteria

- [ ] Interactive `dots install` without selection opens the Tag selector; JSON, Confirmed Install, text-prompt, and non-terminal execution do not.
- [ ] The selector loads authoritative intent, expands Profiles for editing, supports presets/search/details, and persists confirmed changes as explicit current Tags.
- [ ] Checkbox intent and observed Tag status remain separate, with component-level explanations and `not-applicable` visibility.
- [ ] One Selection Reconciliation Plan drives plan, dry-run, text, JSON, and TUI preview behavior.
- [ ] Explicit reductions retire only proven dots-owned Managed Configuration and never activate from manifest evolution alone.
- [ ] Whole retired targets with Drift or lost ownership are preserved and released; ambiguous partial retirement of a still-selected shared target blocks before mutation.
- [ ] Structured ownership, source override fallback, and Seeded Runtime State preservation follow their existing contracts.
- [ ] Dependencies, Provisioner effects, Backup Sets, and user-owned external state are preserved and reported as Retained External State.
- [ ] Empty selection requires `clear` interactively or the complete explicit non-interactive acknowledgement flags.
- [ ] Cancelation or failure preserves the previous Installed Selection; successful execution commits the requested explicit Tags only at terminal success.
- [ ] `dots uninstall` remains global and unchanged in meaning.
- [ ] Glossary and ADR documentation record the approved reconciliation boundary.
- [ ] Focused validation and the full CI-equivalent suite pass using only sandboxed filesystem roots and stubbed external executables.

### Validation notes

- `gofmt -l .`
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- Exercise command and TUI flows only with temporary `--home`, `--source-root`, and `--state-root` values.
- Stub dependency probes, provisioners, package managers, and `npx` in sandboxed tests; never reach the real home or network.

```
</details>

### Acceptance coverage

| Acceptance criterion | Evidence |
|---|---|
| One pure report over both intents/surfaces, metadata, and inspected state | `internal/selectionreconciliation.Build` and package tests |
| Deterministic create/update/preserve/reconcile/remove/retain/blocked/retained-external-state | Pure classifier tables, command parity tests, envelope/text goldens |
| Distinct Drift, lost ownership, and ambiguous partial ownership | Exact v7 evidence checks and targeted negative tests |
| Dependency/Provisioner reductions retain external state with zero Managed Entry removals | External-only and same-tool Provisioner command-identity tests |
| Same actions/order in plan, install dry-run, text, and JSON | Command-level JSON/text parity tests |
| Explicit reductions previewed; manifest evolution never authorizes retirement | Intent-authority and removed-declaration/receipt tests |
| No filesystem or Installation Metadata mutation | Before/after byte assertions and manual SHA-256 verification |
| Stable schema/version and semantic exits | Schema 10 goldens; plan findings exit 2; install dry-run remains exit 0 |
| Glossary and ADR | `CONTEXT.md` and ADR 0019 |

### Automated validation

Current reviewed head: `4da32b1a52579a9a51f6e301b4474d28f53fdd30`.

- PASS — `gofmt -l .` (no output)
- PASS — `go vet ./...`
- PASS — `go build ./...`
- PASS — `go test ./...`
- PASS — `go test -race ./internal/selectionreconciliation ./internal/plan`
- PASS — `go test -race ./internal/cli -run TestSelectionReconciliation -count=1`
- PASS — `go run ./cmd/dots manifest validate --file dots.yaml`
- PASS — sandboxed real-manifest `dots plan` with explicit temporary home/state roots

### Manual verification

Built the branch binary and established a full-selection installation only under `/tmp/dots-465-manual.PXZM1S` with explicit `--home`, `--source-root`, and `--state-root`. `dots plan --profile reduced --output json` and `dots install --dry-run --skip-deps --profile reduced --output json` both exited 0 and produced the identical ordered outcomes `remove,create,preserve,remove` under schema 10. The retired target SHA-256 remained `207d2fc9a5c43d9230afc00fac78db454e422a24a7fa1a9eb13388fece1d3f07`; Installation Metadata remained `3121a7d2e27d1a97d2f07a603bc8303336756060b16a161adef1cadaffc837bb`. No real home configuration or external package/provisioner command was touched.

### Independent review

- Spec: clean on current head; all issue #465 acceptance criteria and governing #459 read-only-slice decisions covered, with no actionable findings.
- Standards: clean on current head; exact evidence, parent-symlink confinement, schema/golden coverage, and repository conventions verified, with no actionable findings.

<!-- delivery-issue:evidence:end -->
