### PR TITLE
feat(selection): retire whole targets on explicit reduction

### DIFF
--- a/docs/adr/0019-selection-reconciliation-plan.md
+++ b/docs/adr/0019-selection-reconciliation-plan.md
@@ -62,3 +62,47 @@ findings as divergence. Install dry-run remains a successful action preview
 while carrying the identical findings. No action in this report promises that a
 future mutating command can apply it without revalidating ownership and target
 state.
+
+## Whole-target retirement amendment
+
+Issue #466 authorizes `dots install` to consume the Selection Reconciliation
+Plan only for an acknowledged, explicit Installed Selection reduction. The
+plan remains pure and read-only; a separate retirement adapter validates the
+complete report before any dependency or filesystem mutation, then revalidates
+Installation Metadata, target ownership, and home confinement immediately
+before applying each action. Retirement and the later terminal commit use the
+same state-layer lock for serialized Installation Metadata transactions, so
+unrelated concurrent records and receipts cannot be overwritten by a stale
+read-modify-write cycle.
+
+Known non-interactive Conflict decisions and interactive Conflict Resolution
+are resolved before dependency mutation. The complete forward plan, including
+the selected replace/adopt policy, and the complete retirement plan must both
+validate before a package manager, Managed Entry, or Provisioner can mutate.
+
+When a whole target leaves the requested Selected Surface, exact ownership
+evidence produces `remove`. Drift, a missing target, changed target type, or
+lost ownership produces `retain`: dots preserves the live target and releases
+its Installation Metadata record without claiming deletion. Seeded Runtime
+State likewise remains physically present while its ownership record is
+released. Backup Sets are preserved and never restored by selection
+retirement. Dependencies, Dependency Installation Metadata, Provisioner
+receipts and effects, and user-owned state remain untouched; their known
+selection residue stays `retained-external-state` in the shared report.
+
+An entirely deselected structured target can be removed when exact subset
+evidence proves that subtraction leaves it empty; if external content remains,
+the target is retained and its ownership record is released. Partial retirement
+from a still-selected target, including structured subset ownership and
+source-override reconciliation, remains blocked before mutation and belongs to
+the subsequent contribution-reconciliation slice. Install Manifest evolution
+remains report-only and never authorizes retirement.
+
+`--clear-selection` supplies explicit empty-selection authority. Interactive
+execution requires the literal `clear` acknowledgement. Non-interactive
+execution, including a dry run, requires `--clear-selection`, `--yes`, and
+`--acknowledge-selection-change`; omitted Profile/Tag flags never mean an empty
+selection. A successful terminal run records empty ordered intent, while any
+decline, block, cancellation, or failure preserves the prior authoritative
+Installed Selection. Rerunning after a partial removal converges from current
+filesystem and metadata evidence without manual repair.

--- a/docs/agents/output-contract.md
+++ b/docs/agents/output-contract.md
@@ -204,6 +204,12 @@ prose the text surface prints:
   `selection-change-acknowledgement-required`; error `data` contains `code` and
   the complete `selection_change`. This acknowledgement is independent from
   Conflict Resolution and `--backup-and-replace`.
+- `install --clear-selection` is the only explicit empty-selection request.
+  Interactive execution requires typing `clear`; non-interactive and JSON
+  execution, including `--dry-run`, requires `--clear-selection`, `--yes`, and
+  `--acknowledge-selection-change`. Successful reports keep the ordinary
+  `data.selection` shape with empty `profiles`, `extra_tags`, and
+  `effective_tags`; omitted selection flags never imply these empty arrays.
 - After a successful `install`, `update`, or `upgrade` finds sufficiently
   specific historical Installation Metadata evidence for retired Gentle AI or
   Codex delegation capabilities, `data.retirement` records portable `removed`
@@ -244,7 +250,8 @@ prose the text surface prints:
   target-wide inventory without receiving raw configuration bytes.
 - Schema version `10` adds the Selection Reconciliation Plan under
   `plan`'s `data.selection_reconciliation`. The same report is embedded under
-  `install --dry-run`'s `data.plan.selection_reconciliation`; both surfaces
+  `install`'s `data.plan.selection_reconciliation` for previews and confirmed
+  reductions; all surfaces
   preserve identical semantic actions, reasons, and deterministic ordering.
   Reconciliation actions are `create`, `update`, `preserve`, `reconcile`,
   `remove`, `retain`, `blocked`, and `retained-external-state`. Reasons
@@ -254,6 +261,15 @@ prose the text surface prints:
   this report never removes or reverses their installed effects. Install
   Manifest evolution is report-only and does not authorize retirement or
   Installation Metadata mutation.
+  A confirmed explicit retirement of a target that entirely leaves the
+  Selected Surface may additionally emit optional
+  `data.selection_retirement`. Its `removed` array lists targets that were
+  deleted after last-moment ownership revalidation; its `retained` array lists
+  Drifted, missing, no-longer-owned, or externally extended subset targets
+  whose filesystem state was preserved while dots released its ownership
+  record. Empty arrays remain
+  present when the result object is emitted. This optional result is
+  schema-compatible with version `10`.
   Provisioner actions include a non-sensitive `identity` digest of the exact
   rendered command so separate effects from the same tool remain distinguishable
   without exposing command arguments.

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/spf13/cobra v1.8.1
 	github.com/tailscale/hujson v0.0.0-20241010212012-29efb4a0184b
+	golang.org/x/sys v0.36.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -33,6 +34,5 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/sys v0.36.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
 )

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -23,6 +23,7 @@ import (
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/provision"
 	"github.com/yersonargotev/dots/internal/selection"
+	"github.com/yersonargotev/dots/internal/selectionretirement"
 	"github.com/yersonargotev/dots/internal/state"
 	"github.com/yersonargotev/dots/internal/tui"
 	"github.com/yersonargotev/dots/internal/version"
@@ -52,6 +53,7 @@ func newInstallCommand() *cobra.Command {
 		skipDeps         bool
 		backupAndReplace bool
 		ackSelection     bool
+		clearSelection   bool
 	)
 
 	cmd := &cobra.Command{
@@ -90,24 +92,31 @@ func newInstallCommand() *cobra.Command {
 			}
 			intentProfiles := profiles
 			intentTags := extraTags
-			if len(intentProfiles) == 0 && len(intentTags) == 0 {
-				requestedSelection, err := selection.Resolve(*m, nil, nil)
-				if err != nil {
-					return err
+			var effective selection.Effective
+			if clearSelection {
+				effective, err = selection.ResolveIntent(*m, selection.Intent{
+					Source:     selection.SourceExplicit,
+					AllowEmpty: true,
+				})
+			} else {
+				if len(intentProfiles) == 0 && len(intentTags) == 0 {
+					requestedSelection, resolveErr := selection.Resolve(*m, nil, nil)
+					if resolveErr != nil {
+						return resolveErr
+					}
+					intentProfiles = requestedSelection.Profiles
+					intentTags = requestedSelection.ExtraTags
 				}
-				intentProfiles = requestedSelection.Profiles
-				intentTags = requestedSelection.ExtraTags
+				effective, err = selection.ResolveIntent(*m, selection.Intent{
+					Source:    selection.SourceExplicit,
+					Profiles:  intentProfiles,
+					ExtraTags: intentTags,
+				})
 			}
-			effective, err := selection.ResolveIntent(*m, selection.Intent{
-				Source:    selection.SourceExplicit,
-				Profiles:  intentProfiles,
-				ExtraTags: intentTags,
-			})
 			if err != nil {
 				return err
 			}
 			selectedProfiles := effective.Profiles
-			selectedTags := effective.ExtraTags
 
 			meta, err := loadInstallationMetadata(paths, stateRoot)
 			if err != nil {
@@ -115,7 +124,7 @@ func newInstallCommand() *cobra.Command {
 			}
 			effective = selection.CompareInstalled(*m, effective, meta.InstalledSelection, installHostOS)
 			proceed, _, err := guardSelectionChange(cmd, &effective, selectionChangePolicy{
-				DryRun: dryRun, Confirmed: yes, Acknowledge: ackSelection,
+				DryRun: dryRun, Confirmed: yes, Acknowledge: ackSelection, ClearSelection: clearSelection,
 			})
 			if err != nil {
 				return err
@@ -127,7 +136,7 @@ func newInstallCommand() *cobra.Command {
 
 			hostOS := installHostOS
 			hostArch := installHostArch
-			depOptions := deps.Options{Profiles: selectedProfiles, ExtraTags: selectedTags, OS: hostOS, Arch: hostArch, Home: paths.Home, StateRoot: paths.StateRoot, AppLookup: appInstalled(hostOS, paths.Home), HTTPClient: depsHTTPClient, RollingReleaseURL: depsRollingReleaseURL}
+			depOptions := deps.Options{Selection: &effective.Selection, OS: hostOS, Arch: hostArch, Home: paths.Home, StateRoot: paths.StateRoot, AppLookup: appInstalled(hostOS, paths.Home), HTTPClient: depsHTTPClient, RollingReleaseURL: depsRollingReleaseURL}
 			depTier, err := resolveInstallTier(hostOS)
 			if err != nil {
 				return err
@@ -166,16 +175,16 @@ func newInstallCommand() *cobra.Command {
 				fmt.Fprintln(cmd.OutOrStdout())
 			}
 
+			p, provPlan, err := buildInstallPlanAndProvisioners(*m, meta, effective.Selection, hostOS, paths, prep.SourceReadRoot, prep.LegacyMigrations)
+			if err != nil {
+				return err
+			}
+			p.Selection = &effective.Report
+			p.SelectionReconciliation, err = buildSelectionReconciliation(*m, meta, effective, p, hostOS, paths, prep.SourceReadRoot, len(profiles) > 0 || len(extraTags) > 0 || clearSelection)
+			if err != nil {
+				return err
+			}
 			if dryRun {
-				p, provPlan, err := buildInstallPlanAndProvisioners(*m, meta, selectedProfiles, selectedTags, hostOS, paths, prep.SourceReadRoot, prep.LegacyMigrations)
-				if err != nil {
-					return err
-				}
-				p.Selection = &effective.Report
-				p.SelectionReconciliation, err = buildSelectionReconciliation(*m, meta, effective, p, hostOS, paths, prep.SourceReadRoot, len(profiles) > 0 || len(extraTags) > 0)
-				if err != nil {
-					return err
-				}
 				if wantsJSON(cmd) {
 					return emitOK(cmd, installReport{RepositoryRefresh: prep.Refresh, DryRun: true, Selection: effective.Report, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan})
 				}
@@ -185,9 +194,25 @@ func newInstallCommand() *cobra.Command {
 				return nil
 			}
 
-			var p plan.Plan
-			var provPlan provision.Plan
-			installPlanReady := false
+			retirementOptions := selectionretirement.Options{SourceRoot: paths.SourceRoot, Home: paths.Home, StateRoot: paths.StateRoot}
+			var selectionRetirementPlan selectionretirement.Plan
+			if p.SelectionReconciliation != nil {
+				selectionRetirementPlan, err = selectionretirement.Build(*p.SelectionReconciliation, meta, retirementOptions)
+				if err != nil {
+					return err
+				}
+			}
+			conflictDecisions, proceed, err := resolveConflictDecisions(cmd, p, paths, yes, noTUI, backupAndReplace)
+			if err != nil {
+				return err
+			}
+			if !proceed {
+				return nil
+			}
+			if err := install.ValidateManagedEntries(p, install.Options{SourceRoot: paths.SourceRoot, Home: paths.Home, StateRoot: paths.StateRoot, ConflictDecisions: conflictDecisions}); err != nil {
+				return err
+			}
+
 			var dependencyEnvironment []string
 
 			if !skipDeps {
@@ -233,13 +258,6 @@ func newInstallCommand() *cobra.Command {
 					renderDepsInstallPreview(cmd.OutOrStdout(), depPreview)
 					depsConfirmed = true
 				}
-				p, provPlan, err = buildInstallPlanAndProvisioners(*m, meta, selectedProfiles, selectedTags, hostOS, paths, prep.SourceReadRoot, prep.LegacyMigrations)
-				if err != nil {
-					return err
-				}
-				p.Selection = &effective.Report
-				installPlanReady = true
-
 				depReport, depsApplied, runEnvironment, err := runInstallDependencies(cmd, *m, depOptions, depTier, paths.Home, depPreview, depsConfirmed, depLookup, brewDetection.Path)
 				dependencyEnvironment = runEnvironment
 				dependenciesReport.Result = &depReport
@@ -254,14 +272,6 @@ func newInstallCommand() *cobra.Command {
 				}
 			}
 
-			if !installPlanReady {
-				p, provPlan, err = buildInstallPlanAndProvisioners(*m, meta, selectedProfiles, selectedTags, hostOS, paths, prep.SourceReadRoot, prep.LegacyMigrations)
-				if err != nil {
-					return err
-				}
-				p.Selection = &effective.Report
-			}
-
 			if !wantsJSON(cmd) {
 				if err := renderInstallPlanAndProvisioners(cmd, *m, p, provPlan, selectedProfiles); err != nil {
 					return err
@@ -272,7 +282,7 @@ func newInstallCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			applied, metadataCommit, err := resolveAndApply(cmd, p, paths, yes, noTUI, backupAndReplace)
+			applied, metadataCommit, err := applyResolvedPlan(p, paths, conflictDecisions)
 			if err != nil {
 				return err
 			}
@@ -287,12 +297,23 @@ func newInstallCommand() *cobra.Command {
 				return nil
 			}
 
-			provResult, err := runProvisionersWithEnvironment(cmd, *m, selectedProfiles, selectedTags, paths.Home, paths.StateRoot, paths.SourceRoot, dependencyEnvironment)
+			provResult, err := runProvisionersWithOptionsAndEnvironment(cmd, *m, provision.Options{Selection: &effective.Selection, OS: hostOS}, paths.Home, paths.StateRoot, paths.SourceRoot, dependencyEnvironment)
 			if err != nil {
 				if wantsJSON(cmd) {
 					return installProvisionerError{err: err, report: installReport{RepositoryRefresh: prep.Refresh, DryRun: false, Selection: effective.Report, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan, BackupSets: createdBackups, ProvisionerResults: &provResult}}
 				}
 				return err
+			}
+			var selectionRetirement *selectionretirement.Result
+			if len(selectionRetirementPlan.Actions) > 0 {
+				result, applyErr := selectionretirement.Apply(selectionRetirementPlan, retirementOptions)
+				selectionRetirement = &result
+				if applyErr != nil {
+					if wantsJSON(cmd) {
+						return installRetirementError{err: applyErr, report: installReport{RepositoryRefresh: prep.Refresh, DryRun: false, Selection: effective.Report, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan, BackupSets: createdBackups, ProvisionerResults: &provResult, SelectionRetirement: selectionRetirement}}
+					}
+					return applyErr
+				}
 			}
 			retirement, err := retireHistoricalAgentState(meta, paths.Home)
 			if err != nil {
@@ -303,10 +324,11 @@ func newInstallCommand() *cobra.Command {
 				return err
 			}
 			if !wantsJSON(cmd) {
+				renderSelectionRetirement(cmd.OutOrStdout(), selectionRetirement)
 				renderHistoricalRetirement(cmd.OutOrStdout(), retirement)
 			}
 			if wantsJSON(cmd) {
-				return emitOK(cmd, installReport{RepositoryRefresh: prep.Refresh, DryRun: false, Selection: effective.Report, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan, BackupSets: createdBackups, Retirement: retirement})
+				return emitOK(cmd, installReport{RepositoryRefresh: prep.Refresh, DryRun: false, Selection: effective.Report, PackageManagerSetup: packageManagerSetup, Dependencies: dependenciesReport, Plan: p, Provisioners: provPlan, BackupSets: createdBackups, SelectionRetirement: selectionRetirement, Retirement: retirement})
 			}
 			return nil
 		},
@@ -324,6 +346,9 @@ func newInstallCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&skipDeps, "skip-deps", false, "skip dependency provisioning before applying managed configuration")
 	cmd.Flags().BoolVar(&backupAndReplace, "backup-and-replace", false, "with --yes, replace every conflict after creating Backup Sets")
 	cmd.Flags().BoolVar(&ackSelection, "acknowledge-selection-change", false, "with --yes, acknowledge removal of previously selected Profiles or extra Tags")
+	cmd.Flags().BoolVar(&clearSelection, "clear-selection", false, "request an explicitly empty Installed Selection")
+	cmd.MarkFlagsMutuallyExclusive("clear-selection", "profile")
+	cmd.MarkFlagsMutuallyExclusive("clear-selection", "tag")
 	registerSelectionFlagCompletion(cmd)
 	return cmd
 }
@@ -342,10 +367,9 @@ func renderInstallPlanAndProvisioners(cmd *cobra.Command, m manifest.Manifest, p
 	return renderSkippedProvisionerHint(cmd.OutOrStdout(), m, profiles, runtime.GOOS)
 }
 
-func buildInstallPlanAndProvisioners(m manifest.Manifest, meta state.Metadata, profiles []string, extraTags []string, hostOS string, paths resolvedPaths, sourceReadRoot string, legacyMigrations map[string]plan.LegacyMigration) (plan.Plan, provision.Plan, error) {
+func buildInstallPlanAndProvisioners(m manifest.Manifest, meta state.Metadata, selected manifest.Selection, hostOS string, paths resolvedPaths, sourceReadRoot string, legacyMigrations map[string]plan.LegacyMigration) (plan.Plan, provision.Plan, error) {
 	p, err := plan.Build(m, plan.Options{
-		Profiles:         profiles,
-		ExtraTags:        extraTags,
+		Selection:        &selected,
 		OS:               hostOS,
 		SourceRoot:       paths.SourceRoot,
 		SourceReadRoot:   sourceReadRoot,
@@ -358,7 +382,7 @@ func buildInstallPlanAndProvisioners(m manifest.Manifest, meta state.Metadata, p
 		return plan.Plan{}, provision.Plan{}, err
 	}
 
-	provPlan, err := provision.Build(m, provision.Options{Profiles: profiles, ExtraTags: extraTags, OS: hostOS})
+	provPlan, err := provision.Build(m, provision.Options{Selection: &selected, OS: hostOS})
 	if err != nil {
 		return plan.Plan{}, provision.Plan{}, err
 	}
@@ -439,6 +463,17 @@ func (e installProvisionerError) Error() string { return e.err.Error() }
 func (e installProvisionerError) Unwrap() error { return e.err }
 
 func (e installProvisionerError) JSONErrorData() any { return e.report }
+
+type installRetirementError struct {
+	err    error
+	report installReport
+}
+
+func (e installRetirementError) Error() string { return e.err.Error() }
+
+func (e installRetirementError) Unwrap() error { return e.err }
+
+func (e installRetirementError) JSONErrorData() any { return e.report }
 
 // runInstallDependencies executes the dependency gate for dots install before any
 // Managed Configuration is applied. Interactive runs reuse the deps confirmation
@@ -570,6 +605,14 @@ func selectedCodeGraphAgents(selected []manifest.Provisioner) []string {
 // is shared by install and update so post-update installation reuses identical
 // Conflict Resolution and filesystem machinery instead of reimplementing it.
 func resolveAndApply(cmd *cobra.Command, p plan.Plan, paths resolvedPaths, yes, noTUI, backupAndReplace bool) (bool, install.MetadataCommit, error) {
+	decisions, proceed, err := resolveConflictDecisions(cmd, p, paths, yes, noTUI, backupAndReplace)
+	if err != nil || !proceed {
+		return false, install.MetadataCommit{}, err
+	}
+	return applyResolvedPlan(p, paths, decisions)
+}
+
+func resolveConflictDecisions(cmd *cobra.Command, p plan.Plan, paths resolvedPaths, yes, noTUI, backupAndReplace bool) (map[string]install.ConflictDecision, bool, error) {
 	var (
 		decisions map[string]install.ConflictDecision
 		err       error
@@ -583,19 +626,22 @@ func resolveAndApply(cmd *cobra.Command, p plan.Plan, paths resolvedPaths, yes, 
 	case noTUI:
 		decisions, err = promptConflictDecisions(cmd, p, paths.Home, paths.SourceRoot)
 		if err != nil {
-			return false, install.MetadataCommit{}, err
+			return nil, false, err
 		}
 	default:
 		decisions, err = resolveConflictsTUI(cmd, p, paths.Home, paths.SourceRoot)
 		if errors.Is(err, tui.ErrCanceled) {
 			fmt.Fprintln(cmd.OutOrStdout(), "Conflict resolution canceled; no changes applied.")
-			return false, install.MetadataCommit{}, nil
+			return nil, false, nil
 		}
 		if err != nil {
-			return false, install.MetadataCommit{}, err
+			return nil, false, err
 		}
 	}
+	return decisions, true, nil
+}
 
+func applyResolvedPlan(p plan.Plan, paths resolvedPaths, decisions map[string]install.ConflictDecision) (bool, install.MetadataCommit, error) {
 	commit, err := install.ApplyManagedEntries(p, install.Options{SourceRoot: paths.SourceRoot, Home: paths.Home, StateRoot: paths.StateRoot, ConflictDecisions: decisions})
 	return true, commit, err
 }
@@ -774,27 +820,25 @@ func recordProvisionerMetadata(stateRoot, sourceRoot string, report provision.Re
 		return nil
 	}
 	path := state.Path(stateRoot)
-	meta, err := state.Load(path)
-	if err != nil {
-		return err
-	}
-	if meta.Version < 2 {
-		meta.Version = 2
-	}
-	meta.Provenance = state.CaptureProvenance(sourceRoot, version.Value)
-	now := time.Now().UTC().Format(time.RFC3339)
-	for _, item := range report.Items {
-		meta.UpsertProvisioner(state.ProvisionerRecord{
-			Profile:    report.Profile,
-			Profiles:   append([]string(nil), report.Profiles...),
-			Tags:       append([]string(nil), report.Tags...),
-			Tool:       item.Tool,
-			Executable: item.Executable,
-			Args:       append([]string(nil), item.Args...),
-			Status:     string(item.Status),
-			Missing:    append([]string(nil), item.Missing...),
-			LastRunAt:  now,
-		})
-	}
-	return state.Save(path, meta)
+	return state.Update(path, func(meta *state.Metadata) error {
+		if meta.Version < 2 {
+			meta.Version = 2
+		}
+		meta.Provenance = state.CaptureProvenance(sourceRoot, version.Value)
+		now := time.Now().UTC().Format(time.RFC3339)
+		for _, item := range report.Items {
+			meta.UpsertProvisioner(state.ProvisionerRecord{
+				Profile:    report.Profile,
+				Profiles:   append([]string(nil), report.Profiles...),
+				Tags:       append([]string(nil), report.Tags...),
+				Tool:       item.Tool,
+				Executable: item.Executable,
+				Args:       append([]string(nil), item.Args...),
+				Status:     string(item.Status),
+				Missing:    append([]string(nil), item.Missing...),
+				LastRunAt:  now,
+			})
+		}
+		return nil
+	})
 }

--- a/internal/cli/install_deps_test.go
+++ b/internal/cli/install_deps_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/yersonargotev/dots/internal/backups"
 	"github.com/yersonargotev/dots/internal/cli"
+	"golang.org/x/sys/unix"
 )
 
 func seedDesktopNerdFont(t *testing.T, home string) {
@@ -119,6 +120,64 @@ func TestInstallRunsDependenciesBeforeManagedConfiguration(t *testing.T) {
 	planIdx := strings.Index(got, "Plan for profile")
 	if previewIdx < 0 || installIdx < 0 || planIdx < 0 || previewIdx > installIdx || installIdx > planIdx {
 		t.Fatalf("dependency actions must render before file plan:\n%s", got)
+	}
+}
+
+func TestInstallValidatesManagedPlanBeforeDependencyMutation(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	binDir := t.TempDir()
+	installMarker := filepath.Join(binDir, "brew-install-ran")
+	writeExecStub(t, filepath.Join(binDir, "brew"), "#!/bin/sh\nif [ \"$1\" = install ]; then touch \"$BREW_INSTALL_MARKER\"; fi\nexit 0\n")
+	t.Setenv("BREW_INSTALL_MARKER", installMarker)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	manifestPath := writeCLIManifest(t, home, installDepsManifest)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"install", "--yes", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "missing-source") {
+		t.Fatalf("Execute() error = %v, want preflight missing-source\noutput:\n%s", err, out.String())
+	}
+	if _, statErr := os.Stat(installMarker); !os.IsNotExist(statErr) {
+		t.Fatalf("dependency provider ran before complete plan validation: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(home, ".zshrc")); !os.IsNotExist(statErr) {
+		t.Fatalf("invalid plan wrote Managed Entry: %v", statErr)
+	}
+}
+
+func TestInstallValidatesConfirmedReplacementBeforeDependencyMutation(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	binDir := t.TempDir()
+	installMarker := filepath.Join(binDir, "brew-install-ran")
+	writeExecStub(t, filepath.Join(binDir, "brew"), "#!/bin/sh\nif [ \"$1\" = install ]; then touch \"$BREW_INSTALL_MARKER\"; fi\nexit 0\n")
+	t.Setenv("BREW_INSTALL_MARKER", installMarker)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	writeCLISource(t, sourceRoot, "configs/zsh/zshrc", "managed\n")
+	manifestPath := writeCLIManifest(t, home, installDepsManifest)
+	target := filepath.Join(home, ".zshrc")
+	if err := unix.Mkfifo(target, 0o600); err != nil {
+		t.Fatalf("create conflicting FIFO: %v", err)
+	}
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"install", "--yes", "--backup-and-replace", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "not a regular file, directory, or symlink") {
+		t.Fatalf("Execute() error = %v, want preflight replacement rejection\noutput:\n%s", err, out.String())
+	}
+	if _, statErr := os.Stat(installMarker); !os.IsNotExist(statErr) {
+		t.Fatalf("dependency provider ran before confirmed replacement validation: %v", statErr)
 	}
 }
 

--- a/internal/cli/install_retirement_test.go
+++ b/internal/cli/install_retirement_test.go
@@ -1,0 +1,617 @@
+package cli_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/cli"
+	"github.com/yersonargotev/dots/internal/state"
+)
+
+func TestInstallExplicitReductionRemovesOwnedWholeTarget(t *testing.T) {
+	fixture := newWholeTargetRetirementFixture(t)
+	backupSentinel := filepath.Join(fixture.stateRoot, "backups", "preserved")
+	if err := os.MkdirAll(filepath.Dir(backupSentinel), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(backupSentinel, []byte("backup\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	userState := filepath.Join(fixture.home, ".local", "share", "app", "history")
+	if err := os.MkdirAll(filepath.Dir(userState), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(userState, []byte("user\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out := fixture.reduce(t, "--profile", "keep")
+
+	if _, err := os.Lstat(filepath.Join(fixture.home, ".old")); !os.IsNotExist(err) {
+		t.Fatalf("retired owned target still exists: %v", err)
+	}
+	if got, err := os.ReadFile(filepath.Join(fixture.home, ".keep")); err != nil || string(got) != "keep\n" {
+		t.Fatalf("selected target = %q, %v", got, err)
+	}
+	for path, want := range map[string]string{backupSentinel: "backup\n", userState: "user\n"} {
+		if got, err := os.ReadFile(path); err != nil || string(got) != want {
+			t.Fatalf("preserved state %s = %q, %v; want %q", path, got, err, want)
+		}
+	}
+	meta, err := state.Load(state.Path(fixture.stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(meta.Entries) != 1 || meta.Entries[0].Target != filepath.Join(fixture.home, ".keep") {
+		t.Fatalf("entries = %#v, want only selected target", meta.Entries)
+	}
+	if meta.InstalledSelection == nil || !reflect.DeepEqual(meta.InstalledSelection.Profiles, []string{"keep"}) {
+		t.Fatalf("Installed Selection = %#v, want keep", meta.InstalledSelection)
+	}
+	result := parseSelectionRetirementResult(t, out)
+	if !reflect.DeepEqual(result.Removed, []string{filepath.Join(fixture.home, ".old")}) || len(result.Retained) != 0 {
+		t.Fatalf("JSON result does not distinguish removed retirement:\n%s", out)
+	}
+}
+
+func TestInstallExplicitReductionPreservesDriftAndReleasesOwnership(t *testing.T) {
+	fixture := newWholeTargetRetirementFixture(t)
+	retired := filepath.Join(fixture.home, ".old")
+	if err := os.WriteFile(retired, []byte("external\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var planOut, planErr bytes.Buffer
+	planCode := cli.Run([]string{
+		"plan", "--output", "json", "--profile", "keep",
+		"--file", fixture.manifestPath, "--home", fixture.home, "--source-root", fixture.sourceRoot, "--state-root", fixture.stateRoot,
+	}, &planOut, &planErr)
+	if planCode != cli.ExitFindings || !strings.Contains(planOut.String(), `"status": "findings"`) {
+		t.Fatalf("Drifted reduction plan = code %d\nstdout:\n%s\nstderr:\n%s", planCode, planOut.String(), planErr.String())
+	}
+
+	out := fixture.reduce(t, "--profile", "keep")
+
+	if got, err := os.ReadFile(retired); err != nil || string(got) != "external\n" {
+		t.Fatalf("Drifted target = %q, %v; want preserved external bytes", got, err)
+	}
+	meta, err := state.Load(state.Path(fixture.stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := meta.FindByTarget(retired); ok {
+		t.Fatalf("Drifted retired target remains dots-owned: %#v", meta.Entries)
+	}
+	result := parseSelectionRetirementResult(t, out)
+	if len(result.Removed) != 0 || !reflect.DeepEqual(result.Retained, []string{retired}) {
+		t.Fatalf("JSON result claims the preserved target was deleted:\n%s", out)
+	}
+}
+
+func TestInstallExplicitReductionPreservesNoLongerOwnedTarget(t *testing.T) {
+	fixture := newWholeTargetRetirementFixture(t)
+	retired := filepath.Join(fixture.home, ".old")
+	if err := os.Remove(retired); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(retired, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	out := fixture.reduce(t, "--profile", "keep")
+
+	if info, err := os.Stat(retired); err != nil || !info.IsDir() {
+		t.Fatalf("no-longer-owned target = %#v, %v; want preserved directory", info, err)
+	}
+	meta, err := state.Load(state.Path(fixture.stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := meta.FindByTarget(retired); ok {
+		t.Fatalf("no-longer-owned target remains dots-owned: %#v", meta.Entries)
+	}
+	result := parseSelectionRetirementResult(t, out)
+	if len(result.Removed) != 0 || !reflect.DeepEqual(result.Retained, []string{retired}) {
+		t.Fatalf("JSON result claims no-longer-owned target was deleted:\n%s", out)
+	}
+}
+
+func TestInstallMixedSelectionChangeAddsBeforeRetiringWholeTarget(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	writeCLISource(t, sourceRoot, "configs/old", "old\n")
+	writeCLISource(t, sourceRoot, "configs/new", "new\n")
+	manifestPath := writeCLIManifest(t, home, `version: 1
+profiles:
+  previous:
+    tags: [old]
+  current:
+    tags: [new]
+entries:
+  - source: configs/old
+    target: ~/.old
+    strategy: copy
+    tags: [old]
+  - source: configs/new
+    target: ~/.new
+    strategy: copy
+    tags: [new]
+`)
+	runInstallForRetirementTest(t, manifestPath, home, sourceRoot, stateRoot, "previous")
+
+	var out, errOut bytes.Buffer
+	code := cli.Run([]string{
+		"install", "--yes", "--acknowledge-selection-change", "--skip-deps", "--output", "json", "--profile", "current",
+		"--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot,
+	}, &out, &errOut)
+	if code != cli.ExitOK {
+		t.Fatalf("mixed selection change = code %d\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
+	}
+	if _, err := os.Lstat(filepath.Join(home, ".old")); !os.IsNotExist(err) {
+		t.Fatalf("mixed change retained retired target: %v", err)
+	}
+	if got, err := os.ReadFile(filepath.Join(home, ".new")); err != nil || string(got) != "new\n" {
+		t.Fatalf("mixed change new target = %q, %v", got, err)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(meta.Entries) != 1 || meta.Entries[0].Target != filepath.Join(home, ".new") || meta.InstalledSelection == nil || !reflect.DeepEqual(meta.InstalledSelection.Profiles, []string{"current"}) {
+		t.Fatalf("mixed change metadata = %#v", meta)
+	}
+}
+
+func TestInstallClearSelectionRequiresExplicitAuthorityAndRecordsEmptyIntent(t *testing.T) {
+	fixture := newWholeTargetRetirementFixture(t)
+
+	var rejectedOut, rejectedErr bytes.Buffer
+	code := cli.Run([]string{
+		"install", "--clear-selection", "--yes", "--skip-deps", "--output", "json",
+		"--file", fixture.manifestPath, "--home", fixture.home, "--source-root", fixture.sourceRoot, "--state-root", fixture.stateRoot,
+	}, &rejectedOut, &rejectedErr)
+	if code != cli.ExitError || !strings.Contains(rejectedOut.String(), "selection-change-acknowledgement-required") {
+		t.Fatalf("clear without reduction acknowledgement = code %d\nstdout:\n%s\nstderr:\n%s", code, rejectedOut.String(), rejectedErr.String())
+	}
+	for _, name := range []string{".old", ".keep"} {
+		if _, err := os.Lstat(filepath.Join(fixture.home, name)); err != nil {
+			t.Fatalf("rejected clear changed %s: %v", name, err)
+		}
+	}
+
+	out := fixture.reduce(t, "--clear-selection")
+	for _, name := range []string{".old", ".keep"} {
+		if _, err := os.Lstat(filepath.Join(fixture.home, name)); !os.IsNotExist(err) {
+			t.Fatalf("clear selection retained owned target %s: %v", name, err)
+		}
+	}
+	meta, err := state.Load(state.Path(fixture.stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.InstalledSelection == nil || len(meta.InstalledSelection.Profiles) != 0 || len(meta.InstalledSelection.ExtraTags) != 0 || len(meta.InstalledSelection.ResolvedTags) != 0 {
+		t.Fatalf("Installed Selection = %#v, want valid empty selection", meta.InstalledSelection)
+	}
+	if len(meta.Entries) != 0 || !strings.Contains(out, `"profiles": []`) || !strings.Contains(out, `"effective_tags": []`) {
+		t.Fatalf("clear result/state is incomplete: entries=%#v\n%s", meta.Entries, out)
+	}
+}
+
+func TestInstallClearSelectionDryRunRequiresNonInteractiveAcknowledgement(t *testing.T) {
+	fixture := newWholeTargetRetirementFixture(t)
+	args := []string{
+		"install", "--clear-selection", "--dry-run", "--skip-deps", "--output", "json",
+		"--file", fixture.manifestPath, "--home", fixture.home, "--source-root", fixture.sourceRoot, "--state-root", fixture.stateRoot,
+	}
+	var rejectedOut, rejectedErr bytes.Buffer
+	code := cli.Run(args, &rejectedOut, &rejectedErr)
+	if code != cli.ExitError || !strings.Contains(rejectedOut.String(), "selection-change-acknowledgement-required") {
+		t.Fatalf("clear dry-run without acknowledgement = code %d\nstdout:\n%s\nstderr:\n%s", code, rejectedOut.String(), rejectedErr.String())
+	}
+
+	args = append(args, "--yes", "--acknowledge-selection-change")
+	var acceptedOut, acceptedErr bytes.Buffer
+	code = cli.Run(args, &acceptedOut, &acceptedErr)
+	if code != cli.ExitOK || !strings.Contains(acceptedOut.String(), `"dry_run": true`) {
+		t.Fatalf("acknowledged clear dry-run = code %d\nstdout:\n%s\nstderr:\n%s", code, acceptedOut.String(), acceptedErr.String())
+	}
+	for _, name := range []string{".old", ".keep"} {
+		if _, err := os.Lstat(filepath.Join(fixture.home, name)); err != nil {
+			t.Fatalf("clear dry-run changed %s: %v", name, err)
+		}
+	}
+}
+
+func TestInstallExplicitReductionDoesNotRetireManifestEvolutionOnlyEntry(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	writeCLISource(t, sourceRoot, "configs/old", "old\n")
+	writeCLISource(t, sourceRoot, "configs/keep", "keep\n")
+	manifestPath := writeCLIManifest(t, home, `version: 1
+profiles:
+  all:
+    tags: [old, keep]
+  keep:
+    tags: [keep]
+entries:
+  - source: configs/old
+    target: ~/.old
+    strategy: copy
+    tags: [old]
+  - source: configs/keep
+    target: ~/.keep
+    strategy: copy
+    tags: [keep]
+`)
+	runInstallForRetirementTest(t, manifestPath, home, sourceRoot, stateRoot, "all")
+
+	manifestPath = writeCLIManifest(t, home, `version: 1
+profiles:
+  all:
+    tags: [keep]
+  keep:
+    tags: [keep]
+entries:
+  - source: configs/keep
+    target: ~/.keep
+    strategy: copy
+    tags: [keep]
+`)
+	var out, errOut bytes.Buffer
+	code := cli.Run([]string{
+		"install", "--yes", "--acknowledge-selection-change", "--skip-deps", "--output", "json", "--profile", "keep",
+		"--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot,
+	}, &out, &errOut)
+	if code != cli.ExitOK {
+		t.Fatalf("mixed manifest evolution/reduction = code %d\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
+	}
+	oldTarget := filepath.Join(home, ".old")
+	if got, err := os.ReadFile(oldTarget); err != nil || string(got) != "old\n" {
+		t.Fatalf("manifest-evolution target = %q, %v; want preserved", got, err)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := meta.FindByTarget(oldTarget); !ok {
+		t.Fatal("explicit reduction released manifest-evolution-only ownership")
+	}
+	if strings.Contains(out.String(), `"selection_retirement"`) {
+		t.Fatalf("manifest evolution leaked into selection retirement result:\n%s", out.String())
+	}
+}
+
+func TestInstallClearSelectionInteractiveRequiresLiteralClear(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		input   string
+		cleared bool
+	}{
+		{name: "ordinary yes declines", input: "yes\n"},
+		{name: "literal clear accepts", input: "clear\n", cleared: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newWholeTargetRetirementFixture(t)
+			cmd := cli.NewRootCommand()
+			var out bytes.Buffer
+			cmd.SetIn(strings.NewReader(test.input))
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs([]string{
+				"install", "--clear-selection", "--skip-deps", "--no-tui",
+				"--file", fixture.manifestPath, "--home", fixture.home, "--source-root", fixture.sourceRoot, "--state-root", fixture.stateRoot,
+			})
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v\n%s", err, out.String())
+			}
+			if !strings.Contains(out.String(), "Type clear to remove every selected Managed Entry") {
+				t.Fatalf("clear confirmation prompt missing:\n%s", out.String())
+			}
+			for _, name := range []string{".old", ".keep"} {
+				_, err := os.Lstat(filepath.Join(fixture.home, name))
+				if test.cleared && !os.IsNotExist(err) {
+					t.Fatalf("accepted clear retained %s: %v", name, err)
+				}
+				if !test.cleared && err != nil {
+					t.Fatalf("declined clear changed %s: %v", name, err)
+				}
+			}
+			meta, err := state.Load(state.Path(fixture.stateRoot))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if test.cleared {
+				if meta.InstalledSelection == nil || len(meta.InstalledSelection.ResolvedTags) != 0 {
+					t.Fatalf("accepted clear selection = %#v, want empty", meta.InstalledSelection)
+				}
+			} else if meta.InstalledSelection == nil || !reflect.DeepEqual(meta.InstalledSelection.Profiles, []string{"all"}) {
+				t.Fatalf("declined clear selection = %#v, want previous", meta.InstalledSelection)
+			}
+		})
+	}
+}
+
+func TestInstallClearSelectionIsMutuallyExclusiveWithSelectionFlags(t *testing.T) {
+	fixture := newWholeTargetRetirementFixture(t)
+	var out, errOut bytes.Buffer
+	code := cli.Run([]string{
+		"install", "--clear-selection", "--profile", "keep", "--yes", "--acknowledge-selection-change", "--skip-deps",
+		"--file", fixture.manifestPath, "--home", fixture.home, "--source-root", fixture.sourceRoot, "--state-root", fixture.stateRoot,
+	}, &out, &errOut)
+	if code != cli.ExitError || !strings.Contains(errOut.String(), "clear-selection") {
+		t.Fatalf("mixed clear/selection flags = code %d\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
+	}
+	for _, name := range []string{".old", ".keep"} {
+		if _, err := os.Lstat(filepath.Join(fixture.home, name)); err != nil {
+			t.Fatalf("flag rejection changed %s: %v", name, err)
+		}
+	}
+}
+
+func TestInstallRetiresEntireProvenSubsetOwnedTarget(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	writeCLISource(t, sourceRoot, "configs/shared.json", "{\"owned\":true}\n")
+	writeCLISource(t, sourceRoot, "configs/new", "new\n")
+	manifestPath := writeCLIManifest(t, home, `version: 1
+profiles:
+  old:
+    tags: [shared]
+  next:
+    tags: [new]
+entries:
+  - source: configs/shared.json
+    target: ~/.shared.json
+    strategy: copy
+    ownership: json-subset
+    tags: [shared]
+  - source: configs/new
+    target: ~/.new
+    strategy: copy
+    tags: [new]
+`)
+	runInstallForRetirementTest(t, manifestPath, home, sourceRoot, stateRoot, "old")
+
+	var out, errOut bytes.Buffer
+	code := cli.Run([]string{
+		"install", "--yes", "--acknowledge-selection-change", "--skip-deps", "--output", "json", "--profile", "next",
+		"--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot,
+	}, &out, &errOut)
+	if code != cli.ExitOK {
+		t.Fatalf("entire subset target retirement = code %d\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
+	}
+	if got, err := os.ReadFile(filepath.Join(home, ".new")); err != nil || string(got) != "new\n" {
+		t.Fatalf("forward addition = %q, %v", got, err)
+	}
+	if _, err := os.Lstat(filepath.Join(home, ".shared.json")); !os.IsNotExist(err) {
+		t.Fatalf("entire proven subset target remains: %v", err)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.InstalledSelection == nil || !reflect.DeepEqual(meta.InstalledSelection.Profiles, []string{"next"}) {
+		t.Fatalf("terminal selection = %#v, want next", meta.InstalledSelection)
+	}
+}
+
+func TestInstallRetainsDriftedEntireSubsetTargetAndReleasesOwnership(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	writeCLISource(t, sourceRoot, "configs/shared.json", "{\"owned\":true}\n")
+	writeCLISource(t, sourceRoot, "configs/new", "new\n")
+	manifestPath := writeCLIManifest(t, home, `version: 1
+profiles:
+  old:
+    tags: [shared]
+  next:
+    tags: [new]
+entries:
+  - source: configs/shared.json
+    target: ~/.shared.json
+    strategy: copy
+    ownership: json-subset
+    tags: [shared]
+  - source: configs/new
+    target: ~/.new
+    strategy: copy
+    tags: [new]
+`)
+	runInstallForRetirementTest(t, manifestPath, home, sourceRoot, stateRoot, "old")
+	target := filepath.Join(home, ".shared.json")
+	drifted := []byte("{\"owned\":false,\"external\":true}\n")
+	if err := os.WriteFile(target, drifted, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var planOut, planErr bytes.Buffer
+	planCode := cli.Run([]string{
+		"plan", "--output", "json", "--profile", "next",
+		"--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot,
+	}, &planOut, &planErr)
+	if planCode != cli.ExitFindings || !strings.Contains(planOut.String(), `"reason": "ambiguous-partial-ownership"`) {
+		t.Fatalf("drifted subset plan = code %d\nstdout:\n%s\nstderr:\n%s", planCode, planOut.String(), planErr.String())
+	}
+
+	var out, errOut bytes.Buffer
+	code := cli.Run([]string{
+		"install", "--yes", "--acknowledge-selection-change", "--skip-deps", "--output", "json", "--profile", "next",
+		"--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot,
+	}, &out, &errOut)
+	if code != cli.ExitOK {
+		t.Fatalf("drifted subset retirement = code %d\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
+	}
+	if got, err := os.ReadFile(target); err != nil || !bytes.Equal(got, drifted) {
+		t.Fatalf("drifted subset target = %q, %v; want preserved bytes", got, err)
+	}
+	if got, err := os.ReadFile(filepath.Join(home, ".new")); err != nil || string(got) != "new\n" {
+		t.Fatalf("forward addition = %q, %v", got, err)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := meta.FindByTarget(target); ok {
+		t.Fatalf("retained target ownership was not released: %#v", meta.Entries)
+	}
+	if meta.InstalledSelection == nil || !reflect.DeepEqual(meta.InstalledSelection.Profiles, []string{"next"}) {
+		t.Fatalf("terminal selection = %#v, want next", meta.InstalledSelection)
+	}
+	result := parseSelectionRetirementResult(t, out.String())
+	if !reflect.DeepEqual(result.Retained, []string{target}) || len(result.Removed) != 0 {
+		t.Fatalf("JSON result does not report retained retirement:\n%s", out.String())
+	}
+}
+
+func TestInstallBlocksSubsetRetirementFromStillSelectedTargetBeforeForwardMutation(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	writeCLISource(t, sourceRoot, "configs/base.json", "{\"base\":true}\n")
+	writeCLISource(t, sourceRoot, "configs/retired.json", "{\"retired\":true}\n")
+	writeCLISource(t, sourceRoot, "configs/new", "new\n")
+	manifestPath := writeCLIManifest(t, home, `version: 1
+profiles:
+  old:
+    tags: [base, retired]
+  next:
+    tags: [base, new]
+entries:
+  - source: configs/base.json
+    target: ~/.shared.json
+    strategy: copy
+    ownership: json-subset
+    tags: [base]
+  - source: configs/retired.json
+    target: ~/.shared.json
+    strategy: copy
+    ownership: json-subset
+    tags: [retired]
+  - source: configs/new
+    target: ~/.new
+    strategy: copy
+    tags: [new]
+`)
+	runInstallForRetirementTest(t, manifestPath, home, sourceRoot, stateRoot, "old")
+	sharedBefore, err := os.ReadFile(filepath.Join(home, ".shared.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var out, errOut bytes.Buffer
+	code := cli.Run([]string{
+		"install", "--yes", "--acknowledge-selection-change", "--skip-deps", "--output", "json", "--profile", "next",
+		"--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot,
+	}, &out, &errOut)
+	if code != cli.ExitError || !strings.Contains(out.String(), "partial retirement from a still-selected target") {
+		t.Fatalf("still-selected subset retirement = code %d\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
+	}
+	if _, err := os.Lstat(filepath.Join(home, ".new")); !os.IsNotExist(err) {
+		t.Fatalf("blocked retirement applied forward addition: %v", err)
+	}
+	if got, err := os.ReadFile(filepath.Join(home, ".shared.json")); err != nil || !bytes.Equal(got, sharedBefore) {
+		t.Fatalf("blocked retirement changed shared target: %q, %v", got, err)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.InstalledSelection == nil || !reflect.DeepEqual(meta.InstalledSelection.Profiles, []string{"old"}) {
+		t.Fatalf("blocked retirement selection = %#v, want previous", meta.InstalledSelection)
+	}
+}
+
+type wholeTargetRetirementFixture struct {
+	home         string
+	sourceRoot   string
+	stateRoot    string
+	manifestPath string
+}
+
+func newWholeTargetRetirementFixture(t *testing.T) wholeTargetRetirementFixture {
+	t.Helper()
+	fixture := wholeTargetRetirementFixture{
+		home:       t.TempDir(),
+		sourceRoot: t.TempDir(),
+		stateRoot:  t.TempDir(),
+	}
+	t.Setenv("HOME", t.TempDir())
+	writeCLISource(t, fixture.sourceRoot, "configs/old", "old\n")
+	writeCLISource(t, fixture.sourceRoot, "configs/keep", "keep\n")
+	fixture.manifestPath = writeCLIManifest(t, fixture.home, `version: 1
+profiles:
+  all:
+    tags: [old, keep]
+  keep:
+    tags: [keep]
+entries:
+  - source: configs/old
+    target: ~/.old
+    strategy: copy
+    tags: [old]
+  - source: configs/keep
+    target: ~/.keep
+    strategy: copy
+    tags: [keep]
+`)
+
+	runInstallForRetirementTest(t, fixture.manifestPath, fixture.home, fixture.sourceRoot, fixture.stateRoot, "all")
+	return fixture
+}
+
+func runInstallForRetirementTest(t *testing.T, manifestPath, home, sourceRoot, stateRoot, profile string) {
+	t.Helper()
+	var out, errOut bytes.Buffer
+	code := cli.Run([]string{
+		"install", "--yes", "--skip-deps", "--output", "json", "--profile", profile,
+		"--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot,
+	}, &out, &errOut)
+	if code != cli.ExitOK {
+		t.Fatalf("initial install = code %d\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
+	}
+}
+
+func (f wholeTargetRetirementFixture) reduce(t *testing.T, selectionArgs ...string) string {
+	t.Helper()
+	args := []string{"install", "--yes", "--acknowledge-selection-change", "--skip-deps", "--output", "json"}
+	args = append(args, selectionArgs...)
+	args = append(args, "--file", f.manifestPath, "--home", f.home, "--source-root", f.sourceRoot, "--state-root", f.stateRoot)
+	var out, errOut bytes.Buffer
+	code := cli.Run(args, &out, &errOut)
+	if code != cli.ExitOK {
+		t.Fatalf("selection reduction = code %d\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
+	}
+	return out.String()
+}
+
+func parseSelectionRetirementResult(t *testing.T, output string) struct {
+	Removed  []string `json:"removed"`
+	Retained []string `json:"retained"`
+} {
+	t.Helper()
+	var envelope struct {
+		Data struct {
+			SelectionRetirement struct {
+				Removed  []string `json:"removed"`
+				Retained []string `json:"retained"`
+			} `json:"selection_retirement"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(output), &envelope); err != nil {
+		t.Fatalf("decode install envelope: %v\n%s", err, output)
+	}
+	return envelope.Data.SelectionRetirement
+}

--- a/internal/cli/json_reports.go
+++ b/internal/cli/json_reports.go
@@ -10,6 +10,7 @@ import (
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/provision"
 	"github.com/yersonargotev/dots/internal/selection"
+	"github.com/yersonargotev/dots/internal/selectionretirement"
 	"github.com/yersonargotev/dots/internal/status"
 	"github.com/yersonargotev/dots/internal/uninstall"
 	"github.com/yersonargotev/dots/internal/upgrade"
@@ -49,6 +50,7 @@ type installReport struct {
 	Provisioners        provision.Plan                      `json:"provisioners"`
 	BackupSets          []installBackupSetReport            `json:"backup_sets,omitempty"`
 	ProvisionerResults  *provision.Report                   `json:"provisioner_results,omitempty"`
+	SelectionRetirement *selectionretirement.Result         `json:"selection_retirement,omitempty"`
 	Retirement          *agentinstructions.RetirementReport `json:"retirement,omitempty"`
 }
 

--- a/internal/cli/output_golden_test.go
+++ b/internal/cli/output_golden_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/yersonargotev/dots/internal/selection"
 	"github.com/yersonargotev/dots/internal/selectionmigration"
 	"github.com/yersonargotev/dots/internal/selectionreconciliation"
+	"github.com/yersonargotev/dots/internal/selectionretirement"
 	"github.com/yersonargotev/dots/internal/state"
 	"github.com/yersonargotev/dots/internal/status"
 	"github.com/yersonargotev/dots/internal/uninstall"
@@ -341,6 +342,10 @@ func TestEnvelopeGolden(t *testing.T) {
 						BackupSet: backups.BackupSet{ID: "backup-20260627T140000.000000000Z", CreatedAt: "2026-06-27T14:00:00Z", Reason: "pre-install conflict protection", Targets: []string{"/home/user/.gitconfig"}},
 						Path:      "/home/user/.local/state/dots/backups/backup-20260627T140000.000000000Z",
 					}},
+					SelectionRetirement: &selectionretirement.Result{
+						Removed:  []string{"/home/user/.work"},
+						Retained: []string{"/home/user/.drifted"},
+					},
 					Retirement: &agentinstructions.RetirementReport{
 						Removed:       []string{"~/.codex/AGENTS.md delegation blocks", "~/.codex/agents/dots-explorer.toml"},
 						ManualCleanup: []string{"~/.agents/skills/delegation"},

--- a/internal/cli/read_selection_test.go
+++ b/internal/cli/read_selection_test.go
@@ -109,11 +109,12 @@ entries:
 			emptyRecordedStateRoot := filepath.Join(emptyRecordedHome, ".local", "state", "dots")
 			saveEmptyInstalledSelection(t, emptyRecordedStateRoot)
 			emptyRecordedArgs := selectionCommandArgs(command.args, manifestPath, emptyRecordedHome, sourceRoot, emptyRecordedStateRoot, command.isDeps)
-			code, _, envelopeError = runSelectionJSON(t, emptyRecordedArgs)
-			if code != 1 || envelopeError != "recorded selection: at least one Profile or extra Tag is required" {
-				t.Fatalf("empty recorded selection = code %d error %q", code, envelopeError)
+			code, data, envelopeError = runSelectionJSON(t, emptyRecordedArgs)
+			if code != 0 || envelopeError != "" {
+				t.Fatalf("empty recorded selection = code %d error %q, want valid aligned selection", code, envelopeError)
 			}
-			golden = append(golden, selectionOutcome("empty recorded", code, nil, envelopeError))
+			assertSelectionJSON(t, data, "recorded", nil, nil, nil)
+			golden = append(golden, selectionOutcome("empty recorded", code, data, envelopeError))
 
 			emptyExplicitArgs := append(append([]string{}, command.args...), "--profile", "")
 			emptyExplicitArgs = selectionCommandArgs(emptyExplicitArgs, manifestPath, commandHome, sourceRoot, stateRoot, command.isDeps)

--- a/internal/cli/selection_change.go
+++ b/internal/cli/selection_change.go
@@ -26,6 +26,7 @@ type selectionChangePolicy struct {
 	Confirmed       bool
 	Acknowledge     bool
 	AlreadyAccepted bool
+	ClearSelection  bool
 }
 
 func (e *selectionChangeAcknowledgementError) Error() string {
@@ -41,10 +42,16 @@ func (e *selectionChangeAcknowledgementError) JSONErrorData() any {
 }
 
 func guardSelectionChange(cmd *cobra.Command, effective *selection.Effective, policy selectionChangePolicy) (bool, bool, error) {
-	if effective.Report.Change == nil {
+	if effective.Report.Change == nil && !policy.ClearSelection {
 		return true, policy.AlreadyAccepted, nil
 	}
+	if effective.Report.Change == nil {
+		effective.Report.Change = &selection.Change{}
+	}
 	change := effective.Report.Change
+	if policy.ClearSelection {
+		change.AcknowledgementRequired = true
+	}
 	if policy.AlreadyAccepted {
 		change.AcknowledgementAccepted = true
 		return true, true, nil
@@ -58,7 +65,7 @@ func guardSelectionChange(cmd *cobra.Command, effective *selection.Effective, po
 		return true, change.AcknowledgementAccepted, nil
 	}
 
-	if policy.DryRun {
+	if policy.DryRun && !policy.ClearSelection {
 		if !wantsJSON(cmd) {
 			renderSelectionChange(cmd.OutOrStdout(), *change)
 		}
@@ -79,7 +86,13 @@ func guardSelectionChange(cmd *cobra.Command, effective *selection.Effective, po
 	if !wantsJSON(cmd) {
 		renderSelectionChange(cmd.OutOrStdout(), *change)
 	}
-	confirmed, err := confirmSelectionChange(cmd.InOrStdin(), cmd.OutOrStdout())
+	var confirmed bool
+	var err error
+	if policy.ClearSelection {
+		confirmed, err = confirmClearSelection(cmd.InOrStdin(), cmd.OutOrStdout())
+	} else {
+		confirmed, err = confirmSelectionChange(cmd.InOrStdin(), cmd.OutOrStdout())
+	}
 	if err != nil {
 		return false, false, err
 	}
@@ -90,6 +103,18 @@ func guardSelectionChange(cmd *cobra.Command, effective *selection.Effective, po
 	change.AcknowledgementAccepted = true
 	fmt.Fprintln(cmd.OutOrStdout(), "Installed Selection change acknowledgement accepted.")
 	return true, true, nil
+}
+
+func confirmClearSelection(r io.Reader, w io.Writer) (bool, error) {
+	fmt.Fprint(w, "Type clear to remove every selected Managed Entry from dots management: ")
+	scanner := bufio.NewScanner(r)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return false, fmt.Errorf("read clear-selection confirmation: %w", err)
+		}
+		return false, nil
+	}
+	return strings.TrimSpace(scanner.Text()) == "clear", nil
 }
 
 func renderSelectionChange(w io.Writer, change selection.Change) {

--- a/internal/cli/selection_reconciliation_test.go
+++ b/internal/cli/selection_reconciliation_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/yersonargotev/dots/internal/cli"
+	"github.com/yersonargotev/dots/internal/deps"
 	"github.com/yersonargotev/dots/internal/state"
 )
 
@@ -75,6 +76,54 @@ func TestSelectionReconciliationRetainsDependencyAndProvisionerExternalState(t *
 		if action["scope"] == "managed-entry" && action["outcome"] == "remove" {
 			t.Fatalf("external-only reduction reported Managed Entry removal: %#v", action)
 		}
+	}
+}
+
+func TestInstallReductionLeavesDependencyMetadataAndProvisionerEffectsUntouched(t *testing.T) {
+	fixture := newSelectionReconciliationFixture(t, true)
+	metadataPath := state.Path(fixture.stateRoot)
+	metadata, err := state.Load(metadataPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	provisioner := state.ProvisionerRecord{
+		Profiles: []string{"full"}, Tags: []string{"retired"}, Tool: "claude", Executable: "claude",
+		Args: []string{"plugin", "marketplace", "add", "example/tools"}, Status: "provisioned",
+	}
+	metadata.Provisioners = []state.ProvisionerRecord{provisioner}
+	if err := state.Save(metadataPath, metadata); err != nil {
+		t.Fatal(err)
+	}
+	dependencyMetadata := deps.DependencyMetadata{Dependencies: []deps.DependencyRecord{{
+		Dependency: "retired-tool", Provider: "user-local", Path: filepath.Join(fixture.root, "bin", "retired-tool"), InstalledAt: "2026-08-22T00:00:00Z",
+	}}}
+	dependencyPath := deps.DependencyMetadataPath(fixture.stateRoot)
+	if err := deps.SaveDependencyMetadata(dependencyPath, dependencyMetadata); err != nil {
+		t.Fatal(err)
+	}
+	dependencyBefore := mustReadSelectionFile(t, dependencyPath)
+	externalEffect := filepath.Join(fixture.root, "provisioner-effect")
+	if err := os.WriteFile(externalEffect, []byte("external\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	output := runSelectionReconciliationJSON(t, cli.ExitOK, append([]string{"install", "--yes", "--acknowledge-selection-change", "--skip-deps"}, fixture.args...)...)
+	actions := jsonPathSelection(t, output, "data", "plan", "selection_reconciliation", "actions")
+	assertSelectionAction(t, actions, "dependency", "retained-external-state", "retired-tool")
+	assertSelectionAction(t, actions, "provisioner", "retained-external-state", "claude")
+
+	if got := mustReadSelectionFile(t, dependencyPath); !bytes.Equal(got, dependencyBefore) {
+		t.Fatalf("Dependency Installation Metadata changed:\nbefore: %s\nafter: %s", dependencyBefore, got)
+	}
+	if got, err := os.ReadFile(externalEffect); err != nil || string(got) != "external\n" {
+		t.Fatalf("Provisioner effect = %q, %v; want untouched", got, err)
+	}
+	gotMetadata, err := state.Load(metadataPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(gotMetadata.Provisioners, []state.ProvisionerRecord{provisioner}) {
+		t.Fatalf("Provisioner metadata = %#v, want preserved receipt", gotMetadata.Provisioners)
 	}
 }
 

--- a/internal/cli/selection_retirement.go
+++ b/internal/cli/selection_retirement.go
@@ -1,0 +1,22 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/yersonargotev/dots/internal/selectionretirement"
+)
+
+func renderSelectionRetirement(w io.Writer, result *selectionretirement.Result) {
+	if result == nil || len(result.Removed)+len(result.Retained) == 0 {
+		return
+	}
+	fmt.Fprintln(w, "Selection retirement:")
+	for _, target := range result.Removed {
+		fmt.Fprintf(w, "  removed %s and released dots ownership\n", target)
+	}
+	for _, target := range result.Retained {
+		fmt.Fprintf(w, "  retained %s and released dots ownership\n", target)
+	}
+	fmt.Fprintln(w)
+}

--- a/internal/cli/testdata/envelope_install.golden
+++ b/internal/cli/testdata/envelope_install.golden
@@ -340,6 +340,14 @@
         "path": "/home/user/.local/state/dots/backups/backup-20260627T140000.000000000Z"
       }
     ],
+    "selection_retirement": {
+      "removed": [
+        "/home/user/.work"
+      ],
+      "retained": [
+        "/home/user/.drifted"
+      ]
+    },
     "retirement": {
       "removed": [
         "~/.codex/AGENTS.md delegation blocks",

--- a/internal/cli/testdata/selection_deps_check.golden
+++ b/internal/cli/testdata/selection_deps_check.golden
@@ -61,8 +61,13 @@
   },
   {
     "scenario": "empty recorded",
-    "exit_code": 1,
-    "error": "recorded selection: at least one Profile or extra Tag is required"
+    "exit_code": 0,
+    "selection": {
+      "effective_tags": [],
+      "extra_tags": [],
+      "profiles": [],
+      "source": "recorded"
+    }
   },
   {
     "scenario": "empty explicit",

--- a/internal/cli/testdata/selection_deps_plan.golden
+++ b/internal/cli/testdata/selection_deps_plan.golden
@@ -61,8 +61,13 @@
   },
   {
     "scenario": "empty recorded",
-    "exit_code": 1,
-    "error": "recorded selection: at least one Profile or extra Tag is required"
+    "exit_code": 0,
+    "selection": {
+      "effective_tags": [],
+      "extra_tags": [],
+      "profiles": [],
+      "source": "recorded"
+    }
   },
   {
     "scenario": "empty explicit",

--- a/internal/cli/testdata/selection_doctor.golden
+++ b/internal/cli/testdata/selection_doctor.golden
@@ -61,8 +61,13 @@
   },
   {
     "scenario": "empty recorded",
-    "exit_code": 1,
-    "error": "recorded selection: at least one Profile or extra Tag is required"
+    "exit_code": 0,
+    "selection": {
+      "effective_tags": [],
+      "extra_tags": [],
+      "profiles": [],
+      "source": "recorded"
+    }
   },
   {
     "scenario": "empty explicit",

--- a/internal/cli/testdata/selection_plan.golden
+++ b/internal/cli/testdata/selection_plan.golden
@@ -61,8 +61,13 @@
   },
   {
     "scenario": "empty recorded",
-    "exit_code": 1,
-    "error": "recorded selection: at least one Profile or extra Tag is required"
+    "exit_code": 0,
+    "selection": {
+      "effective_tags": [],
+      "extra_tags": [],
+      "profiles": [],
+      "source": "recorded"
+    }
   },
   {
     "scenario": "empty explicit",

--- a/internal/cli/testdata/selection_status.golden
+++ b/internal/cli/testdata/selection_status.golden
@@ -61,8 +61,13 @@
   },
   {
     "scenario": "empty recorded",
-    "exit_code": 1,
-    "error": "recorded selection: at least one Profile or extra Tag is required"
+    "exit_code": 0,
+    "selection": {
+      "effective_tags": [],
+      "extra_tags": [],
+      "profiles": [],
+      "source": "recorded"
+    }
   },
   {
     "scenario": "empty explicit",

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -123,60 +123,65 @@ func ApplyManagedEntries(p plan.Plan, opts Options) (MetadataCommit, error) {
 	return commit, nil
 }
 
+// ValidateManagedEntries validates the complete forward Install Plan without
+// mutating the filesystem or Installation Metadata. Action workflows call it
+// before dependency or provisioner effects, then ApplyManagedEntries repeats
+// validation against the latest filesystem state immediately before applying.
+func ValidateManagedEntries(p plan.Plan, opts Options) error {
+	_, err := validatePlan(p, opts)
+	return err
+}
+
 // Commit revalidates sources and live targets, then atomically records exact
 // contribution evidence and, when supplied, the authoritative selection.
 func (c MetadataCommit) Commit(installed *state.InstalledSelection) error {
 	if c.opts.StateRoot == "" {
 		return nil
 	}
-	if err := c.validateTerminalPaths(); err != nil {
-		return err
-	}
-
 	path := state.Path(c.opts.StateRoot)
-	meta, err := state.Load(path)
-	if err != nil {
-		return err
-	}
-	meta.Version = state.CurrentVersion
-	meta.Provenance = state.CaptureProvenance(c.opts.SourceRoot, version.Value)
-
-	now := time.Now().UTC().Format(time.RFC3339)
-	legacyTargets := map[string]struct{}{}
-	for _, stagedAction := range c.actions {
-		if !stagedAction.recordsEvidence {
-			continue
-		}
-		action := stagedAction.action
-		staged, err := stagedAction.evidence()
-		if err != nil {
+	return state.Update(path, func(meta *state.Metadata) error {
+		if err := c.validateTerminalPaths(); err != nil {
 			return err
 		}
-		current, err := buildMetadataRecord(c.profiles, c.tags, action, stagedAction.resolvedSources, staged.InstalledAt)
-		if err != nil {
-			return err
-		}
-		if !sameRecordEvidence(staged, current) {
-			return fmt.Errorf("source contribution evidence changed before terminal metadata commit for %s: %w", action.Target, ownershipevidence.ErrDrift)
-		}
-		if err := validateMetadataRecord(action, stagedAction.resolvedSources, staged); err != nil {
-			return fmt.Errorf("validate staged contribution evidence for %s: %w", action.Target, err)
-		}
-		staged.InstalledAt = now
-		upsertRecord(&meta, staged)
-		if action.Migration != nil && action.Migration.LegacyTarget != "" {
-			legacyTargets[action.Migration.LegacyTarget] = struct{}{}
-		}
-	}
-	for target := range legacyTargets {
-		meta = meta.Remove(target)
-	}
-	if installed != nil {
-		selection := *installed
-		meta.InstalledSelection = &selection
-	}
+		meta.Version = state.CurrentVersion
+		meta.Provenance = state.CaptureProvenance(c.opts.SourceRoot, version.Value)
 
-	return state.Save(path, meta)
+		now := time.Now().UTC().Format(time.RFC3339)
+		legacyTargets := map[string]struct{}{}
+		for _, stagedAction := range c.actions {
+			if !stagedAction.recordsEvidence {
+				continue
+			}
+			action := stagedAction.action
+			staged, err := stagedAction.evidence()
+			if err != nil {
+				return err
+			}
+			current, err := buildMetadataRecord(c.profiles, c.tags, action, stagedAction.resolvedSources, staged.InstalledAt)
+			if err != nil {
+				return err
+			}
+			if !sameRecordEvidence(staged, current) {
+				return fmt.Errorf("source contribution evidence changed before terminal metadata commit for %s: %w", action.Target, ownershipevidence.ErrDrift)
+			}
+			if err := validateMetadataRecord(action, stagedAction.resolvedSources, staged); err != nil {
+				return fmt.Errorf("validate staged contribution evidence for %s: %w", action.Target, err)
+			}
+			staged.InstalledAt = now
+			upsertRecord(meta, staged)
+			if action.Migration != nil && action.Migration.LegacyTarget != "" {
+				legacyTargets[action.Migration.LegacyTarget] = struct{}{}
+			}
+		}
+		for target := range legacyTargets {
+			*meta = meta.Remove(target)
+		}
+		if installed != nil {
+			selection := *installed
+			meta.InstalledSelection = &selection
+		}
+		return nil
+	})
 }
 
 func (c *MetadataCommit) captureStagedEvidence() error {
@@ -202,28 +207,26 @@ func (c MetadataCommit) recordPartialInventory() error {
 		return nil
 	}
 	path := state.Path(c.opts.StateRoot)
-	meta, err := state.Load(path)
-	if err != nil {
-		return err
-	}
-	meta.Version = state.CurrentVersion
-	meta.Provenance = state.CaptureProvenance(c.opts.SourceRoot, version.Value)
-	for _, stagedAction := range c.actions {
-		if !stagedAction.recordsEvidence {
-			continue
+	return state.Update(path, func(meta *state.Metadata) error {
+		meta.Version = state.CurrentVersion
+		meta.Provenance = state.CaptureProvenance(c.opts.SourceRoot, version.Value)
+		for _, stagedAction := range c.actions {
+			if !stagedAction.recordsEvidence {
+				continue
+			}
+			action := stagedAction.action
+			if hasCommittedContributions(*meta, action.Target) {
+				continue
+			}
+			record, err := stagedAction.evidence()
+			if err != nil {
+				return err
+			}
+			record.Contributions = nil
+			upsertRecord(meta, record)
 		}
-		action := stagedAction.action
-		if hasCommittedContributions(meta, action.Target) {
-			continue
-		}
-		record, err := stagedAction.evidence()
-		if err != nil {
-			return err
-		}
-		record.Contributions = nil
-		upsertRecord(&meta, record)
-	}
-	return state.Save(path, meta)
+		return nil
+	})
 }
 
 func (a metadataAction) evidence() (state.Record, error) {

--- a/internal/selection/selection.go
+++ b/internal/selection/selection.go
@@ -102,15 +102,17 @@ type Effective struct {
 	// repository evolution and binary continuation. Persisted ExtraTags remain
 	// normalized current Tags.
 	intentExtraTags []string
+	allowEmpty      bool
 }
 
 // Intent is the authoritative Profile and explicit extra Tag input together
 // with its provenance. It is safe to carry across process boundaries because it
 // excludes the resolved Tag snapshot, which is audit data rather than intent.
 type Intent struct {
-	Source    Source
-	Profiles  []string
-	ExtraTags []string
+	Source     Source
+	Profiles   []string
+	ExtraTags  []string
+	AllowEmpty bool
 }
 
 // ResolveEffective chooses and validates the selection for a command. Any
@@ -121,7 +123,12 @@ func ResolveEffective(m manifest.Manifest, explicitProfiles, explicitTags []stri
 		if recorded == nil {
 			return Effective{}, ErrSelectionRequired
 		}
-		intent = Intent{Source: SourceRecorded, Profiles: recorded.Profiles, ExtraTags: recorded.ExtraTags}
+		intent = Intent{
+			Source:     SourceRecorded,
+			Profiles:   recorded.Profiles,
+			ExtraTags:  recorded.ExtraTags,
+			AllowEmpty: len(recorded.Profiles) == 0 && len(recorded.ExtraTags) == 0,
+		}
 	}
 	return ResolveIntent(m, intent)
 }
@@ -139,7 +146,7 @@ func ResolveIntent(m manifest.Manifest, intent Intent) (Effective, error) {
 	if intent.Source != SourceExplicit && intent.Source != SourceRecorded && intent.Source != SourceMigration {
 		return Effective{}, fmt.Errorf("selection source %q is invalid", intent.Source)
 	}
-	if err := validateIntent(intent.Source, intent.Profiles, intent.ExtraTags); err != nil {
+	if err := validateIntent(intent.Source, intent.Profiles, intent.ExtraTags, intent.AllowEmpty); err != nil {
 		return Effective{}, err
 	}
 
@@ -159,6 +166,7 @@ func ResolveIntent(m manifest.Manifest, intent Intent) (Effective, error) {
 		Profiles:        cloneStrings(orderedProfiles),
 		ExtraTags:       cloneStrings(orderedExtraTags),
 		intentExtraTags: cloneStrings(intent.ExtraTags),
+		allowEmpty:      intent.AllowEmpty,
 		Selection: manifest.Selection{
 			Profile:      resolved.Profile,
 			Profiles:     cloneStrings(orderedProfiles),
@@ -182,9 +190,10 @@ func (e Effective) Intent() Intent {
 		extraTags = e.ExtraTags
 	}
 	return Intent{
-		Source:    e.Report.Source,
-		Profiles:  cloneStrings(e.Profiles),
-		ExtraTags: cloneStrings(extraTags),
+		Source:     e.Report.Source,
+		Profiles:   cloneStrings(e.Profiles),
+		ExtraTags:  cloneStrings(extraTags),
+		AllowEmpty: e.allowEmpty,
 	}
 }
 
@@ -453,7 +462,7 @@ func equalStrings(left, right []string) bool {
 	return true
 }
 
-func validateIntent(source Source, profiles, extraTags []string) error {
+func validateIntent(source Source, profiles, extraTags []string, allowEmpty bool) error {
 	for _, profile := range profiles {
 		if strings.TrimSpace(profile) == "" {
 			return fmt.Errorf("%s selection: profile names must not be empty", source)
@@ -464,7 +473,7 @@ func validateIntent(source Source, profiles, extraTags []string) error {
 			return fmt.Errorf("%s selection: tags must not be empty", source)
 		}
 	}
-	if len(profiles) == 0 && len(extraTags) == 0 {
+	if len(profiles) == 0 && len(extraTags) == 0 && !allowEmpty {
 		return fmt.Errorf("%s selection: at least one Profile or extra Tag is required", source)
 	}
 	return nil

--- a/internal/selection/selection_test.go
+++ b/internal/selection/selection_test.go
@@ -688,6 +688,67 @@ func TestResolveReadOnlyRequiresInvocationOrRecordedSelection(t *testing.T) {
 	}
 }
 
+func TestResolveIntentAcceptsExplicitlyAllowedEmptySelection(t *testing.T) {
+	m := manifest.Manifest{Profiles: map[string]manifest.Profile{
+		"default": {Tags: []string{"must-not-be-used"}},
+	}}
+
+	got, err := selection.ResolveIntent(m, selection.Intent{
+		Source:     selection.SourceExplicit,
+		AllowEmpty: true,
+	})
+	if err != nil {
+		t.Fatalf("ResolveIntent() error = %v", err)
+	}
+	if len(got.Profiles) != 0 || len(got.ExtraTags) != 0 || len(got.Selection.Tags) != 0 || len(got.Report.EffectiveTags) != 0 {
+		t.Fatalf("Effective = %#v, want empty selection", got)
+	}
+	if intent := got.Intent(); !intent.AllowEmpty {
+		t.Fatalf("Intent() = %#v, want empty-selection authority preserved", intent)
+	}
+
+	evolved, err := selection.CompareEvolution(m, m, got, "linux")
+	if err != nil {
+		t.Fatalf("CompareEvolution() error = %v", err)
+	}
+	if !evolved.Intent().AllowEmpty || len(evolved.Selection.Tags) != 0 {
+		t.Fatalf("evolved Effective = %#v, want authorized empty selection", evolved)
+	}
+
+	installed := evolved.InstalledSelection(state.Provenance{})
+	if len(installed.Profiles) != 0 || len(installed.ExtraTags) != 0 || len(installed.ResolvedTags) != 0 {
+		t.Fatalf("InstalledSelection() = %#v, want empty selection", installed)
+	}
+}
+
+func TestResolveIntentRejectsUnapprovedEmptySelection(t *testing.T) {
+	_, err := selection.ResolveIntent(manifest.Manifest{}, selection.Intent{Source: selection.SourceExplicit})
+	if err == nil || err.Error() != "explicit selection: at least one Profile or extra Tag is required" {
+		t.Fatalf("ResolveIntent() error = %v, want unapproved empty selection rejection", err)
+	}
+}
+
+func TestResolveReadOnlyAcceptsRecordedEmptySelection(t *testing.T) {
+	m := manifest.Manifest{Profiles: map[string]manifest.Profile{
+		"default": {Tags: []string{"must-not-be-used"}},
+	}}
+
+	got, err := selection.ResolveReadOnly(m, nil, nil, &state.InstalledSelection{})
+	if err != nil {
+		t.Fatalf("ResolveReadOnly() error = %v", err)
+	}
+	if got.Report.Source != selection.SourceRecorded {
+		t.Fatalf("Source = %q, want %q", got.Report.Source, selection.SourceRecorded)
+	}
+	if len(got.Profiles) != 0 || len(got.ExtraTags) != 0 || len(got.Selection.Tags) != 0 || len(got.Report.EffectiveTags) != 0 {
+		t.Fatalf("Effective = %#v, want empty recorded selection", got)
+	}
+	installed := got.InstalledSelection(state.Provenance{})
+	if len(installed.Profiles) != 0 || len(installed.ExtraTags) != 0 || len(installed.ResolvedTags) != 0 {
+		t.Fatalf("InstalledSelection() = %#v, want empty selection", installed)
+	}
+}
+
 func TestResolveReadOnlyValidatesSelectedSource(t *testing.T) {
 	m := manifest.Manifest{Profiles: map[string]manifest.Profile{
 		"core": {Tags: []string{"core"}},
@@ -729,7 +790,6 @@ func TestResolveReadOnlyRejectsEmptyIntentValues(t *testing.T) {
 		{name: "explicit empty tag", tags: []string{""}, want: "explicit selection: tags must not be empty"},
 		{name: "explicit whitespace profile", profiles: []string{" \t"}, want: "explicit selection: profile names must not be empty"},
 		{name: "explicit whitespace tag", tags: []string{" \t"}, want: "explicit selection: tags must not be empty"},
-		{name: "recorded empty", recorded: &state.InstalledSelection{}, want: "recorded selection: at least one Profile or extra Tag is required"},
 		{name: "recorded whitespace tag", recorded: &state.InstalledSelection{ExtraTags: []string{" "}}, want: "recorded selection: tags must not be empty"},
 	}
 	for _, tt := range tests {

--- a/internal/selectionreconciliation/reconciliation.go
+++ b/internal/selectionreconciliation/reconciliation.go
@@ -176,11 +176,16 @@ type Report struct {
 	Actions         []Action `json:"actions"`
 }
 
-// HasFindings reports whether any action is blocked. Retained External State is
-// intentionally informational and does not by itself become a finding.
+// HasFindings reports whether the plan contains a blocked action or unsafe
+// whole-target evidence that a read-only caller must surface as divergence.
+// Retained External State and manifest-evolution retention stay informational.
 func (r Report) HasFindings() bool {
 	for _, action := range r.Actions {
 		if action.Outcome == OutcomeBlocked {
+			return true
+		}
+		if action.Scope == ScopeManagedEntry && action.Outcome == OutcomeRetain &&
+			(action.Reason == ReasonWholeTargetDrift || action.Reason == ReasonLostOwnership || action.Reason == ReasonAmbiguousPartialOwnership) {
 			return true
 		}
 	}
@@ -406,6 +411,11 @@ func buildTargetAction(previous, current targetGroup, input Input) (Action, erro
 		return action, nil
 	}
 	if !target.Exists {
+		if current.target == "" {
+			action.Outcome = OutcomeRetain
+			action.Reason = ReasonLostOwnership
+			return action, nil
+		}
 		return blocked(action, ReasonLostOwnership), nil
 	}
 
@@ -413,6 +423,11 @@ func buildTargetAction(previous, current targetGroup, input Input) (Action, erro
 		return classifySymlink(action, previous, current, target, currentSources, record, recorded, input.Evidence.Sources), nil
 	}
 	if target.Kind != TargetKindRegular {
+		if current.target == "" {
+			action.Outcome = OutcomeRetain
+			action.Reason = ReasonLostOwnership
+			return action, nil
+		}
 		return blocked(action, ReasonLostOwnership), nil
 	}
 	if ownership == "whole" {
@@ -426,15 +441,24 @@ func buildTargetAction(previous, current targetGroup, input Input) (Action, erro
 
 func classifySymlink(action Action, previous, current targetGroup, target TargetEvidence, currentSources []SourceEvidence, record state.Record, recorded bool, evidence []SourceEvidence) Action {
 	if target.Kind != TargetKindSymlink {
+		if current.target == "" {
+			action.Outcome = OutcomeRetain
+			action.Reason = ReasonLostOwnership
+			return action
+		}
 		return blocked(action, ReasonLostOwnership)
 	}
 	if current.target == "" {
 		if !recorded || target.LinkDestination == "" || !recordHasExactContributions(record, action.PreviousSources, "symlink", "whole") {
-			return blocked(action, ReasonLostOwnership)
+			action.Outcome = OutcomeRetain
+			action.Reason = ReasonLostOwnership
+			return action
 		}
 		if len(action.PreviousSources) != 1 ||
 			target.LinkDestination != resolvedSource(evidence, previous.target, action.PreviousSources[0]) {
-			return blocked(action, ReasonLostOwnership)
+			action.Outcome = OutcomeRetain
+			action.Reason = ReasonLostOwnership
+			return action
 		}
 		action.Outcome = OutcomeRemove
 		return action
@@ -462,10 +486,20 @@ func classifyWhole(action Action, previous, current targetGroup, live, desired [
 		return action
 	}
 	if !recorded || previous.target == "" || !recordHasExactContributions(record, action.PreviousSources, previous.entries[0].Entry.Strategy, "whole") {
+		if current.target == "" {
+			action.Outcome = OutcomeRetain
+			action.Reason = ReasonLostOwnership
+			return action
+		}
 		return blocked(action, ReasonLostOwnership)
 	}
 	contribution, _ := exactContribution(record.Contributions, action.PreviousSources[0], "whole")
 	if contribution.Hash == "" || state.HashBytes(live) != contribution.Hash {
+		if current.target == "" {
+			action.Outcome = OutcomeRetain
+			action.Reason = ReasonWholeTargetDrift
+			return action
+		}
 		return blocked(action, ReasonWholeTargetDrift)
 	}
 	if current.target == "" {
@@ -518,6 +552,11 @@ func classifyPartial(action Action, previous, current targetGroup, ownership str
 		return action, nil
 	}
 	if !recorded || !recordHasExactContributions(record, action.PreviousSources, previous.entries[0].Entry.Strategy, ownership) {
+		if current.target == "" {
+			action.Outcome = OutcomeRetain
+			action.Reason = ReasonAmbiguousPartialOwnership
+			return action, nil
+		}
 		return blocked(action, ReasonAmbiguousPartialOwnership), nil
 	}
 	previousOwned, ok, err := exactPreviousContent(previous, ownership, record)
@@ -525,6 +564,11 @@ func classifyPartial(action Action, previous, current targetGroup, ownership str
 		return Action{}, fmt.Errorf("compose exact previous contribution: %w", err)
 	}
 	if !ok {
+		if current.target == "" {
+			action.Outcome = OutcomeRetain
+			action.Reason = ReasonAmbiguousPartialOwnership
+			return action, nil
+		}
 		return blocked(action, ReasonAmbiguousPartialOwnership), nil
 	}
 
@@ -534,10 +578,13 @@ func classifyPartial(action Action, previous, current targetGroup, ownership str
 			return Action{}, fmt.Errorf("analyze partial retirement: %w", removeErr)
 		}
 		if !compatible {
-			return blocked(action, ReasonAmbiguousPartialOwnership), nil
+			action.Outcome = OutcomeRetain
+			action.Reason = ReasonAmbiguousPartialOwnership
+			return action, nil
 		}
 		if !changed {
-			action.Outcome = OutcomePreserve
+			action.Outcome = OutcomeRetain
+			action.Reason = ReasonAmbiguousPartialOwnership
 		} else if empty {
 			action.Outcome = OutcomeRemove
 		} else {

--- a/internal/selectionreconciliation/reconciliation_test.go
+++ b/internal/selectionreconciliation/reconciliation_test.go
@@ -129,10 +129,50 @@ func TestBuildRequiresExactWholeTargetContributionEvidence(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Build() error = %v", err)
 			}
-			if got := report.Actions[0]; got.Outcome != OutcomeBlocked || got.Reason != ReasonLostOwnership {
-				t.Fatalf("Action = %#v, want lost ownership block", got)
+			if got := report.Actions[0]; got.Outcome != OutcomeRetain || got.Reason != ReasonLostOwnership {
+				t.Fatalf("Action = %#v, want lost ownership retention", got)
 			}
 		})
+	}
+}
+
+func TestBuildRetainsRetiredWholeTargetWhenLiveContentDrifted(t *testing.T) {
+	previous := selectedEntry("old", "~/.target", "copy", "whole")
+	input := baseInput([]selectedsurface.SelectedEntry{previous}, nil, TargetEvidence{
+		DeclarativeTarget: "~/.target",
+		ResolvedTarget:    "/home/test/.target",
+		Exists:            true,
+		Kind:              TargetKindRegular,
+		Content:           []byte("external\n"),
+	})
+	input.Metadata.Entries = []state.Record{{
+		Target:    "/home/test/.target",
+		Source:    "old",
+		Strategy:  "copy",
+		Ownership: "whole",
+		Contributions: []state.Contribution{{
+			Source: "old", Ownership: "whole", EvidenceRecorded: true, Hash: state.HashBytes([]byte("old\n")),
+		}},
+	}}
+
+	report, err := Build(input)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if got := report.Actions[0]; got.Outcome != OutcomeRetain || got.Reason != ReasonWholeTargetDrift {
+		t.Fatalf("Action = %#v, want whole-target Drift retention", got)
+	}
+	if !report.HasFindings() {
+		t.Fatal("retired whole-target Drift must remain a read-only finding")
+	}
+}
+
+func TestReportTreatsLostWholeTargetOwnershipAsFinding(t *testing.T) {
+	report := Report{Actions: []Action{{
+		Scope: ScopeManagedEntry, Outcome: OutcomeRetain, Reason: ReasonLostOwnership,
+	}}}
+	if !report.HasFindings() {
+		t.Fatal("lost whole-target ownership must remain a read-only finding")
 	}
 }
 
@@ -156,8 +196,8 @@ func TestBuildBlocksMultipleWholeTargetContributions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Build() error = %v", err)
 	}
-	if got := report.Actions[0]; got.Outcome != OutcomeBlocked || got.Reason != ReasonLostOwnership {
-		t.Fatalf("Action = %#v, want lost ownership block", got)
+	if got := report.Actions[0]; got.Outcome != OutcomeRetain || got.Reason != ReasonLostOwnership {
+		t.Fatalf("Action = %#v, want lost ownership retention", got)
 	}
 }
 
@@ -181,8 +221,8 @@ func TestBuildRequiresExactSymlinkContributionSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Build() error = %v", err)
 	}
-	if got := report.Actions[0]; got.Outcome != OutcomeBlocked || got.Reason != ReasonLostOwnership {
-		t.Fatalf("Action = %#v, want lost ownership block", got)
+	if got := report.Actions[0]; got.Outcome != OutcomeRetain || got.Reason != ReasonLostOwnership {
+		t.Fatalf("Action = %#v, want lost ownership retention", got)
 	}
 }
 
@@ -235,7 +275,7 @@ func TestBuildReconcilesSharedJSONTargetInSelectedSurfaceOrder(t *testing.T) {
 	}
 }
 
-func TestBuildNeverUsesLegacyTargetWideProjectionForPartialRetirement(t *testing.T) {
+func TestBuildRetainsPartialRetirementWithoutExactContributionEvidence(t *testing.T) {
 	previous := selectedEntry("a.json", "~/.shared.json", "copy", "json-subset")
 	input := baseInput([]selectedsurface.SelectedEntry{previous}, nil, TargetEvidence{
 		DeclarativeTarget: "~/.shared.json",
@@ -255,20 +295,25 @@ func TestBuildNeverUsesLegacyTargetWideProjectionForPartialRetirement(t *testing
 	if err != nil {
 		t.Fatalf("Build() error = %v", err)
 	}
-	if got := report.Actions[0]; got.Outcome != OutcomeBlocked || got.Reason != ReasonAmbiguousPartialOwnership {
-		t.Fatalf("Action = %#v, want ambiguous partial ownership block", got)
+	if got := report.Actions[0]; got.Outcome != OutcomeRetain || got.Reason != ReasonAmbiguousPartialOwnership {
+		t.Fatalf("Action = %#v, want ambiguous partial ownership retention", got)
+	}
+	if !report.HasFindings() {
+		t.Fatal("ambiguous partial ownership must remain a read-only finding")
 	}
 }
 
 func TestBuildClassifiesExactPartialRetirement(t *testing.T) {
 	tests := []struct {
-		name string
-		live []byte
-		want Outcome
+		name       string
+		live       []byte
+		want       Outcome
+		wantReason string
 	}{
 		{name: "remove empty target", live: []byte(`{"a":1}`), want: OutcomeRemove},
 		{name: "retain external target bytes", live: []byte(`{"a":1,"external":true}`), want: OutcomeRetain},
-		{name: "changed owned value blocks", live: []byte(`{"a":2}`), want: OutcomeBlocked},
+		{name: "retain changed owned value", live: []byte(`{"a":2}`), want: OutcomeRetain, wantReason: ReasonAmbiguousPartialOwnership},
+		{name: "retain missing owned value", live: []byte(`{"external":true}`), want: OutcomeRetain, wantReason: ReasonAmbiguousPartialOwnership},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -287,11 +332,11 @@ func TestBuildClassifiesExactPartialRetirement(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Build() error = %v", err)
 			}
-			if got := report.Actions[0].Outcome; got != test.want {
-				t.Fatalf("Outcome = %q, want %q (action %#v)", got, test.want, report.Actions[0])
+			if got := report.Actions[0]; got.Outcome != test.want || got.Reason != test.wantReason {
+				t.Fatalf("Action = %#v, want outcome %q reason %q", got, test.want, test.wantReason)
 			}
-			if test.want == OutcomeBlocked && report.Actions[0].Reason != ReasonAmbiguousPartialOwnership {
-				t.Fatalf("Reason = %q, want ambiguous partial ownership", report.Actions[0].Reason)
+			if test.wantReason != "" && !report.HasFindings() {
+				t.Fatal("unsafe retained partial target must remain a read-only finding")
 			}
 		})
 	}

--- a/internal/selectionretirement/retirement.go
+++ b/internal/selectionretirement/retirement.go
@@ -1,0 +1,382 @@
+// Package selectionretirement applies the filesystem and Installation Metadata
+// effects of explicit selection reductions. It deliberately handles only whole
+// Managed Entry retirement; shared-ownership subtraction belongs to the
+// ownership-specific reconciliation flow.
+package selectionretirement
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+
+	"github.com/yersonargotev/dots/internal/configsubset"
+	"github.com/yersonargotev/dots/internal/plan"
+	"github.com/yersonargotev/dots/internal/selectionreconciliation"
+	"github.com/yersonargotev/dots/internal/state"
+	"github.com/yersonargotev/dots/internal/textblock"
+)
+
+// Options contains the resolved roots needed to validate and apply retirement.
+type Options struct {
+	SourceRoot string
+	Home       string
+	StateRoot  string
+}
+
+// Action is one validated retirement effect.
+type Action struct {
+	Target  string                          `json:"target"`
+	Outcome selectionreconciliation.Outcome `json:"outcome"`
+}
+
+// Plan is a validated, deterministic sequence of retirement effects.
+type Plan struct {
+	Actions []Action `json:"actions"`
+	records map[string]state.Record
+}
+
+// Result distinguishes targets deleted by dots from targets preserved while
+// dots released its ownership record. Both slices are always non-nil.
+type Result struct {
+	Removed  []string `json:"removed"`
+	Retained []string `json:"retained"`
+}
+
+// Build validates every Managed Entry retirement before returning a plan. It
+// performs no mutation.
+func Build(report selectionreconciliation.Report, meta state.Metadata, opts Options) (Plan, error) {
+	home, err := cleanAbs(opts.Home)
+	if err != nil {
+		return Plan{}, fmt.Errorf("build selection retirement: resolve home: %w", err)
+	}
+	if opts.Home == "" {
+		return Plan{}, fmt.Errorf("build selection retirement: home is required")
+	}
+	if opts.SourceRoot == "" {
+		return Plan{}, fmt.Errorf("build selection retirement: source root is required")
+	}
+
+	result := Plan{Actions: make([]Action, 0), records: make(map[string]state.Record)}
+	if report.RequestedIntent.Authority != selectionreconciliation.AuthorityExplicitRequest {
+		return result, nil
+	}
+	if !hasSelectionReduction(report.Actions) {
+		return result, nil
+	}
+	seen := make(map[string]bool)
+	for _, action := range report.Actions {
+		if action.Scope != selectionreconciliation.ScopeManagedEntry || !retiresSource(action.PreviousSources, action.CurrentSources) {
+			continue
+		}
+		if action.Reason == selectionreconciliation.ReasonManifestEvolution {
+			continue
+		}
+		if len(action.CurrentSources) != 0 {
+			return Plan{}, fmt.Errorf("build selection retirement for %s: partial retirement from a still-selected target is not supported", action.ResolvedTarget)
+		}
+		if action.ResolvedTarget == "" {
+			return Plan{}, fmt.Errorf("build selection retirement: managed entry target is required")
+		}
+		if seen[action.ResolvedTarget] {
+			return Plan{}, fmt.Errorf("build selection retirement: duplicate target %s", action.ResolvedTarget)
+		}
+		seen[action.ResolvedTarget] = true
+		if err := validateTarget(action.ResolvedTarget, home); err != nil {
+			return Plan{}, fmt.Errorf("build selection retirement for %s: %w", action.ResolvedTarget, err)
+		}
+		if action.Outcome != selectionreconciliation.OutcomeRemove && action.Outcome != selectionreconciliation.OutcomeRetain {
+			return Plan{}, fmt.Errorf("build selection retirement for %s: outcome %q is unsupported", action.ResolvedTarget, action.Outcome)
+		}
+
+		rec, ok := meta.FindByTarget(action.ResolvedTarget)
+		if !ok {
+			if action.Outcome == selectionreconciliation.OutcomeRemove {
+				return Plan{}, fmt.Errorf("build selection retirement for %s: installation metadata record is required", action.ResolvedTarget)
+			}
+			result.Actions = append(result.Actions, Action{Target: action.ResolvedTarget, Outcome: action.Outcome})
+			continue
+		}
+
+		if action.Outcome == selectionreconciliation.OutcomeRemove {
+			removable, classifyErr := entireTargetRemovable(rec, opts.SourceRoot, home)
+			if classifyErr != nil {
+				return Plan{}, fmt.Errorf("build selection retirement for %s: %w", action.ResolvedTarget, classifyErr)
+			}
+			if !removable {
+				return Plan{}, fmt.Errorf("build selection retirement for %s: target is not proven entirely removable", action.ResolvedTarget)
+			}
+		}
+		result.Actions = append(result.Actions, Action{Target: action.ResolvedTarget, Outcome: action.Outcome})
+		result.records[action.ResolvedTarget] = rec.Clone()
+	}
+	return result, nil
+}
+
+func hasSelectionReduction(actions []selectionreconciliation.Action) bool {
+	for _, action := range actions {
+		if action.Scope == selectionreconciliation.ScopeSelection && action.Outcome == selectionreconciliation.OutcomeRemove {
+			return true
+		}
+	}
+	return false
+}
+
+func retiresSource(previous, current []string) bool {
+	selected := make(map[string]bool, len(current))
+	for _, source := range current {
+		selected[source] = true
+	}
+	for _, source := range previous {
+		if !selected[source] {
+			return true
+		}
+	}
+	return false
+}
+
+// Apply reloads Installation Metadata and revalidates every target immediately
+// before acting. A stale remove is converted to retain-and-release.
+func Apply(retirement Plan, opts Options) (Result, error) {
+	return applyWithRemove(retirement, opts, nil)
+}
+
+func applyWithRemove(retirement Plan, opts Options, injectedRemove func(string) error) (Result, error) {
+	result := Result{Removed: make([]string, 0), Retained: make([]string, 0)}
+	home, err := cleanAbs(opts.Home)
+	if err != nil {
+		return result, fmt.Errorf("apply selection retirement: resolve home: %w", err)
+	}
+	if opts.Home == "" {
+		return result, fmt.Errorf("apply selection retirement: home is required")
+	}
+	if opts.SourceRoot == "" {
+		return result, fmt.Errorf("apply selection retirement: source root is required")
+	}
+	if opts.StateRoot == "" {
+		return result, fmt.Errorf("apply selection retirement: state root is required")
+	}
+	if err := validateStateRoot(opts.StateRoot, home); err != nil {
+		return result, fmt.Errorf("apply selection retirement: %w", err)
+	}
+
+	metadataPath := state.Path(opts.StateRoot)
+	locked, err := state.LockMetadata(metadataPath)
+	if err != nil {
+		return result, fmt.Errorf("apply selection retirement: lock installation metadata: %w", err)
+	}
+	meta, err := locked.Load()
+	if err != nil {
+		return result, errors.Join(fmt.Errorf("apply selection retirement: load installation metadata: %w", err), locked.Close())
+	}
+	homeRoot, err := os.OpenRoot(home)
+	if err != nil {
+		return result, errors.Join(fmt.Errorf("apply selection retirement: open home root: %w", err), locked.Close())
+	}
+	result, applyErr := applyLoaded(retirement, opts, home, locked, meta, homeRoot, injectedRemove)
+	if closeErr := homeRoot.Close(); closeErr != nil {
+		applyErr = errors.Join(applyErr, fmt.Errorf("apply selection retirement: close home root: %w", closeErr))
+	}
+	if closeErr := locked.Close(); closeErr != nil {
+		applyErr = errors.Join(applyErr, closeErr)
+	}
+	return result, applyErr
+}
+
+func applyLoaded(retirement Plan, opts Options, home string, metadata *state.LockedMetadata, meta state.Metadata, homeRoot *os.Root, injectedRemove func(string) error) (Result, error) {
+	result := Result{Removed: make([]string, 0), Retained: make([]string, 0)}
+	if err := prevalidateMetadata(retirement, meta); err != nil {
+		return result, err
+	}
+	changed := false
+	for _, action := range retirement.Actions {
+		latest, err := metadata.Load()
+		if err != nil {
+			return result, fmt.Errorf("apply selection retirement: reload installation metadata: %w", err)
+		}
+		if err := prevalidateActionMetadata(action, retirement.records, latest); err != nil {
+			return result, err
+		}
+		rec, ok := latest.FindByTarget(action.Target)
+		if !ok {
+			result.Retained = append(result.Retained, action.Target)
+			continue
+		}
+		if err := validateTarget(rec.Target, home); err != nil {
+			return result, fmt.Errorf("apply selection retirement for %s: %w", action.Target, err)
+		}
+
+		remove := false
+		if action.Outcome == selectionreconciliation.OutcomeRemove {
+			var classifyErr error
+			remove, classifyErr = entireTargetRemovable(rec, opts.SourceRoot, home)
+			if classifyErr != nil {
+				return result, fmt.Errorf("apply selection retirement for %s: %w", action.Target, classifyErr)
+			}
+		} else if _, statErr := os.Lstat(rec.Target); statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+			return result, fmt.Errorf("apply selection retirement for %s: revalidate retained target: %w", action.Target, statErr)
+		}
+		if remove {
+			if err := plan.ValidateBackupableTarget(rec.Target); err != nil {
+				return result, fmt.Errorf("apply selection retirement for %s: %w", action.Target, err)
+			}
+			removeFn := injectedRemove
+			if removeFn == nil {
+				relative, relErr := filepath.Rel(home, rec.Target)
+				if relErr != nil {
+					return result, fmt.Errorf("apply selection retirement for %s: resolve target relative to home: %w", action.Target, relErr)
+				}
+				if !filepath.IsLocal(relative) {
+					return result, fmt.Errorf("apply selection retirement for %s: target is not local to home", action.Target)
+				}
+				removeFn = func(string) error { return homeRoot.Remove(relative) }
+			}
+			if err := removeFn(rec.Target); err != nil {
+				return result, fmt.Errorf("apply selection retirement for %s: remove target: %w", action.Target, err)
+			}
+			result.Removed = append(result.Removed, action.Target)
+		} else {
+			result.Retained = append(result.Retained, action.Target)
+		}
+		changed = true
+	}
+
+	if changed {
+		latest, err := metadata.Load()
+		if err != nil {
+			return result, fmt.Errorf("apply selection retirement: reload installation metadata before prune: %w", err)
+		}
+		if err := prevalidateMetadata(retirement, latest); err != nil {
+			return result, err
+		}
+		for _, action := range retirement.Actions {
+			if _, planned := retirement.records[action.Target]; planned {
+				latest = latest.Remove(action.Target)
+			}
+		}
+		if err := metadata.Save(latest); err != nil {
+			return result, fmt.Errorf("apply selection retirement: save pruned installation metadata: %w", err)
+		}
+	}
+	return result, nil
+}
+
+func prevalidateActionMetadata(action Action, records map[string]state.Record, meta state.Metadata) error {
+	current, exists := meta.FindByTarget(action.Target)
+	if !exists {
+		return nil
+	}
+	planned, plannedExists := records[action.Target]
+	if !plannedExists || !reflect.DeepEqual(current, planned) {
+		return fmt.Errorf("apply selection retirement for %s: installation metadata changed after build", action.Target)
+	}
+	return nil
+}
+
+func prevalidateMetadata(retirement Plan, meta state.Metadata) error {
+	seen := make(map[string]bool)
+	for _, action := range retirement.Actions {
+		if seen[action.Target] {
+			return fmt.Errorf("apply selection retirement: duplicate target %s", action.Target)
+		}
+		seen[action.Target] = true
+		if action.Outcome != selectionreconciliation.OutcomeRemove && action.Outcome != selectionreconciliation.OutcomeRetain {
+			return fmt.Errorf("apply selection retirement for %s: outcome %q is unsupported", action.Target, action.Outcome)
+		}
+		if err := prevalidateActionMetadata(action, retirement.records, meta); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func classify(rec state.Record, sourceRoot, home string) (plan.UninstallStatus, error) {
+	p, err := plan.BuildUninstall(state.Metadata{Entries: []state.Record{rec}}, plan.UninstallOptions{SourceRoot: sourceRoot, Home: home})
+	if err != nil {
+		return "", fmt.Errorf("classify target: %w", err)
+	}
+	if len(p.Actions) != 1 {
+		return "", fmt.Errorf("classify target: expected one uninstall action, got %d", len(p.Actions))
+	}
+	return p.Actions[0].Status, nil
+}
+
+func entireTargetRemovable(rec state.Record, sourceRoot, home string) (bool, error) {
+	if !supportedRetirementOwnership(rec.Ownership) || rec.Ownership == "seeded" {
+		return false, fmt.Errorf("ownership %q cannot remove an entire target", rec.Ownership)
+	}
+	status, err := classify(rec, sourceRoot, home)
+	if err != nil || status != plan.UninstallRemove {
+		return false, err
+	}
+	if rec.Ownership == "whole" {
+		return true, nil
+	}
+	live, err := os.ReadFile(rec.Target)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read partial target: %w", err)
+	}
+	var empty, compatible bool
+	switch rec.Ownership {
+	case "json-subset":
+		_, _, empty, compatible, err = configsubset.RemoveJSON(live, rec.OwnedContent)
+	case "jsonc-subset":
+		_, _, empty, compatible, err = configsubset.RemoveJSONC(live, rec.OwnedContent)
+	case "toml-subset":
+		_, _, empty, compatible, err = configsubset.RemoveTOML(live, rec.OwnedBytes)
+	case "marked-block":
+		_, _, empty, compatible = textblock.RemoveOwned(live, rec.OwnedBytes, textblock.DotsManagedMarkers())
+	}
+	if err != nil {
+		return false, fmt.Errorf("analyze entire partial target removal: %w", err)
+	}
+	return compatible && empty, nil
+}
+
+func supportedRetirementOwnership(ownership string) bool {
+	switch ownership {
+	case "whole", "seeded", "json-subset", "jsonc-subset", "toml-subset", "marked-block":
+		return true
+	default:
+		return false
+	}
+}
+
+func validateTarget(target, home string) error {
+	if err := plan.ValidateResolvedTarget(target, home); err != nil {
+		return err
+	}
+	if err := plan.ValidateTargetParentInsideHome(target, home); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateStateRoot(stateRoot, home string) error {
+	stateAbs, err := cleanAbs(stateRoot)
+	if err != nil {
+		return fmt.Errorf("resolve state root: %w", err)
+	}
+	if !plan.InsideRoot(stateAbs, home) {
+		return nil
+	}
+	if err := plan.ValidatePathInsideHomeNoSymlinkEscape(stateAbs, home, "state root"); err != nil {
+		return err
+	}
+	return plan.ValidateFilePathInsideHomeNoSymlinkEscape(state.Path(stateAbs), home, "installation metadata")
+}
+
+func cleanAbs(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(abs), nil
+}

--- a/internal/selectionretirement/retirement_test.go
+++ b/internal/selectionretirement/retirement_test.go
@@ -1,0 +1,566 @@
+package selectionretirement
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/selectionreconciliation"
+	"github.com/yersonargotev/dots/internal/state"
+)
+
+func TestBuildSelectsOnlySupportedRetirements(t *testing.T) {
+	home := t.TempDir()
+	removed := writeTarget(t, home, ".remove", "owned")
+	retained := writeTarget(t, home, ".retain", "local")
+	meta := state.Metadata{Entries: []state.Record{
+		wholeRecord(removed, "owned"),
+		{Target: retained, Source: "retain", Strategy: "copy", Ownership: "seeded"},
+	}}
+	report := explicitReport(
+		selectionreconciliation.Action{Scope: selectionreconciliation.ScopeSelection, Outcome: selectionreconciliation.OutcomeRemove},
+		retirementAction(removed, selectionreconciliation.OutcomeRemove),
+		retirementAction(retained, selectionreconciliation.OutcomeRetain),
+		selectionreconciliation.Action{Scope: selectionreconciliation.ScopeManagedEntry, Outcome: selectionreconciliation.OutcomePreserve, ResolvedTarget: filepath.Join(home, ".active"), CurrentSources: []string{"active"}},
+	)
+
+	got, err := Build(report, meta, Options{Home: home, SourceRoot: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	want := []Action{
+		{Target: removed, Outcome: selectionreconciliation.OutcomeRemove},
+		{Target: retained, Outcome: selectionreconciliation.OutcomeRetain},
+	}
+	if !reflect.DeepEqual(got.Actions, want) {
+		t.Fatalf("Build() actions = %#v, want %#v", got.Actions, want)
+	}
+}
+
+func TestBuildKeepsManifestEvolutionRetirementReportOnly(t *testing.T) {
+	home := t.TempDir()
+	target := writeTarget(t, home, ".retain", "owned")
+	meta := state.Metadata{Entries: []state.Record{wholeRecord(target, "owned")}}
+	report := selectionreconciliation.Report{
+		RequestedIntent: selectionreconciliation.Intent{Authority: selectionreconciliation.AuthorityManifestEvolution},
+		Actions: []selectionreconciliation.Action{
+			retirementAction(target, selectionreconciliation.OutcomeRetain),
+		},
+	}
+
+	got, err := Build(report, meta, Options{Home: home, SourceRoot: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if len(got.Actions) != 0 {
+		t.Fatalf("Build() actions = %#v, want manifest evolution to remain report-only", got.Actions)
+	}
+	if _, ok := meta.FindByTarget(target); !ok {
+		t.Fatal("Build mutated Installation Metadata")
+	}
+}
+
+func TestBuildKeepsSupplementedManifestEvolutionReportOnlyDuringExplicitReduction(t *testing.T) {
+	home := t.TempDir()
+	target := writeTarget(t, home, ".retain", "owned")
+	meta := state.Metadata{Entries: []state.Record{wholeRecord(target, "owned")}}
+	action := retirementAction(target, selectionreconciliation.OutcomeRetain)
+	action.Reason = selectionreconciliation.ReasonManifestEvolution
+	report := explicitReport(action)
+
+	got, err := Build(report, meta, Options{Home: home, SourceRoot: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if len(got.Actions) != 0 {
+		t.Fatalf("Build() actions = %#v, want supplemented manifest evolution to remain report-only", got.Actions)
+	}
+}
+
+func TestBuildLeavesAdditionOnlySourceChangesToForwardInstall(t *testing.T) {
+	home := t.TempDir()
+	target := writeTarget(t, home, ".config", "old")
+	report := explicitReport(
+		selectionreconciliation.Action{Scope: selectionreconciliation.ScopeSelection, Outcome: selectionreconciliation.OutcomeCreate, Names: []string{"added"}},
+		selectionreconciliation.Action{
+			Scope: selectionreconciliation.ScopeManagedEntry, Outcome: selectionreconciliation.OutcomeUpdate,
+			ResolvedTarget: target, PreviousSources: []string{"base"}, CurrentSources: []string{"override"},
+		},
+	)
+
+	got, err := Build(report, state.Metadata{}, Options{Home: home, SourceRoot: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if len(got.Actions) != 0 {
+		t.Fatalf("Build() actions = %#v, want addition-only change left to forward install", got.Actions)
+	}
+}
+
+func writeTarget(t *testing.T, home, name, content string) string {
+	t.Helper()
+	target := filepath.Join(home, name)
+	if err := os.WriteFile(target, []byte(content), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	return target
+}
+
+func wholeRecord(target, content string) state.Record {
+	return state.Record{Target: target, Source: filepath.Base(target), Strategy: "copy", Ownership: "whole", Hash: state.HashBytes([]byte(content))}
+}
+
+func retirementAction(target string, outcome selectionreconciliation.Outcome) selectionreconciliation.Action {
+	return selectionreconciliation.Action{
+		Scope:           selectionreconciliation.ScopeManagedEntry,
+		Outcome:         outcome,
+		ResolvedTarget:  target,
+		PreviousSources: []string{filepath.Base(target)},
+		CurrentSources:  []string{},
+	}
+}
+
+func explicitReport(actions ...selectionreconciliation.Action) selectionreconciliation.Report {
+	hasSelectionAction := false
+	for _, action := range actions {
+		if action.Scope == selectionreconciliation.ScopeSelection {
+			hasSelectionAction = true
+			break
+		}
+	}
+	if !hasSelectionAction {
+		actions = append([]selectionreconciliation.Action{{
+			Scope: selectionreconciliation.ScopeSelection, Outcome: selectionreconciliation.OutcomeRemove,
+		}}, actions...)
+	}
+	return selectionreconciliation.Report{
+		RequestedIntent: selectionreconciliation.Intent{Authority: selectionreconciliation.AuthorityExplicitRequest},
+		Actions:         actions,
+	}
+}
+
+func TestBuildRejectsBlockedAndUnsupportedRetirementsBeforeMutation(t *testing.T) {
+	home := t.TempDir()
+	target := writeTarget(t, home, ".owned", "owned")
+	meta := state.Metadata{Entries: []state.Record{wholeRecord(target, "owned")}}
+
+	tests := []struct {
+		name   string
+		action selectionreconciliation.Action
+	}{
+		{name: "blocked", action: retirementAction(target, selectionreconciliation.OutcomeBlocked)},
+		{name: "unsupported outcome", action: retirementAction(target, selectionreconciliation.OutcomePreserve)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Build(explicitReport(tt.action), meta, Options{Home: home, SourceRoot: t.TempDir()})
+			if err == nil {
+				t.Fatal("Build() error = nil, want rejection")
+			}
+			if got, readErr := os.ReadFile(target); readErr != nil || string(got) != "owned" {
+				t.Fatalf("target changed during Build: content=%q err=%v", got, readErr)
+			}
+		})
+	}
+}
+
+func TestBuildAllowsEntirePartialOwnershipTargetToRetire(t *testing.T) {
+	home := t.TempDir()
+	removed := writeTarget(t, home, ".remove.json", `{"owned":true}`)
+	retained := writeTarget(t, home, ".retain.json", `{"owned":true,"external":true}`)
+	record := func(target string) state.Record {
+		return state.Record{
+			Target: target, Source: filepath.Base(target), Strategy: "copy", Ownership: "json-subset",
+			OwnedContent: []byte(`{"owned":true}`),
+			Contributions: []state.Contribution{{
+				Source: filepath.Base(target), Ownership: "json-subset", EvidenceRecorded: true, OwnedContent: []byte(`{"owned":true}`),
+			}},
+		}
+	}
+	meta := state.Metadata{Entries: []state.Record{record(removed), record(retained)}}
+
+	got, err := Build(explicitReport(
+		retirementAction(removed, selectionreconciliation.OutcomeRemove),
+		retirementAction(retained, selectionreconciliation.OutcomeRetain),
+	), meta, Options{Home: home, SourceRoot: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	want := []Action{
+		{Target: removed, Outcome: selectionreconciliation.OutcomeRemove},
+		{Target: retained, Outcome: selectionreconciliation.OutcomeRetain},
+	}
+	if !reflect.DeepEqual(got.Actions, want) {
+		t.Fatalf("Build() actions = %#v, want %#v", got.Actions, want)
+	}
+}
+
+func TestBuildRejectsPartialRetirementFromStillSelectedTarget(t *testing.T) {
+	home := t.TempDir()
+	target := writeTarget(t, home, ".shared.json", `{}`)
+	report := explicitReport(selectionreconciliation.Action{
+		Scope:           selectionreconciliation.ScopeManagedEntry,
+		Outcome:         selectionreconciliation.OutcomeReconcile,
+		ResolvedTarget:  target,
+		PreviousSources: []string{"removed.json", "kept.json"},
+		CurrentSources:  []string{"kept.json"},
+	})
+
+	_, err := Build(report, state.Metadata{}, Options{Home: home, SourceRoot: t.TempDir()})
+	if err == nil {
+		t.Fatal("Build() error = nil, want partial-retirement rejection")
+	}
+	if got, readErr := os.ReadFile(target); readErr != nil || string(got) != `{}` {
+		t.Fatalf("target changed during Build: content=%q err=%v", got, readErr)
+	}
+}
+
+func TestBuildRejectsTargetOutsideHome(t *testing.T) {
+	home := t.TempDir()
+	outside := writeTarget(t, t.TempDir(), ".outside", "owned")
+	meta := state.Metadata{Entries: []state.Record{wholeRecord(outside, "owned")}}
+
+	_, err := Build(
+		explicitReport(retirementAction(outside, selectionreconciliation.OutcomeRemove)),
+		meta,
+		Options{Home: home, SourceRoot: t.TempDir()},
+	)
+	if err == nil {
+		t.Fatal("Build() error = nil, want home-confinement rejection")
+	}
+	if got, readErr := os.ReadFile(outside); readErr != nil || string(got) != "owned" {
+		t.Fatalf("outside target changed: content=%q err=%v", got, readErr)
+	}
+}
+
+func TestBuildAllowsRetainWithoutInventory(t *testing.T) {
+	home := t.TempDir()
+	target := filepath.Join(home, ".stale-selection")
+	action := retirementAction(target, selectionreconciliation.OutcomeRetain)
+
+	got, err := Build(
+		explicitReport(action),
+		state.Metadata{},
+		Options{Home: home, SourceRoot: t.TempDir()},
+	)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if !reflect.DeepEqual(got.Actions, []Action{{Target: target, Outcome: selectionreconciliation.OutcomeRetain}}) {
+		t.Fatalf("Build() actions = %#v", got.Actions)
+	}
+}
+
+func TestBuildAllowsRetainForLostLegacyOwnership(t *testing.T) {
+	home := t.TempDir()
+	target := writeTarget(t, home, ".legacy", "external")
+	action := retirementAction(target, selectionreconciliation.OutcomeRetain)
+	meta := state.Metadata{Entries: []state.Record{{Target: target, Source: "legacy", Strategy: "copy"}}}
+
+	got, err := Build(explicitReport(action), meta, Options{Home: home, SourceRoot: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if !reflect.DeepEqual(got.Actions, []Action{{Target: target, Outcome: selectionreconciliation.OutcomeRetain}}) {
+		t.Fatalf("Build() actions = %#v", got.Actions)
+	}
+}
+
+func TestApplyRemovesOrRetainsAndPreservesIndependentMetadata(t *testing.T) {
+	home := t.TempDir()
+	stateRoot := filepath.Join(home, ".state")
+	removed := writeTarget(t, home, ".remove", "owned")
+	retained := writeTarget(t, home, ".retain", "local")
+	selection := &state.InstalledSelection{Profiles: []string{"previous"}, ResolvedTags: []string{"previous"}}
+	provisioners := []state.ProvisionerRecord{{Tool: "tool", Executable: "tool", Status: "ok"}}
+	meta := state.Metadata{
+		Version:            state.CurrentVersion,
+		Provenance:         state.Provenance{SourceRoot: "/source"},
+		Entries:            []state.Record{wholeRecord(removed, "owned"), {Target: retained, Source: "retain", Strategy: "copy", Ownership: "seeded"}},
+		Provisioners:       provisioners,
+		InstalledSelection: selection,
+	}
+	if err := state.Save(state.Path(stateRoot), meta); err != nil {
+		t.Fatalf("save metadata: %v", err)
+	}
+	report := explicitReport(
+		retirementAction(removed, selectionreconciliation.OutcomeRemove),
+		retirementAction(retained, selectionreconciliation.OutcomeRetain),
+	)
+	opts := Options{Home: home, SourceRoot: t.TempDir(), StateRoot: stateRoot}
+	p, err := Build(report, meta, opts)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	result, err := Apply(p, opts)
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if !reflect.DeepEqual(result, Result{Removed: []string{removed}, Retained: []string{retained}}) {
+		t.Fatalf("Apply() result = %#v", result)
+	}
+	if _, err := os.Lstat(removed); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("removed target still exists: %v", err)
+	}
+	if got, err := os.ReadFile(retained); err != nil || string(got) != "local" {
+		t.Fatalf("retained target = %q, %v", got, err)
+	}
+	got, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load pruned metadata: %v", err)
+	}
+	if len(got.Entries) != 0 || !reflect.DeepEqual(got.Provisioners, provisioners) || !reflect.DeepEqual(got.InstalledSelection, selection) || got.Provenance != meta.Provenance {
+		t.Fatalf("pruned metadata = %#v, want independent fields preserved", got)
+	}
+	if _, err := os.Stat(state.Path(stateRoot)); err != nil {
+		t.Fatalf("empty metadata was not persisted: %v", err)
+	}
+}
+
+func TestApplyPreservesDriftedPlannedRemovalAndReleasesMetadata(t *testing.T) {
+	home := t.TempDir()
+	stateRoot := filepath.Join(home, ".state")
+	target := writeTarget(t, home, ".owned", "owned")
+	meta := state.Metadata{Version: state.CurrentVersion, Entries: []state.Record{wholeRecord(target, "owned")}}
+	if err := state.Save(state.Path(stateRoot), meta); err != nil {
+		t.Fatal(err)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	opts := Options{Home: home, SourceRoot: t.TempDir(), StateRoot: stateRoot}
+	p, err := Build(explicitReport(retirementAction(target, selectionreconciliation.OutcomeRemove)), meta, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("drift"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Apply(p, opts)
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if !reflect.DeepEqual(result, Result{Removed: []string{}, Retained: []string{target}}) {
+		t.Fatalf("Apply() result = %#v", result)
+	}
+	if got, err := os.ReadFile(target); err != nil || string(got) != "drift" {
+		t.Fatalf("drifted target = %q, %v", got, err)
+	}
+	got, err := state.Load(state.Path(stateRoot))
+	if err != nil || len(got.Entries) != 0 {
+		t.Fatalf("metadata after release = %#v, %v", got, err)
+	}
+}
+
+func TestApplyPreservesSubsetTargetExtendedAfterBuild(t *testing.T) {
+	home := t.TempDir()
+	stateRoot := filepath.Join(home, ".state")
+	target := writeTarget(t, home, ".owned.json", `{"owned":true}`)
+	rec := state.Record{
+		Target: target, Source: "owned.json", Strategy: "copy", Ownership: "json-subset",
+		OwnedContent: []byte(`{"owned":true}`),
+		Contributions: []state.Contribution{{
+			Source: "owned.json", Ownership: "json-subset", EvidenceRecorded: true, OwnedContent: []byte(`{"owned":true}`),
+		}},
+	}
+	meta := state.Metadata{Version: state.CurrentVersion, Entries: []state.Record{rec}}
+	if err := state.Save(state.Path(stateRoot), meta); err != nil {
+		t.Fatal(err)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	opts := Options{Home: home, SourceRoot: t.TempDir(), StateRoot: stateRoot}
+	p, err := Build(explicitReport(retirementAction(target, selectionreconciliation.OutcomeRemove)), meta, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte(`{"owned":true,"external":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Apply(p, opts)
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if !reflect.DeepEqual(result, Result{Removed: []string{}, Retained: []string{target}}) {
+		t.Fatalf("Apply() result = %#v", result)
+	}
+	if got, err := os.ReadFile(target); err != nil || string(got) != `{"owned":true,"external":true}` {
+		t.Fatalf("extended subset target = %q, %v", got, err)
+	}
+	got, err := state.Load(state.Path(stateRoot))
+	if err != nil || len(got.Entries) != 0 {
+		t.Fatalf("metadata after retained release = %#v, %v", got, err)
+	}
+}
+
+func TestApplyRejectsChangedMetadataBeforeFilesystemMutation(t *testing.T) {
+	home := t.TempDir()
+	stateRoot := filepath.Join(home, ".state")
+	target := writeTarget(t, home, ".owned", "owned")
+	meta := state.Metadata{Version: state.CurrentVersion, Entries: []state.Record{wholeRecord(target, "owned")}}
+	if err := state.Save(state.Path(stateRoot), meta); err != nil {
+		t.Fatal(err)
+	}
+	opts := Options{Home: home, SourceRoot: t.TempDir(), StateRoot: stateRoot}
+	p, err := Build(explicitReport(retirementAction(target, selectionreconciliation.OutcomeRemove)), meta, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	changed := meta
+	changed.Entries = []state.Record{wholeRecord(target, "replacement")}
+	if err := state.Save(state.Path(stateRoot), changed); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Apply(p, opts)
+	if err == nil {
+		t.Fatalf("Apply() = (%#v, nil), want stale metadata error", result)
+	}
+	if got, err := os.ReadFile(target); err != nil || string(got) != "owned" {
+		t.Fatalf("target after metadata change = %q, %v", got, err)
+	}
+	got, err := state.Load(state.Path(stateRoot))
+	if err != nil || !reflect.DeepEqual(got.Entries, changed.Entries) {
+		t.Fatalf("metadata after rejection = %#v, %v", got, err)
+	}
+}
+
+func TestApplyPrevalidatesAllMetadataBeforeFirstRemoval(t *testing.T) {
+	home := t.TempDir()
+	stateRoot := filepath.Join(home, ".state")
+	first := writeTarget(t, home, ".first", "first")
+	second := writeTarget(t, home, ".second", "second")
+	meta := state.Metadata{Version: state.CurrentVersion, Entries: []state.Record{wholeRecord(first, "first"), wholeRecord(second, "second")}}
+	if err := state.Save(state.Path(stateRoot), meta); err != nil {
+		t.Fatal(err)
+	}
+	opts := Options{Home: home, SourceRoot: t.TempDir(), StateRoot: stateRoot}
+	report := explicitReport(
+		retirementAction(first, selectionreconciliation.OutcomeRemove),
+		retirementAction(second, selectionreconciliation.OutcomeRemove),
+	)
+	p, err := Build(report, meta, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	changed := meta
+	changed.Entries = append([]state.Record(nil), meta.Entries...)
+	changed.Entries[1].Hash = state.HashBytes([]byte("replacement"))
+	if err := state.Save(state.Path(stateRoot), changed); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Apply(p, opts); err == nil {
+		t.Fatal("Apply() error = nil, want stale metadata rejection")
+	}
+	for _, target := range []string{first, second} {
+		if _, err := os.Stat(target); err != nil {
+			t.Fatalf("target %s mutated before metadata prevalidation: %v", target, err)
+		}
+	}
+}
+
+func TestApplyMergesConcurrentIndependentMetadataBeforePruning(t *testing.T) {
+	home := t.TempDir()
+	stateRoot := filepath.Join(home, ".state")
+	target := writeTarget(t, home, ".owned", "owned")
+	meta := state.Metadata{Version: state.CurrentVersion, Entries: []state.Record{wholeRecord(target, "owned")}}
+	if err := state.Save(state.Path(stateRoot), meta); err != nil {
+		t.Fatal(err)
+	}
+	opts := Options{Home: home, SourceRoot: t.TempDir(), StateRoot: stateRoot}
+	p, err := Build(explicitReport(retirementAction(target, selectionreconciliation.OutcomeRemove)), meta, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt := state.ProvisionerRecord{Tool: "concurrent", Executable: "tool", Status: "provisioned"}
+	updateStarted := make(chan struct{})
+	updateDone := make(chan error, 1)
+
+	result, err := applyWithRemove(p, opts, func(target string) error {
+		if err := os.Remove(target); err != nil {
+			return err
+		}
+		go func() {
+			close(updateStarted)
+			updateDone <- state.Update(state.Path(stateRoot), func(latest *state.Metadata) error {
+				latest.Provisioners = append(latest.Provisioners, receipt)
+				return nil
+			})
+		}()
+		<-updateStarted
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if err := <-updateDone; err != nil {
+		t.Fatalf("concurrent metadata update: %v", err)
+	}
+	if !reflect.DeepEqual(result.Removed, []string{target}) {
+		t.Fatalf("Apply() result = %#v", result)
+	}
+	got, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Entries) != 0 || !reflect.DeepEqual(got.Provisioners, []state.ProvisionerRecord{receipt}) {
+		t.Fatalf("metadata after prune = %#v, want concurrent receipt preserved", got)
+	}
+}
+
+func TestApplyRemovalFailureLeavesMetadataRepairableAndRerunConverges(t *testing.T) {
+	home := t.TempDir()
+	stateRoot := filepath.Join(home, ".state")
+	first := writeTarget(t, home, ".first", "first")
+	second := writeTarget(t, home, ".second", "second")
+	selection := &state.InstalledSelection{Profiles: []string{"previous"}, ResolvedTags: []string{"previous"}}
+	meta := state.Metadata{Version: state.CurrentVersion, Entries: []state.Record{wholeRecord(first, "first"), wholeRecord(second, "second")}, InstalledSelection: selection}
+	if err := state.Save(state.Path(stateRoot), meta); err != nil {
+		t.Fatal(err)
+	}
+	opts := Options{Home: home, SourceRoot: t.TempDir(), StateRoot: stateRoot}
+	report := explicitReport(
+		retirementAction(first, selectionreconciliation.OutcomeRemove),
+		retirementAction(second, selectionreconciliation.OutcomeRemove),
+	)
+	p, err := Build(report, meta, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	calls := 0
+	result, err := applyWithRemove(p, opts, func(target string) error {
+		calls++
+		if calls == 2 {
+			return errors.New("injected removal failure")
+		}
+		return os.Remove(target)
+	})
+	if err == nil || !reflect.DeepEqual(result.Removed, []string{first}) {
+		t.Fatalf("first Apply() = (%#v, %v)", result, err)
+	}
+	got, loadErr := state.Load(state.Path(stateRoot))
+	if loadErr != nil || len(got.Entries) != 2 || !reflect.DeepEqual(got.InstalledSelection, selection) {
+		t.Fatalf("metadata after failure = %#v, %v", got, loadErr)
+	}
+
+	result, err = Apply(p, opts)
+	if err != nil {
+		t.Fatalf("rerun Apply() error = %v", err)
+	}
+	if !reflect.DeepEqual(result, Result{Removed: []string{second}, Retained: []string{first}}) {
+		t.Fatalf("rerun Apply() = %#v", result)
+	}
+	got, loadErr = state.Load(state.Path(stateRoot))
+	if loadErr != nil || len(got.Entries) != 0 || !reflect.DeepEqual(got.InstalledSelection, selection) {
+		t.Fatalf("metadata after rerun = %#v, %v", got, loadErr)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -15,6 +16,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 // CurrentVersion is the current Installation Metadata schema version.
@@ -120,6 +123,29 @@ func (r Record) HasSource(source string) bool {
 	return false
 }
 
+// Clone returns a deep copy suitable for retaining an immutable evidence
+// snapshot while other metadata values continue to evolve.
+func (r Record) Clone() Record {
+	cloned := r
+	cloned.Sources = append([]string(nil), r.Sources...)
+	cloned.OwnedContent = append([]byte(nil), r.OwnedContent...)
+	cloned.OwnedBytes = append([]byte(nil), r.OwnedBytes...)
+	cloned.SeededBaseline = append([]byte(nil), r.SeededBaseline...)
+	cloned.Profiles = append([]string(nil), r.Profiles...)
+	cloned.Tags = append([]string(nil), r.Tags...)
+	if r.Contributions != nil {
+		cloned.Contributions = make([]Contribution, len(r.Contributions))
+		for index, contribution := range r.Contributions {
+			cloned.Contributions[index] = contribution
+			cloned.Contributions[index].SelectorTags = append([]string(nil), contribution.SelectorTags...)
+			cloned.Contributions[index].OwnedContent = append([]byte(nil), contribution.OwnedContent...)
+			cloned.Contributions[index].OwnedBytes = append([]byte(nil), contribution.OwnedBytes...)
+			cloned.Contributions[index].SeededBaseline = append([]byte(nil), contribution.SeededBaseline...)
+		}
+	}
+	return cloned
+}
+
 // ProvisionerRecord describes the last known result for one selected
 // Provisioner command in a profile.
 type ProvisionerRecord struct {
@@ -159,6 +185,10 @@ func CaptureProvenance(sourceRoot, dotsVersion string) Provenance {
 // it simply means nothing has been recorded yet, so an empty Metadata is
 // returned.
 func Load(path string) (Metadata, error) {
+	return load(path)
+}
+
+func load(path string) (Metadata, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -174,9 +204,128 @@ func Load(path string) (Metadata, error) {
 	return meta, nil
 }
 
-// Save atomically writes Installation Metadata to path, creating the state
-// directory if needed. A failed write leaves any prior metadata file intact.
+// LockedMetadata serializes Installation Metadata read-modify-write operations
+// for one installed.json path. Callers must Close it.
+type LockedMetadata struct {
+	path   string
+	file   *os.File
+	closed bool
+}
+
+// LockMetadata acquires an exclusive advisory lock next to installed.json.
+// Every production writer uses this lock so a complete read-modify-write cycle
+// cannot overwrite another dots process's entries or receipts.
+func LockMetadata(path string) (*LockedMetadata, error) {
+	if path == "" {
+		return nil, fmt.Errorf("lock installation metadata: path is required")
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("lock installation metadata: create state directory: %w", err)
+	}
+	lockPath := path + ".lock"
+	fd, err := unix.Open(lockPath, unix.O_CREAT|unix.O_RDWR|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("lock installation metadata: open lock file: %w", err)
+	}
+	file := os.NewFile(uintptr(fd), lockPath)
+	if file == nil {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("lock installation metadata: open lock file returned no handle")
+	}
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("lock installation metadata: stat lock file: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		_ = file.Close()
+		return nil, fmt.Errorf("lock installation metadata: lock path is not a regular file")
+	}
+	if err := unix.Flock(fd, unix.LOCK_EX); err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("lock installation metadata: acquire: %w", err)
+	}
+	return &LockedMetadata{path: path, file: file}, nil
+}
+
+// Load reads the metadata while the exclusive lock is held.
+func (l *LockedMetadata) Load() (Metadata, error) {
+	if l == nil || l.closed {
+		return Metadata{}, fmt.Errorf("load locked installation metadata: lock is closed")
+	}
+	return load(l.path)
+}
+
+// Save atomically writes metadata while the exclusive lock is held.
+func (l *LockedMetadata) Save(meta Metadata) error {
+	if l == nil || l.closed {
+		return fmt.Errorf("save locked installation metadata: lock is closed")
+	}
+	return save(l.path, meta)
+}
+
+// Remove deletes installed.json while the exclusive lock is held.
+func (l *LockedMetadata) Remove() error {
+	if l == nil || l.closed {
+		return fmt.Errorf("remove locked installation metadata: lock is closed")
+	}
+	if err := os.Remove(l.path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove installation metadata: %w", err)
+	}
+	return nil
+}
+
+// Close releases the metadata lock.
+func (l *LockedMetadata) Close() error {
+	if l == nil || l.closed {
+		return nil
+	}
+	l.closed = true
+	unlockErr := unix.Flock(int(l.file.Fd()), unix.LOCK_UN)
+	closeErr := l.file.Close()
+	if unlockErr != nil {
+		unlockErr = fmt.Errorf("unlock installation metadata: %w", unlockErr)
+	}
+	if closeErr != nil {
+		closeErr = fmt.Errorf("close installation metadata lock: %w", closeErr)
+	}
+	return errors.Join(unlockErr, closeErr)
+}
+
+// Update performs one serialized read-modify-write transaction.
+func Update(path string, update func(*Metadata) error) (resultErr error) {
+	if update == nil {
+		return fmt.Errorf("update installation metadata: callback is required")
+	}
+	locked, err := LockMetadata(path)
+	if err != nil {
+		return err
+	}
+	defer func() { resultErr = errors.Join(resultErr, locked.Close()) }()
+	meta, err := locked.Load()
+	if err != nil {
+		return err
+	}
+	if err := update(&meta); err != nil {
+		return err
+	}
+	return locked.Save(meta)
+}
+
+// Save serializes and atomically writes Installation Metadata to path,
+// creating the state directory if needed. A failed write leaves prior metadata
+// intact.
 func Save(path string, meta Metadata) error {
+	locked, err := LockMetadata(path)
+	if err != nil {
+		return err
+	}
+	saveErr := locked.Save(meta)
+	return errors.Join(saveErr, locked.Close())
+}
+
+func save(path string, meta Metadata) error {
 	data, err := json.MarshalIndent(meta, "", "  ")
 	if err != nil {
 		return fmt.Errorf("encode installation metadata: %w", err)

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -7,7 +7,9 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/yersonargotev/dots/internal/state"
 )
@@ -21,6 +23,84 @@ func TestLoadReturnsEmptyMetadataWhenFileAbsent(t *testing.T) {
 	}
 	if len(got.Entries) != 0 {
 		t.Fatalf("Load() entries = %d, want 0 for absent file", len(got.Entries))
+	}
+}
+
+func TestLockedMetadataSerializesReadModifyWrite(t *testing.T) {
+	path := state.Path(t.TempDir())
+	if err := state.Save(path, state.Metadata{Version: state.CurrentVersion}); err != nil {
+		t.Fatal(err)
+	}
+	locked, err := state.LockMetadata(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	done := make(chan error, 1)
+	go func() {
+		defer wg.Done()
+		done <- state.Update(path, func(meta *state.Metadata) error {
+			meta.Provisioners = append(meta.Provisioners, state.ProvisionerRecord{Tool: "serialized"})
+			return nil
+		})
+	}()
+	select {
+	case err := <-done:
+		t.Fatalf("Update() completed before lock release: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	if err := locked.Close(); err != nil {
+		t.Fatal(err)
+	}
+	wg.Wait()
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	got, err := state.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Provisioners) != 1 || got.Provisioners[0].Tool != "serialized" {
+		t.Fatalf("serialized metadata = %#v", got)
+	}
+}
+
+func TestLockMetadataRejectsSymlinkLockFile(t *testing.T) {
+	stateRoot := t.TempDir()
+	path := state.Path(stateRoot)
+	outside := filepath.Join(t.TempDir(), "outside")
+	if err := os.WriteFile(outside, []byte("unchanged"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, path+".lock"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := state.LockMetadata(path); err == nil {
+		t.Fatal("LockMetadata() error = nil, want symlink rejection")
+	}
+	got, err := os.ReadFile(outside)
+	if err != nil || string(got) != "unchanged" {
+		t.Fatalf("outside lock target = %q, %v", got, err)
+	}
+}
+
+func TestRecordCloneDoesNotAliasEvidence(t *testing.T) {
+	original := state.Record{
+		Sources:      []string{"source"},
+		OwnedContent: []byte("owned"),
+		Contributions: []state.Contribution{{
+			SelectorTags: []string{"tag"}, OwnedBytes: []byte("bytes"),
+		}},
+	}
+	cloned := original.Clone()
+	cloned.Sources[0] = "changed"
+	cloned.OwnedContent[0] = 'X'
+	cloned.Contributions[0].SelectorTags[0] = "changed"
+	cloned.Contributions[0].OwnedBytes[0] = 'X'
+	if original.Sources[0] != "source" || string(original.OwnedContent) != "owned" || original.Contributions[0].SelectorTags[0] != "tag" || string(original.Contributions[0].OwnedBytes) != "bytes" {
+		t.Fatalf("Clone() aliases original evidence: %#v", original)
 	}
 }
 

--- a/internal/uninstall/uninstall.go
+++ b/internal/uninstall/uninstall.go
@@ -6,6 +6,7 @@
 package uninstall
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -52,8 +53,7 @@ type Result struct {
 // stale plan or a target that drifted between preview and apply is never removed
 // by surprise. Every removal is confined to home, metadata is pruned for what
 // was removed, and the metadata file is deleted once empty.
-func Apply(p plan.UninstallPlan, opts Options) (Result, error) {
-	var result Result
+func Apply(p plan.UninstallPlan, opts Options) (result Result, resultErr error) {
 	var restorableRemoved []string
 
 	home, err := cleanAbs(opts.Home)
@@ -70,7 +70,12 @@ func Apply(p plan.UninstallPlan, opts Options) (Result, error) {
 		return result, err
 	}
 
-	meta, err := state.Load(state.Path(opts.StateRoot))
+	metadata, err := state.LockMetadata(state.Path(opts.StateRoot))
+	if err != nil {
+		return result, err
+	}
+	defer func() { resultErr = errors.Join(resultErr, metadata.Close()) }()
+	meta, err := metadata.Load()
 	if err != nil {
 		return result, err
 	}
@@ -155,7 +160,7 @@ func Apply(p plan.UninstallPlan, opts Options) (Result, error) {
 	}
 
 	prunedTargets := append(append(append([]string(nil), result.Removed...), result.Updated...), result.Retained...)
-	if err := pruneMetadata(opts.StateRoot, meta, prunedTargets); err != nil {
+	if err := pruneMetadata(metadata, meta, prunedTargets); err != nil {
 		return result, err
 	}
 
@@ -413,19 +418,15 @@ func latestSetContaining(meta backups.Metadata, target string) (backups.BackupSe
 // pruneMetadata drops the records for removed targets and persists the result. To
 // leave a clean state, the metadata file is deleted entirely once no records
 // remain rather than left as an empty entry list.
-func pruneMetadata(stateRoot string, meta state.Metadata, removed []string) error {
+func pruneMetadata(metadata *state.LockedMetadata, meta state.Metadata, removed []string) error {
 	if len(removed) == 0 {
 		return nil
 	}
 	pruned := meta.Remove(removed...)
-	path := state.Path(stateRoot)
 	if len(pruned.Entries) == 0 {
-		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("remove emptied installation metadata: %w", err)
-		}
-		return nil
+		return metadata.Remove()
 	}
-	return state.Save(path, pruned)
+	return metadata.Save(pruned)
 }
 
 // validateStateRoot mirrors install's guard: a state root inside home must not


### PR DESCRIPTION
Closes #466

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Apply confirmed explicit selection reductions by removing only targets whose ownership remains proven.
- Preserve Drifted, no-longer-owned, seeded, shared-external, dependency, and Provisioner state while releasing dots ownership where authorized.
- Add explicit clear-selection authority, terminal selection commits, serialized metadata updates, stable JSON reporting, and sandboxed regression coverage.

## Changes

| File | Change |
|------|--------|
| `internal/selectionreconciliation/` | Classify complete selection changes, safe retirements, retained external state, and blocked partial ownership. |
| `internal/selectionretirement/` | Validate and apply whole-target retirement with home confinement, ownership revalidation, metadata pruning, and convergent failure recovery. |
| `internal/cli/` | Integrate complete-plan validation, clear-selection acknowledgement, ordered install mutations, terminal selection commit, and JSON results. |
| `internal/state/`, `internal/install/`, `internal/uninstall/` | Serialize Installation Metadata writers and preserve unrelated concurrent records and receipts. |
| `docs/adr/0019-selection-reconciliation-plan.md`, `docs/agents/output-contract.md`, `CONTEXT.md` | Document the reconciliation boundary and schema-10 output contract. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile core --source-root "$PWD" --home <tmp>`
- [x] `go build ./...`
- [x] `go test -race ./internal/state ./internal/selectionretirement -count=1`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked one issue with an admitted Delivery Contract using `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label.
- [x] Delivery Evidence records the Contract Source snapshot, Acceptance coverage, and Independent review.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

### Contract Source

- Composed source: implementation issue #466 plus parent specification #459.
- #466: `I_kwDOSzLlmM8AAAABNwY1WA`, `https://github.com/yersonargotev/dots/issues/466`, updated `2026-08-21T20:58:10Z`, body SHA-256 `35652db0c39b4f14981d622d1b9f8617ad766a62ac2928666dafc3aa73e81d6a`.
- #459: `I_kwDOSzLlmM8AAAABNwWsmQ`, `https://github.com/yersonargotev/dots/issues/459`, updated `2026-08-21T20:59:00Z`, body SHA-256 `85febbb601376376f0b74c2b155d6556d1f63d209272fdc033a0b178169dc556`.
- Admission: #466 is open with `enhancement` and `ready-for-agent`; it has no sub-issues or comments. Native relationships are blocked-by #465 (closed) and blocks #467 (open).
- Reviewed head: `3b318c1ae7c6b673f1ae6a9094ef129b2bb27c19`; merge-base and `origin/main`: `db7ea8446fe76dcca47f08eeac316cf02744cbf9`.

### Acceptance Coverage

- Confirmed explicit reductions consume the shared reconciliation report and validate forward, conflict, and retirement decisions before dependency or filesystem mutation.
- Proven unchanged whole targets and entirely owned structured targets are removed; Drift, missing/lost ownership, external structured content, and Seeded Runtime State are retained while their ownership records are released.
- Partial retirement from a still-selected shared target remains blocked for #467; manifest evolution remains report-only.
- Backup Sets, dependencies, dependency metadata, Provisioner effects, and user state remain untouched and known external residue is reported.
- Interactive clear-all requires literal `clear`; non-interactive and JSON clear-all, including dry-run, require `--clear-selection --yes --acknowledge-selection-change`. Missing selection flags never clear intent.
- Additions and selected Provisioners precede retirement; the requested selection, including an empty selection, is committed only after terminal success. Decline, block, cancellation, and failures retain the prior selection, and injected partial failures converge on rerun.
- Global `dots uninstall` retains its existing meaning and participates in serialized Installation Metadata updates.
- JSON schema 10 reports deterministic reconciliation actions and optional `data.selection_retirement` removed/retained results.

### Automated Validation

- `gofmt -l .` — passed with no output.
- `go vet ./...` — passed.
- `go build ./...` — passed.
- `go test ./...` — passed.
- `go test ./internal/selectionreconciliation ./internal/selectionretirement ./internal/cli -count=1` — passed.
- `go test -race ./internal/state ./internal/selectionretirement -count=1` — passed.
- `git diff --check` — passed.
- `go run ./cmd/dots manifest validate --file dots.yaml` — passed.
- Sandboxed `go run ./cmd/dots plan --file dots.yaml --profile core --source-root "$PWD" --home <tmp>` — passed.

### Manual Verification

- Built the real `dots` binary and exercised installs only with explicit temporary home, source, state, and process-HOME roots.
- Verified proven whole-target removal, clear-selection preview/acknowledgement, Drift retention, global uninstall, entirely owned structured removal, and mixed addition/removal behavior.
- Verified a Drifted entirely deselected `json-subset` target produces plan findings/exit 2 with `retain` plus `ambiguous-partial-ownership`, then confirmed install exits 0, preserves exact live bytes, releases its metadata record, applies the addition, and commits the requested selection.

### Independent Review

- Standards: PASS, 0 actionable findings at `3b318c1ae7c6b673f1ae6a9094ef129b2bb27c19`.
- Spec: PASS, 0 actionable findings at `3b318c1ae7c6b673f1ae6a9094ef129b2bb27c19`.
- Non-blocking observation: ownership-mode dispatch is repeated across reconciliation and retirement helpers and may be a future refactoring opportunity.
<!-- delivery-issue:evidence:end -->
