### PR TITLE
feat(selection): reconcile shared contributions

### DIFF
--- a/docs/adr/0019-selection-reconciliation-plan.md
+++ b/docs/adr/0019-selection-reconciliation-plan.md
@@ -92,11 +92,10 @@ selection residue stays `retained-external-state` in the shared report.
 
 An entirely deselected structured target can be removed when exact subset
 evidence proves that subtraction leaves it empty; if external content remains,
-the target is retained and its ownership record is released. Partial retirement
-from a still-selected target, including structured subset ownership and
-source-override reconciliation, remains blocked before mutation and belongs to
-the subsequent contribution-reconciliation slice. Install Manifest evolution
-remains report-only and never authorizes retirement.
+the target is retained and its ownership record is released. The contribution
+reconciliation amendment below governs partial retirement from a still-selected
+target and source-override fallback. Install Manifest evolution remains
+report-only and never authorizes retirement.
 
 `--clear-selection` supplies explicit empty-selection authority. Interactive
 execution requires the literal `clear` acknowledgement. Non-interactive
@@ -106,3 +105,34 @@ selection. A successful terminal run records empty ordered intent, while any
 decline, block, cancellation, or failure preserves the prior authoritative
 Installed Selection. Rerunning after a partial removal converges from current
 filesystem and metadata evidence without manual repair.
+
+## Contribution reconciliation amendment
+
+Issue #467 authorizes an acknowledged explicit Installed Selection reduction to
+reconcile a target that remains selected when exact ordered per-contribution
+Installation Metadata proves both the retired and retained Source of Truth
+inputs. The read-only Selection Reconciliation Plan remains the authority for
+the semantic outcome. Before any dependency or filesystem mutation, the
+retirement gate requires every safe `create`, `update`, `preserve`, or
+`reconcile` outcome to have a matching forward Managed Entry action; `blocked`,
+ambiguous, incompatible, or mismatched forward behavior stops the entire run.
+
+The forward Managed Entry plan owns each still-selected target and applies it
+exactly once. Shared JSON targets compose only the selected contributions before
+three-way reconciliation. JSON, JSONC, TOML, and marked-block updates subtract
+retired values only from exact compatible evidence and preserve target-only
+content according to their existing ownership contracts. A whole-target source
+override may return to its selected base source only when the live target still
+matches the exact previously recorded contribution hash. Missing or legacy
+target-wide attribution, changed retired values, unsafe target types, and stale
+forward classifications fail closed before mutation.
+
+Source override retirement replaces the prior override contribution with the
+selected base contribution. Successful shared reconciliation records only the
+retained ordered contributions and commits the requested Installed Selection at
+terminal success. A failure after the filesystem update preserves the previous
+Installed Selection and contribution evidence; rerunning recognizes already
+removed retired values while still rejecting changed owned values, then
+converges without applying the target twice. Seeded Runtime State keeps its
+existing whole-retirement rule: its physical bytes remain while dots releases
+only the ownership record.

--- a/docs/adr/0019-selection-reconciliation-plan.md
+++ b/docs/adr/0019-selection-reconciliation-plan.md
@@ -144,7 +144,12 @@ contribution evidence and clears the receipt. Both writes compare the locked
 record with the exact evidence fingerprint that authorized the plan; the
 terminal replacement additionally requires the exact receipt produced by that
 action. A concurrent record or receipt change therefore aborts without
-overwriting either metadata or the prior Installed Selection.
+overwriting either metadata or the prior Installed Selection. The initial
+receipt transaction holds that metadata lock while it snapshots the selected
+sources, applies those exact bytes through the confined target descriptor, and
+persists hashes of those source and resulting target bytes. If receipt storage
+fails, dots restores the target bytes captured by the same descriptor before
+returning the metadata error.
 
 Every in-place copy update is confined beneath the selected home through an
 opened filesystem root. Whole, JSON, JSONC, TOML, marked-block, and seeded

--- a/docs/adr/0019-selection-reconciliation-plan.md
+++ b/docs/adr/0019-selection-reconciliation-plan.md
@@ -121,7 +121,9 @@ The forward Managed Entry plan owns each still-selected target and applies it
 exactly once. Shared JSON targets compose only the selected contributions before
 three-way reconciliation. JSON, JSONC, TOML, and marked-block updates subtract
 retired values only from exact compatible evidence and preserve target-only
-content according to their existing ownership contracts. A whole-target source
+content according to their existing ownership contracts. Target-wide
+compatibility fields must equal the projection of exact ordered contribution
+evidence; contradictory metadata fails closed. A whole-target source
 override may return to its selected base source only when the live target still
 matches the exact previously recorded contribution hash. Missing or legacy
 target-wide attribution, changed retired values, unsafe target types, and stale
@@ -136,6 +138,8 @@ adds a recovery-only reconciliation receipt containing the exact resulting
 target hash plus the ordered current source identities and hashes. A rerun may
 recognize already removed retired values only when that receipt matches every
 byte and source; absent or mismatched receipts remain ambiguous and fail closed.
-Terminal metadata commit replaces the old contribution evidence and clears the
-receipt. Seeded Runtime State keeps its existing whole-retirement rule: its
+The receipt is persisted immediately after each applied reconciliation, before
+the next Managed Entry action; terminal metadata commit replaces the old
+contribution evidence and clears the receipt. Seeded Runtime State keeps its
+existing whole-retirement rule: its
 physical bytes remain while dots releases only the ownership record.

--- a/docs/adr/0019-selection-reconciliation-plan.md
+++ b/docs/adr/0019-selection-reconciliation-plan.md
@@ -148,7 +148,9 @@ overwriting either metadata or the prior Installed Selection. The initial
 receipt transaction holds that metadata lock while it snapshots the selected
 sources through confined, identity-checked descriptors, applies those exact
 bytes through the confined target descriptor, and persists hashes of those
-source and resulting target bytes. If receipt storage fails, dots restores the
+source and resulting target bytes. Source symlinks retain the repository's
+existing contract: in-root destinations are allowed and escapes are rejected
+by the opened root. If receipt storage fails, dots restores the
 target bytes captured by the same descriptor only while the live target still
 equals the result dots just wrote; a concurrent application edit is preserved
 and reported instead of being overwritten.

--- a/docs/adr/0019-selection-reconciliation-plan.md
+++ b/docs/adr/0019-selection-reconciliation-plan.md
@@ -146,10 +146,12 @@ terminal replacement additionally requires the exact receipt produced by that
 action. A concurrent record or receipt change therefore aborts without
 overwriting either metadata or the prior Installed Selection. The initial
 receipt transaction holds that metadata lock while it snapshots the selected
-sources, applies those exact bytes through the confined target descriptor, and
-persists hashes of those source and resulting target bytes. If receipt storage
-fails, dots restores the target bytes captured by the same descriptor before
-returning the metadata error.
+sources through confined, identity-checked descriptors, applies those exact
+bytes through the confined target descriptor, and persists hashes of those
+source and resulting target bytes. If receipt storage fails, dots restores the
+target bytes captured by the same descriptor only while the live target still
+equals the result dots just wrote; a concurrent application edit is preserved
+and reported instead of being overwritten.
 
 Every in-place copy update is confined beneath the selected home through an
 opened filesystem root. Whole, JSON, JSONC, TOML, marked-block, and seeded

--- a/docs/adr/0019-selection-reconciliation-plan.md
+++ b/docs/adr/0019-selection-reconciliation-plan.md
@@ -140,6 +140,18 @@ recognize already removed retired values only when that receipt matches every
 byte and source; absent or mismatched receipts remain ambiguous and fail closed.
 The receipt is persisted immediately after each applied reconciliation, before
 the next Managed Entry action; terminal metadata commit replaces the old
-contribution evidence and clears the receipt. Seeded Runtime State keeps its
-existing whole-retirement rule: its
-physical bytes remain while dots releases only the ownership record.
+contribution evidence and clears the receipt. Both writes compare the locked
+record with the exact evidence fingerprint that authorized the plan; the
+terminal replacement additionally requires the exact receipt produced by that
+action. A concurrent record or receipt change therefore aborts without
+overwriting either metadata or the prior Installed Selection.
+
+Every in-place copy update is confined beneath the selected home through an
+opened filesystem root. Whole, JSON, JSONC, TOML, marked-block, and seeded
+updates reject a final symlink, verify that the opened descriptor is the same
+regular file that was inspected, and read and write through that descriptor.
+The shared read-only report also treats a conflicting or missing forward action
+for a partial retirement as blocked, so reporting and mutation gates cannot
+disagree about authority. Seeded Runtime State keeps its existing
+whole-retirement rule: its physical bytes remain while dots releases only the
+ownership record.

--- a/docs/adr/0019-selection-reconciliation-plan.md
+++ b/docs/adr/0019-selection-reconciliation-plan.md
@@ -131,8 +131,11 @@ Source override retirement replaces the prior override contribution with the
 selected base contribution. Successful shared reconciliation records only the
 retained ordered contributions and commits the requested Installed Selection at
 terminal success. A failure after the filesystem update preserves the previous
-Installed Selection and contribution evidence; rerunning recognizes already
-removed retired values while still rejecting changed owned values, then
-converges without applying the target twice. Seeded Runtime State keeps its
-existing whole-retirement rule: its physical bytes remain while dots releases
-only the ownership record.
+Installed Selection and contribution evidence. Installation Metadata version 8
+adds a recovery-only reconciliation receipt containing the exact resulting
+target hash plus the ordered current source identities and hashes. A rerun may
+recognize already removed retired values only when that receipt matches every
+byte and source; absent or mismatched receipts remain ambiguous and fail closed.
+Terminal metadata commit replaces the old contribution evidence and clears the
+receipt. Seeded Runtime State keeps its existing whole-retirement rule: its
+physical bytes remain while dots releases only the ownership record.

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -194,7 +194,7 @@ func newInstallCommand() *cobra.Command {
 				return nil
 			}
 
-			retirementOptions := selectionretirement.Options{SourceRoot: paths.SourceRoot, Home: paths.Home, StateRoot: paths.StateRoot}
+			retirementOptions := selectionretirement.Options{SourceRoot: paths.SourceRoot, Home: paths.Home, StateRoot: paths.StateRoot, ForwardPlan: &p}
 			var selectionRetirementPlan selectionretirement.Plan
 			if p.SelectionReconciliation != nil {
 				selectionRetirementPlan, err = selectionretirement.Build(*p.SelectionReconciliation, meta, retirementOptions)

--- a/internal/cli/install_retirement_test.go
+++ b/internal/cli/install_retirement_test.go
@@ -3,6 +3,7 @@ package cli_test
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -475,13 +476,302 @@ entries:
 	}
 }
 
-func TestInstallBlocksSubsetRetirementFromStillSelectedTargetBeforeForwardMutation(t *testing.T) {
+func TestInstallReconcilesOpenCodeSharedJSONContribution(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	writeCLISource(t, sourceRoot, "configs/opencode/opencode.json", "{\"base\":true}\n")
+	writeCLISource(t, sourceRoot, "configs/opencode/mcp.json", "{\"retired\":true}\n")
+	writeCLISource(t, sourceRoot, "configs/new", "new\n")
+	manifestPath := writeCLIManifest(t, home, `version: 1
+profiles:
+  old:
+    tags: [opencode, opencode-chrome-devtools]
+  next:
+    tags: [opencode, new]
+entries:
+  - source: configs/opencode/opencode.json
+    target: ~/.config/opencode/opencode.json
+    strategy: copy
+    ownership: json-subset
+    tags: [opencode]
+  - source: configs/opencode/mcp.json
+    target: ~/.config/opencode/opencode.json
+    strategy: copy
+    ownership: json-subset
+    tags: [opencode-chrome-devtools]
+  - source: configs/new
+    target: ~/.new
+    strategy: copy
+    tags: [new]
+`)
+	runInstallForRetirementTest(t, manifestPath, home, sourceRoot, stateRoot, "old")
+	target := filepath.Join(home, ".config", "opencode", "opencode.json")
+	if err := os.WriteFile(target, []byte("{\"base\":true,\"retired\":true,\"external\":\"preserve\"}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out, errOut bytes.Buffer
+	code := cli.Run([]string{
+		"install", "--yes", "--acknowledge-selection-change", "--skip-deps", "--output", "json", "--profile", "next",
+		"--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot,
+	}, &out, &errOut)
+	if code != cli.ExitOK {
+		t.Fatalf("still-selected subset retirement = code %d\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
+	}
+	if got, err := os.ReadFile(filepath.Join(home, ".new")); err != nil || string(got) != "new\n" {
+		t.Fatalf("forward addition = %q, %v; want new content", got, err)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var content map[string]any
+	if err := json.Unmarshal(got, &content); err != nil {
+		t.Fatalf("decode reconciled shared target: %v\n%s", err, got)
+	}
+	if content["base"] != true || content["external"] != "preserve" {
+		t.Fatalf("reconciled shared target = %#v, want selected and external content", content)
+	}
+	if _, retired := content["retired"]; retired {
+		t.Fatalf("reconciled shared target retained retired contribution: %#v", content)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.InstalledSelection == nil || !reflect.DeepEqual(meta.InstalledSelection.Profiles, []string{"next"}) {
+		t.Fatalf("reconciled retirement selection = %#v, want next", meta.InstalledSelection)
+	}
+	record, ok := meta.FindByTarget(target)
+	if !ok || len(record.Contributions) != 1 || record.Contributions[0].Source != "configs/opencode/opencode.json" || !reflect.DeepEqual(record.Contributions[0].SelectorTags, []string{"opencode"}) {
+		t.Fatalf("reconciled contribution evidence = %#v, want selected base only", record)
+	}
+	if !strings.Contains(out.String(), `"outcome": "reconcile"`) || !strings.Contains(out.String(), `"previous_sources": [`) {
+		t.Fatalf("JSON result does not explain contribution reconciliation:\n%s", out.String())
+	}
+}
+
+func TestInstallReconcilesAntigravitySharedJSONContribution(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	writeCLISource(t, sourceRoot, "configs/antigravity/settings.json", "{\"base\":true}\n")
+	writeCLISource(t, sourceRoot, "configs/antigravity/mobile-mcp-settings.json", "{\"retired\":true}\n")
+	manifestPath := writeCLIManifest(t, home, `version: 1
+profiles:
+  old:
+    tags: [antigravity, antigravity-dart-mcp]
+  next:
+    tags: [antigravity]
+entries:
+  - source: configs/antigravity/settings.json
+    target: ~/.gemini/antigravity-cli/settings.json
+    strategy: copy
+    ownership: json-subset
+    tags: [antigravity]
+  - source: configs/antigravity/mobile-mcp-settings.json
+    target: ~/.gemini/antigravity-cli/settings.json
+    strategy: copy
+    ownership: json-subset
+    tags: [antigravity-dart-mcp]
+`)
+	runInstallForRetirementTest(t, manifestPath, home, sourceRoot, stateRoot, "old")
+	target := filepath.Join(home, ".gemini", "antigravity-cli", "settings.json")
+	if err := os.WriteFile(target, []byte("{\"base\":true,\"retired\":true,\"external\":\"preserve\"}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out, errOut bytes.Buffer
+	code := cli.Run([]string{
+		"install", "--yes", "--acknowledge-selection-change", "--skip-deps", "--output", "json", "--profile", "next",
+		"--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot,
+	}, &out, &errOut)
+	if code != cli.ExitOK {
+		t.Fatalf("Antigravity shared contribution retirement = code %d\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var content map[string]any
+	if err := json.Unmarshal(got, &content); err != nil {
+		t.Fatalf("decode reconciled Antigravity target: %v\n%s", err, got)
+	}
+	if content["base"] != true || content["external"] != "preserve" {
+		t.Fatalf("reconciled Antigravity target = %#v, want selected and external content", content)
+	}
+	if _, retired := content["retired"]; retired {
+		t.Fatalf("reconciled Antigravity target retained retired contribution: %#v", content)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, ok := meta.FindByTarget(target)
+	if !ok || len(record.Contributions) != 1 || record.Contributions[0].Source != "configs/antigravity/settings.json" || !reflect.DeepEqual(record.Contributions[0].SelectorTags, []string{"antigravity"}) {
+		t.Fatalf("reconciled Antigravity contribution evidence = %#v, want selected base only", record)
+	}
+	if meta.InstalledSelection == nil || !reflect.DeepEqual(meta.InstalledSelection.Profiles, []string{"next"}) || !strings.Contains(out.String(), `"outcome": "reconcile"`) {
+		t.Fatalf("Antigravity reconciliation result is incomplete: selection=%#v\n%s", meta.InstalledSelection, out.String())
+	}
+}
+
+func TestInstallReconcilesStructuredSourceOverridesToSelectedBase(t *testing.T) {
+	block := func(body string) string {
+		return "# >>> dots managed block >>>\n" + body + "\n# <<< dots managed block <<<\n"
+	}
+	tests := []struct {
+		name        string
+		ownership   string
+		base        string
+		override    string
+		live        string
+		want        func(*testing.T, []byte)
+		wantOutcome string
+	}{
+		{
+			name:        "Herdr adaptive TOML",
+			ownership:   "toml-subset",
+			base:        "# managed base\nbase = true\n",
+			override:    "# managed adaptive\nadaptive = true\n",
+			live:        "# external sentinel\nexternal = \"keep\"\n# managed adaptive\nadaptive = true\n",
+			wantOutcome: "reconcile",
+			want: func(t *testing.T, got []byte) {
+				t.Helper()
+				if !bytes.HasPrefix(got, []byte("# external sentinel\nexternal = \"keep\"\n")) || !bytes.Contains(got, []byte("base = true")) || bytes.Contains(got, []byte("adaptive = true")) {
+					t.Fatalf("reconciled TOML did not preserve external bytes and selected base:\n%s", got)
+				}
+			},
+		},
+		{
+			name:        "Codex codegraph TOML",
+			ownership:   "toml-subset",
+			base:        "model = \"base\"\n",
+			override:    "model = \"base\"\n[hooks]\ncodegraph = true\n",
+			live:        "# external sentinel\ntui = \"alternate\"\nmodel = \"base\"\n[hooks]\ncodegraph = true\n",
+			wantOutcome: "reconcile",
+			want: func(t *testing.T, got []byte) {
+				t.Helper()
+				if !bytes.HasPrefix(got, []byte("# external sentinel\ntui = \"alternate\"\n")) || !bytes.Contains(got, []byte("model = \"base\"")) || bytes.Contains(got, []byte("codegraph")) {
+					t.Fatalf("reconciled Codex TOML did not preserve external bytes and remove CodeGraph:\n%s", got)
+				}
+			},
+		},
+		{
+			name:        "JSONC",
+			ownership:   "jsonc-subset",
+			base:        "{\n  // managed base\n  \"base\": true,\n}\n",
+			override:    "{\n  // managed override\n  \"override\": true,\n}\n",
+			live:        "{\n  // managed override\n  \"override\": true,\n  // external sentinel\n  \"external\": true,\n}\n",
+			wantOutcome: "reconcile",
+			want: func(t *testing.T, got []byte) {
+				t.Helper()
+				if !bytes.Contains(got, []byte("  // external sentinel\n  \"external\": true,")) || !bytes.Contains(got, []byte("\"base\": true")) || bytes.Contains(got, []byte("\"override\"")) {
+					t.Fatalf("reconciled JSONC did not preserve external bytes and selected base:\n%s", got)
+				}
+			},
+		},
+		{
+			name:        "marked block",
+			ownership:   "marked-block",
+			base:        block("base=1"),
+			override:    block("override=1"),
+			live:        block("override=1") + "# external sentinel\nexternal=keep\n",
+			wantOutcome: "reconcile",
+			want: func(t *testing.T, got []byte) {
+				t.Helper()
+				want := block("base=1") + "# external sentinel\nexternal=keep\n"
+				if string(got) != want {
+					t.Fatalf("reconciled marked block = %q, want exact %q", got, want)
+				}
+			},
+		},
+		{
+			name:        "Zellij adaptive whole target",
+			ownership:   "",
+			base:        "theme \"base\"\n",
+			override:    "theme \"adaptive\"\n",
+			live:        "theme \"adaptive\"\n",
+			wantOutcome: "update",
+			want: func(t *testing.T, got []byte) {
+				t.Helper()
+				if string(got) != "theme \"base\"\n" {
+					t.Fatalf("reconciled whole target = %q, want selected base", got)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			home := t.TempDir()
+			sourceRoot := t.TempDir()
+			stateRoot := t.TempDir()
+			t.Setenv("HOME", t.TempDir())
+			writeCLISource(t, sourceRoot, "configs/base", test.base)
+			writeCLISource(t, sourceRoot, "configs/override", test.override)
+			ownership := ""
+			if test.ownership != "" {
+				ownership = "\n    ownership: " + test.ownership
+			}
+			manifestPath := writeCLIManifest(t, home, fmt.Sprintf(`version: 1
+profiles:
+  previous:
+    tags: [consumer, opt-in]
+  current:
+    tags: [consumer]
+entries:
+  - source: configs/base
+    source_overrides:
+      opt-in: configs/override
+    target: ~/.config/app/settings
+    strategy: copy%s
+    tags: [consumer]
+`, ownership))
+			runInstallForRetirementTest(t, manifestPath, home, sourceRoot, stateRoot, "previous")
+			target := filepath.Join(home, ".config", "app", "settings")
+			if err := os.WriteFile(target, []byte(test.live), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			var out, errOut bytes.Buffer
+			code := cli.Run([]string{
+				"install", "--yes", "--acknowledge-selection-change", "--skip-deps", "--output", "json", "--profile", "current",
+				"--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot,
+			}, &out, &errOut)
+			if code != cli.ExitOK {
+				t.Fatalf("structured source override retirement = code %d\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
+			}
+			got, err := os.ReadFile(target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			test.want(t, got)
+			meta, err := state.Load(state.Path(stateRoot))
+			if err != nil {
+				t.Fatal(err)
+			}
+			record, ok := meta.FindByTarget(target)
+			if !ok || len(record.Contributions) != 1 || record.Contributions[0].Source != "configs/base" || !reflect.DeepEqual(record.Contributions[0].SelectorTags, []string{"consumer"}) {
+				t.Fatalf("reconciled contribution evidence = %#v, want selected base only", record)
+			}
+			if !strings.Contains(out.String(), `"outcome": "`+test.wantOutcome+`"`) || !strings.Contains(out.String(), `"previous_sources": [`) {
+				t.Fatalf("JSON result does not explain structured reconciliation:\n%s", out.String())
+			}
+		})
+	}
+}
+
+func TestInstallBlocksAmbiguousSharedContributionBeforeAnyMutation(t *testing.T) {
 	home := t.TempDir()
 	sourceRoot := t.TempDir()
 	stateRoot := t.TempDir()
 	t.Setenv("HOME", t.TempDir())
 	writeCLISource(t, sourceRoot, "configs/base.json", "{\"base\":true}\n")
-	writeCLISource(t, sourceRoot, "configs/retired.json", "{\"retired\":true}\n")
+	writeCLISource(t, sourceRoot, "configs/retired.json", "{\"retired\":\"owned\"}\n")
 	writeCLISource(t, sourceRoot, "configs/new", "new\n")
 	manifestPath := writeCLIManifest(t, home, `version: 1
 profiles:
@@ -506,8 +796,9 @@ entries:
     tags: [new]
 `)
 	runInstallForRetirementTest(t, manifestPath, home, sourceRoot, stateRoot, "old")
-	sharedBefore, err := os.ReadFile(filepath.Join(home, ".shared.json"))
-	if err != nil {
+	target := filepath.Join(home, ".shared.json")
+	drifted := []byte("{\"base\":true,\"retired\":\"changed\",\"external\":\"preserve\"}\n")
+	if err := os.WriteFile(target, drifted, 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -516,21 +807,175 @@ entries:
 		"install", "--yes", "--acknowledge-selection-change", "--skip-deps", "--output", "json", "--profile", "next",
 		"--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot,
 	}, &out, &errOut)
-	if code != cli.ExitError || !strings.Contains(out.String(), "partial retirement from a still-selected target") {
-		t.Fatalf("still-selected subset retirement = code %d\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
+	if code != cli.ExitError || !strings.Contains(out.String(), "ambiguous-partial-ownership") {
+		t.Fatalf("ambiguous shared retirement = code %d\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
 	}
 	if _, err := os.Lstat(filepath.Join(home, ".new")); !os.IsNotExist(err) {
-		t.Fatalf("blocked retirement applied forward addition: %v", err)
+		t.Fatalf("blocked reconciliation applied forward addition: %v", err)
 	}
-	if got, err := os.ReadFile(filepath.Join(home, ".shared.json")); err != nil || !bytes.Equal(got, sharedBefore) {
-		t.Fatalf("blocked retirement changed shared target: %q, %v", got, err)
+	if got, err := os.ReadFile(target); err != nil || !bytes.Equal(got, drifted) {
+		t.Fatalf("blocked reconciliation changed target: %q, %v", got, err)
 	}
 	meta, err := state.Load(state.Path(stateRoot))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if meta.InstalledSelection == nil || !reflect.DeepEqual(meta.InstalledSelection.Profiles, []string{"old"}) {
-		t.Fatalf("blocked retirement selection = %#v, want previous", meta.InstalledSelection)
+		t.Fatalf("blocked reconciliation selection = %#v, want previous", meta.InstalledSelection)
+	}
+	if record, ok := meta.FindByTarget(target); !ok || len(record.Contributions) != 2 {
+		t.Fatalf("blocked reconciliation changed contribution evidence: %#v", record)
+	}
+}
+
+func TestInstallSharedReconciliationFailurePreservesIntentAndRerunsSafely(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	writeCLISource(t, sourceRoot, "configs/base.json", "{\"base\":true}\n")
+	writeCLISource(t, sourceRoot, "configs/retired.json", "{\"retired\":true}\n")
+	manifestPath := writeCLIManifest(t, home, `version: 1
+profiles:
+  old:
+    tags: [base, retired]
+  next:
+    tags: [base, provision]
+entries:
+  - source: configs/base.json
+    target: ~/.shared.json
+    strategy: copy
+    ownership: json-subset
+    tags: [base]
+  - source: configs/retired.json
+    target: ~/.shared.json
+    strategy: copy
+    ownership: json-subset
+    tags: [retired]
+provisioners:
+  - tool: claude
+    tags: [provision]
+    spec:
+      marketplace: example/tools
+    dependencies:
+      - name: claude
+`)
+	runInstallForRetirementTest(t, manifestPath, home, sourceRoot, stateRoot, "old")
+	target := filepath.Join(home, ".shared.json")
+	binDir := t.TempDir()
+	claude := filepath.Join(binDir, "claude")
+	writeExecStub(t, claude, "#!/bin/sh\nexit 17\n")
+	t.Setenv("PATH", binDir)
+
+	run := func() (int, string, string) {
+		t.Helper()
+		var out, errOut bytes.Buffer
+		code := cli.Run([]string{
+			"install", "--yes", "--acknowledge-selection-change", "--skip-deps", "--output", "json", "--profile", "next",
+			"--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot,
+		}, &out, &errOut)
+		return code, out.String(), errOut.String()
+	}
+
+	code, out, errOut := run()
+	if code != cli.ExitError {
+		t.Fatalf("failing reconciliation run = code %d\nstdout:\n%s\nstderr:\n%s", code, out, errOut)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var content map[string]any
+	if err := json.Unmarshal(got, &content); err != nil {
+		t.Fatal(err)
+	}
+	if content["base"] != true {
+		t.Fatalf("failed run did not apply safe forward reconciliation: %#v", content)
+	}
+	if _, retired := content["retired"]; retired {
+		t.Fatalf("failed run retained retired contribution in live target: %#v", content)
+	}
+	failedMeta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	failedRecord, ok := failedMeta.FindByTarget(target)
+	if !ok || len(failedRecord.Contributions) != 2 {
+		t.Fatalf("failed run replaced previous contribution evidence: %#v", failedRecord)
+	}
+	if failedMeta.InstalledSelection == nil || !reflect.DeepEqual(failedMeta.InstalledSelection.Profiles, []string{"old"}) {
+		t.Fatalf("failed run committed requested selection: %#v", failedMeta.InstalledSelection)
+	}
+
+	writeExecStub(t, claude, "#!/bin/sh\nexit 0\n")
+	code, out, errOut = run()
+	if code != cli.ExitOK {
+		t.Fatalf("rerun reconciliation = code %d\nstdout:\n%s\nstderr:\n%s", code, out, errOut)
+	}
+	finalMeta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	finalRecord, ok := finalMeta.FindByTarget(target)
+	if !ok || len(finalRecord.Contributions) != 1 || finalRecord.Contributions[0].Source != "configs/base.json" {
+		t.Fatalf("rerun contribution evidence = %#v, want selected base only", finalRecord)
+	}
+	if finalMeta.InstalledSelection == nil || !reflect.DeepEqual(finalMeta.InstalledSelection.Profiles, []string{"next"}) {
+		t.Fatalf("rerun Installed Selection = %#v, want next", finalMeta.InstalledSelection)
+	}
+}
+
+func TestInstallReleasesSeededRuntimeStateWithoutRemovingItsBytes(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	writeCLISource(t, sourceRoot, "configs/seeded", "baseline\n")
+	writeCLISource(t, sourceRoot, "configs/new", "new\n")
+	manifestPath := writeCLIManifest(t, home, `version: 1
+profiles:
+  old:
+    tags: [seeded]
+  next:
+    tags: [new]
+entries:
+  - source: configs/seeded
+    target: ~/.config/app/runtime
+    strategy: copy
+    ownership: seeded
+    tags: [seeded]
+  - source: configs/new
+    target: ~/.new
+    strategy: copy
+    tags: [new]
+`)
+	runInstallForRetirementTest(t, manifestPath, home, sourceRoot, stateRoot, "old")
+	target := filepath.Join(home, ".config", "app", "runtime")
+	evolved := []byte("application-owned evolution\n")
+	if err := os.WriteFile(target, evolved, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out, errOut bytes.Buffer
+	code := cli.Run([]string{
+		"install", "--yes", "--acknowledge-selection-change", "--skip-deps", "--output", "json", "--profile", "next",
+		"--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot,
+	}, &out, &errOut)
+	if code != cli.ExitOK {
+		t.Fatalf("seeded retirement = code %d\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
+	}
+	if got, err := os.ReadFile(target); err != nil || !bytes.Equal(got, evolved) {
+		t.Fatalf("Seeded Runtime State = %q, %v; want exact evolved bytes", got, err)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := meta.FindByTarget(target); ok {
+		t.Fatalf("Seeded Runtime State remains dots-owned: %#v", meta.Entries)
+	}
+	if meta.InstalledSelection == nil || !reflect.DeepEqual(meta.InstalledSelection.Profiles, []string{"next"}) || !strings.Contains(out.String(), `"retained": [`) {
+		t.Fatalf("seeded retirement result is incomplete: selection=%#v\n%s", meta.InstalledSelection, out.String())
 	}
 }
 

--- a/internal/cli/install_retirement_test.go
+++ b/internal/cli/install_retirement_test.go
@@ -527,6 +527,9 @@ entries:
 	if err != nil {
 		t.Fatal(err)
 	}
+	if want := []byte("{\"base\":true,\"external\":\"preserve\"}\n"); !bytes.Equal(got, want) {
+		t.Fatalf("reconciled shared target bytes = %q, want unrelated compact bytes preserved as %q", got, want)
+	}
 	var content map[string]any
 	if err := json.Unmarshal(got, &content); err != nil {
 		t.Fatalf("decode reconciled shared target: %v\n%s", err, got)
@@ -595,6 +598,9 @@ entries:
 	got, err := os.ReadFile(target)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if want := []byte("{\"base\":true,\"external\":\"preserve\"}\n"); !bytes.Equal(got, want) {
+		t.Fatalf("reconciled Antigravity target bytes = %q, want unrelated compact bytes preserved as %q", got, want)
 	}
 	var content map[string]any
 	if err := json.Unmarshal(got, &content); err != nil {
@@ -903,6 +909,10 @@ provisioners:
 	if !ok || len(failedRecord.Contributions) != 2 {
 		t.Fatalf("failed run replaced previous contribution evidence: %#v", failedRecord)
 	}
+	if failedRecord.PendingReconciliation == nil || failedRecord.PendingReconciliation.TargetHash != state.HashBytes(got) ||
+		!reflect.DeepEqual(failedRecord.PendingReconciliation.Sources, []string{"configs/base.json"}) {
+		t.Fatalf("failed run recovery receipt = %#v, want exact reconciled target and current source", failedRecord.PendingReconciliation)
+	}
 	if failedMeta.InstalledSelection == nil || !reflect.DeepEqual(failedMeta.InstalledSelection.Profiles, []string{"old"}) {
 		t.Fatalf("failed run committed requested selection: %#v", failedMeta.InstalledSelection)
 	}
@@ -919,6 +929,9 @@ provisioners:
 	finalRecord, ok := finalMeta.FindByTarget(target)
 	if !ok || len(finalRecord.Contributions) != 1 || finalRecord.Contributions[0].Source != "configs/base.json" {
 		t.Fatalf("rerun contribution evidence = %#v, want selected base only", finalRecord)
+	}
+	if finalRecord.PendingReconciliation != nil {
+		t.Fatalf("terminal commit retained recovery receipt: %#v", finalRecord.PendingReconciliation)
 	}
 	if finalMeta.InstalledSelection == nil || !reflect.DeepEqual(finalMeta.InstalledSelection.Profiles, []string{"next"}) {
 		t.Fatalf("rerun Installed Selection = %#v, want next", finalMeta.InstalledSelection)

--- a/internal/cli/issue385_subset_lifecycle_test.go
+++ b/internal/cli/issue385_subset_lifecycle_test.go
@@ -68,7 +68,7 @@ func TestJSONSubsetLifecycleReconcilesAndUninstallsOwnedContribution(t *testing.
 	if err != nil {
 		t.Fatalf("read reconciled target: %v", err)
 	}
-	for _, want := range []string{`"added": "new"`, `"external": "preserve"`, `"targetOnly": true`, `"external"`} {
+	for _, want := range []string{`"added":"new"`, `"external":"preserve"`, `"targetOnly":true`, `"external"`} {
 		if !strings.Contains(string(got), want) {
 			t.Fatalf("reconciled target missing %s:\n%s", want, got)
 		}

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -262,7 +262,7 @@ entries:
 		t.Fatalf("target not migrated to regular file: mode=%v err=%v", info, err)
 	}
 	content, _ := os.ReadFile(target)
-	if string(content) != "{\n  \"owned\": 2,\n  \"runtime\": true\n}\n" {
+	if string(content) != "{\"owned\":2,\"runtime\":true}\n" {
 		t.Fatalf("migrated content = %q", content)
 	}
 	after, err := backups.Load(backups.Path(stateRoot))

--- a/internal/configsubset/jsonc.go
+++ b/internal/configsubset/jsonc.go
@@ -161,6 +161,11 @@ func reconcileJSONCValue(target, previous, current any) (any, bool, bool) {
 			currentChild, remainsOwned := currentObject[key]
 			targetChild, exists := targetObject[key]
 			if !exists {
+				if !remainsOwned {
+					// A prior interrupted reconciliation may already have
+					// removed this retired value.
+					continue
+				}
 				return target, false, false
 			}
 			if !remainsOwned {

--- a/internal/configsubset/jsonc.go
+++ b/internal/configsubset/jsonc.go
@@ -161,11 +161,6 @@ func reconcileJSONCValue(target, previous, current any) (any, bool, bool) {
 			currentChild, remainsOwned := currentObject[key]
 			targetChild, exists := targetObject[key]
 			if !exists {
-				if !remainsOwned {
-					// A prior interrupted reconciliation may already have
-					// removed this retired value.
-					continue
-				}
 				return target, false, false
 			}
 			if !remainsOwned {
@@ -367,7 +362,7 @@ func applyJSONCDesired(value *hujson.Value, target, desired any) error {
 
 func moveJSONCMemberExtra(object *hujson.Object, index int) {
 	member := object.Members[index]
-	extra := append(hujson.Extra(nil), member.Name.BeforeExtra...)
+	extra := appendJSONCCommentExtra(nil, member.Name.BeforeExtra)
 	extra = appendJSONCCommentExtra(extra, member.Name.AfterExtra)
 	extra = appendJSONCValueComments(extra, member.Value)
 	if len(extra) == 0 {

--- a/internal/configsubset/jsonc_test.go
+++ b/internal/configsubset/jsonc_test.go
@@ -93,6 +93,20 @@ func TestReconcileJSONCRemovesRetiredKeysAndPreservesTargetOnlyContent(t *testin
 	}
 }
 
+func TestReconcileJSONCAcceptsAlreadyRemovedRetiredKey(t *testing.T) {
+	target := []byte("{\n  // external sentinel\n  \"external\": true,\n  \"keep\": true,\n}\n")
+	previous := []byte(`{"keep":true,"retired":"old"}`)
+	current := []byte(`{"keep":true}`)
+
+	got, err := ReconcileJSONC(target, previous, current)
+	if err != nil {
+		t.Fatalf("ReconcileJSONC() error = %v", err)
+	}
+	if !got.Compatible || got.Changed || !bytes.Equal(got.Content, target) {
+		t.Fatalf("ReconcileJSONC() = %#v, want already-removed key to preserve exact bytes", got)
+	}
+}
+
 func TestReconcileJSONCReportsRemovingEmptyOwnedObjectAsChange(t *testing.T) {
 	got, err := ReconcileJSONC(
 		[]byte(`{"settings":{},"local":true}`),

--- a/internal/configsubset/jsonc_test.go
+++ b/internal/configsubset/jsonc_test.go
@@ -93,7 +93,7 @@ func TestReconcileJSONCRemovesRetiredKeysAndPreservesTargetOnlyContent(t *testin
 	}
 }
 
-func TestReconcileJSONCAcceptsAlreadyRemovedRetiredKey(t *testing.T) {
+func TestReconcileJSONCRejectsAlreadyRemovedRetiredKeyWithoutReceipt(t *testing.T) {
 	target := []byte("{\n  // external sentinel\n  \"external\": true,\n  \"keep\": true,\n}\n")
 	previous := []byte(`{"keep":true,"retired":"old"}`)
 	current := []byte(`{"keep":true}`)
@@ -102,8 +102,8 @@ func TestReconcileJSONCAcceptsAlreadyRemovedRetiredKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReconcileJSONC() error = %v", err)
 	}
-	if !got.Compatible || got.Changed || !bytes.Equal(got.Content, target) {
-		t.Fatalf("ReconcileJSONC() = %#v, want already-removed key to preserve exact bytes", got)
+	if got.Compatible || got.Changed || got.Content != nil {
+		t.Fatalf("ReconcileJSONC() = %#v, want ambiguous missing key rejected", got)
 	}
 }
 

--- a/internal/configsubset/subset.go
+++ b/internal/configsubset/subset.go
@@ -312,7 +312,9 @@ func reconcileJSONValue(target, previous, current any) jsonMergeResult {
 			currentChild, currentExists := currentObject[key]
 			if !currentExists {
 				if !targetExists {
-					return jsonMergeResult{value: target}
+					// A prior interrupted reconciliation may already have
+					// removed this retired value. No subtraction is needed.
+					continue
 				}
 				removed := subtractJSONValue(targetChild, previousChild)
 				if !removed.compatible {
@@ -375,7 +377,9 @@ func reconcileJSONValue(target, previous, current any) jsonMergeResult {
 		for _, previousItem := range multisetDifference(previousArray, currentArray) {
 			index := equalJSONIndex(result, previousItem)
 			if index < 0 {
-				return jsonMergeResult{value: target}
+				// Treat an already-removed retired item as converged while
+				// preserving every target-only array item.
+				continue
 			}
 			result = append(result[:index], result[index+1:]...)
 			changed = true

--- a/internal/configsubset/subset.go
+++ b/internal/configsubset/subset.go
@@ -144,12 +144,12 @@ func ReconcileJSON(targetData, previousData, currentData []byte) (JSONReconcilia
 	if !result.compatible {
 		return JSONReconciliation{}, nil
 	}
-	data, err := json.MarshalIndent(result.value, "", "  ")
+	data, err := patchJSONC(targetData, targetValue, result.value)
 	if err != nil {
-		return JSONReconciliation{}, fmt.Errorf("encode reconciled JSON: %w", err)
+		return JSONReconciliation{}, fmt.Errorf("patch reconciled JSON: %w", err)
 	}
 	return JSONReconciliation{
-		Content:    append(data, '\n'),
+		Content:    data,
 		Changed:    result.changed,
 		Compatible: true,
 	}, nil
@@ -312,9 +312,7 @@ func reconcileJSONValue(target, previous, current any) jsonMergeResult {
 			currentChild, currentExists := currentObject[key]
 			if !currentExists {
 				if !targetExists {
-					// A prior interrupted reconciliation may already have
-					// removed this retired value. No subtraction is needed.
-					continue
+					return jsonMergeResult{value: target}
 				}
 				removed := subtractJSONValue(targetChild, previousChild)
 				if !removed.compatible {
@@ -377,9 +375,7 @@ func reconcileJSONValue(target, previous, current any) jsonMergeResult {
 		for _, previousItem := range multisetDifference(previousArray, currentArray) {
 			index := equalJSONIndex(result, previousItem)
 			if index < 0 {
-				// Treat an already-removed retired item as converged while
-				// preserving every target-only array item.
-				continue
+				return jsonMergeResult{value: target}
 			}
 			result = append(result[:index], result[index+1:]...)
 			changed = true

--- a/internal/configsubset/subset_test.go
+++ b/internal/configsubset/subset_test.go
@@ -137,18 +137,7 @@ func TestReconcileJSONAddsAndRemovesOwnedValuesWhilePreservingTargetOnlyContent(
 	if !got.Compatible || !got.Changed {
 		t.Fatalf("ReconcileJSON() = %#v, want compatible change", got)
 	}
-	want := `{
-  "items": [
-    "external",
-    "new"
-  ],
-  "settings": {
-    "added": "new",
-    "external": "local",
-    "keep": true
-  }
-}
-`
+	want := "{\"settings\":{\"keep\":true,\"external\":\"local\", \"added\":\"new\"},\"items\":[\"external\",\"new\"]}"
 	if string(got.Content) != want {
 		t.Fatalf("ReconcileJSON() content =\n%s\nwant:\n%s", got.Content, want)
 	}
@@ -168,7 +157,22 @@ func TestReconcileJSONRejectsChangedRetiredValue(t *testing.T) {
 	}
 }
 
-func TestReconcileJSONAcceptsAlreadyRemovedRetiredObjectKey(t *testing.T) {
+func TestReconcileJSONPreservesExactUnrelatedBytes(t *testing.T) {
+	target := []byte("{\n  \"external\" : { \"spacing\": [1,  2] },\n  \"owned\": true,\n  \"retired\": \"old\"\n}\n")
+	previous := []byte(`{"owned":true,"retired":"old"}`)
+	current := []byte(`{"owned":true}`)
+	want := []byte("{\n  \"external\" : { \"spacing\": [1,  2] },\n  \"owned\": true\n}\n")
+
+	got, err := ReconcileJSON(target, previous, current)
+	if err != nil {
+		t.Fatalf("ReconcileJSON() error = %v", err)
+	}
+	if !got.Compatible || !got.Changed || !bytes.Equal(got.Content, want) {
+		t.Fatalf("ReconcileJSON() = %q, want exact unrelated bytes %q", got.Content, want)
+	}
+}
+
+func TestReconcileJSONRejectsAlreadyRemovedRetiredObjectKeyWithoutReceipt(t *testing.T) {
 	target := []byte(`{"settings":{"external":true}}`)
 	previous := []byte(`{"settings":{"retired":"old"}}`)
 	current := []byte(`{"settings":{}}`)
@@ -177,12 +181,12 @@ func TestReconcileJSONAcceptsAlreadyRemovedRetiredObjectKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReconcileJSON() error = %v", err)
 	}
-	if !got.Compatible || got.Changed || !bytes.Contains(got.Content, []byte(`"external": true`)) {
-		t.Fatalf("ReconcileJSON() = %#v, want already-removed key to be converged", got)
+	if got.Compatible || got.Changed || got.Content != nil {
+		t.Fatalf("ReconcileJSON() = %#v, want ambiguous missing key rejected", got)
 	}
 }
 
-func TestReconcileJSONAcceptsAlreadyRemovedRetiredArrayItem(t *testing.T) {
+func TestReconcileJSONRejectsAlreadyRemovedRetiredArrayItemWithoutReceipt(t *testing.T) {
 	target := []byte(`{"items":["locally-changed"]}`)
 	previous := []byte(`{"items":["old"]}`)
 	current := []byte(`{"items":[]}`)
@@ -191,8 +195,8 @@ func TestReconcileJSONAcceptsAlreadyRemovedRetiredArrayItem(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReconcileJSON() error = %v", err)
 	}
-	if !got.Compatible || got.Changed || !bytes.Contains(got.Content, []byte(`"locally-changed"`)) {
-		t.Fatalf("ReconcileJSON() = %#v, want target-only array item preserved", got)
+	if got.Compatible || got.Changed || got.Content != nil {
+		t.Fatalf("ReconcileJSON() = %#v, want ambiguous array replacement rejected", got)
 	}
 }
 
@@ -575,7 +579,7 @@ runtime = false # Atuin wrote this
 	}
 }
 
-func TestReconcileTOMLAcceptsAlreadyRemovedRetiredValue(t *testing.T) {
+func TestReconcileTOMLRejectsAlreadyRemovedRetiredValueWithoutReceipt(t *testing.T) {
 	previous := []byte("keep = true\nretired = \"old\"\n")
 	current := []byte("keep = true\n")
 	target := []byte("# external sentinel\nexternal = \"keep\"\nkeep = true\n")
@@ -584,8 +588,8 @@ func TestReconcileTOMLAcceptsAlreadyRemovedRetiredValue(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReconcileTOML() error = %v", err)
 	}
-	if !got.Compatible || got.Changed || !bytes.Equal(got.Content, target) {
-		t.Fatalf("ReconcileTOML() = %#v, want already-removed value to be converged", got)
+	if got.Compatible || got.Changed || got.Content != nil {
+		t.Fatalf("ReconcileTOML() = %#v, want ambiguous missing value rejected", got)
 	}
 }
 

--- a/internal/configsubset/subset_test.go
+++ b/internal/configsubset/subset_test.go
@@ -168,7 +168,7 @@ func TestReconcileJSONRejectsChangedRetiredValue(t *testing.T) {
 	}
 }
 
-func TestReconcileJSONRejectsMissingRetiredObjectKey(t *testing.T) {
+func TestReconcileJSONAcceptsAlreadyRemovedRetiredObjectKey(t *testing.T) {
 	target := []byte(`{"settings":{"external":true}}`)
 	previous := []byte(`{"settings":{"retired":"old"}}`)
 	current := []byte(`{"settings":{}}`)
@@ -177,12 +177,12 @@ func TestReconcileJSONRejectsMissingRetiredObjectKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReconcileJSON() error = %v", err)
 	}
-	if got.Compatible || got.Changed || got.Content != nil {
-		t.Fatalf("ReconcileJSON() = %#v, want missing retired key to be incompatible", got)
+	if !got.Compatible || got.Changed || !bytes.Contains(got.Content, []byte(`"external": true`)) {
+		t.Fatalf("ReconcileJSON() = %#v, want already-removed key to be converged", got)
 	}
 }
 
-func TestReconcileJSONRejectsMissingRetiredArrayItem(t *testing.T) {
+func TestReconcileJSONAcceptsAlreadyRemovedRetiredArrayItem(t *testing.T) {
 	target := []byte(`{"items":["locally-changed"]}`)
 	previous := []byte(`{"items":["old"]}`)
 	current := []byte(`{"items":[]}`)
@@ -191,8 +191,8 @@ func TestReconcileJSONRejectsMissingRetiredArrayItem(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReconcileJSON() error = %v", err)
 	}
-	if got.Compatible {
-		t.Fatalf("ReconcileJSON() = %#v, want conservative array conflict", got)
+	if !got.Compatible || got.Changed || !bytes.Contains(got.Content, []byte(`"locally-changed"`)) {
+		t.Fatalf("ReconcileJSON() = %#v, want target-only array item preserved", got)
 	}
 }
 
@@ -572,6 +572,20 @@ runtime = false # Atuin wrote this
 	}
 	if strings.Contains(got, `retired = "old"`) {
 		t.Fatalf("reconciled TOML retained retired value:\n%s", got)
+	}
+}
+
+func TestReconcileTOMLAcceptsAlreadyRemovedRetiredValue(t *testing.T) {
+	previous := []byte("keep = true\nretired = \"old\"\n")
+	current := []byte("keep = true\n")
+	target := []byte("# external sentinel\nexternal = \"keep\"\nkeep = true\n")
+
+	got, err := ReconcileTOML(target, previous, current)
+	if err != nil {
+		t.Fatalf("ReconcileTOML() error = %v", err)
+	}
+	if !got.Compatible || got.Changed || !bytes.Equal(got.Content, target) {
+		t.Fatalf("ReconcileTOML() = %#v, want already-removed value to be converged", got)
 	}
 }
 

--- a/internal/configsubset/toml.go
+++ b/internal/configsubset/toml.go
@@ -233,6 +233,11 @@ func reconcileParsedTOML(targetData []byte, previous, current *tomlDocument) (TO
 		targetValue, targetExists := tomlValueAt(target.values, previousEntry.path)
 		targetEntry, targetHasExpression := target.entries[pathKey]
 		if !targetExists || !targetHasExpression {
+			if _, remainsOwned := current.entries[pathKey]; !remainsOwned {
+				// A prior interrupted reconciliation may already have
+				// removed this retired value.
+				continue
+			}
 			return TOMLReconciliation{}, nil
 		}
 		currentEntry, remainsOwned := current.entries[pathKey]

--- a/internal/configsubset/toml.go
+++ b/internal/configsubset/toml.go
@@ -233,11 +233,6 @@ func reconcileParsedTOML(targetData []byte, previous, current *tomlDocument) (TO
 		targetValue, targetExists := tomlValueAt(target.values, previousEntry.path)
 		targetEntry, targetHasExpression := target.entries[pathKey]
 		if !targetExists || !targetHasExpression {
-			if _, remainsOwned := current.entries[pathKey]; !remainsOwned {
-				// A prior interrupted reconciliation may already have
-				// removed this retired value.
-				continue
-			}
 			return TOMLReconciliation{}, nil
 		}
 		currentEntry, remainsOwned := current.entries[pathKey]

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"time"
 
 	"github.com/yersonargotev/dots/internal/backups"
@@ -133,7 +134,7 @@ func applyManagedAction(action plan.Action, source string, opts Options) error {
 
 func recordAppliedReconciliation(profiles, tags []string, action plan.Action, resolvedSources []string, opts Options) error {
 	if opts.StateRoot == "" || action.Status != plan.StatusUpdate ||
-		(len(action.PreviousContent) == 0 && action.PreviousHash == "") {
+		action.PreviousRecordFingerprint == "" || (len(action.PreviousContent) == 0 && action.PreviousHash == "") {
 		return nil
 	}
 	record, err := buildMetadataRecord(profiles, tags, action, resolvedSources, time.Now().UTC().Format(time.RFC3339))
@@ -148,8 +149,16 @@ func recordAppliedReconciliation(profiles, tags []string, action plan.Action, re
 		return nil
 	}
 	return state.Update(state.Path(opts.StateRoot), func(meta *state.Metadata) error {
-		if !hasCommittedContributions(*meta, action.Target) {
-			return nil
+		record, ok := meta.FindByTarget(action.Target)
+		if !ok || len(record.Contributions) == 0 {
+			return fmt.Errorf("record reconciliation receipt for %s: authorizing contribution record disappeared", action.Target)
+		}
+		fingerprint, err := state.RecordEvidenceFingerprint(record)
+		if err != nil {
+			return err
+		}
+		if fingerprint != action.PreviousRecordFingerprint {
+			return fmt.Errorf("record reconciliation receipt for %s: authorizing contribution record changed concurrently", action.Target)
 		}
 		meta.Version = state.CurrentVersion
 		meta.Provenance = state.CaptureProvenance(opts.SourceRoot, version.Value)
@@ -188,6 +197,11 @@ func (c MetadataCommit) Commit(installed *state.InstalledSelection) error {
 				continue
 			}
 			action := stagedAction.action
+			if stagedAction.pending != nil {
+				if err := validatePendingReconciliation(*meta, action, stagedAction.pending); err != nil {
+					return err
+				}
+			}
 			staged, err := stagedAction.evidence()
 			if err != nil {
 				return err
@@ -241,8 +255,8 @@ func (c *MetadataCommit) captureStagedEvidence() error {
 }
 
 func buildReconciliationReceipt(action plan.Action, record state.Record) (*state.ReconciliationReceipt, error) {
-	if action.Strategy != "copy" || (action.Status != plan.StatusUpdate && action.Status != plan.StatusUnchanged) ||
-		(len(action.PreviousContent) == 0 && action.PreviousHash == "") {
+	if action.Strategy != "copy" || action.Status != plan.StatusUpdate ||
+		action.PreviousRecordFingerprint == "" || (len(action.PreviousContent) == 0 && action.PreviousHash == "") {
 		return nil, nil
 	}
 	sources := record.SourceList()
@@ -286,7 +300,9 @@ func (c MetadataCommit) recordPartialInventory() error {
 			action := stagedAction.action
 			if hasCommittedContributions(*meta, action.Target) {
 				if stagedAction.pending != nil {
-					setPendingReconciliation(meta, action.Target, stagedAction.pending)
+					if err := validatePendingReconciliation(*meta, action, stagedAction.pending); err != nil {
+						return err
+					}
 				}
 				continue
 			}
@@ -299,6 +315,24 @@ func (c MetadataCommit) recordPartialInventory() error {
 		}
 		return nil
 	})
+}
+
+func validatePendingReconciliation(meta state.Metadata, action plan.Action, receipt *state.ReconciliationReceipt) error {
+	record, ok := meta.FindByTarget(action.Target)
+	if !ok {
+		return fmt.Errorf("validate reconciliation receipt for %s: authorizing record disappeared", action.Target)
+	}
+	fingerprint, err := state.RecordEvidenceFingerprint(record)
+	if err != nil {
+		return err
+	}
+	if action.PreviousRecordFingerprint == "" || fingerprint != action.PreviousRecordFingerprint {
+		return fmt.Errorf("validate reconciliation receipt for %s: authorizing record changed concurrently", action.Target)
+	}
+	if record.PendingReconciliation == nil || !reflect.DeepEqual(*record.PendingReconciliation, *receipt) {
+		return fmt.Errorf("validate reconciliation receipt for %s: receipt changed concurrently", action.Target)
+	}
+	return nil
 }
 
 func setPendingReconciliation(meta *state.Metadata, target string, receipt *state.ReconciliationReceipt) {
@@ -969,18 +1003,22 @@ func applyUpdate(action plan.Action, source string, opts Options) error {
 					return fmt.Errorf("read current owned JSON %s: %w", source, err)
 				}
 			}
-			if err := reconcileJSONContentFile(action.Target, action.PreviousContent, current); err != nil {
+			if err := reconcileJSONContentFile(action.Target, action.PreviousContent, current, opts.Home); err != nil {
 				return fmt.Errorf("reconcile JSON update for %s: %w", action.Target, err)
 			}
 			return nil
 		}
 		if len(action.Content) > 0 {
-			if err := mergeJSONContentFile(action.Target, action.Content); err != nil {
+			if err := mergeJSONContentFile(action.Target, action.Content, opts.Home); err != nil {
 				return fmt.Errorf("merge composed JSON update for %s: %w", action.Target, err)
 			}
 			return nil
 		}
-		if err := configsubset.MergeJSONFile(action.Target, source); err != nil {
+		current, err := os.ReadFile(source)
+		if err != nil {
+			return fmt.Errorf("read current owned JSON %s: %w", source, err)
+		}
+		if err := mergeJSONContentFile(action.Target, current, opts.Home); err != nil {
 			return fmt.Errorf("merge JSON update for %s: %w", action.Target, err)
 		}
 	case "jsonc-subset":
@@ -989,12 +1027,12 @@ func applyUpdate(action plan.Action, source string, opts Options) error {
 			return fmt.Errorf("read current owned JSONC %s: %w", source, err)
 		}
 		if len(action.PreviousContent) > 0 {
-			if err := reconcileJSONCContentFile(action.Target, action.PreviousContent, current); err != nil {
+			if err := reconcileJSONCContentFile(action.Target, action.PreviousContent, current, opts.Home); err != nil {
 				return fmt.Errorf("reconcile JSONC update for %s: %w", action.Target, err)
 			}
 			return nil
 		}
-		if err := mergeJSONCContentFile(action.Target, current); err != nil {
+		if err := mergeJSONCContentFile(action.Target, current, opts.Home); err != nil {
 			return fmt.Errorf("merge JSONC update for %s: %w", action.Target, err)
 		}
 	case "toml-subset":
@@ -1003,51 +1041,43 @@ func applyUpdate(action plan.Action, source string, opts Options) error {
 			if err != nil {
 				return fmt.Errorf("read current owned TOML %s: %w", source, err)
 			}
-			if err := reconcileTOMLContentFile(action.Target, action.PreviousContent, current); err != nil {
+			if err := reconcileTOMLContentFile(action.Target, action.PreviousContent, current, opts.Home); err != nil {
 				return fmt.Errorf("reconcile TOML update for %s: %w", action.Target, err)
 			}
 			return nil
 		}
-		if err := configsubset.MergeTOMLFile(action.Target, source); err != nil {
+		current, err := os.ReadFile(source)
+		if err != nil {
+			return fmt.Errorf("read current owned TOML %s: %w", source, err)
+		}
+		if err := mergeTOMLContentFile(action.Target, current, opts.Home); err != nil {
 			return fmt.Errorf("merge TOML update for %s: %w", action.Target, err)
 		}
 	case "seeded":
-		live, err := os.ReadFile(action.Target)
-		if err != nil {
-			return fmt.Errorf("read seeded target %s: %w", action.Target, err)
-		}
-		if !bytes.Equal(live, action.PreviousContent) {
-			return fmt.Errorf("install plan is stale: seeded target %s evolved before baseline advancement", action.Target)
-		}
 		current, err := os.ReadFile(source)
 		if err != nil {
 			return fmt.Errorf("read seeded baseline %s: %w", source, err)
 		}
-		info, err := os.Stat(action.Target)
-		if err != nil {
-			return fmt.Errorf("stat seeded target %s: %w", action.Target, err)
-		}
-		if err := os.WriteFile(action.Target, current, info.Mode().Perm()); err != nil {
+		if err := updateConfinedRegularFile(action.Target, opts.Home, func(live []byte) ([]byte, bool, error) {
+			if !bytes.Equal(live, action.PreviousContent) {
+				return nil, false, fmt.Errorf("install plan is stale: seeded target %s evolved before baseline advancement", action.Target)
+			}
+			return current, !bytes.Equal(live, current), nil
+		}); err != nil {
 			return fmt.Errorf("advance seeded target %s: %w", action.Target, err)
 		}
 	case "marked-block":
-		live, err := os.ReadFile(action.Target)
-		if err != nil {
-			return fmt.Errorf("read marked-block target %s: %w", action.Target, err)
-		}
 		current, err := os.ReadFile(source)
 		if err != nil {
 			return fmt.Errorf("read marked-block source %s: %w", source, err)
 		}
-		reconciliation := textblock.ReconcileOwned(live, action.PreviousContent, current, textblock.DotsManagedMarkers())
-		if !reconciliation.Compatible {
-			return fmt.Errorf("install plan is stale: marked block %s changed before update", action.Target)
-		}
-		info, err := os.Stat(action.Target)
-		if err != nil {
-			return fmt.Errorf("stat marked-block target %s: %w", action.Target, err)
-		}
-		if err := os.WriteFile(action.Target, reconciliation.Content, info.Mode().Perm()); err != nil {
+		if err := updateConfinedRegularFile(action.Target, opts.Home, func(live []byte) ([]byte, bool, error) {
+			reconciliation := textblock.ReconcileOwned(live, action.PreviousContent, current, textblock.DotsManagedMarkers())
+			if !reconciliation.Compatible {
+				return nil, false, fmt.Errorf("install plan is stale: marked block %s changed before update", action.Target)
+			}
+			return reconciliation.Content, !bytes.Equal(reconciliation.Content, live), nil
+		}); err != nil {
 			return fmt.Errorf("update marked block %s: %w", action.Target, err)
 		}
 	case "", "whole":
@@ -1068,17 +1098,28 @@ func updateWholeTarget(action plan.Action, source, home string) error {
 	if err != nil {
 		return fmt.Errorf("read current whole target source %s: %w", source, err)
 	}
+	return updateConfinedRegularFile(action.Target, home, func(live []byte) ([]byte, bool, error) {
+		if state.HashBytes(live) != action.PreviousHash {
+			return nil, false, fmt.Errorf("install plan is stale: whole target %s changed before update", action.Target)
+		}
+		return current, !bytes.Equal(live, current), nil
+	})
+}
+
+type confinedTransform func([]byte) ([]byte, bool, error)
+
+func updateConfinedRegularFile(target, home string, transform confinedTransform) error {
 	homeAbs, err := cleanAbs(home)
 	if err != nil {
-		return fmt.Errorf("resolve home for whole target %s: %w", action.Target, err)
+		return fmt.Errorf("resolve home for target %s: %w", target, err)
 	}
-	targetAbs, err := cleanAbs(action.Target)
+	targetAbs, err := cleanAbs(target)
 	if err != nil {
-		return fmt.Errorf("resolve whole target %s: %w", action.Target, err)
+		return fmt.Errorf("resolve target %s: %w", target, err)
 	}
 	relative, err := filepath.Rel(homeAbs, targetAbs)
 	if err != nil || !filepath.IsLocal(relative) || relative == "." {
-		return fmt.Errorf("confine whole target %s beneath home %s", action.Target, homeAbs)
+		return fmt.Errorf("confine target %s beneath home %s", target, homeAbs)
 	}
 	root, err := os.OpenRoot(homeAbs)
 	if err != nil {
@@ -1087,48 +1128,49 @@ func updateWholeTarget(action plan.Action, source, home string) error {
 	defer root.Close()
 	observed, err := root.Lstat(relative)
 	if err != nil {
-		return fmt.Errorf("inspect confined whole target %s: %w", action.Target, err)
+		return fmt.Errorf("inspect confined target %s: %w", target, err)
 	}
 	if observed.Mode()&os.ModeSymlink != 0 || !observed.Mode().IsRegular() {
-		return fmt.Errorf("confined whole target %s is not a non-symlink regular file", action.Target)
+		return fmt.Errorf("confined target %s is not a non-symlink regular file", target)
 	}
 	file, err := root.OpenFile(relative, os.O_RDWR, 0)
 	if err != nil {
-		return fmt.Errorf("open confined whole target %s: %w", action.Target, err)
+		return fmt.Errorf("open confined target %s: %w", target, err)
 	}
 	defer file.Close()
 	info, err := file.Stat()
 	if err != nil {
-		return fmt.Errorf("stat confined whole target %s: %w", action.Target, err)
+		return fmt.Errorf("stat confined target %s: %w", target, err)
 	}
-	if !info.Mode().IsRegular() {
-		return fmt.Errorf("confined whole target %s is not a regular file", action.Target)
-	}
-	if !os.SameFile(observed, info) {
-		return fmt.Errorf("install plan is stale: whole target %s changed identity before update", action.Target)
+	if !info.Mode().IsRegular() || !os.SameFile(observed, info) {
+		return fmt.Errorf("install plan is stale: target %s changed identity before update", target)
 	}
 	live, err := io.ReadAll(file)
 	if err != nil {
-		return fmt.Errorf("read confined whole target %s: %w", action.Target, err)
+		return fmt.Errorf("read confined target %s: %w", target, err)
 	}
-	if state.HashBytes(live) != action.PreviousHash {
-		return fmt.Errorf("install plan is stale: whole target %s changed before update", action.Target)
+	updated, changed, err := transform(live)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		return nil
 	}
 	if _, err := file.Seek(0, io.SeekStart); err != nil {
-		return fmt.Errorf("rewind confined whole target %s: %w", action.Target, err)
+		return fmt.Errorf("rewind confined target %s: %w", target, err)
 	}
 	if err := file.Truncate(0); err != nil {
-		return fmt.Errorf("truncate confined whole target %s: %w", action.Target, err)
+		return fmt.Errorf("truncate confined target %s: %w", target, err)
 	}
-	written, err := file.Write(current)
+	written, err := file.Write(updated)
 	if err != nil {
-		return fmt.Errorf("write confined whole target %s: %w", action.Target, err)
+		return fmt.Errorf("write confined target %s: %w", target, err)
 	}
-	if written != len(current) {
-		return fmt.Errorf("write confined whole target %s: wrote %d of %d bytes", action.Target, written, len(current))
+	if written != len(updated) {
+		return fmt.Errorf("write confined target %s: wrote %d of %d bytes", target, written, len(updated))
 	}
 	if err := file.Sync(); err != nil {
-		return fmt.Errorf("sync confined whole target %s: %w", action.Target, err)
+		return fmt.Errorf("sync confined target %s: %w", target, err)
 	}
 	return nil
 }
@@ -1335,103 +1377,62 @@ func writeNewFileFromSourceMode(source, target string, data []byte) error {
 	return nil
 }
 
-func mergeJSONContentFile(target string, sourceData []byte) error {
-	targetData, err := os.ReadFile(target)
-	if err != nil {
-		return err
-	}
-	info, err := os.Stat(target)
-	if err != nil {
-		return err
-	}
-	merged, err := configsubset.MergeJSON(targetData, sourceData)
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(target, merged, info.Mode().Perm())
+func mergeJSONContentFile(target string, sourceData []byte, home string) error {
+	return updateConfinedRegularFile(target, home, func(targetData []byte) ([]byte, bool, error) {
+		merged, err := configsubset.MergeJSON(targetData, sourceData)
+		return merged, err == nil && !bytes.Equal(merged, targetData), err
+	})
 }
 
-func reconcileJSONContentFile(target string, previousData, currentData []byte) error {
-	targetData, err := os.ReadFile(target)
-	if err != nil {
-		return err
-	}
-	info, err := os.Stat(target)
-	if err != nil {
-		return err
-	}
-	reconciliation, err := configsubset.ReconcileJSON(targetData, previousData, currentData)
-	if err != nil {
-		return err
-	}
-	if !reconciliation.Compatible {
-		return fmt.Errorf("live target changed a previously owned JSON value")
-	}
-	if !reconciliation.Changed {
-		return nil
-	}
-	return os.WriteFile(target, reconciliation.Content, info.Mode().Perm())
+func reconcileJSONContentFile(target string, previousData, currentData []byte, home string) error {
+	return updateConfinedRegularFile(target, home, func(targetData []byte) ([]byte, bool, error) {
+		reconciliation, err := configsubset.ReconcileJSON(targetData, previousData, currentData)
+		if err != nil {
+			return nil, false, err
+		}
+		if !reconciliation.Compatible {
+			return nil, false, fmt.Errorf("live target changed a previously owned JSON value")
+		}
+		return reconciliation.Content, reconciliation.Changed, nil
+	})
 }
 
-func mergeJSONCContentFile(target string, sourceData []byte) error {
-	targetData, err := os.ReadFile(target)
-	if err != nil {
-		return err
-	}
-	info, err := os.Stat(target)
-	if err != nil {
-		return err
-	}
-	merged, err := configsubset.MergeJSONC(targetData, sourceData)
-	if err != nil {
-		return err
-	}
-	if bytes.Equal(merged, targetData) {
-		return nil
-	}
-	return os.WriteFile(target, merged, info.Mode().Perm())
+func mergeJSONCContentFile(target string, sourceData []byte, home string) error {
+	return updateConfinedRegularFile(target, home, func(targetData []byte) ([]byte, bool, error) {
+		merged, err := configsubset.MergeJSONC(targetData, sourceData)
+		return merged, err == nil && !bytes.Equal(merged, targetData), err
+	})
 }
 
-func reconcileJSONCContentFile(target string, previousData, currentData []byte) error {
-	targetData, err := os.ReadFile(target)
-	if err != nil {
-		return err
-	}
-	info, err := os.Stat(target)
-	if err != nil {
-		return err
-	}
-	reconciliation, err := configsubset.ReconcileJSONC(targetData, previousData, currentData)
-	if err != nil {
-		return err
-	}
-	if !reconciliation.Compatible {
-		return fmt.Errorf("live target changed a previously owned JSONC value")
-	}
-	if !reconciliation.Changed {
-		return nil
-	}
-	return os.WriteFile(target, reconciliation.Content, info.Mode().Perm())
+func reconcileJSONCContentFile(target string, previousData, currentData []byte, home string) error {
+	return updateConfinedRegularFile(target, home, func(targetData []byte) ([]byte, bool, error) {
+		reconciliation, err := configsubset.ReconcileJSONC(targetData, previousData, currentData)
+		if err != nil {
+			return nil, false, err
+		}
+		if !reconciliation.Compatible {
+			return nil, false, fmt.Errorf("live target changed a previously owned JSONC value")
+		}
+		return reconciliation.Content, reconciliation.Changed, nil
+	})
 }
 
-func reconcileTOMLContentFile(target string, previousData, currentData []byte) error {
-	targetData, err := os.ReadFile(target)
-	if err != nil {
-		return err
-	}
-	info, err := os.Stat(target)
-	if err != nil {
-		return err
-	}
-	reconciliation, err := configsubset.ReconcileTOML(targetData, previousData, currentData)
-	if err != nil {
-		return err
-	}
-	if !reconciliation.Compatible {
-		return fmt.Errorf("live target changed a previously owned TOML value")
-	}
-	if !reconciliation.Changed {
-		return nil
-	}
-	return os.WriteFile(target, reconciliation.Content, info.Mode().Perm())
+func mergeTOMLContentFile(target string, sourceData []byte, home string) error {
+	return updateConfinedRegularFile(target, home, func(targetData []byte) ([]byte, bool, error) {
+		merged, err := configsubset.MergeTOML(targetData, sourceData)
+		return merged, err == nil && !bytes.Equal(merged, targetData), err
+	})
+}
+
+func reconcileTOMLContentFile(target string, previousData, currentData []byte, home string) error {
+	return updateConfinedRegularFile(target, home, func(targetData []byte) ([]byte, bool, error) {
+		reconciliation, err := configsubset.ReconcileTOML(targetData, previousData, currentData)
+		if err != nil {
+			return nil, false, err
+		}
+		if !reconciliation.Compatible {
+			return nil, false, fmt.Errorf("live target changed a previously owned TOML value")
+		}
+		return reconciliation.Content, reconciliation.Changed, nil
+	})
 }

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -3,6 +3,7 @@ package install
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -53,6 +54,7 @@ type metadataAction struct {
 	action          plan.Action
 	resolvedSources []string
 	stagedRecord    state.Record
+	pending         *state.ReconciliationReceipt
 	recordsEvidence bool
 }
 
@@ -196,8 +198,42 @@ func (c *MetadataCommit) captureStagedEvidence() error {
 			return err
 		}
 		stagedAction.stagedRecord = record
+		pending, err := buildReconciliationReceipt(stagedAction.action, record)
+		if err != nil {
+			return err
+		}
+		stagedAction.pending = pending
 	}
 	return nil
+}
+
+func buildReconciliationReceipt(action plan.Action, record state.Record) (*state.ReconciliationReceipt, error) {
+	if action.Strategy != "copy" || (action.Status != plan.StatusUpdate && action.Status != plan.StatusUnchanged) ||
+		(len(action.PreviousContent) == 0 && action.PreviousHash == "") {
+		return nil, nil
+	}
+	sources := record.SourceList()
+	if len(sources) == 0 || len(record.Contributions) != len(sources) {
+		return nil, fmt.Errorf("record reconciliation receipt for %s: exact current contributions are required", action.Target)
+	}
+	sourceHashes := make([]string, len(record.Contributions))
+	for i, contribution := range record.Contributions {
+		if contribution.Source != sources[i] || contribution.Hash == "" {
+			return nil, fmt.Errorf("record reconciliation receipt for %s: exact hash for source %q is required", action.Target, sources[i])
+		}
+		sourceHashes[i] = contribution.Hash
+	}
+	targetHash, err := state.HashFile(action.Target)
+	if err != nil {
+		return nil, fmt.Errorf("record reconciliation receipt for %s: %w", action.Target, err)
+	}
+	return &state.ReconciliationReceipt{
+		TargetHash:   targetHash,
+		Sources:      append([]string(nil), sources...),
+		SourceHashes: sourceHashes,
+		Strategy:     action.Strategy,
+		Ownership:    record.Ownership,
+	}, nil
 }
 
 // recordPartialInventory retains the existing rerunnable failed-install
@@ -216,6 +252,9 @@ func (c MetadataCommit) recordPartialInventory() error {
 			}
 			action := stagedAction.action
 			if hasCommittedContributions(*meta, action.Target) {
+				if stagedAction.pending != nil {
+					setPendingReconciliation(meta, action.Target, stagedAction.pending)
+				}
 				continue
 			}
 			record, err := stagedAction.evidence()
@@ -227,6 +266,19 @@ func (c MetadataCommit) recordPartialInventory() error {
 		}
 		return nil
 	})
+}
+
+func setPendingReconciliation(meta *state.Metadata, target string, receipt *state.ReconciliationReceipt) {
+	for i := range meta.Entries {
+		if meta.Entries[i].Target != target {
+			continue
+		}
+		pending := *receipt
+		pending.Sources = append([]string(nil), receipt.Sources...)
+		pending.SourceHashes = append([]string(nil), receipt.SourceHashes...)
+		meta.Entries[i].PendingReconciliation = &pending
+		return
+	}
 }
 
 func (a metadataAction) evidence() (state.Record, error) {
@@ -966,29 +1018,74 @@ func applyUpdate(action plan.Action, source string, opts Options) error {
 			return fmt.Errorf("update marked block %s: %w", action.Target, err)
 		}
 	case "", "whole":
-		if action.PreviousHash == "" {
-			return fmt.Errorf("previous whole-target evidence is required for %s", action.Target)
-		}
-		liveHash, err := state.HashFile(action.Target)
-		if err != nil {
-			return fmt.Errorf("hash whole target %s: %w", action.Target, err)
-		}
-		if liveHash != action.PreviousHash {
-			return fmt.Errorf("install plan is stale: whole target %s changed before update", action.Target)
-		}
-		current, err := os.ReadFile(source)
-		if err != nil {
-			return fmt.Errorf("read current whole target source %s: %w", source, err)
-		}
-		info, err := os.Stat(action.Target)
-		if err != nil {
-			return fmt.Errorf("stat whole target %s: %w", action.Target, err)
-		}
-		if err := os.WriteFile(action.Target, current, info.Mode().Perm()); err != nil {
-			return fmt.Errorf("update whole target %s: %w", action.Target, err)
+		if err := updateWholeTarget(action, source, opts.Home); err != nil {
+			return err
 		}
 	default:
 		return fmt.Errorf("update ownership %q is not supported for %s", action.Ownership, action.Target)
+	}
+	return nil
+}
+
+func updateWholeTarget(action plan.Action, source, home string) error {
+	if action.PreviousHash == "" {
+		return fmt.Errorf("previous whole-target evidence is required for %s", action.Target)
+	}
+	current, err := os.ReadFile(source)
+	if err != nil {
+		return fmt.Errorf("read current whole target source %s: %w", source, err)
+	}
+	homeAbs, err := cleanAbs(home)
+	if err != nil {
+		return fmt.Errorf("resolve home for whole target %s: %w", action.Target, err)
+	}
+	targetAbs, err := cleanAbs(action.Target)
+	if err != nil {
+		return fmt.Errorf("resolve whole target %s: %w", action.Target, err)
+	}
+	relative, err := filepath.Rel(homeAbs, targetAbs)
+	if err != nil || !filepath.IsLocal(relative) || relative == "." {
+		return fmt.Errorf("confine whole target %s beneath home %s", action.Target, homeAbs)
+	}
+	root, err := os.OpenRoot(homeAbs)
+	if err != nil {
+		return fmt.Errorf("open home root %s: %w", homeAbs, err)
+	}
+	defer root.Close()
+	file, err := root.OpenFile(relative, os.O_RDWR, 0)
+	if err != nil {
+		return fmt.Errorf("open confined whole target %s: %w", action.Target, err)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("stat confined whole target %s: %w", action.Target, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("confined whole target %s is not a regular file", action.Target)
+	}
+	live, err := io.ReadAll(file)
+	if err != nil {
+		return fmt.Errorf("read confined whole target %s: %w", action.Target, err)
+	}
+	if state.HashBytes(live) != action.PreviousHash {
+		return fmt.Errorf("install plan is stale: whole target %s changed before update", action.Target)
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("rewind confined whole target %s: %w", action.Target, err)
+	}
+	if err := file.Truncate(0); err != nil {
+		return fmt.Errorf("truncate confined whole target %s: %w", action.Target, err)
+	}
+	written, err := file.Write(current)
+	if err != nil {
+		return fmt.Errorf("write confined whole target %s: %w", action.Target, err)
+	}
+	if written != len(current) {
+		return fmt.Errorf("write confined whole target %s: wrote %d of %d bytes", action.Target, written, len(current))
+	}
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("sync confined whole target %s: %w", action.Target, err)
 	}
 	return nil
 }

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -166,7 +166,7 @@ func applyActionWithReconciliationReceipt(action plan.Action, source string, res
 		return prepared, nil, err
 	}
 
-	prepared, sourceContents, err := snapshotReconciliationSources(action, resolvedSources)
+	prepared, sourceContents, err := snapshotReconciliationSources(action, resolvedSources, opts.SourceRoot)
 	if err != nil {
 		return action, nil, err
 	}
@@ -191,7 +191,7 @@ func applyActionWithReconciliationReceipt(action plan.Action, source string, res
 	meta.Provenance = state.CaptureProvenance(opts.SourceRoot, version.Value)
 	setPendingReconciliation(&meta, action.Target, receipt)
 	if err := locked.Save(meta); err != nil {
-		rollbackErr := restoreConfinedRegularFile(action.Target, opts.Home, result.PreviousTargetContent)
+		rollbackErr := restoreConfinedRegularFile(action.Target, opts.Home, result.TargetContent, result.PreviousTargetContent)
 		return prepared, nil, errors.Join(fmt.Errorf("persist reconciliation receipt for %s: %w", action.Target, err), rollbackErr)
 	}
 	return prepared, receipt, nil
@@ -202,10 +202,10 @@ func requiresReconciliationReceipt(action plan.Action, opts Options) bool {
 		action.PreviousRecordFingerprint != "" && (len(action.PreviousContent) > 0 || action.PreviousHash != "")
 }
 
-func snapshotReconciliationSources(action plan.Action, resolvedSources []string) (plan.Action, [][]byte, error) {
+func snapshotReconciliationSources(action plan.Action, resolvedSources []string, sourceRoot string) (plan.Action, [][]byte, error) {
 	contents := make([][]byte, len(resolvedSources))
 	for i, source := range resolvedSources {
-		data, err := os.ReadFile(source)
+		data, err := readConfinedRegularFile(source, sourceRoot)
 		if err != nil {
 			return action, nil, fmt.Errorf("snapshot reconciliation source %s: %w", source, err)
 		}
@@ -213,10 +213,10 @@ func snapshotReconciliationSources(action plan.Action, resolvedSources []string)
 	}
 	prepared := action
 	if len(action.Sources) == 0 {
-		prepared.Content = append([]byte(nil), contents[0]...)
+		prepared.Content = append([]byte{}, contents[0]...)
 		return prepared, contents, nil
 	}
-	composed := append([]byte(nil), contents[0]...)
+	composed := append([]byte{}, contents[0]...)
 	for i := 1; i < len(contents); i++ {
 		merged, err := configsubset.MergeJSON(composed, contents[i])
 		if err != nil {
@@ -229,6 +229,50 @@ func snapshotReconciliationSources(action plan.Action, resolvedSources []string)
 	}
 	prepared.Content = composed
 	return prepared, contents, nil
+}
+
+func readConfinedRegularFile(path, rootPath string) ([]byte, error) {
+	rootAbs, err := cleanAbs(rootPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve source root %s: %w", rootPath, err)
+	}
+	pathAbs, err := cleanAbs(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve source %s: %w", path, err)
+	}
+	relative, err := filepath.Rel(rootAbs, pathAbs)
+	if err != nil || !filepath.IsLocal(relative) || relative == "." {
+		return nil, fmt.Errorf("confine source %s beneath source root %s", path, rootAbs)
+	}
+	root, err := os.OpenRoot(rootAbs)
+	if err != nil {
+		return nil, fmt.Errorf("open source root %s: %w", rootAbs, err)
+	}
+	defer root.Close()
+	observed, err := root.Lstat(relative)
+	if err != nil {
+		return nil, fmt.Errorf("inspect confined source %s: %w", path, err)
+	}
+	if observed.Mode()&os.ModeSymlink != 0 || !observed.Mode().IsRegular() {
+		return nil, fmt.Errorf("confined source %s is not a non-symlink regular file", path)
+	}
+	file, err := root.OpenFile(relative, os.O_RDONLY, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open confined source %s: %w", path, err)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat confined source %s: %w", path, err)
+	}
+	if !info.Mode().IsRegular() || !os.SameFile(observed, info) {
+		return nil, fmt.Errorf("install plan is stale: source %s changed identity before snapshot", path)
+	}
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, fmt.Errorf("read confined source %s: %w", path, err)
+	}
+	return data, nil
 }
 
 func actionSourceList(action plan.Action) []string {
@@ -1269,9 +1313,12 @@ func updateConfinedRegularFile(target, home string, transform confinedTransform)
 	return result, nil
 }
 
-func restoreConfinedRegularFile(target, home string, content []byte) error {
+func restoreConfinedRegularFile(target, home string, applied, previous []byte) error {
 	_, err := updateConfinedRegularFile(target, home, func(live []byte) ([]byte, bool, error) {
-		return content, !bytes.Equal(live, content), nil
+		if !bytes.Equal(live, applied) {
+			return nil, false, fmt.Errorf("target changed after reconciliation; refusing rollback")
+		}
+		return previous, !bytes.Equal(live, previous), nil
 	})
 	if err != nil {
 		return fmt.Errorf("restore target %s after metadata failure: %w", target, err)

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -249,12 +249,12 @@ func readConfinedRegularFile(path, rootPath string) ([]byte, error) {
 		return nil, fmt.Errorf("open source root %s: %w", rootAbs, err)
 	}
 	defer root.Close()
-	observed, err := root.Lstat(relative)
+	observed, err := root.Stat(relative)
 	if err != nil {
 		return nil, fmt.Errorf("inspect confined source %s: %w", path, err)
 	}
-	if observed.Mode()&os.ModeSymlink != 0 || !observed.Mode().IsRegular() {
-		return nil, fmt.Errorf("confined source %s is not a non-symlink regular file", path)
+	if !observed.Mode().IsRegular() {
+		return nil, fmt.Errorf("confined source %s does not resolve to a regular file", path)
 	}
 	file, err := root.OpenFile(relative, os.O_RDONLY, 0)
 	if err != nil {
@@ -1294,23 +1294,72 @@ func updateConfinedRegularFile(target, home string, transform confinedTransform)
 		result.TargetContent = append([]byte(nil), live...)
 		return result, nil
 	}
-	if _, err := file.Seek(0, io.SeekStart); err != nil {
-		return managedActionResult{}, fmt.Errorf("rewind confined target %s: %w", target, err)
-	}
-	if err := file.Truncate(0); err != nil {
-		return managedActionResult{}, fmt.Errorf("truncate confined target %s: %w", target, err)
-	}
-	written, err := file.Write(updated)
-	if err != nil {
-		return managedActionResult{}, fmt.Errorf("write confined target %s: %w", target, err)
-	}
-	if written != len(updated) {
-		return managedActionResult{}, fmt.Errorf("write confined target %s: wrote %d of %d bytes", target, written, len(updated))
-	}
-	if err := file.Sync(); err != nil {
-		return managedActionResult{}, fmt.Errorf("sync confined target %s: %w", target, err)
+	if err := rewriteOpenedRegularFile(file, target, updated, live); err != nil {
+		return managedActionResult{}, err
 	}
 	return result, nil
+}
+
+type openedRegularFile interface {
+	io.Writer
+	io.Seeker
+	Truncate(int64) error
+	Sync() error
+}
+
+func rewriteOpenedRegularFile(file openedRegularFile, target string, updated, previous []byte) error {
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("rewind confined target %s: %w", target, err)
+	}
+	if err := file.Truncate(0); err != nil {
+		return errors.Join(
+			fmt.Errorf("truncate confined target %s: %w", target, err),
+			restoreOpenedRegularFile(file, target, previous),
+		)
+	}
+	if err := writeAll(file, updated); err != nil {
+		return errors.Join(
+			fmt.Errorf("write confined target %s: %w", target, err),
+			restoreOpenedRegularFile(file, target, previous),
+		)
+	}
+	if err := file.Sync(); err != nil {
+		return errors.Join(
+			fmt.Errorf("sync confined target %s: %w", target, err),
+			restoreOpenedRegularFile(file, target, previous),
+		)
+	}
+	return nil
+}
+
+func restoreOpenedRegularFile(file openedRegularFile, target string, previous []byte) error {
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("restore confined target %s: rewind: %w", target, err)
+	}
+	if err := file.Truncate(0); err != nil {
+		return fmt.Errorf("restore confined target %s: truncate: %w", target, err)
+	}
+	if err := writeAll(file, previous); err != nil {
+		return fmt.Errorf("restore confined target %s: write: %w", target, err)
+	}
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("restore confined target %s: sync: %w", target, err)
+	}
+	return nil
+}
+
+func writeAll(writer io.Writer, data []byte) error {
+	for len(data) > 0 {
+		written, err := writer.Write(data)
+		if err != nil {
+			return err
+		}
+		if written == 0 {
+			return io.ErrShortWrite
+		}
+		data = data[written:]
+	}
+	return nil
 }
 
 func restoreConfinedRegularFile(target, home string, applied, previous []byte) error {

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -73,6 +73,12 @@ func Apply(p plan.Plan, opts Options) error {
 // only compatibility inventory. Exact per-contribution evidence is kept out of
 // Installation Metadata until the returned commit reaches terminal success.
 func ApplyManagedEntries(p plan.Plan, opts Options) (MetadataCommit, error) {
+	return applyManagedEntriesWithApply(p, opts, applyManagedAction)
+}
+
+type managedActionApply func(plan.Action, string, Options) error
+
+func applyManagedEntriesWithApply(p plan.Plan, opts Options, applyAction managedActionApply) (MetadataCommit, error) {
 	resolvedSources, err := validatePlan(p, opts)
 	if err != nil {
 		return MetadataCommit{}, err
@@ -80,36 +86,11 @@ func ApplyManagedEntries(p plan.Plan, opts Options) (MetadataCommit, error) {
 
 	for i, action := range p.Actions {
 		source := resolvedSources[i][0]
-		switch action.Status {
-		case plan.StatusUnchanged:
-			continue
-		case plan.StatusCreate:
-			if err := applyCreate(action, source); err != nil {
-				return MetadataCommit{}, err
-			}
-		case plan.StatusUpdate:
-			if err := applyUpdate(action, source, opts); err != nil {
-				return MetadataCommit{}, err
-			}
-		case plan.StatusMigrate:
-			if err := applyMigration(action, source, opts); err != nil {
-				return MetadataCommit{}, err
-			}
-		case plan.StatusConflict:
-			switch conflictDecision(action, opts) {
-			case DecisionSkip:
-				// Safe default for unresolved conflicts is skip: do not mutate the
-				// existing workstation target, but continue applying safe actions.
-				continue
-			case DecisionReplace:
-				if err := applyReplace(action, source, opts); err != nil {
-					return MetadataCommit{}, err
-				}
-			case DecisionAdopt:
-				if err := applyAdopt(action, source, opts); err != nil {
-					return MetadataCommit{}, err
-				}
-			}
+		if err := applyAction(action, source, opts); err != nil {
+			return MetadataCommit{}, err
+		}
+		if err := recordAppliedReconciliation(p.Profiles, p.Tags, action, resolvedSources[i], opts); err != nil {
+			return MetadataCommit{}, err
 		}
 	}
 
@@ -123,6 +104,58 @@ func ApplyManagedEntries(p plan.Plan, opts Options) (MetadataCommit, error) {
 		return MetadataCommit{}, err
 	}
 	return commit, nil
+}
+
+func applyManagedAction(action plan.Action, source string, opts Options) error {
+	switch action.Status {
+	case plan.StatusUnchanged:
+		return nil
+	case plan.StatusCreate:
+		return applyCreate(action, source)
+	case plan.StatusUpdate:
+		return applyUpdate(action, source, opts)
+	case plan.StatusMigrate:
+		return applyMigration(action, source, opts)
+	case plan.StatusConflict:
+		switch conflictDecision(action, opts) {
+		case DecisionSkip:
+			// Safe default for unresolved conflicts is skip: do not mutate the
+			// existing workstation target, but continue applying safe actions.
+			return nil
+		case DecisionReplace:
+			return applyReplace(action, source, opts)
+		case DecisionAdopt:
+			return applyAdopt(action, source, opts)
+		}
+	}
+	return nil
+}
+
+func recordAppliedReconciliation(profiles, tags []string, action plan.Action, resolvedSources []string, opts Options) error {
+	if opts.StateRoot == "" || action.Status != plan.StatusUpdate ||
+		(len(action.PreviousContent) == 0 && action.PreviousHash == "") {
+		return nil
+	}
+	record, err := buildMetadataRecord(profiles, tags, action, resolvedSources, time.Now().UTC().Format(time.RFC3339))
+	if err != nil {
+		return err
+	}
+	receipt, err := buildReconciliationReceipt(action, record)
+	if err != nil {
+		return err
+	}
+	if receipt == nil {
+		return nil
+	}
+	return state.Update(state.Path(opts.StateRoot), func(meta *state.Metadata) error {
+		if !hasCommittedContributions(*meta, action.Target) {
+			return nil
+		}
+		meta.Version = state.CurrentVersion
+		meta.Provenance = state.CaptureProvenance(opts.SourceRoot, version.Value)
+		setPendingReconciliation(meta, action.Target, receipt)
+		return nil
+	})
 }
 
 // ValidateManagedEntries validates the complete forward Install Plan without
@@ -1052,6 +1085,13 @@ func updateWholeTarget(action plan.Action, source, home string) error {
 		return fmt.Errorf("open home root %s: %w", homeAbs, err)
 	}
 	defer root.Close()
+	observed, err := root.Lstat(relative)
+	if err != nil {
+		return fmt.Errorf("inspect confined whole target %s: %w", action.Target, err)
+	}
+	if observed.Mode()&os.ModeSymlink != 0 || !observed.Mode().IsRegular() {
+		return fmt.Errorf("confined whole target %s is not a non-symlink regular file", action.Target)
+	}
 	file, err := root.OpenFile(relative, os.O_RDWR, 0)
 	if err != nil {
 		return fmt.Errorf("open confined whole target %s: %w", action.Target, err)
@@ -1063,6 +1103,9 @@ func updateWholeTarget(action plan.Action, source, home string) error {
 	}
 	if !info.Mode().IsRegular() {
 		return fmt.Errorf("confined whole target %s is not a regular file", action.Target)
+	}
+	if !os.SameFile(observed, info) {
+		return fmt.Errorf("install plan is stale: whole target %s changed identity before update", action.Target)
 	}
 	live, err := io.ReadAll(file)
 	if err != nil {

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -542,7 +542,8 @@ func validatePlan(p plan.Plan, opts Options) ([][]string, error) {
 			if opts.StateRoot == "" {
 				return nil, fmt.Errorf("update for %s requires state root for Backup Set metadata", action.Target)
 			}
-			if action.Strategy != "copy" || (action.Ownership != "json-subset" && action.Ownership != "jsonc-subset" && action.Ownership != "toml-subset" && action.Ownership != "marked-block" && action.Ownership != "seeded") {
+			wholeOverride := (action.Ownership == "" || action.Ownership == "whole") && action.PreviousHash != ""
+			if action.Strategy != "copy" || (!wholeOverride && action.Ownership != "json-subset" && action.Ownership != "jsonc-subset" && action.Ownership != "toml-subset" && action.Ownership != "marked-block" && action.Ownership != "seeded") {
 				return nil, fmt.Errorf("update for %s requires copy strategy with reconcilable ownership", action.Target)
 			}
 			if err := validateBackupStateRoot(opts.StateRoot, home); err != nil {
@@ -963,6 +964,28 @@ func applyUpdate(action plan.Action, source string, opts Options) error {
 		}
 		if err := os.WriteFile(action.Target, reconciliation.Content, info.Mode().Perm()); err != nil {
 			return fmt.Errorf("update marked block %s: %w", action.Target, err)
+		}
+	case "", "whole":
+		if action.PreviousHash == "" {
+			return fmt.Errorf("previous whole-target evidence is required for %s", action.Target)
+		}
+		liveHash, err := state.HashFile(action.Target)
+		if err != nil {
+			return fmt.Errorf("hash whole target %s: %w", action.Target, err)
+		}
+		if liveHash != action.PreviousHash {
+			return fmt.Errorf("install plan is stale: whole target %s changed before update", action.Target)
+		}
+		current, err := os.ReadFile(source)
+		if err != nil {
+			return fmt.Errorf("read current whole target source %s: %w", source, err)
+		}
+		info, err := os.Stat(action.Target)
+		if err != nil {
+			return fmt.Errorf("stat whole target %s: %w", action.Target, err)
+		}
+		if err := os.WriteFile(action.Target, current, info.Mode().Perm()); err != nil {
+			return fmt.Errorf("update whole target %s: %w", action.Target, err)
 		}
 	default:
 		return fmt.Errorf("update ownership %q is not supported for %s", action.Ownership, action.Target)

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -2,6 +2,7 @@ package install
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -71,13 +72,20 @@ func Apply(p plan.Plan, opts Options) error {
 }
 
 // ApplyManagedEntries applies and validates Managed Entries while persisting
-// only compatibility inventory. Exact per-contribution evidence is kept out of
-// Installation Metadata until the returned commit reaches terminal success.
+// only compatibility inventory and recovery receipts. Exact current
+// per-contribution evidence is kept out of Installation Metadata until the
+// returned commit reaches terminal success.
 func ApplyManagedEntries(p plan.Plan, opts Options) (MetadataCommit, error) {
 	return applyManagedEntriesWithApply(p, opts, applyManagedAction)
 }
 
-type managedActionApply func(plan.Action, string, Options) error
+type managedActionResult struct {
+	PreviousTargetContent []byte
+	TargetContent         []byte
+	ExactTargetContent    bool
+}
+
+type managedActionApply func(plan.Action, string, Options) (managedActionResult, error)
 
 func applyManagedEntriesWithApply(p plan.Plan, opts Options, applyAction managedActionApply) (MetadataCommit, error) {
 	resolvedSources, err := validatePlan(p, opts)
@@ -85,17 +93,23 @@ func applyManagedEntriesWithApply(p plan.Plan, opts Options, applyAction managed
 		return MetadataCommit{}, err
 	}
 
+	appliedActions := append([]plan.Action(nil), p.Actions...)
+	appliedReceipts := make([]*state.ReconciliationReceipt, len(p.Actions))
 	for i, action := range p.Actions {
 		source := resolvedSources[i][0]
-		if err := applyAction(action, source, opts); err != nil {
+		prepared, receipt, err := applyActionWithReconciliationReceipt(action, source, resolvedSources[i], opts, applyAction)
+		if err != nil {
 			return MetadataCommit{}, err
 		}
-		if err := recordAppliedReconciliation(p.Profiles, p.Tags, action, resolvedSources[i], opts); err != nil {
-			return MetadataCommit{}, err
-		}
+		appliedActions[i] = prepared
+		appliedReceipts[i] = receipt
 	}
 
+	p.Actions = appliedActions
 	commit := newMetadataCommit(p, resolvedSources, opts)
+	for i := range commit.actions {
+		commit.actions[i].pending = appliedReceipts[i]
+	}
 	if opts.StateRoot != "" {
 		if err := commit.captureStagedEvidence(); err != nil {
 			return MetadataCommit{}, err
@@ -107,64 +121,121 @@ func applyManagedEntriesWithApply(p plan.Plan, opts Options, applyAction managed
 	return commit, nil
 }
 
-func applyManagedAction(action plan.Action, source string, opts Options) error {
+func applyManagedAction(action plan.Action, source string, opts Options) (managedActionResult, error) {
 	switch action.Status {
 	case plan.StatusUnchanged:
-		return nil
+		return managedActionResult{}, nil
 	case plan.StatusCreate:
-		return applyCreate(action, source)
+		return managedActionResult{}, applyCreate(action, source)
 	case plan.StatusUpdate:
 		return applyUpdate(action, source, opts)
 	case plan.StatusMigrate:
-		return applyMigration(action, source, opts)
+		return managedActionResult{}, applyMigration(action, source, opts)
 	case plan.StatusConflict:
 		switch conflictDecision(action, opts) {
 		case DecisionSkip:
 			// Safe default for unresolved conflicts is skip: do not mutate the
 			// existing workstation target, but continue applying safe actions.
-			return nil
+			return managedActionResult{}, nil
 		case DecisionReplace:
-			return applyReplace(action, source, opts)
+			return managedActionResult{}, applyReplace(action, source, opts)
 		case DecisionAdopt:
-			return applyAdopt(action, source, opts)
+			return managedActionResult{}, applyAdopt(action, source, opts)
 		}
 	}
-	return nil
+	return managedActionResult{}, nil
 }
 
-func recordAppliedReconciliation(profiles, tags []string, action plan.Action, resolvedSources []string, opts Options) error {
-	if opts.StateRoot == "" || action.Status != plan.StatusUpdate ||
-		action.PreviousRecordFingerprint == "" || (len(action.PreviousContent) == 0 && action.PreviousHash == "") {
-		return nil
+func applyActionWithReconciliationReceipt(action plan.Action, source string, resolvedSources []string, opts Options, applyAction managedActionApply) (prepared plan.Action, receipt *state.ReconciliationReceipt, resultErr error) {
+	prepared = action
+	if !requiresReconciliationReceipt(action, opts) {
+		_, err := applyAction(action, source, opts)
+		return prepared, nil, err
 	}
-	record, err := buildMetadataRecord(profiles, tags, action, resolvedSources, time.Now().UTC().Format(time.RFC3339))
+
+	locked, err := state.LockMetadata(state.Path(opts.StateRoot))
 	if err != nil {
-		return err
+		return prepared, nil, err
 	}
-	receipt, err := buildReconciliationReceipt(action, record)
+	defer func() { resultErr = errors.Join(resultErr, locked.Close()) }()
+	meta, err := locked.Load()
 	if err != nil {
-		return err
+		return prepared, nil, err
 	}
-	if receipt == nil {
-		return nil
+	if err := validateAuthorizingRecord(meta, action, action.PreviousReconciliationReceipt); err != nil {
+		return prepared, nil, err
 	}
-	return state.Update(state.Path(opts.StateRoot), func(meta *state.Metadata) error {
-		record, ok := meta.FindByTarget(action.Target)
-		if !ok || len(record.Contributions) == 0 {
-			return fmt.Errorf("record reconciliation receipt for %s: authorizing contribution record disappeared", action.Target)
-		}
-		fingerprint, err := state.RecordEvidenceFingerprint(record)
+
+	prepared, sourceContents, err := snapshotReconciliationSources(action, resolvedSources)
+	if err != nil {
+		return action, nil, err
+	}
+	result, err := applyAction(prepared, source, opts)
+	if err != nil {
+		return prepared, nil, err
+	}
+	if !result.ExactTargetContent {
+		return prepared, nil, fmt.Errorf("record reconciliation receipt for %s: apply did not return exact target bytes", action.Target)
+	}
+	receipt = &state.ReconciliationReceipt{
+		TargetHash:   state.HashBytes(result.TargetContent),
+		Sources:      actionSourceList(action),
+		SourceHashes: make([]string, len(sourceContents)),
+		Strategy:     action.Strategy,
+		Ownership:    ownershipevidence.For(action.Strategy, action.Ownership).Ownership(),
+	}
+	for i := range sourceContents {
+		receipt.SourceHashes[i] = state.HashBytes(sourceContents[i])
+	}
+	meta.Version = state.CurrentVersion
+	meta.Provenance = state.CaptureProvenance(opts.SourceRoot, version.Value)
+	setPendingReconciliation(&meta, action.Target, receipt)
+	if err := locked.Save(meta); err != nil {
+		rollbackErr := restoreConfinedRegularFile(action.Target, opts.Home, result.PreviousTargetContent)
+		return prepared, nil, errors.Join(fmt.Errorf("persist reconciliation receipt for %s: %w", action.Target, err), rollbackErr)
+	}
+	return prepared, receipt, nil
+}
+
+func requiresReconciliationReceipt(action plan.Action, opts Options) bool {
+	return opts.StateRoot != "" && action.Status == plan.StatusUpdate && action.Strategy == "copy" &&
+		action.PreviousRecordFingerprint != "" && (len(action.PreviousContent) > 0 || action.PreviousHash != "")
+}
+
+func snapshotReconciliationSources(action plan.Action, resolvedSources []string) (plan.Action, [][]byte, error) {
+	contents := make([][]byte, len(resolvedSources))
+	for i, source := range resolvedSources {
+		data, err := os.ReadFile(source)
 		if err != nil {
-			return err
+			return action, nil, fmt.Errorf("snapshot reconciliation source %s: %w", source, err)
 		}
-		if fingerprint != action.PreviousRecordFingerprint {
-			return fmt.Errorf("record reconciliation receipt for %s: authorizing contribution record changed concurrently", action.Target)
+		contents[i] = data
+	}
+	prepared := action
+	if len(action.Sources) == 0 {
+		prepared.Content = append([]byte(nil), contents[0]...)
+		return prepared, contents, nil
+	}
+	composed := append([]byte(nil), contents[0]...)
+	for i := 1; i < len(contents); i++ {
+		merged, err := configsubset.MergeJSON(composed, contents[i])
+		if err != nil {
+			return action, nil, fmt.Errorf("compose snapshotted reconciliation source %s: %w", action.Sources[i], err)
 		}
-		meta.Version = state.CurrentVersion
-		meta.Provenance = state.CaptureProvenance(opts.SourceRoot, version.Value)
-		setPendingReconciliation(meta, action.Target, receipt)
-		return nil
-	})
+		composed = merged
+	}
+	if !bytes.Equal(composed, action.Content) {
+		return action, nil, fmt.Errorf("install plan source content changed before reconciliation for %s", action.Target)
+	}
+	prepared.Content = composed
+	return prepared, contents, nil
+}
+
+func actionSourceList(action plan.Action) []string {
+	if len(action.Sources) > 0 {
+		return append([]string(nil), action.Sources...)
+	}
+	return []string{action.Source}
 }
 
 // ValidateManagedEntries validates the complete forward Install Plan without
@@ -197,8 +268,12 @@ func (c MetadataCommit) Commit(installed *state.InstalledSelection) error {
 				continue
 			}
 			action := stagedAction.action
-			if stagedAction.pending != nil {
-				if err := validatePendingReconciliation(*meta, action, stagedAction.pending); err != nil {
+			if action.PreviousRecordFingerprint != "" {
+				expectedReceipt := action.PreviousReconciliationReceipt
+				if stagedAction.pending != nil {
+					expectedReceipt = stagedAction.pending
+				}
+				if err := validateAuthorizingRecord(*meta, action, expectedReceipt); err != nil {
 					return err
 				}
 			}
@@ -245,42 +320,26 @@ func (c *MetadataCommit) captureStagedEvidence() error {
 			return err
 		}
 		stagedAction.stagedRecord = record
-		pending, err := buildReconciliationReceipt(stagedAction.action, record)
-		if err != nil {
-			return err
+		if stagedAction.pending != nil {
+			if err := validateRecordAgainstReceipt(record, stagedAction.pending); err != nil {
+				return fmt.Errorf("validate snapshotted reconciliation evidence for %s: %w", stagedAction.action.Target, err)
+			}
 		}
-		stagedAction.pending = pending
 	}
 	return nil
 }
 
-func buildReconciliationReceipt(action plan.Action, record state.Record) (*state.ReconciliationReceipt, error) {
-	if action.Strategy != "copy" || action.Status != plan.StatusUpdate ||
-		action.PreviousRecordFingerprint == "" || (len(action.PreviousContent) == 0 && action.PreviousHash == "") {
-		return nil, nil
+func validateRecordAgainstReceipt(record state.Record, receipt *state.ReconciliationReceipt) error {
+	if receipt == nil || record.Strategy != receipt.Strategy || record.Ownership != receipt.Ownership ||
+		!reflect.DeepEqual(record.SourceList(), receipt.Sources) || len(record.Contributions) != len(receipt.SourceHashes) {
+		return fmt.Errorf("record does not match reconciliation receipt identity")
 	}
-	sources := record.SourceList()
-	if len(sources) == 0 || len(record.Contributions) != len(sources) {
-		return nil, fmt.Errorf("record reconciliation receipt for %s: exact current contributions are required", action.Target)
-	}
-	sourceHashes := make([]string, len(record.Contributions))
-	for i, contribution := range record.Contributions {
-		if contribution.Source != sources[i] || contribution.Hash == "" {
-			return nil, fmt.Errorf("record reconciliation receipt for %s: exact hash for source %q is required", action.Target, sources[i])
+	for i := range record.Contributions {
+		if record.Contributions[i].Source != receipt.Sources[i] || record.Contributions[i].Hash != receipt.SourceHashes[i] {
+			return fmt.Errorf("source %q changed after reconciliation", receipt.Sources[i])
 		}
-		sourceHashes[i] = contribution.Hash
 	}
-	targetHash, err := state.HashFile(action.Target)
-	if err != nil {
-		return nil, fmt.Errorf("record reconciliation receipt for %s: %w", action.Target, err)
-	}
-	return &state.ReconciliationReceipt{
-		TargetHash:   targetHash,
-		Sources:      append([]string(nil), sources...),
-		SourceHashes: sourceHashes,
-		Strategy:     action.Strategy,
-		Ownership:    record.Ownership,
-	}, nil
+	return nil
 }
 
 // recordPartialInventory retains the existing rerunnable failed-install
@@ -299,8 +358,12 @@ func (c MetadataCommit) recordPartialInventory() error {
 			}
 			action := stagedAction.action
 			if hasCommittedContributions(*meta, action.Target) {
-				if stagedAction.pending != nil {
-					if err := validatePendingReconciliation(*meta, action, stagedAction.pending); err != nil {
+				if action.PreviousRecordFingerprint != "" {
+					expectedReceipt := action.PreviousReconciliationReceipt
+					if stagedAction.pending != nil {
+						expectedReceipt = stagedAction.pending
+					}
+					if err := validateAuthorizingRecord(*meta, action, expectedReceipt); err != nil {
 						return err
 					}
 				}
@@ -317,7 +380,7 @@ func (c MetadataCommit) recordPartialInventory() error {
 	})
 }
 
-func validatePendingReconciliation(meta state.Metadata, action plan.Action, receipt *state.ReconciliationReceipt) error {
+func validateAuthorizingRecord(meta state.Metadata, action plan.Action, expectedReceipt *state.ReconciliationReceipt) error {
 	record, ok := meta.FindByTarget(action.Target)
 	if !ok {
 		return fmt.Errorf("validate reconciliation receipt for %s: authorizing record disappeared", action.Target)
@@ -329,7 +392,7 @@ func validatePendingReconciliation(meta state.Metadata, action plan.Action, rece
 	if action.PreviousRecordFingerprint == "" || fingerprint != action.PreviousRecordFingerprint {
 		return fmt.Errorf("validate reconciliation receipt for %s: authorizing record changed concurrently", action.Target)
 	}
-	if record.PendingReconciliation == nil || !reflect.DeepEqual(*record.PendingReconciliation, *receipt) {
+	if !reflect.DeepEqual(record.PendingReconciliation, expectedReceipt) {
 		return fmt.Errorf("validate reconciliation receipt for %s: receipt changed concurrently", action.Target)
 	}
 	return nil
@@ -988,115 +1051,140 @@ func applyReplace(action plan.Action, source string, opts Options) error {
 	return nil
 }
 
-func applyUpdate(action plan.Action, source string, opts Options) error {
+func applyUpdate(action plan.Action, source string, opts Options) (managedActionResult, error) {
 	if err := createBackupSet(opts, action.Target); err != nil {
-		return err
+		return managedActionResult{}, err
 	}
 	switch action.Ownership {
 	case "json-subset":
-		if len(action.PreviousContent) > 0 {
-			current := action.Content
-			if len(current) == 0 {
-				var err error
-				current, err = os.ReadFile(source)
-				if err != nil {
-					return fmt.Errorf("read current owned JSON %s: %w", source, err)
-				}
-			}
-			if err := reconcileJSONContentFile(action.Target, action.PreviousContent, current, opts.Home); err != nil {
-				return fmt.Errorf("reconcile JSON update for %s: %w", action.Target, err)
-			}
-			return nil
-		}
-		if len(action.Content) > 0 {
-			if err := mergeJSONContentFile(action.Target, action.Content, opts.Home); err != nil {
-				return fmt.Errorf("merge composed JSON update for %s: %w", action.Target, err)
-			}
-			return nil
-		}
-		current, err := os.ReadFile(source)
-		if err != nil {
-			return fmt.Errorf("read current owned JSON %s: %w", source, err)
-		}
-		if err := mergeJSONContentFile(action.Target, current, opts.Home); err != nil {
-			return fmt.Errorf("merge JSON update for %s: %w", action.Target, err)
-		}
-	case "jsonc-subset":
-		current, err := os.ReadFile(source)
-		if err != nil {
-			return fmt.Errorf("read current owned JSONC %s: %w", source, err)
-		}
-		if len(action.PreviousContent) > 0 {
-			if err := reconcileJSONCContentFile(action.Target, action.PreviousContent, current, opts.Home); err != nil {
-				return fmt.Errorf("reconcile JSONC update for %s: %w", action.Target, err)
-			}
-			return nil
-		}
-		if err := mergeJSONCContentFile(action.Target, current, opts.Home); err != nil {
-			return fmt.Errorf("merge JSONC update for %s: %w", action.Target, err)
-		}
-	case "toml-subset":
-		if len(action.PreviousContent) > 0 {
-			current, err := os.ReadFile(source)
+		current := action.Content
+		if current == nil {
+			var err error
+			current, err = os.ReadFile(source)
 			if err != nil {
-				return fmt.Errorf("read current owned TOML %s: %w", source, err)
+				return managedActionResult{}, fmt.Errorf("read current owned JSON %s: %w", source, err)
 			}
-			if err := reconcileTOMLContentFile(action.Target, action.PreviousContent, current, opts.Home); err != nil {
-				return fmt.Errorf("reconcile TOML update for %s: %w", action.Target, err)
-			}
-			return nil
 		}
-		current, err := os.ReadFile(source)
+		if len(action.PreviousContent) > 0 {
+			result, err := reconcileJSONContentFile(action.Target, action.PreviousContent, current, opts.Home)
+			if err != nil {
+				return managedActionResult{}, fmt.Errorf("reconcile JSON update for %s: %w", action.Target, err)
+			}
+			return result, nil
+		}
+		result, err := mergeJSONContentFile(action.Target, current, opts.Home)
 		if err != nil {
-			return fmt.Errorf("read current owned TOML %s: %w", source, err)
+			return managedActionResult{}, fmt.Errorf("merge JSON update for %s: %w", action.Target, err)
 		}
-		if err := mergeTOMLContentFile(action.Target, current, opts.Home); err != nil {
-			return fmt.Errorf("merge TOML update for %s: %w", action.Target, err)
+		return result, nil
+	case "jsonc-subset":
+		current := action.Content
+		if current == nil {
+			var err error
+			current, err = os.ReadFile(source)
+			if err != nil {
+				return managedActionResult{}, fmt.Errorf("read current owned JSONC %s: %w", source, err)
+			}
 		}
+		if len(action.PreviousContent) > 0 {
+			result, err := reconcileJSONCContentFile(action.Target, action.PreviousContent, current, opts.Home)
+			if err != nil {
+				return managedActionResult{}, fmt.Errorf("reconcile JSONC update for %s: %w", action.Target, err)
+			}
+			return result, nil
+		}
+		result, err := mergeJSONCContentFile(action.Target, current, opts.Home)
+		if err != nil {
+			return managedActionResult{}, fmt.Errorf("merge JSONC update for %s: %w", action.Target, err)
+		}
+		return result, nil
+	case "toml-subset":
+		current := action.Content
+		if current == nil {
+			var err error
+			current, err = os.ReadFile(source)
+			if err != nil {
+				return managedActionResult{}, fmt.Errorf("read current owned TOML %s: %w", source, err)
+			}
+		}
+		if len(action.PreviousContent) > 0 {
+			result, err := reconcileTOMLContentFile(action.Target, action.PreviousContent, current, opts.Home)
+			if err != nil {
+				return managedActionResult{}, fmt.Errorf("reconcile TOML update for %s: %w", action.Target, err)
+			}
+			return result, nil
+		}
+		result, err := mergeTOMLContentFile(action.Target, current, opts.Home)
+		if err != nil {
+			return managedActionResult{}, fmt.Errorf("merge TOML update for %s: %w", action.Target, err)
+		}
+		return result, nil
 	case "seeded":
-		current, err := os.ReadFile(source)
-		if err != nil {
-			return fmt.Errorf("read seeded baseline %s: %w", source, err)
+		current := action.Content
+		if current == nil {
+			var err error
+			current, err = os.ReadFile(source)
+			if err != nil {
+				return managedActionResult{}, fmt.Errorf("read seeded baseline %s: %w", source, err)
+			}
 		}
-		if err := updateConfinedRegularFile(action.Target, opts.Home, func(live []byte) ([]byte, bool, error) {
+		result, err := updateConfinedRegularFile(action.Target, opts.Home, func(live []byte) ([]byte, bool, error) {
 			if !bytes.Equal(live, action.PreviousContent) {
 				return nil, false, fmt.Errorf("install plan is stale: seeded target %s evolved before baseline advancement", action.Target)
 			}
 			return current, !bytes.Equal(live, current), nil
-		}); err != nil {
-			return fmt.Errorf("advance seeded target %s: %w", action.Target, err)
-		}
-	case "marked-block":
-		current, err := os.ReadFile(source)
+		})
 		if err != nil {
-			return fmt.Errorf("read marked-block source %s: %w", source, err)
+			return managedActionResult{}, fmt.Errorf("advance seeded target %s: %w", action.Target, err)
 		}
-		if err := updateConfinedRegularFile(action.Target, opts.Home, func(live []byte) ([]byte, bool, error) {
+		return result, nil
+	case "marked-block":
+		current := action.Content
+		if current == nil {
+			var err error
+			current, err = os.ReadFile(source)
+			if err != nil {
+				return managedActionResult{}, fmt.Errorf("read marked-block source %s: %w", source, err)
+			}
+		}
+		result, err := updateConfinedRegularFile(action.Target, opts.Home, func(live []byte) ([]byte, bool, error) {
 			reconciliation := textblock.ReconcileOwned(live, action.PreviousContent, current, textblock.DotsManagedMarkers())
 			if !reconciliation.Compatible {
 				return nil, false, fmt.Errorf("install plan is stale: marked block %s changed before update", action.Target)
 			}
 			return reconciliation.Content, !bytes.Equal(reconciliation.Content, live), nil
-		}); err != nil {
-			return fmt.Errorf("update marked block %s: %w", action.Target, err)
+		})
+		if err != nil {
+			return managedActionResult{}, fmt.Errorf("update marked block %s: %w", action.Target, err)
 		}
+		return result, nil
 	case "", "whole":
-		if err := updateWholeTarget(action, source, opts.Home); err != nil {
-			return err
+		result, err := updateWholeTargetWithResult(action, source, opts.Home)
+		if err != nil {
+			return managedActionResult{}, err
 		}
+		return result, nil
 	default:
-		return fmt.Errorf("update ownership %q is not supported for %s", action.Ownership, action.Target)
+		return managedActionResult{}, fmt.Errorf("update ownership %q is not supported for %s", action.Ownership, action.Target)
 	}
-	return nil
 }
 
 func updateWholeTarget(action plan.Action, source, home string) error {
+	_, err := updateWholeTargetWithResult(action, source, home)
+	return err
+}
+
+func updateWholeTargetWithResult(action plan.Action, source, home string) (managedActionResult, error) {
 	if action.PreviousHash == "" {
-		return fmt.Errorf("previous whole-target evidence is required for %s", action.Target)
+		return managedActionResult{}, fmt.Errorf("previous whole-target evidence is required for %s", action.Target)
 	}
-	current, err := os.ReadFile(source)
-	if err != nil {
-		return fmt.Errorf("read current whole target source %s: %w", source, err)
+	current := action.Content
+	if current == nil {
+		var err error
+		current, err = os.ReadFile(source)
+		if err != nil {
+			return managedActionResult{}, fmt.Errorf("read current whole target source %s: %w", source, err)
+		}
 	}
 	return updateConfinedRegularFile(action.Target, home, func(live []byte) ([]byte, bool, error) {
 		if state.HashBytes(live) != action.PreviousHash {
@@ -1108,69 +1196,85 @@ func updateWholeTarget(action plan.Action, source, home string) error {
 
 type confinedTransform func([]byte) ([]byte, bool, error)
 
-func updateConfinedRegularFile(target, home string, transform confinedTransform) error {
+func updateConfinedRegularFile(target, home string, transform confinedTransform) (managedActionResult, error) {
 	homeAbs, err := cleanAbs(home)
 	if err != nil {
-		return fmt.Errorf("resolve home for target %s: %w", target, err)
+		return managedActionResult{}, fmt.Errorf("resolve home for target %s: %w", target, err)
 	}
 	targetAbs, err := cleanAbs(target)
 	if err != nil {
-		return fmt.Errorf("resolve target %s: %w", target, err)
+		return managedActionResult{}, fmt.Errorf("resolve target %s: %w", target, err)
 	}
 	relative, err := filepath.Rel(homeAbs, targetAbs)
 	if err != nil || !filepath.IsLocal(relative) || relative == "." {
-		return fmt.Errorf("confine target %s beneath home %s", target, homeAbs)
+		return managedActionResult{}, fmt.Errorf("confine target %s beneath home %s", target, homeAbs)
 	}
 	root, err := os.OpenRoot(homeAbs)
 	if err != nil {
-		return fmt.Errorf("open home root %s: %w", homeAbs, err)
+		return managedActionResult{}, fmt.Errorf("open home root %s: %w", homeAbs, err)
 	}
 	defer root.Close()
 	observed, err := root.Lstat(relative)
 	if err != nil {
-		return fmt.Errorf("inspect confined target %s: %w", target, err)
+		return managedActionResult{}, fmt.Errorf("inspect confined target %s: %w", target, err)
 	}
 	if observed.Mode()&os.ModeSymlink != 0 || !observed.Mode().IsRegular() {
-		return fmt.Errorf("confined target %s is not a non-symlink regular file", target)
+		return managedActionResult{}, fmt.Errorf("confined target %s is not a non-symlink regular file", target)
 	}
 	file, err := root.OpenFile(relative, os.O_RDWR, 0)
 	if err != nil {
-		return fmt.Errorf("open confined target %s: %w", target, err)
+		return managedActionResult{}, fmt.Errorf("open confined target %s: %w", target, err)
 	}
 	defer file.Close()
 	info, err := file.Stat()
 	if err != nil {
-		return fmt.Errorf("stat confined target %s: %w", target, err)
+		return managedActionResult{}, fmt.Errorf("stat confined target %s: %w", target, err)
 	}
 	if !info.Mode().IsRegular() || !os.SameFile(observed, info) {
-		return fmt.Errorf("install plan is stale: target %s changed identity before update", target)
+		return managedActionResult{}, fmt.Errorf("install plan is stale: target %s changed identity before update", target)
 	}
 	live, err := io.ReadAll(file)
 	if err != nil {
-		return fmt.Errorf("read confined target %s: %w", target, err)
+		return managedActionResult{}, fmt.Errorf("read confined target %s: %w", target, err)
 	}
 	updated, changed, err := transform(live)
 	if err != nil {
-		return err
+		return managedActionResult{}, err
+	}
+	result := managedActionResult{
+		PreviousTargetContent: append([]byte(nil), live...),
+		TargetContent:         append([]byte(nil), updated...),
+		ExactTargetContent:    true,
 	}
 	if !changed {
-		return nil
+		result.TargetContent = append([]byte(nil), live...)
+		return result, nil
 	}
 	if _, err := file.Seek(0, io.SeekStart); err != nil {
-		return fmt.Errorf("rewind confined target %s: %w", target, err)
+		return managedActionResult{}, fmt.Errorf("rewind confined target %s: %w", target, err)
 	}
 	if err := file.Truncate(0); err != nil {
-		return fmt.Errorf("truncate confined target %s: %w", target, err)
+		return managedActionResult{}, fmt.Errorf("truncate confined target %s: %w", target, err)
 	}
 	written, err := file.Write(updated)
 	if err != nil {
-		return fmt.Errorf("write confined target %s: %w", target, err)
+		return managedActionResult{}, fmt.Errorf("write confined target %s: %w", target, err)
 	}
 	if written != len(updated) {
-		return fmt.Errorf("write confined target %s: wrote %d of %d bytes", target, written, len(updated))
+		return managedActionResult{}, fmt.Errorf("write confined target %s: wrote %d of %d bytes", target, written, len(updated))
 	}
 	if err := file.Sync(); err != nil {
-		return fmt.Errorf("sync confined target %s: %w", target, err)
+		return managedActionResult{}, fmt.Errorf("sync confined target %s: %w", target, err)
+	}
+	return result, nil
+}
+
+func restoreConfinedRegularFile(target, home string, content []byte) error {
+	_, err := updateConfinedRegularFile(target, home, func(live []byte) ([]byte, bool, error) {
+		return content, !bytes.Equal(live, content), nil
+	})
+	if err != nil {
+		return fmt.Errorf("restore target %s after metadata failure: %w", target, err)
 	}
 	return nil
 }
@@ -1377,14 +1481,14 @@ func writeNewFileFromSourceMode(source, target string, data []byte) error {
 	return nil
 }
 
-func mergeJSONContentFile(target string, sourceData []byte, home string) error {
+func mergeJSONContentFile(target string, sourceData []byte, home string) (managedActionResult, error) {
 	return updateConfinedRegularFile(target, home, func(targetData []byte) ([]byte, bool, error) {
 		merged, err := configsubset.MergeJSON(targetData, sourceData)
 		return merged, err == nil && !bytes.Equal(merged, targetData), err
 	})
 }
 
-func reconcileJSONContentFile(target string, previousData, currentData []byte, home string) error {
+func reconcileJSONContentFile(target string, previousData, currentData []byte, home string) (managedActionResult, error) {
 	return updateConfinedRegularFile(target, home, func(targetData []byte) ([]byte, bool, error) {
 		reconciliation, err := configsubset.ReconcileJSON(targetData, previousData, currentData)
 		if err != nil {
@@ -1397,14 +1501,14 @@ func reconcileJSONContentFile(target string, previousData, currentData []byte, h
 	})
 }
 
-func mergeJSONCContentFile(target string, sourceData []byte, home string) error {
+func mergeJSONCContentFile(target string, sourceData []byte, home string) (managedActionResult, error) {
 	return updateConfinedRegularFile(target, home, func(targetData []byte) ([]byte, bool, error) {
 		merged, err := configsubset.MergeJSONC(targetData, sourceData)
 		return merged, err == nil && !bytes.Equal(merged, targetData), err
 	})
 }
 
-func reconcileJSONCContentFile(target string, previousData, currentData []byte, home string) error {
+func reconcileJSONCContentFile(target string, previousData, currentData []byte, home string) (managedActionResult, error) {
 	return updateConfinedRegularFile(target, home, func(targetData []byte) ([]byte, bool, error) {
 		reconciliation, err := configsubset.ReconcileJSONC(targetData, previousData, currentData)
 		if err != nil {
@@ -1417,14 +1521,14 @@ func reconcileJSONCContentFile(target string, previousData, currentData []byte, 
 	})
 }
 
-func mergeTOMLContentFile(target string, sourceData []byte, home string) error {
+func mergeTOMLContentFile(target string, sourceData []byte, home string) (managedActionResult, error) {
 	return updateConfinedRegularFile(target, home, func(targetData []byte) ([]byte, bool, error) {
 		merged, err := configsubset.MergeTOML(targetData, sourceData)
 		return merged, err == nil && !bytes.Equal(merged, targetData), err
 	})
 }
 
-func reconcileTOMLContentFile(target string, previousData, currentData []byte, home string) error {
+func reconcileTOMLContentFile(target string, previousData, currentData []byte, home string) (managedActionResult, error) {
 	return updateConfinedRegularFile(target, home, func(targetData []byte) ([]byte, bool, error) {
 		reconciliation, err := configsubset.ReconcileTOML(targetData, previousData, currentData)
 		if err != nil {

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -121,7 +121,7 @@ func TestApplyComposedJSONSubsetCreatesAndUpdatesOneSharedTarget(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read updated target: %v", err)
 	}
-	for _, want := range []string{`"userOnly": "keep"`, `"mobile": true`, `"two"`} {
+	for _, want := range []string{`"userOnly":"keep"`, `"mobile":true`, `"two"`} {
 		if !strings.Contains(string(got), want) {
 			t.Fatalf("updated target missing %s:\n%s", want, got)
 		}
@@ -1291,7 +1291,7 @@ func TestApplyReconcilesRecordedJSONContributionAndPreservesExternalContent(t *t
 	if err != nil {
 		t.Fatalf("read target: %v", err)
 	}
-	for _, want := range []string{`"added": "new"`, `"external": "preserve"`, `"targetOnly": true`, `"external"`} {
+	for _, want := range []string{`"added":"new"`, `"external":"preserve"`, `"targetOnly":true`, `"external"`} {
 		if !strings.Contains(string(got), want) {
 			t.Fatalf("reconciled target missing %s:\n%s", want, got)
 		}

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -76,6 +76,9 @@ func TestApplyComposedJSONSubsetCreatesAndUpdatesOneSharedTarget(t *testing.T) {
 	if len(rec.Contributions) != 2 {
 		t.Fatalf("metadata contributions = %+v, want two attributed sources", rec.Contributions)
 	}
+	if _, err := ownershipevidence.ProjectRecord(rec); err != nil {
+		t.Fatalf("project exact metadata contributions: %v; record=%+v", err, rec)
+	}
 	for i, want := range []struct {
 		source string
 		tag    string

--- a/internal/install/recovery_internal_test.go
+++ b/internal/install/recovery_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/yersonargotev/dots/internal/configsubset"
@@ -47,10 +48,15 @@ func TestApplyManagedEntriesPersistsReconciliationReceiptBeforeLaterActionFails(
 	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, Entries: []state.Record{record}, InstalledSelection: oldSelection}); err != nil {
 		t.Fatal(err)
 	}
+	fingerprint, err := state.RecordEvidenceFingerprint(record)
+	if err != nil {
+		t.Fatal(err)
+	}
 	p := plan.Plan{Profiles: []string{"next"}, Tags: []string{"base", "later"}, Actions: []plan.Action{
 		{
 			Source: "base.json", Target: target, Strategy: "copy", Ownership: "json-subset", Status: plan.StatusUpdate,
-			PreviousContent: previous, Contributions: []plan.Contribution{{Source: "base.json", SelectorTags: []string{"base"}}},
+			PreviousContent: previous, PreviousRecordFingerprint: fingerprint,
+			Contributions: []plan.Contribution{{Source: "base.json", SelectorTags: []string{"base"}}},
 		},
 		{Source: "later", Target: filepath.Join(home, ".later"), Strategy: "copy", Status: plan.StatusCreate, Contributions: []plan.Contribution{{Source: "later", SelectorTags: []string{"later"}}}},
 	}}
@@ -83,5 +89,125 @@ func TestApplyManagedEntriesPersistsReconciliationReceiptBeforeLaterActionFails(
 	}
 	if meta.InstalledSelection == nil || !reflect.DeepEqual(meta.InstalledSelection.Profiles, []string{"old"}) {
 		t.Fatalf("failed apply Installed Selection = %#v, want old", meta.InstalledSelection)
+	}
+}
+
+func TestRecordAppliedReconciliationRejectsConcurrentAuthorityChange(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	target := filepath.Join(home, ".shared.json")
+	source := filepath.Join(sourceRoot, "shared.json")
+	previous := []byte(`{"old":true}`)
+	current := []byte(`{"new":true}`)
+	if err := os.WriteFile(target, current, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(source, current, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	record := recoveryAuthorityRecord(target, "shared.json", previous)
+	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, Entries: []state.Record{record}}); err != nil {
+		t.Fatal(err)
+	}
+	fingerprint, err := state.RecordEvidenceFingerprint(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	action := recoveryAuthorityAction(target, "shared.json", previous, fingerprint)
+	if err := state.Update(state.Path(stateRoot), func(meta *state.Metadata) error {
+		meta.Entries[0].Tags = []string{"concurrent"}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	err = recordAppliedReconciliation(nil, nil, action, []string{source}, Options{SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot})
+	if err == nil || !strings.Contains(err.Error(), "changed concurrently") {
+		t.Fatalf("recordAppliedReconciliation() error = %v, want authority CAS rejection", err)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok := meta.FindByTarget(target)
+	if !ok || !reflect.DeepEqual(got.Tags, []string{"concurrent"}) || got.PendingReconciliation != nil {
+		t.Fatalf("concurrent record = %#v, want preserved without receipt", got)
+	}
+}
+
+func TestMetadataCommitRejectsConcurrentAuthorityChange(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	target := filepath.Join(home, ".shared.json")
+	sourceName := "shared.json"
+	source := filepath.Join(sourceRoot, sourceName)
+	previous := []byte(`{"old":true}`)
+	current := []byte(`{"new":true}`)
+	if err := os.WriteFile(target, previous, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(source, current, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	record := recoveryAuthorityRecord(target, sourceName, previous)
+	oldSelection := &state.InstalledSelection{Profiles: []string{"old"}, ResolvedTags: []string{"old"}}
+	if err := state.Save(state.Path(stateRoot), state.Metadata{
+		Version: state.CurrentVersion, Entries: []state.Record{record}, InstalledSelection: oldSelection,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	fingerprint, err := state.RecordEvidenceFingerprint(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	action := recoveryAuthorityAction(target, sourceName, previous, fingerprint)
+	commit, err := ApplyManagedEntries(plan.Plan{Actions: []plan.Action{action}}, Options{
+		SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot,
+	})
+	if err != nil {
+		t.Fatalf("ApplyManagedEntries() error = %v", err)
+	}
+	if err := state.Update(state.Path(stateRoot), func(meta *state.Metadata) error {
+		meta.Entries[0].Tags = []string{"concurrent"}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	err = commit.Commit(&state.InstalledSelection{Profiles: []string{"new"}, ResolvedTags: []string{"new"}})
+	if err == nil || !strings.Contains(err.Error(), "changed concurrently") {
+		t.Fatalf("Commit() error = %v, want authority CAS rejection", err)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok := meta.FindByTarget(target)
+	if !ok || !reflect.DeepEqual(got.Tags, []string{"concurrent"}) || got.PendingReconciliation == nil {
+		t.Fatalf("concurrent record = %#v, want preserved with original receipt", got)
+	}
+	if meta.InstalledSelection == nil || !reflect.DeepEqual(meta.InstalledSelection.Profiles, []string{"old"}) {
+		t.Fatalf("Installed Selection = %#v, want old", meta.InstalledSelection)
+	}
+}
+
+func recoveryAuthorityRecord(target, source string, previous []byte) state.Record {
+	return state.Record{
+		Target: target, Source: source, Strategy: "copy", Ownership: "json-subset",
+		OwnedContent: previous, Hash: state.HashBytes(previous),
+		Contributions: []state.Contribution{{
+			Source: source, Ownership: "json-subset", EvidenceRecorded: true,
+			Hash: state.HashBytes(previous), OwnedContent: previous,
+		}},
+	}
+}
+
+func recoveryAuthorityAction(target, source string, previous []byte, fingerprint string) plan.Action {
+	return plan.Action{
+		Source: source, Target: target, Strategy: "copy", Ownership: "json-subset", Status: plan.StatusUpdate,
+		PreviousContent: previous, PreviousRecordFingerprint: fingerprint,
+		Contributions: []plan.Contribution{{Source: source}},
 	}
 }

--- a/internal/install/recovery_internal_test.go
+++ b/internal/install/recovery_internal_test.go
@@ -3,6 +3,7 @@ package install
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -213,6 +214,156 @@ func TestReconciliationReceiptUsesExactAppliedSourceSnapshot(t *testing.T) {
 	}
 	if meta.InstalledSelection == nil || !reflect.DeepEqual(meta.InstalledSelection.Profiles, []string{"old"}) {
 		t.Fatalf("Installed Selection = %#v, want old", meta.InstalledSelection)
+	}
+}
+
+func TestReconciliationReceiptPreservesEmptySourceSnapshot(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	target := filepath.Join(home, ".config")
+	sourceName := "config"
+	source := filepath.Join(sourceRoot, sourceName)
+	previous := []byte("previous\n")
+	concurrent := []byte("concurrent\n")
+	if err := os.WriteFile(target, previous, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(source, []byte{}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	record := state.Record{
+		Target: target, Source: sourceName, Strategy: "copy", Ownership: "whole", Hash: state.HashBytes(previous),
+		Contributions: []state.Contribution{{
+			Source: sourceName, Ownership: "whole", EvidenceRecorded: true, Hash: state.HashBytes(previous),
+		}},
+	}
+	oldSelection := &state.InstalledSelection{Profiles: []string{"old"}, ResolvedTags: []string{"old"}}
+	if err := state.Save(state.Path(stateRoot), state.Metadata{
+		Version: state.CurrentVersion, Entries: []state.Record{record}, InstalledSelection: oldSelection,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	fingerprint, err := state.RecordEvidenceFingerprint(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	action := plan.Action{
+		Source: sourceName, Target: target, Strategy: "copy", Ownership: "whole", Status: plan.StatusUpdate,
+		PreviousHash: state.HashBytes(previous), PreviousRecordFingerprint: fingerprint,
+		Contributions: []plan.Contribution{{Source: sourceName}},
+	}
+
+	_, err = applyManagedEntriesWithApply(plan.Plan{Actions: []plan.Action{action}}, Options{
+		SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot,
+	}, func(action plan.Action, source string, opts Options) (managedActionResult, error) {
+		if action.Content == nil || len(action.Content) != 0 {
+			return managedActionResult{}, fmt.Errorf("empty source snapshot was not preserved")
+		}
+		if err := os.WriteFile(source, concurrent, 0o600); err != nil {
+			return managedActionResult{}, err
+		}
+		return applyManagedAction(action, source, opts)
+	})
+	if err == nil {
+		t.Fatal("applyManagedEntriesWithApply() succeeded after the source changed")
+	}
+	if got, readErr := os.ReadFile(target); readErr != nil || len(got) != 0 {
+		t.Fatalf("target = %q, %v; want applied empty snapshot", got, readErr)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	failed, ok := meta.FindByTarget(target)
+	if !ok || failed.PendingReconciliation == nil || failed.PendingReconciliation.SourceHashes[0] != state.HashBytes(nil) || failed.PendingReconciliation.TargetHash != state.HashBytes(nil) {
+		t.Fatalf("receipt = %#v, want exact empty source and target hashes", failed.PendingReconciliation)
+	}
+}
+
+func TestReceiptSaveFailureRollsBackOnlyExactAppliedBytes(t *testing.T) {
+	tests := []struct {
+		name       string
+		concurrent []byte
+		want       []byte
+		wantError  string
+	}{
+		{name: "restore unchanged applied target", want: []byte(`{"old":true}`)},
+		{name: "preserve concurrent target edit", concurrent: []byte(`{"external":true}`), want: []byte(`{"external":true}`), wantError: "refusing rollback"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			home := t.TempDir()
+			sourceRoot := t.TempDir()
+			stateParent := t.TempDir()
+			stateRoot := filepath.Join(stateParent, "state")
+			if err := os.Mkdir(stateRoot, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			target := filepath.Join(home, ".shared.json")
+			sourceName := "shared.json"
+			source := filepath.Join(sourceRoot, sourceName)
+			previous := []byte(`{"old":true}`)
+			current := []byte(`{"new":true}`)
+			if err := os.WriteFile(target, previous, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(source, current, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			record := recoveryAuthorityRecord(target, sourceName, previous)
+			if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, Entries: []state.Record{record}}); err != nil {
+				t.Fatal(err)
+			}
+			fingerprint, err := state.RecordEvidenceFingerprint(record)
+			if err != nil {
+				t.Fatal(err)
+			}
+			action := recoveryAuthorityAction(target, sourceName, previous, fingerprint)
+			movedState := filepath.Join(stateParent, "state-moved")
+
+			_, err = applyManagedEntriesWithApply(plan.Plan{Actions: []plan.Action{action}}, Options{
+				SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot,
+			}, func(action plan.Action, source string, opts Options) (managedActionResult, error) {
+				result, applyErr := applyManagedAction(action, source, opts)
+				if applyErr != nil {
+					return managedActionResult{}, applyErr
+				}
+				if test.concurrent != nil {
+					if err := os.WriteFile(target, test.concurrent, 0o600); err != nil {
+						return managedActionResult{}, err
+					}
+				}
+				if err := os.Rename(stateRoot, movedState); err != nil {
+					return managedActionResult{}, err
+				}
+				if err := os.WriteFile(stateRoot, []byte("block state directory"), 0o600); err != nil {
+					return managedActionResult{}, err
+				}
+				return result, nil
+			})
+			if removeErr := os.Remove(stateRoot); removeErr != nil {
+				t.Fatal(removeErr)
+			}
+			if renameErr := os.Rename(movedState, stateRoot); renameErr != nil {
+				t.Fatal(renameErr)
+			}
+			if err == nil || !strings.Contains(err.Error(), "persist reconciliation receipt") || (test.wantError != "" && !strings.Contains(err.Error(), test.wantError)) {
+				t.Fatalf("applyManagedEntriesWithApply() error = %v, want receipt save failure containing %q", err, test.wantError)
+			}
+			got, readErr := os.ReadFile(target)
+			if readErr != nil || !bytes.Equal(got, test.want) {
+				t.Fatalf("target = %q, %v; want %q", got, readErr, test.want)
+			}
+			meta, loadErr := state.Load(state.Path(stateRoot))
+			if loadErr != nil {
+				t.Fatal(loadErr)
+			}
+			failed, ok := meta.FindByTarget(target)
+			if !ok || failed.PendingReconciliation != nil {
+				t.Fatalf("metadata after failed receipt save = %#v, want prior record", meta)
+			}
+		})
 	}
 }
 

--- a/internal/install/recovery_internal_test.go
+++ b/internal/install/recovery_internal_test.go
@@ -1,6 +1,7 @@
 package install
 
 import (
+	"bytes"
 	"errors"
 	"os"
 	"path/filepath"
@@ -61,10 +62,10 @@ func TestApplyManagedEntriesPersistsReconciliationReceiptBeforeLaterActionFails(
 		{Source: "later", Target: filepath.Join(home, ".later"), Strategy: "copy", Status: plan.StatusCreate, Contributions: []plan.Contribution{{Source: "later", SelectorTags: []string{"later"}}}},
 	}}
 	calls := 0
-	_, err = applyManagedEntriesWithApply(p, Options{SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot}, func(action plan.Action, source string, opts Options) error {
+	_, err = applyManagedEntriesWithApply(p, Options{SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot}, func(action plan.Action, source string, opts Options) (managedActionResult, error) {
 		calls++
 		if calls == 2 {
-			return errors.New("injected later Managed Entry failure")
+			return managedActionResult{}, errors.New("injected later Managed Entry failure")
 		}
 		return applyManagedAction(action, source, opts)
 	})
@@ -92,7 +93,7 @@ func TestApplyManagedEntriesPersistsReconciliationReceiptBeforeLaterActionFails(
 	}
 }
 
-func TestRecordAppliedReconciliationRejectsConcurrentAuthorityChange(t *testing.T) {
+func TestReconciliationRejectsConcurrentAuthorityChangeBeforeMutation(t *testing.T) {
 	home := t.TempDir()
 	sourceRoot := t.TempDir()
 	stateRoot := t.TempDir()
@@ -100,7 +101,7 @@ func TestRecordAppliedReconciliationRejectsConcurrentAuthorityChange(t *testing.
 	source := filepath.Join(sourceRoot, "shared.json")
 	previous := []byte(`{"old":true}`)
 	current := []byte(`{"new":true}`)
-	if err := os.WriteFile(target, current, 0o600); err != nil {
+	if err := os.WriteFile(target, previous, 0o600); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(source, current, 0o600); err != nil {
@@ -115,24 +116,103 @@ func TestRecordAppliedReconciliationRejectsConcurrentAuthorityChange(t *testing.
 		t.Fatal(err)
 	}
 	action := recoveryAuthorityAction(target, "shared.json", previous, fingerprint)
+	concurrentReceipt := &state.ReconciliationReceipt{
+		TargetHash: "concurrent", Sources: []string{"shared.json"}, SourceHashes: []string{"concurrent"},
+		Strategy: "copy", Ownership: "json-subset",
+	}
 	if err := state.Update(state.Path(stateRoot), func(meta *state.Metadata) error {
-		meta.Entries[0].Tags = []string{"concurrent"}
+		meta.Entries[0].PendingReconciliation = concurrentReceipt.Clone()
 		return nil
 	}); err != nil {
 		t.Fatal(err)
 	}
 
-	err = recordAppliedReconciliation(nil, nil, action, []string{source}, Options{SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot})
-	if err == nil || !strings.Contains(err.Error(), "changed concurrently") {
-		t.Fatalf("recordAppliedReconciliation() error = %v, want authority CAS rejection", err)
+	mutated := false
+	_, err = applyManagedEntriesWithApply(plan.Plan{Actions: []plan.Action{action}}, Options{
+		SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot,
+	}, func(action plan.Action, source string, opts Options) (managedActionResult, error) {
+		mutated = true
+		return applyManagedAction(action, source, opts)
+	})
+	if err == nil || !strings.Contains(err.Error(), "receipt changed concurrently") {
+		t.Fatalf("applyManagedEntriesWithApply() error = %v, want authority CAS rejection", err)
+	}
+	if mutated {
+		t.Fatal("reconciliation mutated the target before validating concurrent authority")
+	}
+	if got, readErr := os.ReadFile(target); readErr != nil || !bytes.Equal(got, previous) {
+		t.Fatalf("target = %q, %v; want unchanged previous bytes", got, readErr)
 	}
 	meta, err := state.Load(state.Path(stateRoot))
 	if err != nil {
 		t.Fatal(err)
 	}
 	got, ok := meta.FindByTarget(target)
-	if !ok || !reflect.DeepEqual(got.Tags, []string{"concurrent"}) || got.PendingReconciliation != nil {
-		t.Fatalf("concurrent record = %#v, want preserved without receipt", got)
+	if !ok || !reflect.DeepEqual(got.PendingReconciliation, concurrentReceipt) {
+		t.Fatalf("concurrent record = %#v, want concurrent receipt preserved", got)
+	}
+}
+
+func TestReconciliationReceiptUsesExactAppliedSourceSnapshot(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	target := filepath.Join(home, ".shared.json")
+	sourceName := "shared.json"
+	source := filepath.Join(sourceRoot, sourceName)
+	previous := []byte(`{"old":true}`)
+	applied := []byte(`{"kept":true,"removed":true}`)
+	concurrent := []byte(`{"kept":true}`)
+	if err := os.WriteFile(target, previous, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(source, applied, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	record := recoveryAuthorityRecord(target, sourceName, previous)
+	oldSelection := &state.InstalledSelection{Profiles: []string{"old"}, ResolvedTags: []string{"old"}}
+	if err := state.Save(state.Path(stateRoot), state.Metadata{
+		Version: state.CurrentVersion, Entries: []state.Record{record}, InstalledSelection: oldSelection,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	fingerprint, err := state.RecordEvidenceFingerprint(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	action := recoveryAuthorityAction(target, sourceName, previous, fingerprint)
+
+	_, err = applyManagedEntriesWithApply(plan.Plan{Actions: []plan.Action{action}}, Options{
+		SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot,
+	}, func(action plan.Action, source string, opts Options) (managedActionResult, error) {
+		if !bytes.Equal(action.Content, applied) {
+			t.Fatalf("prepared source snapshot = %q, want %q", action.Content, applied)
+		}
+		if err := os.WriteFile(source, concurrent, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return applyManagedAction(action, source, opts)
+	})
+	if err == nil || !strings.Contains(err.Error(), "changed after reconciliation") {
+		t.Fatalf("applyManagedEntriesWithApply() error = %v, want changed source rejection", err)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(got, []byte(`"removed":true`)) {
+		t.Fatalf("target = %q, want exact applied source snapshot", got)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	failed, ok := meta.FindByTarget(target)
+	if !ok || failed.PendingReconciliation == nil || failed.PendingReconciliation.SourceHashes[0] != state.HashBytes(applied) {
+		t.Fatalf("receipt = %#v, want exact applied source hash", failed.PendingReconciliation)
+	}
+	if meta.InstalledSelection == nil || !reflect.DeepEqual(meta.InstalledSelection.Profiles, []string{"old"}) {
+		t.Fatalf("Installed Selection = %#v, want old", meta.InstalledSelection)
 	}
 }
 
@@ -187,6 +267,67 @@ func TestMetadataCommitRejectsConcurrentAuthorityChange(t *testing.T) {
 	got, ok := meta.FindByTarget(target)
 	if !ok || !reflect.DeepEqual(got.Tags, []string{"concurrent"}) || got.PendingReconciliation == nil {
 		t.Fatalf("concurrent record = %#v, want preserved with original receipt", got)
+	}
+	if meta.InstalledSelection == nil || !reflect.DeepEqual(meta.InstalledSelection.Profiles, []string{"old"}) {
+		t.Fatalf("Installed Selection = %#v, want old", meta.InstalledSelection)
+	}
+}
+
+func TestReceiptBackedUnchangedCommitRejectsConcurrentReceiptChange(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	target := filepath.Join(home, ".shared.json")
+	sourceName := "shared.json"
+	source := filepath.Join(sourceRoot, sourceName)
+	content := []byte(`{"current":true}`)
+	if err := os.WriteFile(target, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(source, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	record := recoveryAuthorityRecord(target, sourceName, []byte(`{"retired":true}`))
+	receipt := &state.ReconciliationReceipt{
+		TargetHash: state.HashBytes(content), Sources: []string{sourceName},
+		SourceHashes: []string{state.HashBytes(content)}, Strategy: "copy", Ownership: "json-subset",
+	}
+	record.PendingReconciliation = receipt.Clone()
+	oldSelection := &state.InstalledSelection{Profiles: []string{"old"}, ResolvedTags: []string{"old"}}
+	if err := state.Save(state.Path(stateRoot), state.Metadata{
+		Version: state.CurrentVersion, Entries: []state.Record{record}, InstalledSelection: oldSelection,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	fingerprint, err := state.RecordEvidenceFingerprint(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	action := plan.Action{
+		Source: sourceName, Target: target, Strategy: "copy", Ownership: "json-subset", Status: plan.StatusUnchanged,
+		PreviousContent: record.OwnedContent, PreviousRecordFingerprint: fingerprint,
+		PreviousReconciliationReceipt: receipt.Clone(), Contributions: []plan.Contribution{{Source: sourceName}},
+	}
+	commit, err := ApplyManagedEntries(plan.Plan{Actions: []plan.Action{action}}, Options{
+		SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot,
+	})
+	if err != nil {
+		t.Fatalf("ApplyManagedEntries() error = %v", err)
+	}
+	if err := state.Update(state.Path(stateRoot), func(meta *state.Metadata) error {
+		meta.Entries[0].PendingReconciliation.TargetHash = state.HashBytes([]byte("concurrent"))
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	err = commit.Commit(&state.InstalledSelection{Profiles: []string{"new"}, ResolvedTags: []string{"new"}})
+	if err == nil || !strings.Contains(err.Error(), "receipt changed concurrently") {
+		t.Fatalf("Commit() error = %v, want receipt CAS rejection", err)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
 	}
 	if meta.InstalledSelection == nil || !reflect.DeepEqual(meta.InstalledSelection.Profiles, []string{"old"}) {
 		t.Fatalf("Installed Selection = %#v, want old", meta.InstalledSelection)

--- a/internal/install/recovery_internal_test.go
+++ b/internal/install/recovery_internal_test.go
@@ -1,0 +1,87 @@
+package install
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/configsubset"
+	"github.com/yersonargotev/dots/internal/plan"
+	"github.com/yersonargotev/dots/internal/state"
+)
+
+func TestApplyManagedEntriesPersistsReconciliationReceiptBeforeLaterActionFails(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	baseSource := filepath.Join(sourceRoot, "base.json")
+	retiredSource := filepath.Join(sourceRoot, "retired.json")
+	laterSource := filepath.Join(sourceRoot, "later")
+	base := []byte("{\"base\":true}\n")
+	retired := []byte("{\"retired\":true}\n")
+	for path, content := range map[string][]byte{baseSource: base, retiredSource: retired, laterSource: []byte("later\n")} {
+		if err := os.WriteFile(path, content, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	previous, err := configsubset.MergeJSON(base, retired)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(home, ".shared.json")
+	live := []byte("{\"base\":true,\"retired\":true,\"external\":true}\n")
+	if err := os.WriteFile(target, live, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	oldSelection := &state.InstalledSelection{Profiles: []string{"old"}, ResolvedTags: []string{"base", "retired"}}
+	record := state.Record{
+		Target: target, Source: "base.json", Sources: []string{"base.json", "retired.json"}, Strategy: "copy", Ownership: "json-subset",
+		OwnedContent: previous, Hash: state.HashBytes(previous),
+		Contributions: []state.Contribution{
+			{Source: "base.json", Ownership: "json-subset", EvidenceRecorded: true, Hash: state.HashBytes(base), OwnedContent: base},
+			{Source: "retired.json", Ownership: "json-subset", EvidenceRecorded: true, Hash: state.HashBytes(retired), OwnedContent: retired},
+		},
+	}
+	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, Entries: []state.Record{record}, InstalledSelection: oldSelection}); err != nil {
+		t.Fatal(err)
+	}
+	p := plan.Plan{Profiles: []string{"next"}, Tags: []string{"base", "later"}, Actions: []plan.Action{
+		{
+			Source: "base.json", Target: target, Strategy: "copy", Ownership: "json-subset", Status: plan.StatusUpdate,
+			PreviousContent: previous, Contributions: []plan.Contribution{{Source: "base.json", SelectorTags: []string{"base"}}},
+		},
+		{Source: "later", Target: filepath.Join(home, ".later"), Strategy: "copy", Status: plan.StatusCreate, Contributions: []plan.Contribution{{Source: "later", SelectorTags: []string{"later"}}}},
+	}}
+	calls := 0
+	_, err = applyManagedEntriesWithApply(p, Options{SourceRoot: sourceRoot, Home: home, StateRoot: stateRoot}, func(action plan.Action, source string, opts Options) error {
+		calls++
+		if calls == 2 {
+			return errors.New("injected later Managed Entry failure")
+		}
+		return applyManagedAction(action, source, opts)
+	})
+	if err == nil || err.Error() != "injected later Managed Entry failure" {
+		t.Fatalf("applyManagedEntriesWithApply() error = %v", err)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	failed, ok := meta.FindByTarget(target)
+	if !ok || len(failed.Contributions) != 2 {
+		t.Fatalf("failed metadata replaced committed contributions: %#v", failed)
+	}
+	if failed.PendingReconciliation == nil || failed.PendingReconciliation.TargetHash != state.HashBytes(got) ||
+		!reflect.DeepEqual(failed.PendingReconciliation.Sources, []string{"base.json"}) {
+		t.Fatalf("recovery receipt = %#v, want exact first-action result", failed.PendingReconciliation)
+	}
+	if meta.InstalledSelection == nil || !reflect.DeepEqual(meta.InstalledSelection.Profiles, []string{"old"}) {
+		t.Fatalf("failed apply Installed Selection = %#v, want old", meta.InstalledSelection)
+	}
+}

--- a/internal/install/whole_update_internal_test.go
+++ b/internal/install/whole_update_internal_test.go
@@ -80,3 +80,59 @@ func TestUpdateWholeTargetRejectsSymlinkReplacementInsideHome(t *testing.T) {
 		t.Fatalf("in-home destination = %q, %v; want unchanged", got, readErr)
 	}
 }
+
+func TestApplyPartialUpdateRejectsSymlinkTargets(t *testing.T) {
+	markers := "# >>> dots managed >>>\nold\n# <<< dots managed <<<\n"
+	tests := []struct {
+		name      string
+		ownership string
+		previous  []byte
+		current   []byte
+	}{
+		{name: "JSON", ownership: "json-subset", previous: []byte(`{"old":true}`), current: []byte(`{"new":true}`)},
+		{name: "JSONC", ownership: "jsonc-subset", previous: []byte("{\n  // old\n  \"old\": true\n}\n"), current: []byte("{\n  \"new\": true\n}\n")},
+		{name: "TOML", ownership: "toml-subset", previous: []byte("old = true\n"), current: []byte("new = true\n")},
+		{name: "marked block", ownership: "marked-block", previous: []byte(markers), current: []byte("new\n")},
+		{name: "seeded", ownership: "seeded", previous: []byte("old\n"), current: []byte("new\n")},
+	}
+	for _, test := range tests {
+		for _, destinationScope := range []string{"outside", "inside"} {
+			t.Run(test.name+"/"+destinationScope, func(t *testing.T) {
+				home := t.TempDir()
+				destinationRoot := t.TempDir()
+				if destinationScope == "inside" {
+					destinationRoot = home
+				}
+				destination := filepath.Join(destinationRoot, ".destination")
+				target := filepath.Join(home, ".target")
+				source := filepath.Join(t.TempDir(), "source")
+				if err := os.WriteFile(destination, test.previous, 0o600); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(source, test.current, 0o600); err != nil {
+					t.Fatal(err)
+				}
+				linkDestination := destination
+				if destinationScope == "inside" {
+					linkDestination = filepath.Base(destination)
+				}
+				if err := os.Symlink(linkDestination, target); err != nil {
+					t.Fatal(err)
+				}
+				action := plan.Action{
+					Target: target, Strategy: "copy", Ownership: test.ownership,
+					PreviousContent: test.previous,
+				}
+
+				err := applyUpdate(action, source, Options{Home: home, StateRoot: t.TempDir()})
+				if err == nil || !strings.Contains(err.Error(), "non-symlink regular file") {
+					t.Fatalf("applyUpdate() error = %v, want confined symlink rejection", err)
+				}
+				got, readErr := os.ReadFile(destination)
+				if readErr != nil || string(got) != string(test.previous) {
+					t.Fatalf("destination = %q, %v; want unchanged", got, readErr)
+				}
+			})
+		}
+	}
+}

--- a/internal/install/whole_update_internal_test.go
+++ b/internal/install/whole_update_internal_test.go
@@ -1,0 +1,57 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/plan"
+	"github.com/yersonargotev/dots/internal/state"
+)
+
+func TestUpdateWholeTargetRejectsLastMomentDrift(t *testing.T) {
+	home := t.TempDir()
+	target := filepath.Join(home, ".config")
+	source := filepath.Join(t.TempDir(), "source")
+	if err := os.WriteFile(target, []byte("changed\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(source, []byte("current\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	action := plan.Action{Target: target, PreviousHash: state.HashBytes([]byte("previous\n"))}
+
+	err := updateWholeTarget(action, source, home)
+	if err == nil || !strings.Contains(err.Error(), "changed before update") {
+		t.Fatalf("updateWholeTarget() error = %v, want stale target rejection", err)
+	}
+	if got, readErr := os.ReadFile(target); readErr != nil || string(got) != "changed\n" {
+		t.Fatalf("drifted target = %q, %v; want unchanged", got, readErr)
+	}
+}
+
+func TestUpdateWholeTargetRejectsSymlinkReplacementOutsideHome(t *testing.T) {
+	home := t.TempDir()
+	target := filepath.Join(home, ".config")
+	outside := filepath.Join(t.TempDir(), "outside")
+	source := filepath.Join(t.TempDir(), "source")
+	if err := os.WriteFile(outside, []byte("previous\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(source, []byte("current\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, target); err != nil {
+		t.Fatal(err)
+	}
+	action := plan.Action{Target: target, PreviousHash: state.HashBytes([]byte("previous\n"))}
+
+	err := updateWholeTarget(action, source, home)
+	if err == nil || !strings.Contains(err.Error(), "open confined whole target") {
+		t.Fatalf("updateWholeTarget() error = %v, want root confinement rejection", err)
+	}
+	if got, readErr := os.ReadFile(outside); readErr != nil || string(got) != "previous\n" {
+		t.Fatalf("outside file = %q, %v; want unchanged", got, readErr)
+	}
+}

--- a/internal/install/whole_update_internal_test.go
+++ b/internal/install/whole_update_internal_test.go
@@ -48,10 +48,35 @@ func TestUpdateWholeTargetRejectsSymlinkReplacementOutsideHome(t *testing.T) {
 	action := plan.Action{Target: target, PreviousHash: state.HashBytes([]byte("previous\n"))}
 
 	err := updateWholeTarget(action, source, home)
-	if err == nil || !strings.Contains(err.Error(), "open confined whole target") {
+	if err == nil || !strings.Contains(err.Error(), "non-symlink regular file") {
 		t.Fatalf("updateWholeTarget() error = %v, want root confinement rejection", err)
 	}
 	if got, readErr := os.ReadFile(outside); readErr != nil || string(got) != "previous\n" {
 		t.Fatalf("outside file = %q, %v; want unchanged", got, readErr)
+	}
+}
+
+func TestUpdateWholeTargetRejectsSymlinkReplacementInsideHome(t *testing.T) {
+	home := t.TempDir()
+	target := filepath.Join(home, ".config")
+	other := filepath.Join(home, ".other")
+	source := filepath.Join(t.TempDir(), "source")
+	if err := os.WriteFile(other, []byte("previous\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(source, []byte("current\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Base(other), target); err != nil {
+		t.Fatal(err)
+	}
+	action := plan.Action{Target: target, PreviousHash: state.HashBytes([]byte("previous\n"))}
+
+	err := updateWholeTarget(action, source, home)
+	if err == nil || !strings.Contains(err.Error(), "non-symlink regular file") {
+		t.Fatalf("updateWholeTarget() error = %v, want in-home symlink rejection", err)
+	}
+	if got, readErr := os.ReadFile(other); readErr != nil || string(got) != "previous\n" {
+		t.Fatalf("in-home destination = %q, %v; want unchanged", got, readErr)
 	}
 }

--- a/internal/install/whole_update_internal_test.go
+++ b/internal/install/whole_update_internal_test.go
@@ -124,7 +124,7 @@ func TestApplyPartialUpdateRejectsSymlinkTargets(t *testing.T) {
 					PreviousContent: test.previous,
 				}
 
-				err := applyUpdate(action, source, Options{Home: home, StateRoot: t.TempDir()})
+				_, err := applyUpdate(action, source, Options{Home: home, StateRoot: t.TempDir()})
 				if err == nil || !strings.Contains(err.Error(), "non-symlink regular file") {
 					t.Fatalf("applyUpdate() error = %v, want confined symlink rejection", err)
 				}

--- a/internal/install/whole_update_internal_test.go
+++ b/internal/install/whole_update_internal_test.go
@@ -1,6 +1,7 @@
 package install
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -137,7 +138,7 @@ func TestApplyPartialUpdateRejectsSymlinkTargets(t *testing.T) {
 	}
 }
 
-func TestReadConfinedRegularFileRejectsSymlinkSources(t *testing.T) {
+func TestReadConfinedRegularFileConfinesSymlinkSources(t *testing.T) {
 	root := t.TempDir()
 	outside := filepath.Join(t.TempDir(), "outside")
 	inside := filepath.Join(root, "inside")
@@ -147,20 +148,21 @@ func TestReadConfinedRegularFileRejectsSymlinkSources(t *testing.T) {
 	if err := os.WriteFile(inside, []byte("inside\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	for name, destination := range map[string]string{
-		"outside": outside,
-		"inside":  filepath.Base(inside),
-	} {
-		t.Run(name, func(t *testing.T) {
-			source := filepath.Join(root, name+"-link")
-			if err := os.Symlink(destination, source); err != nil {
-				t.Fatal(err)
-			}
-			_, err := readConfinedRegularFile(source, root)
-			if err == nil || !strings.Contains(err.Error(), "non-symlink regular file") {
-				t.Fatalf("readConfinedRegularFile() error = %v, want symlink rejection", err)
-			}
-		})
+	outsideLink := filepath.Join(root, "outside-link")
+	if err := os.Symlink(outside, outsideLink); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readConfinedRegularFile(outsideLink, root); err == nil {
+		t.Fatal("readConfinedRegularFile() accepted a symlink escaping the source root")
+	}
+
+	insideLink := filepath.Join(root, "inside-link")
+	if err := os.Symlink(filepath.Base(inside), insideLink); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readConfinedRegularFile(insideLink, root)
+	if err != nil || string(got) != "inside\n" {
+		t.Fatalf("readConfinedRegularFile() = %q, %v; want confined in-root symlink content", got, err)
 	}
 }
 
@@ -181,4 +183,42 @@ func TestRestoreConfinedRegularFileRequiresExactAppliedBytes(t *testing.T) {
 	if got, readErr := os.ReadFile(target); readErr != nil || string(got) != string(external) {
 		t.Fatalf("target = %q, %v; want external bytes preserved", got, readErr)
 	}
+}
+
+func TestRewriteOpenedRegularFileRestoresAfterPartialWriteFailure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "target")
+	previous := []byte("previous content\n")
+	updated := []byte("updated content\n")
+	if err := os.WriteFile(path, previous, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	failing := &partialWriteFile{File: file, failNextWrite: true}
+	err = rewriteOpenedRegularFile(failing, path, updated, previous)
+	if closeErr := file.Close(); closeErr != nil {
+		t.Fatal(closeErr)
+	}
+	if err == nil || !strings.Contains(err.Error(), "injected partial write") {
+		t.Fatalf("rewriteOpenedRegularFile() error = %v, want injected write failure", err)
+	}
+	if got, readErr := os.ReadFile(path); readErr != nil || string(got) != string(previous) {
+		t.Fatalf("target = %q, %v; want restored previous bytes", got, readErr)
+	}
+}
+
+type partialWriteFile struct {
+	*os.File
+	failNextWrite bool
+}
+
+func (f *partialWriteFile) Write(data []byte) (int, error) {
+	if !f.failNextWrite {
+		return f.File.Write(data)
+	}
+	f.failNextWrite = false
+	written, err := f.File.Write(data[:len(data)/2])
+	return written, errors.Join(err, errors.New("injected partial write"))
 }

--- a/internal/install/whole_update_internal_test.go
+++ b/internal/install/whole_update_internal_test.go
@@ -136,3 +136,49 @@ func TestApplyPartialUpdateRejectsSymlinkTargets(t *testing.T) {
 		}
 	}
 }
+
+func TestReadConfinedRegularFileRejectsSymlinkSources(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside")
+	inside := filepath.Join(root, "inside")
+	if err := os.WriteFile(outside, []byte("outside\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(inside, []byte("inside\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for name, destination := range map[string]string{
+		"outside": outside,
+		"inside":  filepath.Base(inside),
+	} {
+		t.Run(name, func(t *testing.T) {
+			source := filepath.Join(root, name+"-link")
+			if err := os.Symlink(destination, source); err != nil {
+				t.Fatal(err)
+			}
+			_, err := readConfinedRegularFile(source, root)
+			if err == nil || !strings.Contains(err.Error(), "non-symlink regular file") {
+				t.Fatalf("readConfinedRegularFile() error = %v, want symlink rejection", err)
+			}
+		})
+	}
+}
+
+func TestRestoreConfinedRegularFileRequiresExactAppliedBytes(t *testing.T) {
+	home := t.TempDir()
+	target := filepath.Join(home, ".target")
+	applied := []byte("applied\n")
+	previous := []byte("previous\n")
+	external := []byte("external\n")
+	if err := os.WriteFile(target, external, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := restoreConfinedRegularFile(target, home, applied, previous)
+	if err == nil || !strings.Contains(err.Error(), "refusing rollback") {
+		t.Fatalf("restoreConfinedRegularFile() error = %v, want concurrent edit rejection", err)
+	}
+	if got, readErr := os.ReadFile(target); readErr != nil || string(got) != string(external) {
+		t.Fatalf("target = %q, %v; want external bytes preserved", got, readErr)
+	}
+}

--- a/internal/ownershipevidence/evidence.go
+++ b/internal/ownershipevidence/evidence.go
@@ -145,6 +145,44 @@ func (m Mode) Project(target string, contributions []state.Contribution) (state.
 	}, nil
 }
 
+// ProjectRecord reconstructs target-wide evidence exclusively from exact,
+// ordered per-contribution evidence and rejects contradictory compatibility
+// fields. Legacy records without Contributions are intentionally unsupported.
+func ProjectRecord(record state.Record) (state.Contribution, error) {
+	sources := record.SourceList()
+	if len(sources) == 0 || len(record.Contributions) != len(sources) {
+		return state.Contribution{}, fmt.Errorf("project record for %s: ordered contribution evidence is incomplete", record.Target)
+	}
+	for i, contribution := range record.Contributions {
+		if contribution.Source != sources[i] {
+			return state.Contribution{}, fmt.Errorf("project record for %s: contribution source %q does not match ordered source %q", record.Target, contribution.Source, sources[i])
+		}
+	}
+	projected, err := For(record.Strategy, record.Ownership).Project(record.Target, record.Contributions)
+	if err != nil {
+		return state.Contribution{}, err
+	}
+	if record.Hash != projected.Hash {
+		return state.Contribution{}, fmt.Errorf("project record for %s: target-wide hash contradicts exact contributions: %w", record.Target, ErrDrift)
+	}
+	ownedContentEqual := bytes.Equal(record.OwnedContent, projected.OwnedContent)
+	if record.Ownership == "json-subset" || record.Ownership == "jsonc-subset" {
+		recordCanonical, recordErr := configsubset.CanonicalJSONC(record.OwnedContent)
+		projectedCanonical, projectedErr := configsubset.CanonicalJSONC(projected.OwnedContent)
+		ownedContentEqual = recordErr == nil && projectedErr == nil && bytes.Equal(recordCanonical, projectedCanonical)
+	}
+	if !ownedContentEqual {
+		return state.Contribution{}, fmt.Errorf("project record for %s: target-wide owned content contradicts exact contributions: %w", record.Target, ErrDrift)
+	}
+	if !bytes.Equal(record.OwnedBytes, projected.OwnedBytes) {
+		return state.Contribution{}, fmt.Errorf("project record for %s: target-wide owned bytes contradict exact contributions: %w", record.Target, ErrDrift)
+	}
+	if !bytes.Equal(record.SeededBaseline, projected.SeededBaseline) {
+		return state.Contribution{}, fmt.Errorf("project record for %s: target-wide seeded baseline contradicts exact contributions: %w", record.Target, ErrDrift)
+	}
+	return projected, nil
+}
+
 // Validate confirms that target still converges with evidence immediately
 // before evidence is committed. resolvedSources is used to verify symlink
 // identity. seededFinal accepts zero or one value: zero validates the recorded

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -63,15 +63,18 @@ type Action struct {
 	// exact contribution recorded before switching back to a selected source.
 	PreviousHash string `json:"-"`
 	// PreviousRecordFingerprint binds an applied reconciliation and its recovery
-	// receipt to the exact Installation Metadata record that authorized it.
-	PreviousRecordFingerprint string   `json:"-"`
-	Target                    string   `json:"target"`
-	TargetRoot                string   `json:"target_root,omitempty"`
-	Strategy                  string   `json:"strategy"`
-	Status                    Status   `json:"status"`
-	Reason                    string   `json:"reason,omitempty"`
-	MatchingTags              []string `json:"matching_tags,omitempty"`
-	Ownership                 string   `json:"-"`
+	// receipt to the exact Installation Metadata record that authorized it. The
+	// receipt snapshot is compared separately because the operation may replace
+	// it while retaining the underlying contribution authority.
+	PreviousRecordFingerprint     string                       `json:"-"`
+	PreviousReconciliationReceipt *state.ReconciliationReceipt `json:"-"`
+	Target                        string                       `json:"target"`
+	TargetRoot                    string                       `json:"target_root,omitempty"`
+	Strategy                      string                       `json:"strategy"`
+	Status                        Status                       `json:"status"`
+	Reason                        string                       `json:"reason,omitempty"`
+	MatchingTags                  []string                     `json:"matching_tags,omitempty"`
+	Ownership                     string                       `json:"-"`
 	// Migration carries pre-refresh evidence for an ownership-changing legacy
 	// symlink. It is intentionally excluded from machine output; status is the
 	// portable contract and captured workstation content may be sensitive.
@@ -265,6 +268,7 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 		if rec, ok := opts.Metadata.FindByTarget(target); ok && normalizedEntryOwnership(rec.Ownership) == normalizedEntryOwnership(action.Ownership) {
 			action.PreviousContent = recordedPreviousContent(rec)
 			action.PreviousRecordFingerprint = exactRecordEvidenceFingerprint(rec)
+			action.PreviousReconciliationReceipt = rec.PendingReconciliation.Clone()
 		}
 		if rec, ok := opts.Metadata.FindByTarget(target); ok {
 			if contribution, exact := exactCompatibleRecordedContribution(entry, defaultSource, rec); exact &&

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -303,7 +303,7 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 			if unsafeTargetByTarget[targetKey] || unsafeTargetParent {
 				existing.Status = StatusConflict
 			} else {
-				existing.Status, err = composedJSONStatus(*existing, opts.Metadata)
+				existing.Status, err = composedJSONStatus(*existing, opts.Metadata, readSourcesByTarget[targetKey])
 				if err != nil {
 					return Plan{}, err
 				}
@@ -446,7 +446,7 @@ func scheduledLegacyParent(target string, parents map[string]struct{}) string {
 	return ""
 }
 
-func composedJSONStatus(action Action, meta state.Metadata) (Status, error) {
+func composedJSONStatus(action Action, meta state.Metadata, readSources []string) (Status, error) {
 	info, err := os.Lstat(action.Target)
 	if os.IsNotExist(err) {
 		return StatusCreate, nil
@@ -462,6 +462,15 @@ func composedJSONStatus(action Action, meta state.Metadata) (Status, error) {
 		return StatusUnchanged, nil
 	}
 	rec, ok := meta.FindByTarget(action.Target)
+	if ok {
+		sourceContents, readErr := readSourceContents(readSources)
+		if readErr != nil {
+			return "", readErr
+		}
+		if rec.PendingReconciliationMatches(targetData, action.Strategy, normalizedEntryOwnership(action.Ownership), action.Sources, sourceContents) {
+			return StatusUnchanged, nil
+		}
+	}
 	recordedSources := rec.SourceList()
 	trusted := ok && rec.Strategy == action.Strategy && len(recordedSources) > 0
 	selectedSources := make(map[string]struct{}, len(action.Sources))
@@ -500,6 +509,18 @@ func composedJSONStatus(action Action, meta state.Metadata) (Status, error) {
 	default:
 		return StatusConflict, nil
 	}
+}
+
+func readSourceContents(paths []string) ([][]byte, error) {
+	contents := make([][]byte, len(paths))
+	for i, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read reconciliation source %s: %w", path, err)
+		}
+		contents[i] = data
+	}
+	return contents, nil
 }
 
 // MatchingUnselectedSourceOverrideTags returns the deterministic set of
@@ -829,6 +850,19 @@ func status(entry manifest.Entry, target, sourceAbs, sourceRoot, canonicalSource
 		}
 		if same, err := sameContent(target, sourceAbs); err != nil || !same {
 			rec, recorded := meta.FindByTarget(target)
+			if recorded {
+				targetData, targetErr := os.ReadFile(target)
+				if targetErr != nil {
+					return "", fmt.Errorf("read pending reconciliation target %s: %w", target, targetErr)
+				}
+				sourceData, sourceErr := os.ReadFile(sourceAbs)
+				if sourceErr != nil {
+					return "", fmt.Errorf("read pending reconciliation source %s: %w", sourceAbs, sourceErr)
+				}
+				if rec.PendingReconciliationMatches(targetData, entry.Strategy, normalizedEntryOwnership(entry.Ownership), []string{entry.Source}, [][]byte{sourceData}) {
+					return StatusUnchanged, nil
+				}
+			}
 			previousContribution, exactCompatible := exactCompatibleRecordedContribution(entry, defaultSource, rec)
 			if entry.Ownership == "marked-block" {
 				if !recorded || rec.Strategy != entry.Strategy || rec.Ownership != "marked-block" ||

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -61,14 +61,17 @@ type Action struct {
 	PreviousContent []byte `json:"-"`
 	// PreviousHash proves that a whole-target source override still matches the
 	// exact contribution recorded before switching back to a selected source.
-	PreviousHash string   `json:"-"`
-	Target       string   `json:"target"`
-	TargetRoot   string   `json:"target_root,omitempty"`
-	Strategy     string   `json:"strategy"`
-	Status       Status   `json:"status"`
-	Reason       string   `json:"reason,omitempty"`
-	MatchingTags []string `json:"matching_tags,omitempty"`
-	Ownership    string   `json:"-"`
+	PreviousHash string `json:"-"`
+	// PreviousRecordFingerprint binds an applied reconciliation and its recovery
+	// receipt to the exact Installation Metadata record that authorized it.
+	PreviousRecordFingerprint string   `json:"-"`
+	Target                    string   `json:"target"`
+	TargetRoot                string   `json:"target_root,omitempty"`
+	Strategy                  string   `json:"strategy"`
+	Status                    Status   `json:"status"`
+	Reason                    string   `json:"reason,omitempty"`
+	MatchingTags              []string `json:"matching_tags,omitempty"`
+	Ownership                 string   `json:"-"`
 	// Migration carries pre-refresh evidence for an ownership-changing legacy
 	// symlink. It is intentionally excluded from machine output; status is the
 	// portable contract and captured workstation content may be sensitive.
@@ -259,8 +262,9 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 				}
 			}
 		}
-		if rec, ok := opts.Metadata.FindByTarget(target); ok && rec.Ownership == action.Ownership {
+		if rec, ok := opts.Metadata.FindByTarget(target); ok && normalizedEntryOwnership(rec.Ownership) == normalizedEntryOwnership(action.Ownership) {
 			action.PreviousContent = recordedPreviousContent(rec)
+			action.PreviousRecordFingerprint = exactRecordEvidenceFingerprint(rec)
 		}
 		if rec, ok := opts.Metadata.FindByTarget(target); ok {
 			if contribution, exact := exactCompatibleRecordedContribution(entry, defaultSource, rec); exact &&
@@ -1120,6 +1124,20 @@ func recordedPreviousContent(rec state.Record) []byte {
 		return append([]byte(nil), rec.SeededBaseline...)
 	}
 	return nil
+}
+
+func exactRecordEvidenceFingerprint(rec state.Record) string {
+	if len(rec.Contributions) == 0 {
+		return ""
+	}
+	if _, err := ownershipevidence.ProjectRecord(rec); err != nil {
+		return ""
+	}
+	fingerprint, err := state.RecordEvidenceFingerprint(rec)
+	if err != nil {
+		return ""
+	}
+	return fingerprint
 }
 
 func normalizedEntryOwnership(ownership string) string {

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -55,16 +55,19 @@ type Action struct {
 	// Content is the conservatively composed baseline for a shared json-subset
 	// target. Apply writes or merges it once instead of mutating per contributor.
 	Content []byte `json:"-"`
-	// PreviousContent is the last recorded dots-owned JSON contribution. It is
-	// used only to revalidate a reversible update at apply time.
-	PreviousContent []byte   `json:"-"`
-	Target          string   `json:"target"`
-	TargetRoot      string   `json:"target_root,omitempty"`
-	Strategy        string   `json:"strategy"`
-	Status          Status   `json:"status"`
-	Reason          string   `json:"reason,omitempty"`
-	MatchingTags    []string `json:"matching_tags,omitempty"`
-	Ownership       string   `json:"-"`
+	// PreviousContent is the last recorded dots-owned partial contribution. It
+	// is used only to revalidate a reversible update at apply time.
+	PreviousContent []byte `json:"-"`
+	// PreviousHash proves that a whole-target source override still matches the
+	// exact contribution recorded before switching back to a selected source.
+	PreviousHash string   `json:"-"`
+	Target       string   `json:"target"`
+	TargetRoot   string   `json:"target_root,omitempty"`
+	Strategy     string   `json:"strategy"`
+	Status       Status   `json:"status"`
+	Reason       string   `json:"reason,omitempty"`
+	MatchingTags []string `json:"matching_tags,omitempty"`
+	Ownership    string   `json:"-"`
 	// Migration carries pre-refresh evidence for an ownership-changing legacy
 	// symlink. It is intentionally excluded from machine output; status is the
 	// portable contract and captured workstation content may be sensitive.
@@ -264,6 +267,12 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 				action.PreviousContent = append([]byte(nil), rec.SeededBaseline...)
 			} else if rec.Ownership == "marked-block" {
 				action.PreviousContent = append([]byte(nil), rec.OwnedBytes...)
+			}
+		}
+		if rec, ok := opts.Metadata.FindByTarget(target); ok {
+			if contribution, exact := exactCompatibleRecordedContribution(entry, defaultSource, rec); exact &&
+				normalizedEntryOwnership(entry.Ownership) == "whole" && contribution.Source != action.Source {
+				action.PreviousHash = contribution.Hash
 			}
 		}
 		targetKey := filepath.Clean(target)
@@ -819,10 +828,16 @@ func status(entry manifest.Entry, target, sourceAbs, sourceRoot, canonicalSource
 			return StatusConflict, nil
 		}
 		if same, err := sameContent(target, sourceAbs); err != nil || !same {
+			rec, recorded := meta.FindByTarget(target)
+			previousContribution, exactCompatible := exactCompatibleRecordedContribution(entry, defaultSource, rec)
 			if entry.Ownership == "marked-block" {
-				rec, ok := meta.FindByTarget(target)
-				if !ok || rec.Strategy != entry.Strategy || rec.Source != entry.Source || rec.Ownership != "marked-block" || len(rec.OwnedBytes) == 0 {
+				if !recorded || rec.Strategy != entry.Strategy || rec.Ownership != "marked-block" ||
+					(rec.Source != entry.Source && !exactCompatible) || len(rec.OwnedBytes) == 0 {
 					return StatusConflict, nil
+				}
+				previous := rec.OwnedBytes
+				if exactCompatible {
+					previous = previousContribution.OwnedBytes
 				}
 				live, readErr := os.ReadFile(target)
 				if readErr != nil {
@@ -832,7 +847,7 @@ func status(entry manifest.Entry, target, sourceAbs, sourceRoot, canonicalSource
 				if readErr != nil {
 					return "", fmt.Errorf("read marked-block source %s: %w", sourceAbs, readErr)
 				}
-				reconciliation := textblock.ReconcileOwned(live, rec.OwnedBytes, current, textblock.DotsManagedMarkers())
+				reconciliation := textblock.ReconcileOwned(live, previous, current, textblock.DotsManagedMarkers())
 				if !reconciliation.Compatible {
 					return StatusConflict, nil
 				}
@@ -859,9 +874,13 @@ func status(entry manifest.Entry, target, sourceAbs, sourceRoot, canonicalSource
 				}
 				return StatusUnchanged, nil
 			}
-			if isSubsetOwned(entry.Ownership) && (meta.MatchesEntry(target, entry.Source, entry.Strategy) || meta.MatchesEntry(target, defaultSource, entry.Strategy)) {
+			if isSubsetOwned(entry.Ownership) && (meta.MatchesEntry(target, entry.Source, entry.Strategy) || meta.MatchesEntry(target, defaultSource, entry.Strategy) || exactCompatible) {
 				if isJSONOwnership(entry.Ownership) {
-					if rec, ok := meta.FindByTarget(target); ok && rec.Ownership == entry.Ownership && len(rec.OwnedContent) > 0 {
+					if recorded && rec.Ownership == entry.Ownership && len(rec.OwnedContent) > 0 {
+						previous := rec.OwnedContent
+						if exactCompatible {
+							previous = previousContribution.OwnedContent
+						}
 						targetData, readErr := os.ReadFile(target)
 						if readErr != nil {
 							return "", fmt.Errorf("read JSON target %s: %w", target, readErr)
@@ -873,9 +892,9 @@ func status(entry manifest.Entry, target, sourceAbs, sourceRoot, canonicalSource
 						var reconciliation configsubset.JSONReconciliation
 						var reconcileErr error
 						if entry.Ownership == "jsonc-subset" {
-							reconciliation, reconcileErr = configsubset.ReconcileJSONC(targetData, rec.OwnedContent, currentData)
+							reconciliation, reconcileErr = configsubset.ReconcileJSONC(targetData, previous, currentData)
 						} else {
-							reconciliation, reconcileErr = configsubset.ReconcileJSON(targetData, rec.OwnedContent, currentData)
+							reconciliation, reconcileErr = configsubset.ReconcileJSON(targetData, previous, currentData)
 						}
 						if reconcileErr != nil {
 							return "", fmt.Errorf("reconcile JSON target %s: %w", target, reconcileErr)
@@ -913,7 +932,11 @@ func status(entry manifest.Entry, target, sourceAbs, sourceRoot, canonicalSource
 						return StatusUpdate, nil
 					}
 				} else if entry.Ownership == "toml-subset" {
-					if rec, ok := meta.FindByTarget(target); ok && rec.Ownership == "toml-subset" && len(rec.OwnedBytes) > 0 {
+					if recorded && rec.Ownership == "toml-subset" && len(rec.OwnedBytes) > 0 {
+						previous := rec.OwnedBytes
+						if exactCompatible {
+							previous = previousContribution.OwnedBytes
+						}
 						targetData, readErr := os.ReadFile(target)
 						if readErr != nil {
 							return "", fmt.Errorf("read TOML target %s: %w", target, readErr)
@@ -922,7 +945,7 @@ func status(entry manifest.Entry, target, sourceAbs, sourceRoot, canonicalSource
 						if readErr != nil {
 							return "", fmt.Errorf("read source TOML %s: %w", sourceAbs, readErr)
 						}
-						reconciliation, reconcileErr := configsubset.ReconcileTOML(targetData, rec.OwnedBytes, currentData)
+						reconciliation, reconcileErr := configsubset.ReconcileTOML(targetData, previous, currentData)
 						if reconcileErr != nil {
 							return "", fmt.Errorf("reconcile TOML target %s: %w", target, reconcileErr)
 						}
@@ -953,6 +976,13 @@ func status(entry manifest.Entry, target, sourceAbs, sourceRoot, canonicalSource
 			}
 			if entry.Ownership == "toml-subset" && targetContainsCompatibleRecordedSource(entry, target, sourceRoot, meta, defaultSource) {
 				return StatusUpdate, nil
+			}
+			if normalizedEntryOwnership(entry.Ownership) == "whole" && exactCompatible &&
+				previousContribution.Source != entry.Source && previousContribution.Hash != "" {
+				liveHash, hashErr := state.HashFile(target)
+				if hashErr == nil && liveHash == previousContribution.Hash {
+					return StatusUpdate, nil
+				}
 			}
 			return StatusConflict, nil
 		}
@@ -1004,6 +1034,27 @@ func compatibleEntrySource(entry manifest.Entry, defaultSource, source string) b
 		}
 	}
 	return false
+}
+
+func exactCompatibleRecordedContribution(entry manifest.Entry, defaultSource string, rec state.Record) (state.Contribution, bool) {
+	if rec.Strategy != entry.Strategy || normalizedEntryOwnership(rec.Ownership) != normalizedEntryOwnership(entry.Ownership) || len(rec.Contributions) != 1 {
+		return state.Contribution{}, false
+	}
+	contribution := rec.Contributions[0]
+	sources := rec.SourceList()
+	if !contribution.EvidenceRecorded || len(sources) != 1 || sources[0] != contribution.Source ||
+		normalizedEntryOwnership(contribution.Ownership) != normalizedEntryOwnership(entry.Ownership) ||
+		!compatibleEntrySource(entry, defaultSource, contribution.Source) {
+		return state.Contribution{}, false
+	}
+	return contribution, true
+}
+
+func normalizedEntryOwnership(ownership string) string {
+	if ownership == "" {
+		return "whole"
+	}
+	return ownership
 }
 
 func safeSourceExists(sourceAbs, sourceRoot string) (bool, error) {

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/yersonargotev/dots/internal/configsubset"
 	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/ownershipevidence"
 	"github.com/yersonargotev/dots/internal/seededstate"
 	"github.com/yersonargotev/dots/internal/selectedsurface"
 	"github.com/yersonargotev/dots/internal/selection"
@@ -259,15 +260,7 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 			}
 		}
 		if rec, ok := opts.Metadata.FindByTarget(target); ok && rec.Ownership == action.Ownership {
-			if isJSONOwnership(rec.Ownership) && len(rec.OwnedContent) > 0 {
-				action.PreviousContent = append([]byte(nil), rec.OwnedContent...)
-			} else if rec.Ownership == "toml-subset" && len(rec.OwnedBytes) > 0 {
-				action.PreviousContent = append([]byte(nil), rec.OwnedBytes...)
-			} else if rec.Ownership == "seeded" {
-				action.PreviousContent = append([]byte(nil), rec.SeededBaseline...)
-			} else if rec.Ownership == "marked-block" {
-				action.PreviousContent = append([]byte(nil), rec.OwnedBytes...)
-			}
+			action.PreviousContent = recordedPreviousContent(rec)
 		}
 		if rec, ok := opts.Metadata.FindByTarget(target); ok {
 			if contribution, exact := exactCompatibleRecordedContribution(entry, defaultSource, rec); exact &&
@@ -297,8 +290,8 @@ func Build(m manifest.Manifest, opts Options) (Plan, error) {
 				return Plan{}, fmt.Errorf("compose shared target %s: %w", targetKey, err)
 			}
 			existing.Content = composed
-			if rec, ok := opts.Metadata.FindByTarget(existing.Target); ok && rec.Ownership == "json-subset" && len(rec.OwnedContent) > 0 {
-				existing.PreviousContent = append([]byte(nil), rec.OwnedContent...)
+			if rec, ok := opts.Metadata.FindByTarget(existing.Target); ok && rec.Ownership == "json-subset" {
+				existing.PreviousContent = recordedPreviousContent(rec)
 			}
 			if unsafeTargetByTarget[targetKey] || unsafeTargetParent {
 				existing.Status = StatusConflict
@@ -463,6 +456,11 @@ func composedJSONStatus(action Action, meta state.Metadata, readSources []string
 	}
 	rec, ok := meta.FindByTarget(action.Target)
 	if ok {
+		if len(rec.Contributions) > 0 {
+			if _, projectionErr := ownershipevidence.ProjectRecord(rec); projectionErr != nil {
+				return StatusConflict, nil
+			}
+		}
 		sourceContents, readErr := readSourceContents(readSources)
 		if readErr != nil {
 			return "", readErr
@@ -484,8 +482,9 @@ func composedJSONStatus(action Action, meta state.Metadata, readSources []string
 	if !trusted {
 		return StatusConflict, nil
 	}
-	if rec.Ownership == "json-subset" && len(rec.OwnedContent) > 0 {
-		reconciliation, err := configsubset.ReconcileJSON(targetData, rec.OwnedContent, action.Content)
+	previous := recordedPreviousContent(rec)
+	if rec.Ownership == "json-subset" && len(previous) > 0 {
+		reconciliation, err := configsubset.ReconcileJSON(targetData, previous, action.Content)
 		if err != nil {
 			return "", fmt.Errorf("reconcile shared JSON target %s: %w", action.Target, err)
 		}
@@ -850,6 +849,11 @@ func status(entry manifest.Entry, target, sourceAbs, sourceRoot, canonicalSource
 		}
 		if same, err := sameContent(target, sourceAbs); err != nil || !same {
 			rec, recorded := meta.FindByTarget(target)
+			if recorded && len(rec.Contributions) > 0 {
+				if _, projectionErr := ownershipevidence.ProjectRecord(rec); projectionErr != nil {
+					return StatusConflict, nil
+				}
+			}
 			if recorded {
 				targetData, targetErr := os.ReadFile(target)
 				if targetErr != nil {
@@ -865,11 +869,11 @@ func status(entry manifest.Entry, target, sourceAbs, sourceRoot, canonicalSource
 			}
 			previousContribution, exactCompatible := exactCompatibleRecordedContribution(entry, defaultSource, rec)
 			if entry.Ownership == "marked-block" {
+				previous := recordedPreviousContent(rec)
 				if !recorded || rec.Strategy != entry.Strategy || rec.Ownership != "marked-block" ||
-					(rec.Source != entry.Source && !exactCompatible) || len(rec.OwnedBytes) == 0 {
+					(rec.Source != entry.Source && !exactCompatible) || len(previous) == 0 {
 					return StatusConflict, nil
 				}
-				previous := rec.OwnedBytes
 				if exactCompatible {
 					previous = previousContribution.OwnedBytes
 				}
@@ -895,6 +899,10 @@ func status(entry manifest.Entry, target, sourceAbs, sourceRoot, canonicalSource
 				if !ok || rec.Strategy != entry.Strategy || rec.Source != entry.Source || rec.Ownership != "seeded" {
 					return StatusConflict, nil
 				}
+				previous := recordedPreviousContent(rec)
+				if len(rec.Contributions) > 0 && previous == nil {
+					return StatusConflict, nil
+				}
 				live, readErr := os.ReadFile(target)
 				if readErr != nil {
 					return "", fmt.Errorf("read seeded target %s: %w", target, readErr)
@@ -903,15 +911,15 @@ func status(entry manifest.Entry, target, sourceAbs, sourceRoot, canonicalSource
 				if readErr != nil {
 					return "", fmt.Errorf("read seeded source %s: %w", sourceAbs, readErr)
 				}
-				if seededstate.Reconcile(live, rec.SeededBaseline, current).Classification == seededstate.AdvanceBaseline {
+				if seededstate.Reconcile(live, previous, current).Classification == seededstate.AdvanceBaseline {
 					return StatusUpdate, nil
 				}
 				return StatusUnchanged, nil
 			}
 			if isSubsetOwned(entry.Ownership) && (meta.MatchesEntry(target, entry.Source, entry.Strategy) || meta.MatchesEntry(target, defaultSource, entry.Strategy) || exactCompatible) {
 				if isJSONOwnership(entry.Ownership) {
-					if recorded && rec.Ownership == entry.Ownership && len(rec.OwnedContent) > 0 {
-						previous := rec.OwnedContent
+					previous := recordedPreviousContent(rec)
+					if recorded && rec.Ownership == entry.Ownership && len(previous) > 0 {
 						if exactCompatible {
 							previous = previousContribution.OwnedContent
 						}
@@ -966,8 +974,8 @@ func status(entry manifest.Entry, target, sourceAbs, sourceRoot, canonicalSource
 						return StatusUpdate, nil
 					}
 				} else if entry.Ownership == "toml-subset" {
-					if recorded && rec.Ownership == "toml-subset" && len(rec.OwnedBytes) > 0 {
-						previous := rec.OwnedBytes
+					previous := recordedPreviousContent(rec)
+					if recorded && rec.Ownership == "toml-subset" && len(previous) > 0 {
 						if exactCompatible {
 							previous = previousContribution.OwnedBytes
 						}
@@ -1074,6 +1082,9 @@ func exactCompatibleRecordedContribution(entry manifest.Entry, defaultSource str
 	if rec.Strategy != entry.Strategy || normalizedEntryOwnership(rec.Ownership) != normalizedEntryOwnership(entry.Ownership) || len(rec.Contributions) != 1 {
 		return state.Contribution{}, false
 	}
+	if _, err := ownershipevidence.ProjectRecord(rec); err != nil {
+		return state.Contribution{}, false
+	}
 	contribution := rec.Contributions[0]
 	sources := rec.SourceList()
 	if !contribution.EvidenceRecorded || len(sources) != 1 || sources[0] != contribution.Source ||
@@ -1082,6 +1093,33 @@ func exactCompatibleRecordedContribution(entry manifest.Entry, defaultSource str
 		return state.Contribution{}, false
 	}
 	return contribution, true
+}
+
+func recordedPreviousContent(rec state.Record) []byte {
+	if len(rec.Contributions) > 0 {
+		projected, err := ownershipevidence.ProjectRecord(rec)
+		if err != nil {
+			return nil
+		}
+		switch normalizedEntryOwnership(rec.Ownership) {
+		case "json-subset", "jsonc-subset":
+			return append([]byte(nil), projected.OwnedContent...)
+		case "toml-subset", "marked-block":
+			return append([]byte(nil), projected.OwnedBytes...)
+		case "seeded":
+			return append([]byte(nil), projected.SeededBaseline...)
+		}
+		return nil
+	}
+	switch normalizedEntryOwnership(rec.Ownership) {
+	case "json-subset", "jsonc-subset":
+		return append([]byte(nil), rec.OwnedContent...)
+	case "toml-subset", "marked-block":
+		return append([]byte(nil), rec.OwnedBytes...)
+	case "seeded":
+		return append([]byte(nil), rec.SeededBaseline...)
+	}
+	return nil
 }
 
 func normalizedEntryOwnership(ownership string) string {

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -486,7 +486,7 @@ func TestBuildPlansProvenanceBackedLegacyJSONMigration(t *testing.T) {
 	if len(p.Actions) != 1 || p.Actions[0].Status != plan.StatusMigrate || p.Actions[0].Migration == nil {
 		t.Fatalf("actions = %#v, want migrate", p.Actions)
 	}
-	if got := string(p.Actions[0].Migration.FinalContent); got != "{\n  \"owned\": 2,\n  \"runtime\": true\n}\n" {
+	if got := string(p.Actions[0].Migration.FinalContent); got != "{\"owned\":2,\"runtime\":true}\n" {
 		t.Fatalf("migration content = %q", got)
 	}
 }
@@ -551,8 +551,23 @@ func TestBuildJSONSubsetUsesRecordedContributionForReversibleRemoval(t *testing.
 	action = buildOneWithMetadata(t, sourceRoot, home, manifest.Entry{
 		Source: "configs/shared.json", Target: "~/.config/shared.json", Strategy: "copy", Ownership: "json-subset", Tags: []string{"core"},
 	}, meta)
-	if action.Status != plan.StatusUpdate {
-		t.Fatalf("Status = %q, want convergent update for already removed retired key", action.Status)
+	if action.Status != plan.StatusConflict {
+		t.Fatalf("Status = %q, want conflict for an unproven missing retired key", action.Status)
+	}
+	currentSource := []byte(`{"owned":{"keep":true,"added":"new"}}`)
+	convergedTarget := []byte(`{"owned":{"keep":true,"added":"new"},"external":"preserve"}`)
+	if err := os.WriteFile(target, convergedTarget, 0o600); err != nil {
+		t.Fatalf("write receipt-backed target: %v", err)
+	}
+	meta.Entries[0].PendingReconciliation = &state.ReconciliationReceipt{
+		TargetHash: state.HashBytes(convergedTarget), Sources: []string{"configs/shared.json"},
+		SourceHashes: []string{state.HashBytes(currentSource)}, Strategy: "copy", Ownership: "json-subset",
+	}
+	action = buildOneWithMetadata(t, sourceRoot, home, manifest.Entry{
+		Source: "configs/shared.json", Target: "~/.config/shared.json", Strategy: "copy", Ownership: "json-subset", Tags: []string{"core"},
+	}, meta)
+	if action.Status != plan.StatusUnchanged {
+		t.Fatalf("Status = %q, want unchanged only with exact recovery receipt", action.Status)
 	}
 }
 

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -551,8 +551,8 @@ func TestBuildJSONSubsetUsesRecordedContributionForReversibleRemoval(t *testing.
 	action = buildOneWithMetadata(t, sourceRoot, home, manifest.Entry{
 		Source: "configs/shared.json", Target: "~/.config/shared.json", Strategy: "copy", Ownership: "json-subset", Tags: []string{"core"},
 	}, meta)
-	if action.Status != plan.StatusConflict {
-		t.Fatalf("Status = %q, want conflict for missing retired key", action.Status)
+	if action.Status != plan.StatusUpdate {
+		t.Fatalf("Status = %q, want convergent update for already removed retired key", action.Status)
 	}
 }
 

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -592,6 +592,37 @@ func TestBuildJSONSubsetLegacyMetadataDoesNotAuthorizeRemoval(t *testing.T) {
 	}
 }
 
+func TestBuildRejectsTargetWideEvidenceThatContradictsExactContributions(t *testing.T) {
+	sourceRoot := t.TempDir()
+	home := t.TempDir()
+	source := []byte(`{"owned":{"keep":true}}`)
+	writeSource(t, sourceRoot, "configs/shared.json", string(source))
+	target := filepath.Join(home, ".config", "shared.json")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte(`{"owned":{"keep":true,"retired":"old"},"external":"preserve"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	exact := []byte(`{"owned":{"keep":true,"retired":"old"}}`)
+	contradictory := []byte(`{"owned":{"keep":true,"retired":"old"},"external":"preserve"}`)
+	meta := state.Metadata{Entries: []state.Record{{
+		Target: target, Source: "configs/shared.json", Strategy: "copy", Ownership: "json-subset",
+		OwnedContent: contradictory, Hash: state.HashBytes(contradictory),
+		Contributions: []state.Contribution{{
+			Source: "configs/shared.json", Ownership: "json-subset", EvidenceRecorded: true,
+			Hash: state.HashBytes(exact), OwnedContent: exact,
+		}},
+	}}}
+
+	action := buildOneWithMetadata(t, sourceRoot, home, manifest.Entry{
+		Source: "configs/shared.json", Target: "~/.config/shared.json", Strategy: "copy", Ownership: "json-subset", Tags: []string{"core"},
+	}, meta)
+	if action.Status != plan.StatusConflict || action.PreviousContent != nil {
+		t.Fatalf("Action = %#v, want contradictory target-wide evidence to fail closed", action)
+	}
+}
+
 func TestBuildCopyTOMLSubsetOwnership(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/selectionreconciliation/reconciliation.go
+++ b/internal/selectionreconciliation/reconciliation.go
@@ -436,7 +436,7 @@ func buildTargetAction(previous, current targetGroup, input Input) (Action, erro
 	if ownership == "seeded" {
 		return classifySeeded(action, previous, current, target.Content, currentContent, record, recorded), nil
 	}
-	return classifyPartial(action, previous, current, ownership, target.Content, currentContent, record, recorded)
+	return classifyPartial(action, previous, current, ownership, target.Content, currentContent, currentSources, record, recorded)
 }
 
 func classifySymlink(action Action, previous, current targetGroup, target TargetEvidence, currentSources []SourceEvidence, record state.Record, recorded bool, evidence []SourceEvidence) Action {
@@ -539,7 +539,7 @@ func classifySeeded(action Action, previous, current targetGroup, live, desired 
 	return action
 }
 
-func classifyPartial(action Action, previous, current targetGroup, ownership string, live, desired []byte, record state.Record, recorded bool) (Action, error) {
+func classifyPartial(action Action, previous, current targetGroup, ownership string, live, desired []byte, currentEvidence []SourceEvidence, record state.Record, recorded bool) (Action, error) {
 	if previous.target == "" {
 		outcome, err := analyzePartialAddition(ownership, live, desired)
 		if err != nil {
@@ -558,6 +558,14 @@ func classifyPartial(action Action, previous, current targetGroup, ownership str
 			return action, nil
 		}
 		return blocked(action, ReasonAmbiguousPartialOwnership), nil
+	}
+	currentContents := make([][]byte, len(currentEvidence))
+	for i := range currentEvidence {
+		currentContents[i] = currentEvidence[i].Content
+	}
+	if record.PendingReconciliationMatches(live, previous.entries[0].Entry.Strategy, ownership, action.CurrentSources, currentContents) {
+		action.Outcome = OutcomePreserve
+		return action, nil
 	}
 	previousOwned, ok, err := exactPreviousContent(previous, ownership, record)
 	if err != nil {

--- a/internal/selectionreconciliation/reconciliation.go
+++ b/internal/selectionreconciliation/reconciliation.go
@@ -395,10 +395,13 @@ func buildTargetAction(previous, current targetGroup, input Input) (Action, erro
 		action.Reason = ReasonManifestEvolution
 		return action, nil
 	}
-	if current.target != "" && hasRetiredSources(previous, current) && partialOwnership(ownership) {
+	if current.target != "" && hasRetiredSources(previous, current) {
 		switch target.ForwardStatus {
 		case ForwardConflict:
-			return blocked(action, ReasonAmbiguousPartialOwnership), nil
+			if partialOwnership(ownership) {
+				return blocked(action, ReasonAmbiguousPartialOwnership), nil
+			}
+			return classifyForward(action, ownership, target.ForwardStatus, target.ForwardReason), nil
 		case ForwardMissingSource:
 			return blocked(action, ReasonMissingSource), nil
 		}

--- a/internal/selectionreconciliation/reconciliation.go
+++ b/internal/selectionreconciliation/reconciliation.go
@@ -395,6 +395,14 @@ func buildTargetAction(previous, current targetGroup, input Input) (Action, erro
 		action.Reason = ReasonManifestEvolution
 		return action, nil
 	}
+	if current.target != "" && hasRetiredSources(previous, current) && partialOwnership(ownership) {
+		switch target.ForwardStatus {
+		case ForwardConflict:
+			return blocked(action, ReasonAmbiguousPartialOwnership), nil
+		case ForwardMissingSource:
+			return blocked(action, ReasonMissingSource), nil
+		}
+	}
 	if current.target != "" && !hasRetiredSources(previous, current) && target.ForwardStatus != "" {
 		return classifyForward(action, ownership, target.ForwardStatus, target.ForwardReason), nil
 	}
@@ -437,6 +445,15 @@ func buildTargetAction(previous, current targetGroup, input Input) (Action, erro
 		return classifySeeded(action, previous, current, target.Content, currentContent, record, recorded), nil
 	}
 	return classifyPartial(action, previous, current, ownership, target.Content, currentContent, currentSources, record, recorded)
+}
+
+func partialOwnership(ownership string) bool {
+	switch normalizedOwnership(ownership) {
+	case "json-subset", "jsonc-subset", "toml-subset", "marked-block":
+		return true
+	default:
+		return false
+	}
 }
 
 func classifySymlink(action Action, previous, current targetGroup, target TargetEvidence, currentSources []SourceEvidence, record state.Record, recorded bool, evidence []SourceEvidence) Action {

--- a/internal/selectionreconciliation/reconciliation_test.go
+++ b/internal/selectionreconciliation/reconciliation_test.go
@@ -275,6 +275,50 @@ func TestBuildReconcilesSharedJSONTargetInSelectedSurfaceOrder(t *testing.T) {
 	}
 }
 
+func TestBuildAcceptsAlreadyAppliedSharedReconciliationOnlyWithExactReceipt(t *testing.T) {
+	previous := []selectedsurface.SelectedEntry{
+		selectedEntry("a.json", "~/.shared.json", "copy", "json-subset"),
+		selectedEntry("b.json", "~/.shared.json", "copy", "json-subset"),
+	}
+	current := []selectedsurface.SelectedEntry{selectedEntry("b.json", "~/.shared.json", "copy", "json-subset")}
+	live := []byte(`{"b":2,"external":true}`)
+	currentSource := []byte(`{"b":2}`)
+	input := baseInput(previous, current, TargetEvidence{
+		DeclarativeTarget: "~/.shared.json", ResolvedTarget: "/home/test/.shared.json", Exists: true, Kind: TargetKindRegular, Content: live,
+	})
+	input.Evidence.Sources = []SourceEvidence{{
+		DeclarativeTarget: "~/.shared.json", Source: "b.json", Exists: true, Content: currentSource,
+	}}
+	input.Metadata.Entries = []state.Record{{
+		Target: "/home/test/.shared.json", Strategy: "copy", Ownership: "json-subset",
+		Contributions: []state.Contribution{
+			{Source: "a.json", Ownership: "json-subset", EvidenceRecorded: true, OwnedContent: json.RawMessage(`{"a":1}`)},
+			{Source: "b.json", Ownership: "json-subset", EvidenceRecorded: true, OwnedContent: json.RawMessage(currentSource)},
+		},
+		PendingReconciliation: &state.ReconciliationReceipt{
+			TargetHash: state.HashBytes(live), Sources: []string{"b.json"}, SourceHashes: []string{state.HashBytes(currentSource)},
+			Strategy: "copy", Ownership: "json-subset",
+		},
+	}}
+
+	report, err := Build(input)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if got := report.Actions[0]; got.Outcome != OutcomePreserve || got.Reason != "" {
+		t.Fatalf("receipt-backed Action = %#v, want preserve", got)
+	}
+
+	input.Evidence.Targets[0].Content = []byte(`{"b":2,"external":"changed"}`)
+	report, err = Build(input)
+	if err != nil {
+		t.Fatalf("Build(drifted) error = %v", err)
+	}
+	if got := report.Actions[0]; got.Outcome != OutcomeBlocked || got.Reason != ReasonAmbiguousPartialOwnership {
+		t.Fatalf("drifted receipt Action = %#v, want ambiguous block", got)
+	}
+}
+
 func TestBuildRetainsPartialRetirementWithoutExactContributionEvidence(t *testing.T) {
 	previous := selectedEntry("a.json", "~/.shared.json", "copy", "json-subset")
 	input := baseInput([]selectedsurface.SelectedEntry{previous}, nil, TargetEvidence{

--- a/internal/selectionreconciliation/reconciliation_test.go
+++ b/internal/selectionreconciliation/reconciliation_test.go
@@ -89,6 +89,41 @@ func TestBuildBlocksPartialRetirementWhenForwardPlanConflicts(t *testing.T) {
 	}
 }
 
+func TestBuildBlocksWholeSourceOverrideRetirementWhenForwardPlanConflicts(t *testing.T) {
+	previous := []selectedsurface.SelectedEntry{
+		selectedEntry("override.kdl", "~/.config.kdl", "copy", "whole"),
+	}
+	current := []selectedsurface.SelectedEntry{
+		selectedEntry("base.kdl", "~/.config.kdl", "copy", "whole"),
+	}
+	input := baseInput(previous, current, TargetEvidence{
+		DeclarativeTarget: "~/.config.kdl",
+		ResolvedTarget:    "/home/test/.config.kdl",
+		Exists:            true,
+		Kind:              TargetKindRegular,
+		Content:           []byte("override\n"),
+		ForwardStatus:     ForwardConflict,
+	})
+	input.Metadata.Entries = []state.Record{{
+		Target: "/home/test/.config.kdl", Source: "override.kdl", Strategy: "copy", Ownership: "whole",
+		Hash: state.HashBytes([]byte("contradictory\n")),
+		Contributions: []state.Contribution{{
+			Source: "override.kdl", Ownership: "whole", EvidenceRecorded: true, Hash: state.HashBytes([]byte("override\n")),
+		}},
+	}}
+
+	report, err := Build(input)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if got := report.Actions[0]; got.Outcome != OutcomeBlocked || got.Reason != ReasonLostOwnership {
+		t.Fatalf("Action = %#v, want lost-ownership block", got)
+	}
+	if !report.HasFindings() {
+		t.Fatal("forward conflict must remain a read-only finding")
+	}
+}
+
 func TestBuildClassifiesWholeTargetReplacementFromRecordedEvidence(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/selectionreconciliation/reconciliation_test.go
+++ b/internal/selectionreconciliation/reconciliation_test.go
@@ -50,6 +50,45 @@ func TestBuildReusesForwardClassification(t *testing.T) {
 	}
 }
 
+func TestBuildBlocksPartialRetirementWhenForwardPlanConflicts(t *testing.T) {
+	previous := []selectedsurface.SelectedEntry{
+		selectedEntry("a.json", "~/.shared.json", "copy", "json-subset"),
+		selectedEntry("b.json", "~/.shared.json", "copy", "json-subset"),
+	}
+	current := []selectedsurface.SelectedEntry{
+		selectedEntry("b.json", "~/.shared.json", "copy", "json-subset"),
+	}
+	input := baseInput(previous, current, TargetEvidence{
+		DeclarativeTarget: "~/.shared.json",
+		ResolvedTarget:    "/home/test/.shared.json",
+		Exists:            true,
+		Kind:              TargetKindRegular,
+		Content:           []byte(`{"a":1,"b":2}`),
+		ForwardStatus:     ForwardConflict,
+	})
+	input.Metadata.Entries = []state.Record{{
+		Target:    "/home/test/.shared.json",
+		Strategy:  "copy",
+		Ownership: "json-subset",
+		Contributions: []state.Contribution{
+			{Source: "a.json", Ownership: "json-subset", EvidenceRecorded: true, OwnedContent: json.RawMessage(`{"a":1}`)},
+			{Source: "b.json", Ownership: "json-subset", EvidenceRecorded: true, OwnedContent: json.RawMessage(`{"b":2}`)},
+		},
+		OwnedContent: json.RawMessage(`{"contradictory":true}`),
+	}}
+
+	report, err := Build(input)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if got := report.Actions[0]; got.Outcome != OutcomeBlocked || got.Reason != ReasonAmbiguousPartialOwnership {
+		t.Fatalf("Action = %#v, want ambiguous partial ownership block", got)
+	}
+	if !report.HasFindings() {
+		t.Fatal("forward conflict must remain a read-only finding")
+	}
+}
+
 func TestBuildClassifiesWholeTargetReplacementFromRecordedEvidence(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/selectionretirement/retirement.go
+++ b/internal/selectionretirement/retirement.go
@@ -76,13 +76,17 @@ func Build(report selectionreconciliation.Report, meta state.Metadata, opts Opti
 		if action.Reason == selectionreconciliation.ReasonManifestEvolution {
 			continue
 		}
+		rec, recorded := meta.FindByTarget(action.ResolvedTarget)
 		if len(action.CurrentSources) != 0 {
 			switch action.Outcome {
 			case selectionreconciliation.OutcomeCreate,
 				selectionreconciliation.OutcomeUpdate,
 				selectionreconciliation.OutcomePreserve,
 				selectionreconciliation.OutcomeReconcile:
-				if err := validateForwardReconciliation(action, opts.ForwardPlan); err != nil {
+				if !recorded {
+					return Plan{}, fmt.Errorf("build selection retirement for %s: installation metadata record is required for partial retirement", action.ResolvedTarget)
+				}
+				if err := validateForwardReconciliation(action, rec, opts.ForwardPlan); err != nil {
 					return Plan{}, fmt.Errorf("build selection retirement for %s: %w", action.ResolvedTarget, err)
 				}
 				// The forward Managed Entry plan owns still-selected targets. Its
@@ -108,8 +112,7 @@ func Build(report selectionreconciliation.Report, meta state.Metadata, opts Opti
 			return Plan{}, fmt.Errorf("build selection retirement for %s: outcome %q is unsupported", action.ResolvedTarget, action.Outcome)
 		}
 
-		rec, ok := meta.FindByTarget(action.ResolvedTarget)
-		if !ok {
+		if !recorded {
 			if action.Outcome == selectionreconciliation.OutcomeRemove {
 				return Plan{}, fmt.Errorf("build selection retirement for %s: installation metadata record is required", action.ResolvedTarget)
 			}
@@ -132,7 +135,7 @@ func Build(report selectionreconciliation.Report, meta state.Metadata, opts Opti
 	return result, nil
 }
 
-func validateForwardReconciliation(action selectionreconciliation.Action, forward *plan.Plan) error {
+func validateForwardReconciliation(action selectionreconciliation.Action, record state.Record, forward *plan.Plan) error {
 	if forward == nil {
 		return fmt.Errorf("forward plan is required for partial retirement")
 	}
@@ -145,16 +148,76 @@ func validateForwardReconciliation(action selectionreconciliation.Action, forwar
 	case selectionreconciliation.OutcomePreserve:
 		want = plan.StatusUnchanged
 	}
-	for _, candidate := range forward.Actions {
+	var matched *plan.Action
+	for i := range forward.Actions {
+		candidate := &forward.Actions[i]
 		if candidate.Target != action.ResolvedTarget {
 			continue
 		}
-		if candidate.Status != want {
-			return fmt.Errorf("forward action status %q does not implement safe outcome %q", candidate.Status, action.Outcome)
+		if matched != nil {
+			return fmt.Errorf("forward plan contains duplicate target %s", action.ResolvedTarget)
 		}
-		return nil
+		matched = candidate
 	}
-	return fmt.Errorf("forward action is required for partial retirement")
+	if matched == nil {
+		return fmt.Errorf("forward action is required for partial retirement")
+	}
+	if matched.Status != want {
+		return fmt.Errorf("forward action status %q does not implement safe outcome %q", matched.Status, action.Outcome)
+	}
+	currentSources := []string{matched.Source}
+	if len(matched.Sources) > 0 {
+		currentSources = matched.Sources
+	}
+	if !reflect.DeepEqual(currentSources, action.CurrentSources) {
+		return fmt.Errorf("forward action sources %v do not match reconciliation sources %v", currentSources, action.CurrentSources)
+	}
+	if !reflect.DeepEqual(record.SourceList(), action.PreviousSources) {
+		return fmt.Errorf("recorded sources %v do not match reconciliation evidence %v", record.SourceList(), action.PreviousSources)
+	}
+	if matched.Strategy != record.Strategy || normalizedOwnership(matched.Ownership) != normalizedOwnership(record.Ownership) {
+		return fmt.Errorf("forward action mode %s/%s does not match recorded mode %s/%s", matched.Strategy, normalizedOwnership(matched.Ownership), record.Strategy, normalizedOwnership(record.Ownership))
+	}
+	if len(matched.Contributions) != len(action.CurrentSources) {
+		return fmt.Errorf("forward action has %d contribution identities for %d current sources", len(matched.Contributions), len(action.CurrentSources))
+	}
+	for i, contribution := range matched.Contributions {
+		if contribution.Source != action.CurrentSources[i] {
+			return fmt.Errorf("forward contribution source %q does not match reconciliation source %q", contribution.Source, action.CurrentSources[i])
+		}
+	}
+	if want == plan.StatusUpdate && !matchesPreviousEvidence(*matched, record, action.PreviousSources) {
+		return fmt.Errorf("forward update does not carry the exact recorded previous contribution evidence")
+	}
+	return nil
+}
+
+func normalizedOwnership(ownership string) string {
+	if ownership == "" {
+		return "whole"
+	}
+	return ownership
+}
+
+func matchesPreviousEvidence(action plan.Action, record state.Record, previousSources []string) bool {
+	switch normalizedOwnership(record.Ownership) {
+	case "json-subset", "jsonc-subset":
+		return len(action.PreviousContent) > 0 && reflect.DeepEqual(action.PreviousContent, []byte(record.OwnedContent))
+	case "toml-subset", "marked-block":
+		return len(action.PreviousContent) > 0 && reflect.DeepEqual(action.PreviousContent, record.OwnedBytes)
+	case "seeded":
+		return action.PreviousContent != nil && reflect.DeepEqual(action.PreviousContent, record.SeededBaseline)
+	case "whole":
+		if len(previousSources) != 1 || action.PreviousHash == "" {
+			return false
+		}
+		for _, contribution := range record.Contributions {
+			if contribution.Source == previousSources[0] && contribution.Ownership == "whole" {
+				return action.PreviousHash == contribution.Hash
+			}
+		}
+	}
+	return false
 }
 
 func hasSelectionReduction(actions []selectionreconciliation.Action) bool {

--- a/internal/selectionretirement/retirement.go
+++ b/internal/selectionretirement/retirement.go
@@ -187,6 +187,10 @@ func validateForwardReconciliation(action selectionreconciliation.Action, record
 			return fmt.Errorf("forward contribution source %q does not match reconciliation source %q", contribution.Source, action.CurrentSources[i])
 		}
 	}
+	recordFingerprint, err := state.RecordEvidenceFingerprint(record)
+	if err != nil || matched.PreviousRecordFingerprint == "" || matched.PreviousRecordFingerprint != recordFingerprint {
+		return fmt.Errorf("forward action is not bound to the exact recorded contribution authority")
+	}
 	if want == plan.StatusUpdate && !matchesPreviousEvidence(*matched, record, action.PreviousSources) {
 		return fmt.Errorf("forward update does not carry the exact recorded previous contribution evidence")
 	}

--- a/internal/selectionretirement/retirement.go
+++ b/internal/selectionretirement/retirement.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 
 	"github.com/yersonargotev/dots/internal/configsubset"
+	"github.com/yersonargotev/dots/internal/ownershipevidence"
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/selectionreconciliation"
 	"github.com/yersonargotev/dots/internal/state"
@@ -200,13 +201,17 @@ func normalizedOwnership(ownership string) string {
 }
 
 func matchesPreviousEvidence(action plan.Action, record state.Record, previousSources []string) bool {
+	projected, err := ownershipevidence.ProjectRecord(record)
+	if err != nil {
+		return false
+	}
 	switch normalizedOwnership(record.Ownership) {
 	case "json-subset", "jsonc-subset":
-		return len(action.PreviousContent) > 0 && reflect.DeepEqual(action.PreviousContent, []byte(record.OwnedContent))
+		return len(action.PreviousContent) > 0 && reflect.DeepEqual(action.PreviousContent, []byte(projected.OwnedContent))
 	case "toml-subset", "marked-block":
-		return len(action.PreviousContent) > 0 && reflect.DeepEqual(action.PreviousContent, record.OwnedBytes)
+		return len(action.PreviousContent) > 0 && reflect.DeepEqual(action.PreviousContent, projected.OwnedBytes)
 	case "seeded":
-		return action.PreviousContent != nil && reflect.DeepEqual(action.PreviousContent, record.SeededBaseline)
+		return action.PreviousContent != nil && reflect.DeepEqual(action.PreviousContent, projected.SeededBaseline)
 	case "whole":
 		if len(previousSources) != 1 || action.PreviousHash == "" {
 			return false

--- a/internal/selectionretirement/retirement.go
+++ b/internal/selectionretirement/retirement.go
@@ -23,6 +23,9 @@ type Options struct {
 	SourceRoot string
 	Home       string
 	StateRoot  string
+	// ForwardPlan owns every target that remains selected. Build requires a
+	// matching safe action before delegating contribution reconciliation to it.
+	ForwardPlan *plan.Plan
 }
 
 // Action is one validated retirement effect.
@@ -74,7 +77,22 @@ func Build(report selectionreconciliation.Report, meta state.Metadata, opts Opti
 			continue
 		}
 		if len(action.CurrentSources) != 0 {
-			return Plan{}, fmt.Errorf("build selection retirement for %s: partial retirement from a still-selected target is not supported", action.ResolvedTarget)
+			switch action.Outcome {
+			case selectionreconciliation.OutcomeCreate,
+				selectionreconciliation.OutcomeUpdate,
+				selectionreconciliation.OutcomePreserve,
+				selectionreconciliation.OutcomeReconcile:
+				if err := validateForwardReconciliation(action, opts.ForwardPlan); err != nil {
+					return Plan{}, fmt.Errorf("build selection retirement for %s: %w", action.ResolvedTarget, err)
+				}
+				// The forward Managed Entry plan owns still-selected targets. Its
+				// ownership-specific update also replaces contribution evidence at
+				// the terminal metadata commit, so retirement must only validate the
+				// reconciliation report and avoid applying the target twice.
+				continue
+			default:
+				return Plan{}, fmt.Errorf("build selection retirement for %s: partial retirement outcome %q is unsafe: %s", action.ResolvedTarget, action.Outcome, action.Reason)
+			}
 		}
 		if action.ResolvedTarget == "" {
 			return Plan{}, fmt.Errorf("build selection retirement: managed entry target is required")
@@ -112,6 +130,31 @@ func Build(report selectionreconciliation.Report, meta state.Metadata, opts Opti
 		result.records[action.ResolvedTarget] = rec.Clone()
 	}
 	return result, nil
+}
+
+func validateForwardReconciliation(action selectionreconciliation.Action, forward *plan.Plan) error {
+	if forward == nil {
+		return fmt.Errorf("forward plan is required for partial retirement")
+	}
+	want := plan.StatusUnchanged
+	switch action.Outcome {
+	case selectionreconciliation.OutcomeCreate:
+		want = plan.StatusCreate
+	case selectionreconciliation.OutcomeUpdate, selectionreconciliation.OutcomeReconcile:
+		want = plan.StatusUpdate
+	case selectionreconciliation.OutcomePreserve:
+		want = plan.StatusUnchanged
+	}
+	for _, candidate := range forward.Actions {
+		if candidate.Target != action.ResolvedTarget {
+			continue
+		}
+		if candidate.Status != want {
+			return fmt.Errorf("forward action status %q does not implement safe outcome %q", candidate.Status, action.Outcome)
+		}
+		return nil
+	}
+	return fmt.Errorf("forward action is required for partial retirement")
 }
 
 func hasSelectionReduction(actions []selectionreconciliation.Action) bool {

--- a/internal/selectionretirement/retirement_test.go
+++ b/internal/selectionretirement/retirement_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/yersonargotev/dots/internal/configsubset"
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/selectionreconciliation"
 	"github.com/yersonargotev/dots/internal/state"
@@ -211,15 +212,7 @@ func TestBuildDelegatesSafePartialRetirementToForwardPlan(t *testing.T) {
 		CurrentSources:  []string{"kept.json"},
 	})
 
-	previous := []byte(`{"removed":true,"kept":true}`)
-	record := state.Record{
-		Target: target, Source: "removed.json", Sources: []string{"removed.json", "kept.json"}, Strategy: "copy", Ownership: "json-subset",
-		OwnedContent: previous,
-		Contributions: []state.Contribution{
-			{Source: "removed.json", Ownership: "json-subset", EvidenceRecorded: true, OwnedContent: []byte(`{"removed":true}`)},
-			{Source: "kept.json", Ownership: "json-subset", EvidenceRecorded: true, OwnedContent: []byte(`{"kept":true}`)},
-		},
-	}
+	record, previous := exactSharedJSONRecord(t, target)
 	forward := plan.Plan{Actions: []plan.Action{{
 		Source: "kept.json", Target: target, Strategy: "copy", Ownership: "json-subset", Status: plan.StatusUpdate,
 		PreviousContent: previous, Contributions: []plan.Contribution{{Source: "kept.json"}},
@@ -239,15 +232,11 @@ func TestBuildDelegatesSafePartialRetirementToForwardPlan(t *testing.T) {
 func TestBuildRejectsPartialRetirementWithUnrelatedForwardAction(t *testing.T) {
 	home := t.TempDir()
 	target := writeTarget(t, home, ".shared.json", `{}`)
-	previous := []byte(`{"removed":true,"kept":true}`)
+	record, previous := exactSharedJSONRecord(t, target)
 	report := explicitReport(selectionreconciliation.Action{
 		Scope: selectionreconciliation.ScopeManagedEntry, Outcome: selectionreconciliation.OutcomeReconcile, ResolvedTarget: target,
 		PreviousSources: []string{"removed.json", "kept.json"}, CurrentSources: []string{"kept.json"},
 	})
-	record := state.Record{
-		Target: target, Source: "removed.json", Sources: []string{"removed.json", "kept.json"}, Strategy: "copy", Ownership: "json-subset",
-		OwnedContent: previous,
-	}
 	base := plan.Action{
 		Source: "kept.json", Target: target, Strategy: "copy", Ownership: "json-subset", Status: plan.StatusUpdate,
 		PreviousContent: previous, Contributions: []plan.Contribution{{Source: "kept.json"}},
@@ -272,6 +261,52 @@ func TestBuildRejectsPartialRetirementWithUnrelatedForwardAction(t *testing.T) {
 				t.Fatalf("Build() error = %v, want %q mismatch", err, tt.want)
 			}
 		})
+	}
+}
+
+func exactSharedJSONRecord(t *testing.T, target string) (state.Record, []byte) {
+	t.Helper()
+	removed := []byte(`{"removed":true}`)
+	kept := []byte(`{"kept":true}`)
+	previous, err := configsubset.MergeJSON(removed, kept)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return state.Record{
+		Target: target, Source: "removed.json", Sources: []string{"removed.json", "kept.json"}, Strategy: "copy", Ownership: "json-subset",
+		OwnedContent: previous, Hash: state.HashBytes(previous),
+		Contributions: []state.Contribution{
+			{Source: "removed.json", Ownership: "json-subset", EvidenceRecorded: true, Hash: state.HashBytes(removed), OwnedContent: removed},
+			{Source: "kept.json", Ownership: "json-subset", EvidenceRecorded: true, Hash: state.HashBytes(kept), OwnedContent: kept},
+		},
+	}, previous
+}
+
+func TestBuildRejectsForwardEvidenceFromContradictoryTargetWideRecord(t *testing.T) {
+	home := t.TempDir()
+	target := writeTarget(t, home, ".shared.json", `{}`)
+	exact := []byte(`{"removed":true,"kept":true}`)
+	contradictory := []byte(`{"removed":true,"kept":true,"external":"not-owned"}`)
+	report := explicitReport(selectionreconciliation.Action{
+		Scope: selectionreconciliation.ScopeManagedEntry, Outcome: selectionreconciliation.OutcomeReconcile, ResolvedTarget: target,
+		PreviousSources: []string{"recorded.json"}, CurrentSources: []string{"kept.json"},
+	})
+	record := state.Record{
+		Target: target, Source: "recorded.json", Strategy: "copy", Ownership: "json-subset", OwnedContent: contradictory,
+		Hash: state.HashBytes(contradictory),
+		Contributions: []state.Contribution{{
+			Source: "recorded.json", Ownership: "json-subset", EvidenceRecorded: true,
+			Hash: state.HashBytes(exact), OwnedContent: exact,
+		}},
+	}
+	forward := plan.Plan{Actions: []plan.Action{{
+		Source: "kept.json", Target: target, Strategy: "copy", Ownership: "json-subset", Status: plan.StatusUpdate,
+		PreviousContent: contradictory, Contributions: []plan.Contribution{{Source: "kept.json"}},
+	}}}
+
+	_, err := Build(report, state.Metadata{Entries: []state.Record{record}}, Options{Home: home, SourceRoot: t.TempDir(), ForwardPlan: &forward})
+	if err == nil || !strings.Contains(err.Error(), "exact recorded previous contribution evidence") {
+		t.Fatalf("Build() error = %v, want contradictory target-wide evidence rejected", err)
 	}
 }
 

--- a/internal/selectionretirement/retirement_test.go
+++ b/internal/selectionretirement/retirement_test.go
@@ -211,8 +211,20 @@ func TestBuildDelegatesSafePartialRetirementToForwardPlan(t *testing.T) {
 		CurrentSources:  []string{"kept.json"},
 	})
 
-	forward := plan.Plan{Actions: []plan.Action{{Target: target, Status: plan.StatusUpdate}}}
-	got, err := Build(report, state.Metadata{}, Options{Home: home, SourceRoot: t.TempDir(), ForwardPlan: &forward})
+	previous := []byte(`{"removed":true,"kept":true}`)
+	record := state.Record{
+		Target: target, Source: "removed.json", Sources: []string{"removed.json", "kept.json"}, Strategy: "copy", Ownership: "json-subset",
+		OwnedContent: previous,
+		Contributions: []state.Contribution{
+			{Source: "removed.json", Ownership: "json-subset", EvidenceRecorded: true, OwnedContent: []byte(`{"removed":true}`)},
+			{Source: "kept.json", Ownership: "json-subset", EvidenceRecorded: true, OwnedContent: []byte(`{"kept":true}`)},
+		},
+	}
+	forward := plan.Plan{Actions: []plan.Action{{
+		Source: "kept.json", Target: target, Strategy: "copy", Ownership: "json-subset", Status: plan.StatusUpdate,
+		PreviousContent: previous, Contributions: []plan.Contribution{{Source: "kept.json"}},
+	}}}
+	got, err := Build(report, state.Metadata{Entries: []state.Record{record}}, Options{Home: home, SourceRoot: t.TempDir(), ForwardPlan: &forward})
 	if err != nil {
 		t.Fatalf("Build() error = %v", err)
 	}
@@ -221,6 +233,45 @@ func TestBuildDelegatesSafePartialRetirementToForwardPlan(t *testing.T) {
 	}
 	if got, readErr := os.ReadFile(target); readErr != nil || string(got) != `{}` {
 		t.Fatalf("target changed during Build: content=%q err=%v", got, readErr)
+	}
+}
+
+func TestBuildRejectsPartialRetirementWithUnrelatedForwardAction(t *testing.T) {
+	home := t.TempDir()
+	target := writeTarget(t, home, ".shared.json", `{}`)
+	previous := []byte(`{"removed":true,"kept":true}`)
+	report := explicitReport(selectionreconciliation.Action{
+		Scope: selectionreconciliation.ScopeManagedEntry, Outcome: selectionreconciliation.OutcomeReconcile, ResolvedTarget: target,
+		PreviousSources: []string{"removed.json", "kept.json"}, CurrentSources: []string{"kept.json"},
+	})
+	record := state.Record{
+		Target: target, Source: "removed.json", Sources: []string{"removed.json", "kept.json"}, Strategy: "copy", Ownership: "json-subset",
+		OwnedContent: previous,
+	}
+	base := plan.Action{
+		Source: "kept.json", Target: target, Strategy: "copy", Ownership: "json-subset", Status: plan.StatusUpdate,
+		PreviousContent: previous, Contributions: []plan.Contribution{{Source: "kept.json"}},
+	}
+	tests := []struct {
+		name string
+		edit func(*plan.Action)
+		want string
+	}{
+		{name: "source", edit: func(action *plan.Action) { action.Source = "other.json" }, want: "sources"},
+		{name: "strategy", edit: func(action *plan.Action) { action.Strategy = "symlink" }, want: "mode"},
+		{name: "ownership", edit: func(action *plan.Action) { action.Ownership = "whole" }, want: "mode"},
+		{name: "previous evidence", edit: func(action *plan.Action) { action.PreviousContent = []byte(`{"other":true}`) }, want: "previous contribution evidence"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			candidate := base
+			tt.edit(&candidate)
+			forward := plan.Plan{Actions: []plan.Action{candidate}}
+			_, err := Build(report, state.Metadata{Entries: []state.Record{record}}, Options{Home: home, SourceRoot: t.TempDir(), ForwardPlan: &forward})
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Build() error = %v, want %q mismatch", err, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/selectionretirement/retirement_test.go
+++ b/internal/selectionretirement/retirement_test.go
@@ -5,8 +5,10 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
+	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/selectionreconciliation"
 	"github.com/yersonargotev/dots/internal/state"
 )
@@ -90,7 +92,8 @@ func TestBuildLeavesAdditionOnlySourceChangesToForwardInstall(t *testing.T) {
 		},
 	)
 
-	got, err := Build(report, state.Metadata{}, Options{Home: home, SourceRoot: t.TempDir()})
+	forward := plan.Plan{Actions: []plan.Action{{Target: target, Status: plan.StatusUpdate}}}
+	got, err := Build(report, state.Metadata{}, Options{Home: home, SourceRoot: t.TempDir(), ForwardPlan: &forward})
 	if err != nil {
 		t.Fatalf("Build() error = %v", err)
 	}
@@ -197,7 +200,7 @@ func TestBuildAllowsEntirePartialOwnershipTargetToRetire(t *testing.T) {
 	}
 }
 
-func TestBuildRejectsPartialRetirementFromStillSelectedTarget(t *testing.T) {
+func TestBuildDelegatesSafePartialRetirementToForwardPlan(t *testing.T) {
 	home := t.TempDir()
 	target := writeTarget(t, home, ".shared.json", `{}`)
 	report := explicitReport(selectionreconciliation.Action{
@@ -208,9 +211,34 @@ func TestBuildRejectsPartialRetirementFromStillSelectedTarget(t *testing.T) {
 		CurrentSources:  []string{"kept.json"},
 	})
 
+	forward := plan.Plan{Actions: []plan.Action{{Target: target, Status: plan.StatusUpdate}}}
+	got, err := Build(report, state.Metadata{}, Options{Home: home, SourceRoot: t.TempDir(), ForwardPlan: &forward})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if len(got.Actions) != 0 {
+		t.Fatalf("Build() actions = %#v, want forward plan to own still-selected target", got.Actions)
+	}
+	if got, readErr := os.ReadFile(target); readErr != nil || string(got) != `{}` {
+		t.Fatalf("target changed during Build: content=%q err=%v", got, readErr)
+	}
+}
+
+func TestBuildRejectsUnsafePartialRetirementBeforeMutation(t *testing.T) {
+	home := t.TempDir()
+	target := writeTarget(t, home, ".shared.json", `{}`)
+	report := explicitReport(selectionreconciliation.Action{
+		Scope:           selectionreconciliation.ScopeManagedEntry,
+		Outcome:         selectionreconciliation.OutcomeBlocked,
+		Reason:          selectionreconciliation.ReasonAmbiguousPartialOwnership,
+		ResolvedTarget:  target,
+		PreviousSources: []string{"removed.json", "kept.json"},
+		CurrentSources:  []string{"kept.json"},
+	})
+
 	_, err := Build(report, state.Metadata{}, Options{Home: home, SourceRoot: t.TempDir()})
-	if err == nil {
-		t.Fatal("Build() error = nil, want partial-retirement rejection")
+	if err == nil || !strings.Contains(err.Error(), "partial retirement outcome \"blocked\" is unsafe") {
+		t.Fatalf("Build() error = %v, want unsafe partial-retirement rejection", err)
 	}
 	if got, readErr := os.ReadFile(target); readErr != nil || string(got) != `{}` {
 		t.Fatalf("target changed during Build: content=%q err=%v", got, readErr)

--- a/internal/selectionretirement/retirement_test.go
+++ b/internal/selectionretirement/retirement_test.go
@@ -213,9 +213,13 @@ func TestBuildDelegatesSafePartialRetirementToForwardPlan(t *testing.T) {
 	})
 
 	record, previous := exactSharedJSONRecord(t, target)
+	fingerprint, err := state.RecordEvidenceFingerprint(record)
+	if err != nil {
+		t.Fatal(err)
+	}
 	forward := plan.Plan{Actions: []plan.Action{{
 		Source: "kept.json", Target: target, Strategy: "copy", Ownership: "json-subset", Status: plan.StatusUpdate,
-		PreviousContent: previous, Contributions: []plan.Contribution{{Source: "kept.json"}},
+		PreviousContent: previous, PreviousRecordFingerprint: fingerprint, Contributions: []plan.Contribution{{Source: "kept.json"}},
 	}}}
 	got, err := Build(report, state.Metadata{Entries: []state.Record{record}}, Options{Home: home, SourceRoot: t.TempDir(), ForwardPlan: &forward})
 	if err != nil {
@@ -233,13 +237,17 @@ func TestBuildRejectsPartialRetirementWithUnrelatedForwardAction(t *testing.T) {
 	home := t.TempDir()
 	target := writeTarget(t, home, ".shared.json", `{}`)
 	record, previous := exactSharedJSONRecord(t, target)
+	fingerprint, err := state.RecordEvidenceFingerprint(record)
+	if err != nil {
+		t.Fatal(err)
+	}
 	report := explicitReport(selectionreconciliation.Action{
 		Scope: selectionreconciliation.ScopeManagedEntry, Outcome: selectionreconciliation.OutcomeReconcile, ResolvedTarget: target,
 		PreviousSources: []string{"removed.json", "kept.json"}, CurrentSources: []string{"kept.json"},
 	})
 	base := plan.Action{
 		Source: "kept.json", Target: target, Strategy: "copy", Ownership: "json-subset", Status: plan.StatusUpdate,
-		PreviousContent: previous, Contributions: []plan.Contribution{{Source: "kept.json"}},
+		PreviousContent: previous, PreviousRecordFingerprint: fingerprint, Contributions: []plan.Contribution{{Source: "kept.json"}},
 	}
 	tests := []struct {
 		name string
@@ -303,6 +311,11 @@ func TestBuildRejectsForwardEvidenceFromContradictoryTargetWideRecord(t *testing
 		Source: "kept.json", Target: target, Strategy: "copy", Ownership: "json-subset", Status: plan.StatusUpdate,
 		PreviousContent: contradictory, Contributions: []plan.Contribution{{Source: "kept.json"}},
 	}}}
+	fingerprint, fingerprintErr := state.RecordEvidenceFingerprint(record)
+	if fingerprintErr != nil {
+		t.Fatal(fingerprintErr)
+	}
+	forward.Actions[0].PreviousRecordFingerprint = fingerprint
 
 	_, err := Build(report, state.Metadata{Entries: []state.Record{record}}, Options{Home: home, SourceRoot: t.TempDir(), ForwardPlan: &forward})
 	if err == nil || !strings.Contains(err.Error(), "exact recorded previous contribution evidence") {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -21,7 +21,7 @@ import (
 )
 
 // CurrentVersion is the current Installation Metadata schema version.
-const CurrentVersion = 7
+const CurrentVersion = 8
 
 // Metadata is the machine-readable record of installed managed targets.
 type Metadata struct {
@@ -57,9 +57,10 @@ func (p Provenance) Empty() bool {
 // Record describes a single managed target the CLI installed. Version 4 records
 // explicit whole or partial Ownership; version 5 adds opaque seeded-baseline
 // evidence, version 6 adds opaque byte contribution evidence for TOML subset
-// and marked-block ownership, and version 7 attributes exact ownership evidence
-// to each Source of Truth contribution. An empty Ownership is legacy and grants
-// no force-removal authority.
+// and marked-block ownership, version 7 attributes exact ownership evidence to
+// each Source of Truth contribution, and version 8 adds an exact recovery
+// receipt for an applied reconciliation whose terminal metadata commit has not
+// completed. An empty Ownership is legacy and grants no force-removal authority.
 // Copy-like strategies may record a source content hash; symlink records leave
 // Hash empty because drift is detected from the link destination.
 type Record struct {
@@ -77,10 +78,25 @@ type Record struct {
 	// itself need not be JSON.
 	SeededBaseline []byte         `json:"seeded_baseline,omitempty"`
 	Contributions  []Contribution `json:"contributions,omitempty"`
-	Hash           string         `json:"hash"`
-	InstalledAt    string         `json:"installedAt"`
-	Profiles       []string       `json:"profiles,omitempty"`
-	Tags           []string       `json:"tags,omitempty"`
+	// PendingReconciliation proves the exact live bytes and selected sources
+	// produced by dots before a later terminal step failed. It never replaces
+	// committed contribution evidence or Installed Selection.
+	PendingReconciliation *ReconciliationReceipt `json:"pending_reconciliation,omitempty"`
+	Hash                  string                 `json:"hash"`
+	InstalledAt           string                 `json:"installedAt"`
+	Profiles              []string               `json:"profiles,omitempty"`
+	Tags                  []string               `json:"tags,omitempty"`
+}
+
+// ReconciliationReceipt is a recovery-only proof for a previously applied
+// forward reconciliation. Source hashes bind the receipt to the same selected
+// Source of Truth inputs; TargetHash rejects any later external mutation.
+type ReconciliationReceipt struct {
+	TargetHash   string   `json:"target_hash"`
+	Sources      []string `json:"sources"`
+	SourceHashes []string `json:"source_hashes"`
+	Strategy     string   `json:"strategy"`
+	Ownership    string   `json:"ownership"`
 }
 
 // Contribution records the exact ownership evidence attributable to one
@@ -133,6 +149,12 @@ func (r Record) Clone() Record {
 	cloned.SeededBaseline = append([]byte(nil), r.SeededBaseline...)
 	cloned.Profiles = append([]string(nil), r.Profiles...)
 	cloned.Tags = append([]string(nil), r.Tags...)
+	if r.PendingReconciliation != nil {
+		pending := *r.PendingReconciliation
+		pending.Sources = append([]string(nil), r.PendingReconciliation.Sources...)
+		pending.SourceHashes = append([]string(nil), r.PendingReconciliation.SourceHashes...)
+		cloned.PendingReconciliation = &pending
+	}
 	if r.Contributions != nil {
 		cloned.Contributions = make([]Contribution, len(r.Contributions))
 		for index, contribution := range r.Contributions {
@@ -144,6 +166,25 @@ func (r Record) Clone() Record {
 		}
 	}
 	return cloned
+}
+
+// PendingReconciliationMatches reports whether a recovery receipt proves that
+// the exact live target was produced from the same ordered current sources.
+func (r Record) PendingReconciliationMatches(targetData []byte, strategy, ownership string, sources []string, sourceContents [][]byte) bool {
+	pending := r.PendingReconciliation
+	if pending == nil || pending.TargetHash == "" || pending.Strategy != strategy || pending.Ownership != ownership ||
+		!stringSlicesEqual(pending.Sources, sources) || len(pending.SourceHashes) != len(sourceContents) {
+		return false
+	}
+	if HashBytes(targetData) != pending.TargetHash {
+		return false
+	}
+	for i, content := range sourceContents {
+		if HashBytes(content) != pending.SourceHashes[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // ProvisionerRecord describes the last known result for one selected

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -99,6 +99,17 @@ type ReconciliationReceipt struct {
 	Ownership    string   `json:"ownership"`
 }
 
+// Clone returns an independent receipt snapshot for compare-and-set checks.
+func (r *ReconciliationReceipt) Clone() *ReconciliationReceipt {
+	if r == nil {
+		return nil
+	}
+	cloned := *r
+	cloned.Sources = append([]string(nil), r.Sources...)
+	cloned.SourceHashes = append([]string(nil), r.SourceHashes...)
+	return &cloned
+}
+
 // Contribution records the exact ownership evidence attributable to one
 // selected Source of Truth contribution. SelectorTags identifies the selected
 // declarative Tags that caused this source to contribute. EvidenceRecorded
@@ -189,6 +200,8 @@ func (r Record) PendingReconciliationMatches(targetData []byte, strategy, owners
 
 // RecordEvidenceFingerprint binds an operation to the exact record that
 // authorized it while excluding the recovery receipt that operation may add.
+// Callers compare the expected receipt separately in the same locked
+// transaction.
 func RecordEvidenceFingerprint(record Record) (string, error) {
 	cloned := record.Clone()
 	cloned.PendingReconciliation = nil

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -187,6 +187,18 @@ func (r Record) PendingReconciliationMatches(targetData []byte, strategy, owners
 	return true
 }
 
+// RecordEvidenceFingerprint binds an operation to the exact record that
+// authorized it while excluding the recovery receipt that operation may add.
+func RecordEvidenceFingerprint(record Record) (string, error) {
+	cloned := record.Clone()
+	cloned.PendingReconciliation = nil
+	data, err := json.Marshal(cloned)
+	if err != nil {
+		return "", fmt.Errorf("fingerprint record evidence for %s: %w", record.Target, err)
+	}
+	return HashBytes(data), nil
+}
+
 // ProvisionerRecord describes the last known result for one selected
 // Provisioner command in a profile.
 type ProvisionerRecord struct {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -356,6 +356,43 @@ func TestLoadPreviousMetadataVersionsDoesNotRewriteOrAttribute(t *testing.T) {
 	}
 }
 
+func TestPendingReconciliationMatchesOnlyExactTargetAndOrderedSources(t *testing.T) {
+	target := []byte("target bytes\n")
+	first := []byte("first source\n")
+	second := []byte("second source\n")
+	record := state.Record{PendingReconciliation: &state.ReconciliationReceipt{
+		TargetHash:   state.HashBytes(target),
+		Sources:      []string{"first", "second"},
+		SourceHashes: []string{state.HashBytes(first), state.HashBytes(second)},
+		Strategy:     "copy",
+		Ownership:    "json-subset",
+	}}
+	if !record.PendingReconciliationMatches(target, "copy", "json-subset", []string{"first", "second"}, [][]byte{first, second}) {
+		t.Fatal("exact reconciliation receipt did not match")
+	}
+	tests := []struct {
+		name      string
+		target    []byte
+		strategy  string
+		ownership string
+		sources   []string
+		contents  [][]byte
+	}{
+		{name: "target drift", target: []byte("changed\n"), strategy: "copy", ownership: "json-subset", sources: []string{"first", "second"}, contents: [][]byte{first, second}},
+		{name: "source drift", target: target, strategy: "copy", ownership: "json-subset", sources: []string{"first", "second"}, contents: [][]byte{first, []byte("changed\n")}},
+		{name: "source order", target: target, strategy: "copy", ownership: "json-subset", sources: []string{"second", "first"}, contents: [][]byte{second, first}},
+		{name: "strategy", target: target, strategy: "symlink", ownership: "json-subset", sources: []string{"first", "second"}, contents: [][]byte{first, second}},
+		{name: "ownership", target: target, strategy: "copy", ownership: "whole", sources: []string{"first", "second"}, contents: [][]byte{first, second}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if record.PendingReconciliationMatches(tt.target, tt.strategy, tt.ownership, tt.sources, tt.contents) {
+				t.Fatal("mismatched reconciliation receipt was accepted")
+			}
+		})
+	}
+}
+
 func TestLoadLegacyMetadataHasNoInstalledSelection(t *testing.T) {
 	for _, version := range []int{1, 2} {
 		t.Run(fmt.Sprintf("v%d", version), func(t *testing.T) {

--- a/internal/textblock/textblock.go
+++ b/internal/textblock/textblock.go
@@ -127,8 +127,14 @@ func ValidOwnedSource(source []byte, markers Markers) bool {
 // byte before and after it. Ambiguous placement or markers fail closed.
 func ReconcileOwned(live, previous, current []byte, markers Markers) Reconciliation {
 	liveBlock, ok := parseOwned(live, markers)
-	if !ok || !ValidOwnedSource(previous, markers) || !ValidOwnedSource(current, markers) ||
-		!bytes.Equal(live[liveBlock.start:liveBlock.end], previous) {
+	if !ok || !ValidOwnedSource(previous, markers) || !ValidOwnedSource(current, markers) {
+		return Reconciliation{}
+	}
+	liveOwned := live[liveBlock.start:liveBlock.end]
+	if bytes.Equal(liveOwned, current) {
+		return Reconciliation{Content: append([]byte(nil), live...), Compatible: true}
+	}
+	if !bytes.Equal(liveOwned, previous) {
 		return Reconciliation{}
 	}
 	content := replaceOwned(live, liveBlock.start, liveBlock.end, current)

--- a/internal/textblock/textblock_test.go
+++ b/internal/textblock/textblock_test.go
@@ -18,6 +18,11 @@ func TestOwnedBlockReconciliationFailsClosedAndPreservesExternalBytes(t *testing
 	if !got.Compatible || !got.Changed || !bytes.Equal(got.Content, want) {
 		t.Fatalf("ReconcileOwned() = %#v, want %q", got, want)
 	}
+	alreadyCurrent := append(append(append([]byte(nil), prefix...), current...), suffix...)
+	got = ReconcileOwned(alreadyCurrent, previous, current, markers)
+	if !got.Compatible || got.Changed || !bytes.Equal(got.Content, alreadyCurrent) {
+		t.Fatalf("ReconcileOwned() after partial run = %#v, want unchanged current block", got)
+	}
 	invalid := map[string][]byte{
 		"duplicate":     append(append([]byte(nil), previous...), previous...),
 		"missing close": []byte(markers.Start + "\nsource old\n"),


### PR DESCRIPTION
Closes #467

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Reconcile retained contributions when an explicit Installed Selection reduction removes part of a shared target or retires a source override.
- Preserve unrelated JSON/JSONC/TOML/marked-block bytes and Seeded Runtime State while failing closed on incomplete, contradictory, or concurrently changed evidence.
- Persist exact recovery receipts under serialized metadata authority so terminal failures remain safely rerunnable.

## Changes

| File | Change |
|------|--------|
| `internal/selectionreconciliation`, `internal/selectionretirement`, `internal/plan` | Align the shared report, retirement gate, and forward Install Plan for partial contributions and source overrides. |
| `internal/install`, `internal/state`, `internal/ownershipevidence` | Apply exact source snapshots through confined descriptors and commit version 8 contribution/receipt evidence transactionally. |
| `internal/configsubset`, `internal/textblock` | Preserve unrelated structured bytes during exact three-way subtraction. |
| `internal/cli/*_test.go`, package tests | Cover OpenCode, Antigravity, Codex, Herdr/Zellij, seeded state, failures, concurrency, symlinks, and recovery. |
| `docs/adr/0019-selection-reconciliation-plan.md` | Record the contribution reconciliation and recovery contract. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --output json --file dots.yaml --profile core --source-root "$PWD" --home <tmp>` (expected exit `2`, valid `findings` envelope)
- [x] `go build ./...`
- [x] `go test -race ./internal/configsubset ./internal/state ./internal/ownershipevidence ./internal/plan ./internal/install ./internal/selectionreconciliation ./internal/selectionretirement`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked one issue with an admitted Delivery Contract using `Closes #467`.
- [x] Added exactly one `type:*` label.
- [x] Delivery Evidence records the Contract Source snapshot, Acceptance coverage, and Independent review.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

### Contract Source snapshot

- Kind: composed Delivery Unit.
- Issue #467: `I_kwDOSzLlmM8AAAABNwY2sA`, updated `2026-08-21T20:58:13Z`, body SHA-256 `ac011bbb545ab0dcee428b6dbc6642ee8b1654207123885f010163331dbef0d6`.
- Parent #459: `I_kwDOSzLlmM8AAAABNwWsmQ`, updated `2026-08-21T20:59:00Z`, body SHA-256 `85febbb601376376f0b74c2b155d6556d1f63d209272fdc033a0b178169dc556`.
- Category/readiness: `enhancement`, `ready-for-agent`; no comments.
- Native relationships: parent #459 open; blocked by #466 closed; blocks #469 open; no sub-issues.
- Revalidated before implementation and PR creation without changes.

### Reviewed commit

`06b6fc69abd7d4d4cdf0a0781b6be5b53ece3a3f`

### Acceptance coverage

- OpenCode and Antigravity reductions preserve their selected baseline plus unrelated target-only JSON.
- JSON, JSONC, TOML, and marked-block retirement requires exact compatible contribution evidence and preserves unrelated bytes.
- Adaptive-theme/codegraph override retirement updates selected consumers to their base Source of Truth.
- Seeded Runtime State remains physically present while its ownership record is released.
- Missing, contradictory, stale, symlink-unsafe, or concurrently changed evidence blocks before mutation.
- Successful reconciliation records only retained contributions and commits Installed Selection at terminal success.
- Failure paths retain previous intent and use exact source/target recovery receipts for safe reruns.
- Human and JSON reports share deterministic updated, retained, and blocked classifications.

### Automated validation

- `gofmt -l .` — clean.
- `go vet ./...` — passed.
- `go build ./...` — passed.
- `go test ./...` — passed.
- Focused race suite listed above — passed.
- `go run ./cmd/dots manifest validate --file dots.yaml` — `manifest is valid`.
- Sandboxed JSON plan — expected semantic exit `2` and valid `findings` envelope.

### Manual verification

- Built the real `dots` binary and used the repository's real `dots.yaml` with temporary `--home` and `--state-root` roots.
- OpenCode: installed `opencode` + `opencode-chrome-devtools`, added an unrelated JSON key, reduced to `opencode`, and verified MCP removal, unrelated-key preservation, retained base-only contribution metadata, cleared receipt, and Installed Selection commit.
- Zellij: installed `zellij` + `adaptive-theme`, reduced to `zellij`, and verified the target exactly matched `configs/zellij/config.kdl` with metadata version 8.
- Every sandbox was moved to the operating-system Trash after verification.

### Independent review

- Spec review on exact commit `06b6fc69abd7d4d4cdf0a0781b6be5b53ece3a3f`: no actionable findings.
- Standards review on exact commit `06b6fc69abd7d4d4cdf0a0781b6be5b53ece3a3f`: no actionable findings.
<!-- delivery-issue:evidence:end -->
