### PR TITLE
feat(tui): browse atomic tag selections

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/exp/teatest v0.0.0-20260607010151-cd19a2bba55f
+	github.com/charmbracelet/x/term v0.2.1
 	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/spf13/cobra v1.8.1
 	github.com/tailscale/hujson v0.0.0-20241010212012-29efb4a0184b
@@ -21,7 +22,6 @@ require (
 	github.com/charmbracelet/x/ansi v0.10.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/exp/golden v0.0.0-20240806155701-69247e0abc2a // indirect
-	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -498,7 +498,7 @@ entries:
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"install", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
+	cmd.SetArgs([]string{"install", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
@@ -550,7 +550,7 @@ entries:
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"install", "--dry-run", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
+	cmd.SetArgs([]string{"install", "--dry-run", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
@@ -598,7 +598,7 @@ entries:
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
 	cmd.SetIn(strings.NewReader("r\n"))
-	cmd.SetArgs([]string{"install", "--no-tui", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+	cmd.SetArgs([]string{"install", "--no-tui", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
@@ -650,7 +650,7 @@ entries:
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
 	cmd.SetIn(strings.NewReader("d\ns\n"))
-	cmd.SetArgs([]string{"install", "--no-tui", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
+	cmd.SetArgs([]string{"install", "--no-tui", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
@@ -704,7 +704,7 @@ entries:
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
 	cmd.SetIn(strings.NewReader("d\ns\n"))
-	cmd.SetArgs([]string{"install", "--no-tui", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
+	cmd.SetArgs([]string{"install", "--no-tui", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
@@ -742,7 +742,7 @@ entries:
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
 	cmd.SetIn(strings.NewReader("a\n"))
-	cmd.SetArgs([]string{"install", "--no-tui", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+	cmd.SetArgs([]string{"install", "--no-tui", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
@@ -783,7 +783,7 @@ entries:
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
 	cmd.SetIn(strings.NewReader("r\n"))
-	cmd.SetArgs([]string{"install", "--yes", "--no-tui", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
+	cmd.SetArgs([]string{"install", "--yes", "--no-tui", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
@@ -822,7 +822,7 @@ entries:
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"install", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
+	cmd.SetArgs([]string{"install", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
 
 	if err := cmd.Execute(); err == nil {
 		t.Fatal("Execute() error = nil, want unsafe target error")
@@ -854,7 +854,7 @@ entries:
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"install", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
+	cmd.SetArgs([]string{"install", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
 
 	if err := cmd.Execute(); err == nil {
 		t.Fatal("Execute() error = nil, want unsafe target error")
@@ -890,7 +890,7 @@ entries:
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"install", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
+	cmd.SetArgs([]string{"install", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
 
 	if err := cmd.Execute(); err == nil {
 		t.Fatal("Execute() error = nil, want unsafe source error")
@@ -926,7 +926,7 @@ entries:
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"install", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
+	cmd.SetArgs([]string{"install", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
 
 	if err := cmd.Execute(); err == nil {
 		t.Fatal("Execute() error = nil, want unsafe target error")
@@ -959,7 +959,7 @@ entries:
 	var installOut bytes.Buffer
 	install.SetOut(&installOut)
 	install.SetErr(&installOut)
-	install.SetArgs([]string{"install", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+	install.SetArgs([]string{"install", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
 	if err := install.Execute(); err != nil {
 		t.Fatalf("install Execute() error = %v\noutput:\n%s", err, installOut.String())
 	}
@@ -1804,7 +1804,7 @@ entries:
 		},
 		{
 			name: "install dry run",
-			args: []string{"install", "--dry-run", "--home", home},
+			args: []string{"install", "--dry-run", "--profile", "default", "--home", home},
 			want: "Summary: 1 create, 0 conflict, 0 unchanged, 0 missing-source",
 		},
 		{
@@ -1905,7 +1905,7 @@ func writeCLIInstalledRepository(t *testing.T, sourceRoot, manifestContent strin
 	}
 }
 
-func TestInstallRequiresExplicitProfileWithRepositoryManifest(t *testing.T) {
+func TestInstallRequiresExplicitSelectionWithRepositoryManifest(t *testing.T) {
 	sourceRoot, err := filepath.Abs(filepath.Clean(filepath.Join("..", "..")))
 	if err != nil {
 		t.Fatalf("resolve repository root: %v", err)
@@ -1925,8 +1925,8 @@ func TestInstallRequiresExplicitProfileWithRepositoryManifest(t *testing.T) {
 		"--source-root", sourceRoot,
 		"--state-root", stateRoot,
 	})
-	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "at least one --profile is required") {
-		t.Fatalf("Execute() error = %v, want explicit profile guidance\noutput:\n%s", err, out.String())
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "selection required") {
+		t.Fatalf("Execute() error = %v, want explicit selection guidance\noutput:\n%s", err, out.String())
 	}
 	if entries, err := os.ReadDir(home); err != nil {
 		t.Fatalf("ReadDir(home) error = %v", err)

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -70,10 +70,19 @@ func newInstallCommand() *cobra.Command {
 			if backupAndReplace && !dryRun && !yes {
 				return fmt.Errorf("--backup-and-replace requires --yes for non-interactive conflict replacement")
 			}
+			hasExplicitSelection := len(profiles) > 0 || len(extraTags) > 0 || clearSelection
+			selectorPreview := false
+			if !hasExplicitSelection {
+				if installTagSelectorRequested(cmd, yes, noTUI) {
+					selectorPreview = true
+				} else {
+					return selection.ErrSelectionRequired
+				}
+			}
 
 			prep := installRepositoryPreparation{SourceReadRoot: paths.SourceRoot, LegacyMigrations: map[string]plan.LegacyMigration{}, cleanup: func() {}}
 			defaultRepository := !cmd.Flags().Changed("file") && !cmd.Flags().Changed("source-root")
-			if defaultRepository {
+			if defaultRepository && !selectorPreview {
 				prep, err = prepareInstallRepository(cmd, paths, dryRun)
 				if err != nil {
 					return err
@@ -90,8 +99,14 @@ func newInstallCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			intentProfiles := profiles
-			intentTags := extraTags
+			if selectorPreview {
+				meta, err := loadInstallationMetadata(paths, stateRoot)
+				if err != nil {
+					return err
+				}
+				return runInstallTagSelectorPreview(cmd, *m, meta, paths, prep.SourceReadRoot, prep.LegacyMigrations)
+			}
+
 			var effective selection.Effective
 			if clearSelection {
 				effective, err = selection.ResolveIntent(*m, selection.Intent{
@@ -99,18 +114,10 @@ func newInstallCommand() *cobra.Command {
 					AllowEmpty: true,
 				})
 			} else {
-				if len(intentProfiles) == 0 && len(intentTags) == 0 {
-					requestedSelection, resolveErr := selection.Resolve(*m, nil, nil)
-					if resolveErr != nil {
-						return resolveErr
-					}
-					intentProfiles = requestedSelection.Profiles
-					intentTags = requestedSelection.ExtraTags
-				}
 				effective, err = selection.ResolveIntent(*m, selection.Intent{
 					Source:    selection.SourceExplicit,
-					Profiles:  intentProfiles,
-					ExtraTags: intentTags,
+					Profiles:  profiles,
+					ExtraTags: extraTags,
 				})
 			}
 			if err != nil {
@@ -193,7 +200,6 @@ func newInstallCommand() *cobra.Command {
 				}
 				return nil
 			}
-
 			retirementOptions := selectionretirement.Options{SourceRoot: paths.SourceRoot, Home: paths.Home, StateRoot: paths.StateRoot, ForwardPlan: &p}
 			var selectionRetirementPlan selectionretirement.Plan
 			if p.SelectionReconciliation != nil {

--- a/internal/cli/install_deps_test.go
+++ b/internal/cli/install_deps_test.go
@@ -65,7 +65,7 @@ entries:
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"install", "--yes", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+	cmd.SetArgs([]string{"install", "--yes", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
 
 	err := cmd.Execute()
 	if err == nil {
@@ -99,7 +99,7 @@ func TestInstallRunsDependenciesBeforeManagedConfiguration(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"install", "--yes", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+	cmd.SetArgs([]string{"install", "--yes", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
@@ -138,7 +138,7 @@ func TestInstallValidatesManagedPlanBeforeDependencyMutation(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"install", "--yes", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+	cmd.SetArgs([]string{"install", "--yes", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
 	err := cmd.Execute()
 	if err == nil || !strings.Contains(err.Error(), "missing-source") {
 		t.Fatalf("Execute() error = %v, want preflight missing-source\noutput:\n%s", err, out.String())
@@ -171,7 +171,7 @@ func TestInstallValidatesConfirmedReplacementBeforeDependencyMutation(t *testing
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"install", "--yes", "--backup-and-replace", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+	cmd.SetArgs([]string{"install", "--yes", "--backup-and-replace", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
 	err := cmd.Execute()
 	if err == nil || !strings.Contains(err.Error(), "not a regular file, directory, or symlink") {
 		t.Fatalf("Execute() error = %v, want preflight replacement rejection\noutput:\n%s", err, out.String())
@@ -279,7 +279,7 @@ entries:
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"install", "--skip-deps", "--yes", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+	cmd.SetArgs([]string{"install", "--skip-deps", "--yes", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
@@ -318,7 +318,7 @@ entries:
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"install", "--skip-deps", "--yes", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+	cmd.SetArgs([]string{"install", "--skip-deps", "--yes", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
@@ -376,7 +376,7 @@ provisioners:
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"install", "--yes", "--backup-and-replace", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+	cmd.SetArgs([]string{"install", "--yes", "--backup-and-replace", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
@@ -427,7 +427,7 @@ entries:
 `)
 
 	var out, errOut bytes.Buffer
-	code := cli.Run([]string{"install", "--skip-deps", "--yes", "--backup-and-replace", "--output", "json", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot}, &out, &errOut)
+	code := cli.Run([]string{"install", "--skip-deps", "--yes", "--backup-and-replace", "--output", "json", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot}, &out, &errOut)
 	if code != cli.ExitOK {
 		t.Fatalf("exit code = %d, want 0\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
 	}
@@ -476,7 +476,7 @@ entries:
 `)
 
 	var out, errOut bytes.Buffer
-	code := cli.Run([]string{"install", "--skip-deps", "--backup-and-replace", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot}, &out, &errOut)
+	code := cli.Run([]string{"install", "--skip-deps", "--backup-and-replace", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot}, &out, &errOut)
 	if code != cli.ExitError {
 		t.Fatalf("exit code = %d, want 1\nstdout:\n%s\nstderr:\n%s", code, out.String(), errOut.String())
 	}
@@ -519,7 +519,7 @@ entries:
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
 	cmd.SetIn(strings.NewReader("n\n"))
-	cmd.SetArgs([]string{"install", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+	cmd.SetArgs([]string{"install", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v, want optional dependency to be non-blocking\noutput:\n%s", err, out.String())
@@ -567,7 +567,7 @@ entries:
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"install", "--yes", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+	cmd.SetArgs([]string{"install", "--yes", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v, want optional dependency to be non-blocking\noutput:\n%s", err, out.String())
@@ -591,7 +591,7 @@ func TestInstallDryRunJSONIncludesDependencyPreviewAndInstallPlan(t *testing.T) 
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"install", "--dry-run", "--output", "json", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
+	cmd.SetArgs([]string{"install", "--dry-run", "--output", "json", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
@@ -640,7 +640,7 @@ func TestInstallDryRunClassifiesMissingFNMToolchainAsInstallableWhenHomebrewIsAv
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"install", "--dry-run", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
+	cmd.SetArgs([]string{"install", "--dry-run", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
@@ -690,7 +690,7 @@ entries:
 `)
 
 	var out, errOut bytes.Buffer
-	code := cli.Run([]string{"install", "--yes", "--output", "json", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot}, &out, &errOut)
+	code := cli.Run([]string{"install", "--yes", "--output", "json", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot}, &out, &errOut)
 	if code != cli.ExitError {
 		t.Fatalf("exit code = %d, want %d\nstderr:\n%s\nstdout:\n%s", code, cli.ExitError, errOut.String(), out.String())
 	}

--- a/internal/cli/install_pkgmgr_test.go
+++ b/internal/cli/install_pkgmgr_test.go
@@ -98,7 +98,7 @@ func TestInstallDryRunJSONReportsHomebrewPackageManagerSetupSeparately(t *testin
 		Exists:   func(path string) bool { return false },
 	}, &recordingPkgMgrRunner{})
 
-	out, err := runInstallCommand(t, "", "install", "--dry-run", "--output", "json", "--file", manifestPath, "--home", home, "--source-root", sourceRoot)
+	out, err := runInstallCommand(t, "", "install", "--dry-run", "--output", "json", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot)
 	if err != nil {
 		t.Fatalf("install --dry-run error = %v\n%s", err, out)
 	}
@@ -142,7 +142,7 @@ func TestInstallYesDoesNotRunHomebrewPackageManagerSetup(t *testing.T) {
 		Exists:   func(path string) bool { return false },
 	}, runner)
 
-	out, err := runInstallCommand(t, "", "install", "--yes", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot)
+	out, err := runInstallCommand(t, "", "install", "--yes", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot)
 	if err == nil {
 		t.Fatalf("install --yes error = nil, want interactive setup error\n%s", out)
 	}
@@ -164,7 +164,7 @@ func TestInstallYesJSONReportsHomebrewPackageManagerSetupGate(t *testing.T) {
 	}, runner)
 
 	var out, errOut bytes.Buffer
-	code := Run([]string{"install", "--yes", "--output", "json", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot}, &out, &errOut)
+	code := Run([]string{"install", "--yes", "--output", "json", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot}, &out, &errOut)
 	if code != ExitError {
 		t.Fatalf("exit code = %d, want %d\nstderr:\n%s\nstdout:\n%s", code, ExitError, errOut.String(), out.String())
 	}
@@ -221,7 +221,7 @@ func TestInstallDecliningHomebrewSetupAbortsBeforeManagedConfiguration(t *testin
 		Exists:   func(path string) bool { return false },
 	}, &recordingPkgMgrRunner{})
 
-	out, err := runInstallCommand(t, "n\n", "install", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot)
+	out, err := runInstallCommand(t, "n\n", "install", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot)
 	if err != nil {
 		t.Fatalf("install decline error = %v\n%s", err, out)
 	}
@@ -257,7 +257,7 @@ func TestInstallAcceptingHomebrewSetupUsesPrefixBrewForCurrentRun(t *testing.T) 
 		Prefixes: []string{brewPath},
 	}, runner)
 
-	out, err := runInstallCommand(t, "y\ny\n", "install", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot)
+	out, err := runInstallCommand(t, "y\ny\n", "install", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot)
 	if err != nil {
 		t.Fatalf("install accept error = %v\n%s", err, out)
 	}

--- a/internal/cli/install_provision_test.go
+++ b/internal/cli/install_provision_test.go
@@ -102,7 +102,7 @@ func TestInstallDryRunRendersProvisionerWithoutInvoking(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"install", "--dry-run", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
+	cmd.SetArgs([]string{"install", "--dry-run", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
@@ -158,7 +158,7 @@ entries:
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"install", "--yes", "--skip-deps", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+	cmd.SetArgs([]string{"install", "--yes", "--skip-deps", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("install error = %v\noutput:\n%s", err, out.String())
 	}
@@ -176,7 +176,7 @@ entries:
 	dryRun := cli.NewRootCommand()
 	dryRun.SetOut(&out)
 	dryRun.SetErr(&out)
-	dryRun.SetArgs([]string{"install", "--dry-run", "--skip-deps", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+	dryRun.SetArgs([]string{"install", "--dry-run", "--skip-deps", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
 	if err := dryRun.Execute(); err != nil {
 		t.Fatalf("dry-run error = %v", err)
 	}
@@ -208,7 +208,7 @@ func TestInstallExecutesProvisionerAfterFilesWithHomeThreaded(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"install", "--yes", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot})
+	cmd.SetArgs([]string{"install", "--yes", "--profile", "default", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
@@ -276,7 +276,7 @@ provisioners:
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"install", "--yes", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot})
+	cmd.SetArgs([]string{"install", "--yes", "--profile", "default", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
@@ -335,7 +335,7 @@ provisioners:
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"install", "--yes", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot})
+	cmd.SetArgs([]string{"install", "--yes", "--profile", "default", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
@@ -401,7 +401,7 @@ provisioners:
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"install", "--yes", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot})
+	cmd.SetArgs([]string{"install", "--yes", "--profile", "default", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
@@ -453,7 +453,7 @@ provisioners:
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"install", "--yes", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot})
+	cmd.SetArgs([]string{"install", "--yes", "--profile", "default", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
@@ -505,7 +505,7 @@ provisioners:
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"install", "--yes", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot})
+	cmd.SetArgs([]string{"install", "--yes", "--profile", "default", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
@@ -813,7 +813,7 @@ provisioners:
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"install", "--yes", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot})
+	cmd.SetArgs([]string{"install", "--yes", "--profile", "default", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
@@ -939,7 +939,7 @@ func TestInstallPersistsFailedProvisionerForStatusResumeGuidance(t *testing.T) {
 	var installOut bytes.Buffer
 	installCmd.SetOut(&installOut)
 	installCmd.SetErr(&installOut)
-	installCmd.SetArgs([]string{"install", "--yes", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot})
+	installCmd.SetArgs([]string{"install", "--yes", "--profile", "default", "--file", manifestPath, "--home", sandboxHome, "--source-root", sourceRoot, "--state-root", stateRoot})
 
 	if err := installCmd.Execute(); err == nil {
 		t.Fatalf("install error = nil, want failing provisioner\noutput:\n%s", installOut.String())

--- a/internal/cli/install_restore_e2e_test.go
+++ b/internal/cli/install_restore_e2e_test.go
@@ -51,6 +51,7 @@ entries:
 
 	installOut, err := runRootCommand(t, "r\n",
 		"install",
+		"--profile", "default",
 		"--file", manifestPath,
 		"--home", home,
 		"--source-root", sourceRoot,

--- a/internal/cli/install_selection_test.go
+++ b/internal/cli/install_selection_test.go
@@ -751,8 +751,8 @@ provisioners:
 		"--state-root", stateRoot,
 	})
 	err := cmd.Execute()
-	if err == nil || !strings.Contains(err.Error(), "at least one --profile is required") {
-		t.Fatalf("Execute() error = %v, want explicit Profile guidance\noutput:\n%s", err, out.String())
+	if err == nil || !strings.Contains(err.Error(), "selection required") {
+		t.Fatalf("Execute() error = %v, want explicit selection guidance\noutput:\n%s", err, out.String())
 	}
 	if _, err := os.Lstat(filepath.Join(home, ".zshrc")); !os.IsNotExist(err) {
 		t.Fatalf("target mutated without Profile; lstat err = %v", err)

--- a/internal/cli/install_tag_selector.go
+++ b/internal/cli/install_tag_selector.go
@@ -1,0 +1,561 @@
+package cli
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/x/term"
+	"github.com/spf13/cobra"
+	"github.com/yersonargotev/dots/internal/catalog"
+	"github.com/yersonargotev/dots/internal/deps"
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/plan"
+	"github.com/yersonargotev/dots/internal/provision"
+	"github.com/yersonargotev/dots/internal/selection"
+	"github.com/yersonargotev/dots/internal/state"
+	"github.com/yersonargotev/dots/internal/status"
+	tagselectortui "github.com/yersonargotev/dots/internal/tui/tagselector"
+)
+
+type installTagSelectorRunnerFunc func(io.Reader, io.Writer, tagselectortui.BrowseData, []string, tagselectortui.PreviewFunc) (tagselectortui.Result, error)
+
+var (
+	installTagSelectorRunner   installTagSelectorRunnerFunc = tagselectortui.Run
+	installTagSelectorTerminal                              = interactiveTerminal
+)
+
+type terminalFile interface {
+	Fd() uintptr
+}
+
+func interactiveTerminal(in io.Reader, out io.Writer) bool {
+	input, inputOK := in.(terminalFile)
+	output, outputOK := out.(terminalFile)
+	return inputOK && outputOK && term.IsTerminal(input.Fd()) && term.IsTerminal(output.Fd())
+}
+
+func installTagSelectorRequested(cmd *cobra.Command, yes, noTUI bool) bool {
+	return !yes && !noTUI && !wantsJSON(cmd) && installTagSelectorTerminal(cmd.InOrStdin(), cmd.OutOrStdout())
+}
+
+func runInstallTagSelectorPreview(cmd *cobra.Command, m manifest.Manifest, meta state.Metadata, paths resolvedPaths, sourceReadRoot string, legacyMigrations map[string]plan.LegacyMigration) error {
+	initial, err := resolveInstallTagSelectorInitial(m, meta.InstalledSelection)
+	if err != nil {
+		return err
+	}
+	browseData, err := buildInstallTagSelectorBrowseData(m, meta, tagSelectorBrowseOptions{
+		OS:             installHostOS,
+		Arch:           installHostArch,
+		SourceReadRoot: sourceReadRoot,
+		Home:           paths.Home,
+		StateRoot:      paths.StateRoot,
+		XDGStateHome:   paths.XDGStateHome,
+		Lookup:         lookupCommand,
+		FontLookup:     fontInstalled(installHostOS, paths.Home),
+		AppLookup:      appInstalled(installHostOS, paths.Home),
+		CommandRunner:  commandOutput,
+	})
+	if err != nil {
+		return err
+	}
+	preview := func(tags []string) (tagselectortui.Preview, error) {
+		return buildInstallTagSelectorPreview(m, meta, paths, sourceReadRoot, legacyMigrations, installHostOS, tags)
+	}
+	result, err := installTagSelectorRunner(cmd.InOrStdin(), cmd.OutOrStdout(), browseData, initial, preview)
+	if errors.Is(err, tagselectortui.ErrCanceled) {
+		fmt.Fprintln(cmd.OutOrStdout(), "Tag selection canceled; nothing was applied.")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("run Tag selector: %w", err)
+	}
+	if result.Preview.SemanticDigest == "" {
+		return fmt.Errorf("run Tag selector: completed without an accepted preview")
+	}
+	if result.Preview.Text != "" {
+		fmt.Fprint(cmd.OutOrStdout(), result.Preview.Text)
+		if !strings.HasSuffix(result.Preview.Text, "\n") {
+			fmt.Fprintln(cmd.OutOrStdout())
+		}
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "Selection preview only; nothing was applied.")
+	return nil
+}
+
+type tagSelectorBrowseOptions struct {
+	OS             string
+	Arch           string
+	SourceReadRoot string
+	Home           string
+	StateRoot      string
+	XDGStateHome   string
+	Lookup         deps.Lookup
+	FontLookup     deps.FontLookup
+	AppLookup      deps.AppLookup
+	CommandRunner  deps.CommandRunner
+}
+
+var tagSelectorGroups = []struct {
+	Profile string
+	Label   string
+}{
+	{Profile: "core", Label: "Core"},
+	{Profile: "desktop", Label: "Desktop"},
+	{Profile: "agents", Label: "Agents"},
+	{Profile: "web", Label: "Web"},
+	{Profile: "mobile", Label: "Mobile"},
+}
+
+func buildInstallTagSelectorBrowseData(m manifest.Manifest, meta state.Metadata, opts tagSelectorBrowseOptions) (tagselectortui.BrowseData, error) {
+	report, err := catalog.Build(m, catalog.Options{OS: opts.OS})
+	if err != nil {
+		return tagselectortui.BrowseData{}, fmt.Errorf("build Tag selector browse data from Install Catalog: %w", err)
+	}
+
+	currentTags := make(map[string]catalog.TagSummary, len(report.Tags))
+	for _, tag := range report.Tags {
+		currentTags[tag.Name] = tag
+	}
+	profileOrder := orderedTagSelectorProfiles(report.Profiles)
+	profileByName := make(map[string]catalog.ProfileSummary, len(report.Profiles))
+	profileTags := make(map[string][]string, len(report.Profiles))
+	memberships := make(map[string][]string, len(report.Tags))
+	for _, profile := range report.Profiles {
+		profileByName[profile.Name] = profile
+		resolved, _, normalizeErr := manifest.NormalizeTags(m, profile.Tags)
+		if normalizeErr != nil {
+			return tagselectortui.BrowseData{}, fmt.Errorf("normalize Tag selector Profile %q: %w", profile.Name, normalizeErr)
+		}
+		for _, tag := range resolved {
+			if _, ok := currentTags[tag]; !ok {
+				continue
+			}
+			profileTags[profile.Name] = appendUniqueString(profileTags[profile.Name], tag)
+		}
+	}
+	for _, profileName := range profileOrder {
+		for _, tag := range profileTags[profileName] {
+			memberships[tag] = append(memberships[tag], profileName)
+		}
+	}
+
+	orderedTags := make([]string, 0, len(report.Tags))
+	groups := make(map[string]string, len(report.Tags))
+	for _, group := range tagSelectorGroups {
+		for _, tag := range profileTags[group.Profile] {
+			if _, grouped := groups[tag]; grouped {
+				continue
+			}
+			groups[tag] = group.Label
+			orderedTags = append(orderedTags, tag)
+		}
+	}
+	remaining := make([]string, 0, len(report.Tags))
+	for _, tag := range report.Tags {
+		if _, grouped := groups[tag.Name]; grouped {
+			continue
+		}
+		groups[tag.Name] = "Global"
+		remaining = append(remaining, tag.Name)
+	}
+	sort.Strings(remaining)
+	orderedTags = append(orderedTags, remaining...)
+
+	result := tagselectortui.BrowseData{Tags: []tagselectortui.Tag{}, Profiles: []tagselectortui.Profile{}}
+	for _, profileName := range profileOrder {
+		profile := profileByName[profileName]
+		result.Profiles = append(result.Profiles, tagselectortui.Profile{
+			Name:        profile.Name,
+			Description: profile.Description,
+			Tags:        append([]string(nil), profileTags[profileName]...),
+		})
+	}
+	for _, tagName := range orderedTags {
+		tag, buildErr := buildInstallTagSelectorTag(m, meta, currentTags[tagName], groups[tagName], memberships[tagName], opts)
+		if buildErr != nil {
+			return tagselectortui.BrowseData{}, buildErr
+		}
+		result.Tags = append(result.Tags, tag)
+	}
+	return result, nil
+}
+
+func orderedTagSelectorProfiles(profiles []catalog.ProfileSummary) []string {
+	available := make(map[string]bool, len(profiles))
+	for _, profile := range profiles {
+		available[profile.Name] = true
+	}
+	result := make([]string, 0, len(profiles))
+	seen := make(map[string]bool, len(profiles))
+	for _, group := range tagSelectorGroups {
+		if available[group.Profile] {
+			result = append(result, group.Profile)
+			seen[group.Profile] = true
+		}
+	}
+	var remaining []string
+	for _, profile := range profiles {
+		if !seen[profile.Name] {
+			remaining = append(remaining, profile.Name)
+		}
+	}
+	sort.Strings(remaining)
+	return append(result, remaining...)
+}
+
+func buildInstallTagSelectorTag(m manifest.Manifest, meta state.Metadata, summary catalog.TagSummary, group string, profiles []string, opts tagSelectorBrowseOptions) (tagselectortui.Tag, error) {
+	effective, err := selection.ResolveIntent(m, selection.Intent{Source: selection.SourceExplicit, ExtraTags: []string{summary.Name}})
+	if err != nil {
+		return tagselectortui.Tag{}, fmt.Errorf("resolve Tag selector Tag %q: %w", summary.Name, err)
+	}
+	detailReport, err := catalog.Tag(m, summary.Name, catalog.Options{OS: opts.OS})
+	if err != nil {
+		return tagselectortui.Tag{}, fmt.Errorf("describe Tag selector Tag %q: %w", summary.Name, err)
+	}
+	detail := detailReport.Tag
+	portableReport, err := catalog.Tag(m, summary.Name, catalog.Options{OS: "all"})
+	if err != nil {
+		return tagselectortui.Tag{}, fmt.Errorf("describe portable Tag selector Tag %q: %w", summary.Name, err)
+	}
+	portable := portableReport.Tag
+
+	entryReport, err := status.Build(m, meta, status.Options{
+		Selection:    &effective.Selection,
+		OS:           opts.OS,
+		SourceRoot:   opts.SourceReadRoot,
+		Home:         opts.Home,
+		XDGStateHome: opts.XDGStateHome,
+	})
+	if err != nil {
+		return tagselectortui.Tag{}, fmt.Errorf("inspect Tag selector Tag %q: %w", summary.Name, err)
+	}
+	dependencyReport, err := deps.CheckWithToolProbes(m, deps.Options{
+		Selection: &effective.Selection,
+		OS:        opts.OS,
+		Arch:      opts.Arch,
+		Home:      opts.Home,
+		StateRoot: opts.StateRoot,
+		AppLookup: opts.AppLookup,
+	}, opts.Lookup, opts.FontLookup, opts.CommandRunner)
+	if err != nil {
+		return tagselectortui.Tag{}, fmt.Errorf("inspect Tag selector Dependencies for %q: %w", summary.Name, err)
+	}
+	provisionPlan, err := provision.Build(m, provision.Options{Selection: &effective.Selection, OS: opts.OS, AppLookup: opts.AppLookup})
+	if err != nil {
+		return tagselectortui.Tag{}, fmt.Errorf("inspect Tag selector Provisioners for %q: %w", summary.Name, err)
+	}
+	provisionReport := buildTagSelectorProvisionStatus(m, provisionPlan, meta, summary.Name)
+
+	result := tagselectortui.Tag{
+		Name:           summary.Name,
+		Description:    summary.Description,
+		Group:          group,
+		Profiles:       append([]string(nil), profiles...),
+		Components:     []tagselectortui.Component{},
+		ManagedEntries: []string{},
+		Dependencies:   []string{},
+		Provisioners:   []string{},
+	}
+	for _, entry := range portable.Entries {
+		result.ManagedEntries = appendUniqueString(result.ManagedEntries, entry.Target)
+	}
+	for _, override := range portable.SourceOverrides {
+		result.ManagedEntries = appendUniqueString(result.ManagedEntries, override.Target)
+	}
+	for _, dependency := range portable.Dependencies {
+		result.Dependencies = appendUniqueString(result.Dependencies, dependency.Name)
+	}
+	for _, item := range portable.Provisioners {
+		result.Provisioners = appendUniqueString(result.Provisioners, item.Tool)
+	}
+	for _, entry := range entryReport.Entries {
+		componentDetail := entry.Reason
+		if entry.State == status.StateUnsupported && componentDetail == "" {
+			componentDetail = "alignment unsupported"
+		}
+		result.Components = append(result.Components, tagselectortui.Component{
+			Kind: "Managed Entry", Name: entry.Target, State: tagSelectorManagedEntryState(entry.State), Detail: componentDetail,
+		})
+		result.ManagedEntries = appendUniqueString(result.ManagedEntries, entry.Target)
+	}
+	for _, dependency := range dependencyReport.Results {
+		detailText := dependency.Warning
+		if detailText == "" {
+			detailText = dependency.Command
+		}
+		result.Components = append(result.Components, tagselectortui.Component{
+			Kind: "Dependency", Name: dependency.Name, State: tagSelectorDependencyState(dependency), Detail: detailText,
+		})
+		result.Dependencies = appendUniqueString(result.Dependencies, dependency.Name)
+		result.ExternalEffectsPresent = result.ExternalEffectsPresent || dependency.Present
+	}
+	for _, item := range provisionReport.Items {
+		detailText := strings.Join(item.Missing, ", ")
+		if detailText == "" {
+			detailText = item.LastRunAt
+		}
+		result.Components = append(result.Components, tagselectortui.Component{
+			Kind: "Provisioner", Name: item.Tool, State: tagSelectorProvisionerState(item.Status), Detail: detailText,
+		})
+		result.Provisioners = appendUniqueString(result.Provisioners, item.Tool)
+		result.ExternalEffectsPresent = result.ExternalEffectsPresent || item.Status == provision.StatusStateProvisioned
+	}
+	applicableDependencies := make(map[string]bool, len(dependencyReport.Results))
+	for _, dependency := range dependencyReport.Results {
+		applicableDependencies[dependency.Name] = true
+	}
+	excludedDependencies := make(map[string]bool)
+	for _, dependency := range portable.Dependencies {
+		if applicableDependencies[dependency.Name] || excludedDependencies[dependency.Name] {
+			continue
+		}
+		excludedDependencies[dependency.Name] = true
+		result.Components = append(result.Components, tagselectortui.Component{
+			Kind: "Dependency", Name: dependency.Name, State: tagselectortui.StateNotApplicable, Detail: "not applicable to " + opts.OS,
+		})
+	}
+	for _, excluded := range detail.Excluded {
+		if excluded.Type == "dependency_set" {
+			continue
+		}
+		result.Components = append(result.Components, tagselectortui.Component{
+			Kind: tagSelectorComponentKind(excluded.Type), Name: excluded.Name, State: tagselectortui.StateNotApplicable, Detail: excluded.Reason,
+		})
+	}
+	result.State = aggregateTagSelectorState(result.Components)
+	return result, nil
+}
+
+func tagSelectorComponentKind(kind string) string {
+	switch kind {
+	case "entry":
+		return "Managed Entry"
+	case "provisioner":
+		return "Provisioner"
+	case "source_override":
+		return "Source Override"
+	default:
+		return "Selected Surface"
+	}
+}
+
+func appendUniqueString(values []string, value string) []string {
+	if value == "" {
+		return values
+	}
+	for _, existing := range values {
+		if existing == value {
+			return values
+		}
+	}
+	return append(values, value)
+}
+
+func tagSelectorManagedEntryState(value status.State) tagselectortui.State {
+	switch value {
+	case status.StateOK:
+		return tagselectortui.StateAligned
+	case status.StateMissing:
+		return tagselectortui.StateMissing
+	case status.StateDrifted:
+		return tagselectortui.StateDrift
+	case status.StateSkipped:
+		return tagselectortui.StateNotApplicable
+	case status.StateConflict, status.StateUnsupported:
+		return tagselectortui.StateConflict
+	default:
+		return tagselectortui.StateConflict
+	}
+}
+
+func tagSelectorDependencyState(value deps.Result) tagselectortui.State {
+	if !value.Present {
+		return tagselectortui.StateMissing
+	}
+	if value.Warning != "" {
+		return tagselectortui.StateDrift
+	}
+	return tagselectortui.StateAligned
+}
+
+func tagSelectorProvisionerState(value provision.StatusState) tagselectortui.State {
+	switch value {
+	case provision.StatusStateProvisioned:
+		return tagselectortui.StateAligned
+	case provision.StatusStatePending, provision.StatusStateMissingDependencies:
+		return tagselectortui.StateMissing
+	case provision.StatusStateFailed:
+		return tagselectortui.StateConflict
+	default:
+		return tagselectortui.StateConflict
+	}
+}
+
+func buildTagSelectorProvisionStatus(m manifest.Manifest, plan provision.Plan, meta state.Metadata, tag string) provision.StatusReport {
+	selectorMeta := state.Metadata{Provisioners: make([]state.ProvisionerRecord, 0, len(plan.Steps))}
+	for _, step := range plan.Steps {
+		record, ok := findTagSelectorProvisionerRecord(m, meta.Provisioners, tag, step)
+		if !ok {
+			continue
+		}
+		record.Profile = plan.Profile
+		selectorMeta.Provisioners = append(selectorMeta.Provisioners, record)
+	}
+	return provision.BuildStatus(plan, selectorMeta)
+}
+
+func findTagSelectorProvisionerRecord(m manifest.Manifest, records []state.ProvisionerRecord, tag string, step provision.Step) (state.ProvisionerRecord, bool) {
+	var tagged state.ProvisionerRecord
+	hasMatchingTag := false
+	var legacy state.ProvisionerRecord
+	hasLegacy := false
+	hasTagged := false
+	for _, record := range records {
+		if record.Tool != step.Tool || record.Executable != step.Executable || !slices.Equal(record.Args, step.Args) {
+			continue
+		}
+		if len(record.Tags) == 0 {
+			if !hasLegacy || tagSelectorProvisionerRecordIsNewer(record, legacy) {
+				legacy, hasLegacy = record, true
+			}
+			continue
+		}
+		hasTagged = true
+		normalizedTags := normalizeTagSelectorProvisionerRecordTags(m, record.Tags)
+		if slices.Contains(normalizedTags, tag) && (!hasMatchingTag || tagSelectorProvisionerRecordIsNewer(record, tagged)) {
+			tagged, hasMatchingTag = record, true
+		}
+	}
+	if hasMatchingTag {
+		return tagged, true
+	}
+	if hasTagged {
+		return state.ProvisionerRecord{}, false
+	}
+	return legacy, hasLegacy
+}
+
+func normalizeTagSelectorProvisionerRecordTags(m manifest.Manifest, tags []string) []string {
+	var normalized []string
+	for _, tag := range tags {
+		resolved, _, err := manifest.NormalizeTags(m, []string{tag})
+		if err != nil {
+			continue
+		}
+		for _, current := range resolved {
+			normalized = appendUniqueString(normalized, current)
+		}
+	}
+	return normalized
+}
+
+// tagSelectorProvisionerRecordIsNewer prefers valid persisted timestamps. A
+// later metadata entry breaks absent, invalid, or equal timestamp ties.
+func tagSelectorProvisionerRecordIsNewer(candidate, current state.ProvisionerRecord) bool {
+	candidateTime, candidateErr := time.Parse(time.RFC3339Nano, candidate.LastRunAt)
+	currentTime, currentErr := time.Parse(time.RFC3339Nano, current.LastRunAt)
+	candidateOK := candidateErr == nil
+	currentOK := currentErr == nil
+	switch {
+	case candidateOK && !currentOK:
+		return true
+	case !candidateOK && currentOK:
+		return false
+	case candidateOK && currentOK && !candidateTime.Equal(currentTime):
+		return candidateTime.After(currentTime)
+	default:
+		return true
+	}
+}
+
+func aggregateTagSelectorState(components []tagselectortui.Component) tagselectortui.State {
+	if len(components) == 0 {
+		return tagselectortui.StateNotApplicable
+	}
+	precedence := map[tagselectortui.State]int{
+		tagselectortui.StateNotApplicable: 0,
+		tagselectortui.StateAligned:       1,
+		tagselectortui.StateMissing:       2,
+		tagselectortui.StateDrift:         3,
+		tagselectortui.StateConflict:      4,
+	}
+	result := tagselectortui.StateNotApplicable
+	for _, component := range components {
+		if precedence[component.State] > precedence[result] {
+			result = component.State
+		}
+	}
+	return result
+}
+
+func resolveInstallTagSelectorInitial(m manifest.Manifest, installed *state.InstalledSelection) ([]string, error) {
+	if installed == nil {
+		return []string{}, nil
+	}
+	effective, err := selection.ResolveIntent(m, selection.Intent{
+		Source:     selection.SourceRecorded,
+		Profiles:   installed.Profiles,
+		ExtraTags:  installed.ExtraTags,
+		AllowEmpty: len(installed.Profiles) == 0 && len(installed.ExtraTags) == 0,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("load Installed Selection for Tag selector: %w", err)
+	}
+	return append([]string(nil), effective.Selection.Tags...), nil
+}
+
+func buildInstallTagSelectorPreview(m manifest.Manifest, meta state.Metadata, paths resolvedPaths, sourceReadRoot string, legacyMigrations map[string]plan.LegacyMigration, hostOS string, tags []string) (tagselectortui.Preview, error) {
+	effective, err := selection.ResolveIntent(m, selection.Intent{
+		Source:     selection.SourceExplicit,
+		ExtraTags:  append([]string(nil), tags...),
+		AllowEmpty: len(tags) == 0,
+	})
+	if err != nil {
+		return tagselectortui.Preview{}, fmt.Errorf("resolve Tag selector draft: %w", err)
+	}
+	effective = selection.CompareInstalled(m, effective, meta.InstalledSelection, hostOS)
+	p, provisionPlan, err := buildInstallPlanAndProvisioners(m, meta, effective.Selection, hostOS, paths, sourceReadRoot, legacyMigrations)
+	if err != nil {
+		return tagselectortui.Preview{}, fmt.Errorf("build Tag selector preview: %w", err)
+	}
+	p.Selection = &effective.Report
+	p.SelectionReconciliation, err = buildSelectionReconciliation(m, meta, effective, p, hostOS, paths, sourceReadRoot, true)
+	if err != nil {
+		return tagselectortui.Preview{}, fmt.Errorf("build Tag selector reconciliation preview: %w", err)
+	}
+
+	forwardOnly := meta.InstalledSelection == nil
+	var rendered bytes.Buffer
+	if forwardOnly {
+		fmt.Fprintln(&rendered, "Forward-only selection preview")
+		fmt.Fprintln(&rendered, "No Installed Selection is recorded; no retirement is authorized.")
+		fmt.Fprintln(&rendered)
+	}
+	renderPlan(&rendered, p)
+	renderProvisionPlan(&rendered, provisionPlan)
+
+	semantic := struct {
+		ForwardOnly  bool             `json:"forward_only"`
+		Selection    selection.Report `json:"selection"`
+		Plan         plan.Plan        `json:"plan"`
+		Provisioners provision.Plan   `json:"provisioners"`
+	}{
+		ForwardOnly: forwardOnly, Selection: effective.Report, Plan: p, Provisioners: provisionPlan,
+	}
+	encoded, err := json.Marshal(semantic)
+	if err != nil {
+		return tagselectortui.Preview{}, fmt.Errorf("encode Tag selector preview: %w", err)
+	}
+	digest := sha256.Sum256(encoded)
+	return tagselectortui.Preview{
+		Text: rendered.String(), SemanticDigest: fmt.Sprintf("sha256:%x", digest), ForwardOnly: forwardOnly,
+	}, nil
+}

--- a/internal/cli/install_tag_selector_internal_test.go
+++ b/internal/cli/install_tag_selector_internal_test.go
@@ -1,0 +1,752 @@
+package cli
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/deps"
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/provision"
+	"github.com/yersonargotev/dots/internal/selection"
+	"github.com/yersonargotev/dots/internal/state"
+	"github.com/yersonargotev/dots/internal/status"
+	tagselectortui "github.com/yersonargotev/dots/internal/tui/tagselector"
+)
+
+func TestInstallTagSelectorRouting(t *testing.T) {
+	manifestPath, sourceRoot, home, stateRoot := writeTagSelectorTestManifest(t)
+	base := []string{"install", "--dry-run", "--skip-deps", "--file", manifestPath, "--source-root", sourceRoot, "--home", home, "--state-root", stateRoot}
+
+	t.Run("interactive terminal previews without applying", func(t *testing.T) {
+		called := 0
+		setInstallTagSelectorTestHooks(t, true, func(_ io.Reader, _ io.Writer, _ tagselectortui.BrowseData, initial []string, preview tagselectortui.PreviewFunc) (tagselectortui.Result, error) {
+			called++
+			if len(initial) != 0 {
+				t.Fatalf("initial Tags = %v, want empty without Installed Selection", initial)
+			}
+			built, err := preview([]string{"one"})
+			return tagselectortui.Result{Tags: []string{"one"}, Preview: built}, err
+		})
+		cmd := NewRootCommand()
+		var out bytes.Buffer
+		cmd.SetIn(strings.NewReader(""))
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+		cmd.SetArgs(base)
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v\n%s", err, out.String())
+		}
+		if called != 1 {
+			t.Fatalf("selector calls = %d, want 1", called)
+		}
+		for _, want := range []string{"Forward-only selection preview", "Selection preview only; nothing was applied."} {
+			if !strings.Contains(out.String(), want) {
+				t.Fatalf("output missing %q\n%s", want, out.String())
+			}
+		}
+		if _, err := os.Stat(state.Path(stateRoot)); !os.IsNotExist(err) {
+			t.Fatalf("Installation Metadata exists after preview-only selector: %v", err)
+		}
+	})
+
+	t.Run("bypass modes reject missing selection", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			terminal bool
+			prefix   []string
+			extra    []string
+		}{
+			{name: "non-terminal", terminal: false},
+			{name: "JSON", terminal: true, prefix: []string{"--output", "json"}},
+			{name: "confirmed", terminal: true, extra: []string{"--yes"}},
+			{name: "text prompt", terminal: true, extra: []string{"--no-tui"}},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				called := 0
+				setInstallTagSelectorTestHooks(t, tt.terminal, func(io.Reader, io.Writer, tagselectortui.BrowseData, []string, tagselectortui.PreviewFunc) (tagselectortui.Result, error) {
+					called++
+					return tagselectortui.Result{}, nil
+				})
+				cmd := NewRootCommand()
+				cmd.SetArgs(append(append(append([]string{}, tt.prefix...), base...), tt.extra...))
+				err := cmd.Execute()
+				if !errors.Is(err, selection.ErrSelectionRequired) {
+					t.Fatalf("Execute() error = %v, want selection required", err)
+				}
+				if called != 0 {
+					t.Fatalf("selector calls = %d, want 0", called)
+				}
+			})
+		}
+	})
+
+	t.Run("explicit selection bypasses selector", func(t *testing.T) {
+		called := 0
+		setInstallTagSelectorTestHooks(t, true, func(io.Reader, io.Writer, tagselectortui.BrowseData, []string, tagselectortui.PreviewFunc) (tagselectortui.Result, error) {
+			called++
+			return tagselectortui.Result{}, nil
+		})
+		cmd := NewRootCommand()
+		cmd.SetArgs(append(append([]string{}, base...), "--profile", "default"))
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		if called != 0 {
+			t.Fatalf("selector calls = %d, want 0", called)
+		}
+	})
+}
+
+func TestInstallTagSelectorCancelIsSuccessfulAndNonMutating(t *testing.T) {
+	manifestPath, sourceRoot, home, stateRoot := writeTagSelectorTestManifest(t)
+	setInstallTagSelectorTestHooks(t, true, func(io.Reader, io.Writer, tagselectortui.BrowseData, []string, tagselectortui.PreviewFunc) (tagselectortui.Result, error) {
+		return tagselectortui.Result{}, tagselectortui.ErrCanceled
+	})
+	cmd := NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"install", "--file", manifestPath, "--source-root", sourceRoot, "--home", home, "--state-root", stateRoot})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Tag selection canceled; nothing was applied.") {
+		t.Fatalf("output missing cancellation guarantee\n%s", out.String())
+	}
+	if _, err := os.Stat(state.Path(stateRoot)); !os.IsNotExist(err) {
+		t.Fatalf("Installation Metadata exists after cancellation: %v", err)
+	}
+}
+
+func TestInstallTagSelectorDefaultRepositoryIsByteStable(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		runner installTagSelectorRunnerFunc
+	}{
+		{
+			name: "completed preview",
+			runner: func(_ io.Reader, _ io.Writer, _ tagselectortui.BrowseData, _ []string, preview tagselectortui.PreviewFunc) (tagselectortui.Result, error) {
+				built, err := preview([]string{"one"})
+				return tagselectortui.Result{Tags: []string{"one"}, Preview: built}, err
+			},
+		},
+		{
+			name: "canceled",
+			runner: func(io.Reader, io.Writer, tagselectortui.BrowseData, []string, tagselectortui.PreviewFunc) (tagselectortui.Result, error) {
+				return tagselectortui.Result{}, tagselectortui.ErrCanceled
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home, sourceRoot := writeTagSelectorGitRepository(t)
+			t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".xdg-state"))
+			before := fingerprintTree(t, home)
+			setInstallTagSelectorTestHooks(t, true, tc.runner)
+
+			cmd := NewRootCommand()
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs([]string{"install", "--home", home})
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v\n%s", err, out.String())
+			}
+			if after := fingerprintTree(t, home); after != before {
+				t.Fatalf("home fingerprint changed after selector path: before %s, after %s", before, after)
+			}
+			if _, err := os.Stat(filepath.Join(home, ".one")); !os.IsNotExist(err) {
+				t.Fatalf("Managed Entry exists after selector path: %v", err)
+			}
+			if _, err := os.Stat(state.Path(defaultStateRoot(home))); !os.IsNotExist(err) {
+				t.Fatalf("Installation Metadata exists after selector path: %v", err)
+			}
+			if !strings.HasPrefix(sourceRoot, home+string(filepath.Separator)) {
+				t.Fatalf("test Installed Repository %q is outside temporary home %q", sourceRoot, home)
+			}
+		})
+	}
+}
+
+func TestInstallTagSelectorMissingDefaultRepositoryDoesNotBootstrap(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := defaultSourceRoot(home)
+	called := 0
+	setInstallTagSelectorTestHooks(t, true, func(io.Reader, io.Writer, tagselectortui.BrowseData, []string, tagselectortui.PreviewFunc) (tagselectortui.Result, error) {
+		called++
+		return tagselectortui.Result{}, nil
+	})
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"install", "--home", home})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "Installed Repository not found") {
+		t.Fatalf("Execute() error = %v, want missing Installed Repository guidance", err)
+	}
+	if called != 0 {
+		t.Fatalf("selector calls = %d, want zero before manifest is available", called)
+	}
+	if _, statErr := os.Stat(sourceRoot); !os.IsNotExist(statErr) {
+		t.Fatalf("selector path bootstrapped Installed Repository: %v", statErr)
+	}
+}
+
+func TestInstallTagSelectorPreviewFailureIsNonMutating(t *testing.T) {
+	manifestPath, sourceRoot, home, stateRoot := writeTagSelectorTestManifest(t)
+	setInstallTagSelectorTestHooks(t, true, func(_ io.Reader, _ io.Writer, _ tagselectortui.BrowseData, _ []string, preview tagselectortui.PreviewFunc) (tagselectortui.Result, error) {
+		_, err := preview([]string{"unknown"})
+		return tagselectortui.Result{}, err
+	})
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"install", "--file", manifestPath, "--source-root", sourceRoot, "--home", home, "--state-root", stateRoot})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), `tag "unknown" is not declared`) {
+		t.Fatalf("Execute() error = %v, want preview failure", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(home, ".one")); !os.IsNotExist(statErr) {
+		t.Fatalf("Managed Entry exists after preview failure: %v", statErr)
+	}
+	if _, statErr := os.Stat(state.Path(stateRoot)); !os.IsNotExist(statErr) {
+		t.Fatalf("Installation Metadata exists after preview failure: %v", statErr)
+	}
+}
+
+func setInstallTagSelectorTestHooks(t *testing.T, terminal bool, runner func(io.Reader, io.Writer, tagselectortui.BrowseData, []string, tagselectortui.PreviewFunc) (tagselectortui.Result, error)) {
+	t.Helper()
+	previousTerminal := installTagSelectorTerminal
+	previousRunner := installTagSelectorRunner
+	installTagSelectorTerminal = func(io.Reader, io.Writer) bool { return terminal }
+	installTagSelectorRunner = runner
+	t.Cleanup(func() {
+		installTagSelectorTerminal = previousTerminal
+		installTagSelectorRunner = previousRunner
+	})
+}
+
+func writeTagSelectorTestManifest(t *testing.T) (manifestPath, sourceRoot, home, stateRoot string) {
+	t.Helper()
+	home = t.TempDir()
+	sourceRoot = t.TempDir()
+	stateRoot = t.TempDir()
+	configDir := filepath.Join(sourceRoot, "config")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("create selector source directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "one"), []byte("one\n"), 0o600); err != nil {
+		t.Fatalf("write selector source: %v", err)
+	}
+	manifestPath = filepath.Join(sourceRoot, "dots.yaml")
+	data := []byte(`version: 1
+tags:
+  one:
+    description: One selectable capability.
+    kind: surface
+    status: current
+profiles:
+  default:
+    tags: [one]
+dependencies:
+  - tags: [one]
+    dependencies:
+      - name: one
+        command: one
+        manual: install one manually
+entries:
+  - source: config/one
+    target: ~/.one
+    strategy: symlink
+    tags: [one]
+`)
+	if err := os.WriteFile(manifestPath, data, 0o600); err != nil {
+		t.Fatalf("write selector manifest: %v", err)
+	}
+	return manifestPath, sourceRoot, home, stateRoot
+}
+
+func writeTagSelectorGitRepository(t *testing.T) (home, sourceRoot string) {
+	t.Helper()
+	home = t.TempDir()
+	sourceRoot = defaultSourceRoot(home)
+	if err := os.MkdirAll(filepath.Join(sourceRoot, "config"), 0o755); err != nil {
+		t.Fatalf("create Installed Repository: %v", err)
+	}
+	manifestData := []byte(`version: 1
+tags:
+  one:
+    description: One selectable capability.
+    kind: surface
+    status: current
+profiles:
+  default:
+    tags: [one]
+entries:
+  - source: config/one
+    target: ~/.one
+    strategy: symlink
+    tags: [one]
+`)
+	if err := os.WriteFile(filepath.Join(sourceRoot, "dots.yaml"), manifestData, 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	managedSource := filepath.Join(sourceRoot, "config", "one")
+	if err := os.WriteFile(managedSource, []byte("committed\n"), 0o600); err != nil {
+		t.Fatalf("write managed source: %v", err)
+	}
+	runGit(t, sourceRoot, "init", "-b", "main")
+	runGit(t, sourceRoot, "config", "user.name", "Dots Tests")
+	runGit(t, sourceRoot, "config", "user.email", "dots-tests@example.invalid")
+	runGit(t, sourceRoot, "add", ".")
+	runGit(t, sourceRoot, "commit", "-m", "test: seed selector repository")
+	if err := os.WriteFile(managedSource, []byte("stashed\n"), 0o600); err != nil {
+		t.Fatalf("write stashed source: %v", err)
+	}
+	runGit(t, sourceRoot, "stash", "push", "-m", "selector-safety")
+	if err := os.WriteFile(managedSource, []byte("working tree\n"), 0o600); err != nil {
+		t.Fatalf("write dirty source: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceRoot, "untracked"), []byte("preserve me\n"), 0o600); err != nil {
+		t.Fatalf("write untracked source: %v", err)
+	}
+	return home, sourceRoot
+}
+
+func runGit(t *testing.T, directory string, args ...string) {
+	t.Helper()
+	commandArgs := append([]string{"-C", directory}, args...)
+	output, err := exec.Command("git", commandArgs...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)
+	}
+}
+
+func fingerprintTree(t *testing.T, root string) string {
+	t.Helper()
+	hash := sha256.New()
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(hash, "%s\x00%s\x00", filepath.ToSlash(relative), info.Mode())
+		if info.Mode()&os.ModeSymlink != 0 {
+			target, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(hash, "%s\x00", target)
+			return nil
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		_, copyErr := io.Copy(hash, file)
+		closeErr := file.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+		return closeErr
+	})
+	if err != nil {
+		t.Fatalf("fingerprint %s: %v", root, err)
+	}
+	return fmt.Sprintf("sha256:%x", hash.Sum(nil))
+}
+
+func TestBuildInstallTagSelectorPreviewUsesSharedReconciliationReport(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	m := manifest.Manifest{
+		Tags: map[string]manifest.Tag{
+			"old": {Kind: "surface", Status: "current"},
+			"new": {Kind: "surface", Status: "current"},
+		},
+		Profiles: map[string]manifest.Profile{},
+		Dependencies: []manifest.DependencySet{
+			{Tags: []string{"old"}, Dependencies: []manifest.Dependency{{Name: "old-tool", Command: "old-tool"}}},
+			{Tags: []string{"new"}, Dependencies: []manifest.Dependency{{Name: "new-tool", Command: "new-tool"}}},
+		},
+	}
+	meta := state.Metadata{InstalledSelection: &state.InstalledSelection{ExtraTags: []string{"old"}, ResolvedTags: []string{"old"}}}
+	tags := []string{"new"}
+	preview, err := buildInstallTagSelectorPreview(m, meta, resolvedPaths{
+		Home: home, SourceRoot: sourceRoot, StateRoot: stateRoot, XDGStateHome: filepath.Join(home, ".local", "state"),
+	}, sourceRoot, nil, "linux", tags)
+	if err != nil {
+		t.Fatalf("buildInstallTagSelectorPreview() error = %v", err)
+	}
+	if preview.ForwardOnly {
+		t.Fatal("Preview.ForwardOnly = true, want shared reconciliation preview")
+	}
+	for _, want := range []string{"Selection reconciliation:", "retained-external-state", "old-tool", "create", "new-tool"} {
+		if !strings.Contains(preview.Text, want) {
+			t.Fatalf("Preview.Text missing %q\n%s", want, preview.Text)
+		}
+	}
+	if !strings.HasPrefix(preview.SemanticDigest, "sha256:") {
+		t.Fatalf("Preview.SemanticDigest = %q, want sha256 digest", preview.SemanticDigest)
+	}
+
+	originalText, originalDigest := preview.Text, preview.SemanticDigest
+	tags[0] = "old"
+	meta.InstalledSelection.ExtraTags[0] = "new"
+	if preview.Text != originalText || preview.SemanticDigest != originalDigest {
+		t.Fatal("opaque Preview changed after caller mutated input slices")
+	}
+}
+
+func TestBuildInstallTagSelectorPreviewWithoutInstalledSelectionIsForwardOnly(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	m := manifest.Manifest{
+		Tags:     map[string]manifest.Tag{"new": {Kind: "surface", Status: "current"}},
+		Profiles: map[string]manifest.Profile{},
+		Dependencies: []manifest.DependencySet{{
+			Tags: []string{"new"}, Dependencies: []manifest.Dependency{{Name: "new-tool", Command: "new-tool"}},
+		}},
+	}
+	meta := state.Metadata{Entries: []state.Record{{Target: filepath.Join(home, ".historical"), Source: "historical", Tags: []string{"old"}}}}
+	preview, err := buildInstallTagSelectorPreview(m, meta, resolvedPaths{
+		Home: home, SourceRoot: sourceRoot, StateRoot: t.TempDir(), XDGStateHome: filepath.Join(home, ".local", "state"),
+	}, sourceRoot, nil, "linux", []string{"new"})
+	if err != nil {
+		t.Fatalf("buildInstallTagSelectorPreview() error = %v", err)
+	}
+	if !preview.ForwardOnly {
+		t.Fatal("Preview.ForwardOnly = false, want forward-only without Installed Selection")
+	}
+	if !strings.Contains(preview.Text, "No Installed Selection is recorded") || !strings.Contains(preview.Text, "no retirement is authorized") {
+		t.Fatalf("Preview.Text missing forward-only authority notice\n%s", preview.Text)
+	}
+	if strings.Contains(preview.Text, "Selection reconciliation:") {
+		t.Fatalf("Preview.Text fabricates a Selection Reconciliation Plan\n%s", preview.Text)
+	}
+}
+
+func TestBuildInstallTagSelectorCatalogGroupsCurrentTagsAndReportsComponents(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	m := manifest.Manifest{
+		Tags: map[string]manifest.Tag{
+			"shared":      {Description: "shared capability", Kind: "surface", Status: "current"},
+			"core-a":      {Description: "core capability", Kind: "surface", Status: "current"},
+			"desktop-b":   {Description: "desktop capability", Kind: "surface", Status: "current"},
+			"agents-c":    {Description: "agent capability", Kind: "surface", Status: "current"},
+			"darwin-only": {Description: "platform capability", Kind: "surface", Status: "current"},
+			"global":      {Description: "global capability", Kind: "surface", Status: "current"},
+			"legacy":      {Description: "legacy alias", Kind: "compatibility", Status: "legacy", ReplacedBy: manifest.ReplacementTags{"core-a"}},
+			"legacy-agents": {
+				Description: "legacy agent alias", Kind: "compatibility", Status: "legacy", ReplacedBy: manifest.ReplacementTags{"agents-c"},
+			},
+		},
+		Profiles: map[string]manifest.Profile{
+			"core":        {Description: "core preset", Tags: []string{"shared", "core-a"}},
+			"desktop":     {Description: "desktop preset", Tags: []string{"desktop-b", "shared"}},
+			"agents":      {Description: "agents preset", Tags: []string{"agents-c"}},
+			"workstation": {Description: "combined preset", Tags: []string{"core-a", "agents-c"}},
+		},
+		Dependencies: []manifest.DependencySet{
+			{
+				Tags:         []string{"desktop-b"},
+				Dependencies: []manifest.Dependency{{Name: "desktop-tool", Command: "desktop-tool"}},
+			},
+			{
+				Tags:         []string{"darwin-only"},
+				OS:           []string{"darwin"},
+				Dependencies: []manifest.Dependency{{Name: "darwin-tool", Command: "darwin-tool"}},
+			},
+		},
+		Entries: []manifest.Entry{
+			{Source: "configs/core", Target: "~/.core", Strategy: "copy", Tags: []string{"core-a"}},
+			{Source: "configs/darwin", Target: "~/.darwin", Strategy: "copy", Tags: []string{"darwin-only"}, OS: []string{"darwin"}},
+		},
+		Provisioners: []manifest.Provisioner{
+			{Tool: "zimfw", Tags: []string{"agents-c"}},
+			{Tool: "zimfw", Tags: []string{"darwin-only"}, OS: []string{"darwin"}},
+		},
+	}
+	meta := state.Metadata{Provisioners: []state.ProvisionerRecord{
+		{
+			Profile: "desktop", Profiles: []string{"desktop"}, Tags: []string{"desktop-b"},
+			Tool: "zimfw", Executable: "zsh", Args: provisionCommandArgs(t, m.Provisioners[0]), Status: string(provision.RunStatusFailed), LastRunAt: "2026-08-22T12:00:00Z",
+		},
+		{
+			Profile: "workstation", Profiles: []string{"workstation"}, Tags: []string{"agents-c"},
+			Tool: "zimfw", Executable: "zsh", Args: provisionCommandArgs(t, m.Provisioners[0]), Status: string(provision.RunStatusFailed), LastRunAt: "2026-08-20T12:00:00Z",
+		},
+		{
+			Profile: "agents", Profiles: []string{"agents"}, Tags: []string{"legacy-agents"},
+			Tool: "zimfw", Executable: "zsh", Args: provisionCommandArgs(t, m.Provisioners[0]), Status: string(provision.RunStatusProvisioned), LastRunAt: "2026-08-21T12:00:00Z",
+		},
+	}}
+
+	got, err := buildInstallTagSelectorBrowseData(m, meta, tagSelectorBrowseOptions{
+		OS: "linux", Arch: "amd64", SourceReadRoot: sourceRoot, Home: home, StateRoot: stateRoot,
+		XDGStateHome: filepath.Join(home, ".local", "state"),
+		Lookup:       func(command string) bool { return command == "desktop-tool" },
+		FontLookup:   func(string) bool { return false },
+		AppLookup:    func(string) bool { return false },
+	})
+	if err != nil {
+		t.Fatalf("buildInstallTagSelectorBrowseData() error = %v", err)
+	}
+
+	var names, groups []string
+	byName := map[string]tagselectortui.Tag{}
+	for _, tag := range got.Tags {
+		names = append(names, tag.Name)
+		groups = append(groups, tag.Group)
+		byName[tag.Name] = tag
+	}
+	if want := []string{"shared", "core-a", "desktop-b", "agents-c", "darwin-only", "global"}; !reflect.DeepEqual(names, want) {
+		t.Fatalf("Tag order = %v, want %v", names, want)
+	}
+	if want := []string{"Core", "Core", "Desktop", "Agents", "Global", "Global"}; !reflect.DeepEqual(groups, want) {
+		t.Fatalf("Tag groups = %v, want %v", groups, want)
+	}
+	if _, exists := byName["legacy"]; exists {
+		t.Fatal("legacy Tag should be hidden from selector browse data")
+	}
+	if want := []string{"core", "desktop"}; !reflect.DeepEqual(byName["shared"].Profiles, want) {
+		t.Fatalf("shared Profiles = %v, want %v", byName["shared"].Profiles, want)
+	}
+	if byName["core-a"].State != tagselectortui.StateMissing {
+		t.Fatalf("core-a State = %q, want missing", byName["core-a"].State)
+	}
+	if byName["desktop-b"].State != tagselectortui.StateAligned || !byName["desktop-b"].ExternalEffectsPresent {
+		t.Fatalf("desktop-b = %+v, want aligned with retained external evidence", byName["desktop-b"])
+	}
+	if byName["agents-c"].State != tagselectortui.StateAligned || !byName["agents-c"].ExternalEffectsPresent {
+		t.Fatalf("agents-c = %+v, want aligned with retained external evidence", byName["agents-c"])
+	}
+	if byName["darwin-only"].State != tagselectortui.StateNotApplicable {
+		t.Fatalf("darwin-only State = %q, want not-applicable", byName["darwin-only"].State)
+	}
+	if want := []string{"darwin-tool"}; !reflect.DeepEqual(byName["darwin-only"].Dependencies, want) {
+		t.Fatalf("darwin-only Dependencies = %v, want portable details %v", byName["darwin-only"].Dependencies, want)
+	}
+	if want := []string{"zimfw"}; !reflect.DeepEqual(byName["darwin-only"].Provisioners, want) {
+		t.Fatalf("darwin-only Provisioners = %v, want portable details %v", byName["darwin-only"].Provisioners, want)
+	}
+	for _, want := range []tagselectortui.Component{
+		{Kind: "Managed Entry", Name: "~/.darwin", State: tagselectortui.StateNotApplicable, Detail: "not applicable to linux"},
+		{Kind: "Dependency", Name: "darwin-tool", State: tagselectortui.StateNotApplicable, Detail: "not applicable to linux"},
+		{Kind: "Provisioner", Name: "zimfw", State: tagselectortui.StateNotApplicable, Detail: "not applicable to linux"},
+	} {
+		if !containsTagSelectorComponent(byName["darwin-only"].Components, want) {
+			t.Fatalf("darwin-only Components missing %+v: %+v", want, byName["darwin-only"].Components)
+		}
+	}
+	if byName["global"].State != tagselectortui.StateNotApplicable {
+		t.Fatalf("global State = %q, want not-applicable without an applicable surface", byName["global"].State)
+	}
+	if got.Profiles[0].Name != "core" || got.Profiles[len(got.Profiles)-1].Name != "workstation" {
+		t.Fatalf("Profile order = %+v, want conceptual Profiles before remaining Profiles", got.Profiles)
+	}
+}
+
+func containsTagSelectorComponent(components []tagselectortui.Component, want tagselectortui.Component) bool {
+	for _, component := range components {
+		if component == want {
+			return true
+		}
+	}
+	return false
+}
+
+func provisionCommandArgs(t *testing.T, declaration manifest.Provisioner) []string {
+	t.Helper()
+	_, args := provision.RenderCommand(declaration)
+	return args
+}
+
+func TestFindTagSelectorProvisionerRecordUsesLatestEvidence(t *testing.T) {
+	m := manifest.Manifest{Tags: map[string]manifest.Tag{"core": {Kind: "surface", Status: "current"}}}
+	step := provision.Step{Tool: "zimfw", Executable: "zsh", Args: []string{"-c", "zimfw install"}}
+	tests := []struct {
+		name        string
+		records     []state.ProvisionerRecord
+		wantProfile string
+	}{
+		{
+			name: "latest valid timestamp",
+			records: []state.ProvisionerRecord{
+				{Profile: "old", Tags: []string{"core"}, Tool: step.Tool, Executable: step.Executable, Args: step.Args, LastRunAt: "2026-08-20T12:00:00Z"},
+				{Profile: "new", Tags: []string{"core"}, Tool: step.Tool, Executable: step.Executable, Args: step.Args, LastRunAt: "2026-08-21T12:00:00Z"},
+			},
+			wantProfile: "new",
+		},
+		{
+			name: "valid timestamp beats missing timestamp",
+			records: []state.ProvisionerRecord{
+				{Profile: "dated", Tags: []string{"core"}, Tool: step.Tool, Executable: step.Executable, Args: step.Args, LastRunAt: "2026-08-20T12:00:00Z"},
+				{Profile: "undated", Tags: []string{"core"}, Tool: step.Tool, Executable: step.Executable, Args: step.Args},
+			},
+			wantProfile: "dated",
+		},
+		{
+			name: "later record breaks timestamp tie",
+			records: []state.ProvisionerRecord{
+				{Profile: "first", Tags: []string{"core"}, Tool: step.Tool, Executable: step.Executable, Args: step.Args},
+				{Profile: "last", Tags: []string{"core"}, Tool: step.Tool, Executable: step.Executable, Args: step.Args},
+			},
+			wantProfile: "last",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := findTagSelectorProvisionerRecord(m, tt.records, "core", step)
+			if !ok {
+				t.Fatal("findTagSelectorProvisionerRecord() found no record")
+			}
+			if got.Profile != tt.wantProfile {
+				t.Fatalf("Profile = %q, want %q", got.Profile, tt.wantProfile)
+			}
+		})
+	}
+}
+
+func TestTagSelectorComponentStateProjection(t *testing.T) {
+	t.Run("managed entries", func(t *testing.T) {
+		tests := []struct {
+			input status.State
+			want  tagselectortui.State
+		}{
+			{status.StateOK, tagselectortui.StateAligned},
+			{status.StateMissing, tagselectortui.StateMissing},
+			{status.StateDrifted, tagselectortui.StateDrift},
+			{status.StateConflict, tagselectortui.StateConflict},
+			{status.StateSkipped, tagselectortui.StateNotApplicable},
+			{status.StateUnsupported, tagselectortui.StateConflict},
+		}
+		for _, tt := range tests {
+			if got := tagSelectorManagedEntryState(tt.input); got != tt.want {
+				t.Fatalf("tagSelectorManagedEntryState(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		}
+	})
+
+	t.Run("dependencies", func(t *testing.T) {
+		tests := []struct {
+			input deps.Result
+			want  tagselectortui.State
+		}{
+			{deps.Result{Present: true}, tagselectortui.StateAligned},
+			{deps.Result{Present: false}, tagselectortui.StateMissing},
+			{deps.Result{Present: true, Warning: "degraded"}, tagselectortui.StateDrift},
+		}
+		for _, tt := range tests {
+			if got := tagSelectorDependencyState(tt.input); got != tt.want {
+				t.Fatalf("tagSelectorDependencyState(%+v) = %q, want %q", tt.input, got, tt.want)
+			}
+		}
+	})
+
+	t.Run("provisioners", func(t *testing.T) {
+		tests := []struct {
+			input provision.StatusState
+			want  tagselectortui.State
+		}{
+			{provision.StatusStateProvisioned, tagselectortui.StateAligned},
+			{provision.StatusStatePending, tagselectortui.StateMissing},
+			{provision.StatusStateMissingDependencies, tagselectortui.StateMissing},
+			{provision.StatusStateFailed, tagselectortui.StateConflict},
+		}
+		for _, tt := range tests {
+			if got := tagSelectorProvisionerState(tt.input); got != tt.want {
+				t.Fatalf("tagSelectorProvisionerState(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		}
+	})
+}
+
+func TestAggregateTagSelectorStateUsesDeterministicPrecedence(t *testing.T) {
+	tests := []struct {
+		name       string
+		components []tagselectortui.Component
+		want       tagselectortui.State
+	}{
+		{name: "no components", want: tagselectortui.StateNotApplicable},
+		{name: "not applicable only", components: []tagselectortui.Component{{State: tagselectortui.StateNotApplicable}}, want: tagselectortui.StateNotApplicable},
+		{name: "aligned beats excluded", components: []tagselectortui.Component{{State: tagselectortui.StateNotApplicable}, {State: tagselectortui.StateAligned}}, want: tagselectortui.StateAligned},
+		{name: "missing beats aligned", components: []tagselectortui.Component{{State: tagselectortui.StateAligned}, {State: tagselectortui.StateMissing}}, want: tagselectortui.StateMissing},
+		{name: "drift beats missing", components: []tagselectortui.Component{{State: tagselectortui.StateMissing}, {State: tagselectortui.StateDrift}}, want: tagselectortui.StateDrift},
+		{name: "conflict beats drift", components: []tagselectortui.Component{{State: tagselectortui.StateDrift}, {State: tagselectortui.StateConflict}}, want: tagselectortui.StateConflict},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := aggregateTagSelectorState(tt.components); got != tt.want {
+				t.Fatalf("aggregateTagSelectorState() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveInstallTagSelectorInitialUsesOnlyAuthoritativeIntent(t *testing.T) {
+	m := manifest.Manifest{
+		Tags: map[string]manifest.Tag{
+			"current-a": {Kind: "surface", Status: "current"},
+			"current-b": {Kind: "surface", Status: "current"},
+			"legacy":    {Kind: "compatibility", Status: "legacy", ReplacedBy: manifest.ReplacementTags{"current-a", "current-b"}},
+		},
+		Profiles: map[string]manifest.Profile{"core": {Tags: []string{"current-a"}}},
+	}
+
+	t.Run("no Installed Selection starts empty", func(t *testing.T) {
+		got, err := resolveInstallTagSelectorInitial(m, nil)
+		if err != nil {
+			t.Fatalf("resolveInstallTagSelectorInitial() error = %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("initial Tags = %v, want empty", got)
+		}
+	})
+
+	t.Run("declared legacy alias normalizes", func(t *testing.T) {
+		installed := &state.InstalledSelection{ExtraTags: []string{"legacy"}, ResolvedTags: []string{"legacy"}}
+		got, err := resolveInstallTagSelectorInitial(m, installed)
+		if err != nil {
+			t.Fatalf("resolveInstallTagSelectorInitial() error = %v", err)
+		}
+		if want := []string{"current-a", "current-b"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("initial Tags = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("missing Profile fails closed", func(t *testing.T) {
+		installed := &state.InstalledSelection{Profiles: []string{"removed"}, ResolvedTags: []string{"current-a"}}
+		if _, err := resolveInstallTagSelectorInitial(m, installed); err == nil {
+			t.Fatal("resolveInstallTagSelectorInitial() error = nil, want stale Profile error")
+		}
+	})
+
+	t.Run("missing extra Tag fails closed", func(t *testing.T) {
+		installed := &state.InstalledSelection{ExtraTags: []string{"removed"}, ResolvedTags: []string{"current-a"}}
+		if _, err := resolveInstallTagSelectorInitial(m, installed); err == nil {
+			t.Fatal("resolveInstallTagSelectorInitial() error = nil, want stale extra Tag error")
+		}
+	})
+}

--- a/internal/cli/install_tui_test.go
+++ b/internal/cli/install_tui_test.go
@@ -43,7 +43,7 @@ entries:
 	cmd.SetErr(&out)
 	// 'r' = replace the highlighted conflict, '\r' (Enter) = apply.
 	cmd.SetIn(strings.NewReader("r\r"))
-	cmd.SetArgs([]string{"install", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+	cmd.SetArgs([]string{"install", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
@@ -95,7 +95,7 @@ entries:
 	cmd.SetErr(&out)
 	// 'r' selects replace, then ctrl+c (0x03) cancels before applying.
 	cmd.SetIn(strings.NewReader("r\x03"))
-	cmd.SetArgs([]string{"install", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
+	cmd.SetArgs([]string{"install", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot, "--state-root", stateRoot})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -139,7 +139,7 @@ func TestNonDiagnosticCommandsHonorJSONOutput(t *testing.T) {
 			name:    "install dry run",
 			command: "install",
 			args: []string{
-				"install", "--dry-run", "--output", "json", "--file", manifestPath,
+				"install", "--dry-run", "--output", "json", "--profile", "default", "--file", manifestPath,
 				"--source-root", sourceRoot, "--home", home, "--state-root", stateRoot,
 			},
 		},
@@ -181,7 +181,7 @@ func TestJSONModeRejectsInteractiveActionCommands(t *testing.T) {
 
 	var out, errOut bytes.Buffer
 	code := cli.Run([]string{
-		"install", "--output", "json", "--file", manifestPath,
+		"install", "--output", "json", "--profile", "default", "--file", manifestPath,
 		"--source-root", sourceRoot, "--home", home, "--state-root", stateRoot,
 	}, &out, &errOut)
 

--- a/internal/cli/provision_hint_test.go
+++ b/internal/cli/provision_hint_test.go
@@ -108,7 +108,7 @@ func TestInstallDryRunHintsSkippedDesktopEntries(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"install", "--dry-run", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
+	cmd.SetArgs([]string{"install", "--dry-run", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
@@ -227,7 +227,7 @@ func TestInstallDryRunHintsSkippedDesktopProvisioners(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"install", "--dry-run", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
+	cmd.SetArgs([]string{"install", "--dry-run", "--profile", "default", "--file", manifestPath, "--home", home, "--source-root", sourceRoot})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())

--- a/internal/tui/tagselector/model.go
+++ b/internal/tui/tagselector/model.go
@@ -1,0 +1,735 @@
+// Package tagselector implements the interactive Tag selection model used by
+// installation flows. It owns draft intent only; callers inject preview work.
+package tagselector
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// State is an observed selector component state.
+type State string
+
+const (
+	StateAligned       State = "aligned"
+	StateMissing       State = "missing"
+	StateDrift         State = "drift"
+	StateConflict      State = "conflict"
+	StateNotApplicable State = "not-applicable"
+)
+
+// Component describes one observed part of a Tag's selected surface.
+type Component struct {
+	Kind   string
+	Name   string
+	State  State
+	Detail string
+}
+
+// Tag is one atomic selectable capability in canonical browse order.
+type Tag struct {
+	Name                   string
+	Description            string
+	Group                  string
+	Profiles               []string
+	ManagedEntries         []string
+	Dependencies           []string
+	Provisioners           []string
+	Components             []Component
+	State                  State
+	ExternalEffectsPresent bool
+}
+
+// Profile is a named preset of Tags.
+type Profile struct {
+	Name        string
+	Description string
+	Tags        []string
+}
+
+// BrowseData combines portable Tag descriptions with read-only workstation
+// observations for presentation by the selector.
+type BrowseData struct {
+	Tags     []Tag
+	Profiles []Profile
+}
+
+// Preview is the opaque preview value returned across the CLI seam.
+type Preview struct {
+	Text           string
+	SemanticDigest string
+	ForwardOnly    bool
+}
+
+// PreviewFunc computes a preview for a detached canonical Tag snapshot.
+type PreviewFunc func([]string) (Preview, error)
+
+// Result is a successfully confirmed selection and its accepted preview.
+type Result struct {
+	Tags    []string
+	Preview Preview
+}
+
+// ErrCanceled means the operator canceled without producing usable intent.
+var ErrCanceled = errors.New("tag selection canceled")
+
+type screen uint8
+
+const (
+	screenList screen = iota
+	screenSearch
+	screenProfiles
+	screenDetail
+	screenLoading
+	screenPreview
+)
+
+// Model is the Bubble Tea model for selecting Tags.
+type Model struct {
+	data          BrowseData
+	selected      []bool
+	initial       []bool
+	cursor        int
+	previewFunc   PreviewFunc
+	screen        screen
+	query         string
+	profile       int
+	detail        int
+	width         int
+	height        int
+	detailScroll  int
+	previewScroll int
+
+	nextRequest  uint64
+	pending      *previewRequest
+	accepted     Preview
+	previewTags  []string
+	previewError string
+	canceled     bool
+	finished     bool
+	quitting     bool
+}
+
+type previewRequest struct {
+	id          uint64
+	fingerprint string
+	tags        []string
+}
+
+type previewResponse struct {
+	id          uint64
+	fingerprint string
+	preview     Preview
+	err         error
+}
+
+// New builds a model with detached browse data and desired checkbox state.
+func New(browseData BrowseData, initial []string, preview PreviewFunc) Model {
+	browseData = cloneBrowseData(browseData)
+	initialSet := make(map[string]bool, len(initial))
+	for _, name := range initial {
+		initialSet[name] = true
+	}
+	selected := make([]bool, len(browseData.Tags))
+	for i, tag := range browseData.Tags {
+		selected[i] = initialSet[tag.Name]
+	}
+	return Model{data: browseData, selected: selected, initial: append([]bool(nil), selected...), previewFunc: preview}
+}
+
+func cloneBrowseData(c BrowseData) BrowseData {
+	out := BrowseData{
+		Tags:     make([]Tag, len(c.Tags)),
+		Profiles: make([]Profile, len(c.Profiles)),
+	}
+	for i, tag := range c.Tags {
+		out.Tags[i] = tag
+		out.Tags[i].Profiles = append([]string(nil), tag.Profiles...)
+		out.Tags[i].ManagedEntries = append([]string(nil), tag.ManagedEntries...)
+		out.Tags[i].Dependencies = append([]string(nil), tag.Dependencies...)
+		out.Tags[i].Provisioners = append([]string(nil), tag.Provisioners...)
+		out.Tags[i].Components = append([]Component(nil), tag.Components...)
+	}
+	for i, profile := range c.Profiles {
+		out.Profiles[i] = profile
+		out.Profiles[i].Tags = append([]string(nil), profile.Tags...)
+	}
+	return out
+}
+
+// Init starts the model without side effects.
+func (m Model) Init() tea.Cmd { return nil }
+
+// Update applies navigation and draft checkbox changes.
+func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
+	if response, ok := message.(previewResponse); ok {
+		return m.acceptPreview(response), nil
+	}
+	if size, ok := message.(tea.WindowSizeMsg); ok {
+		m.width = size.Width
+		m.height = size.Height
+		return m, nil
+	}
+	key, ok := message.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+	if key.Type == tea.KeyCtrlC || (m.screen != screenSearch && key.String() == "q") {
+		return m.cancel(), tea.Quit
+	}
+	if m.screen == screenSearch {
+		switch key.Type {
+		case tea.KeyEsc:
+			m.screen = screenList
+			m.query = ""
+			m.cursor = 0
+		case tea.KeyEnter:
+			m.screen = screenList
+		case tea.KeyDown:
+			if m.cursor+1 < len(m.visibleTags()) {
+				m.cursor++
+			}
+		case tea.KeyUp:
+			if m.cursor > 0 {
+				m.cursor--
+			}
+		case tea.KeyBackspace, tea.KeyDelete:
+			if len(m.query) > 0 {
+				runes := []rune(m.query)
+				m.query = string(runes[:len(runes)-1])
+				m.cursor = 0
+			}
+		case tea.KeyRunes:
+			m.query += string(key.Runes)
+			m.cursor = 0
+		}
+		return m, nil
+	}
+	if m.screen == screenLoading {
+		if key.Type == tea.KeyEsc {
+			m.pending = nil
+			m.screen = screenList
+		}
+		return m, nil
+	}
+	if m.screen == screenPreview {
+		switch key.Type {
+		case tea.KeyEsc:
+			m.accepted = Preview{}
+			m.previewTags = nil
+			m.previewScroll = 0
+			m.screen = screenList
+		case tea.KeyEnter:
+			m.finished = true
+			m.quitting = true
+			return m, tea.Quit
+		}
+		switch key.String() {
+		case "j", "down":
+			m.previewScroll = scrolledOffset(m.previewScroll, 1, len(m.previewContentLines()), m.previewBodyHeight())
+		case "k", "up":
+			m.previewScroll = scrolledOffset(m.previewScroll, -1, len(m.previewContentLines()), m.previewBodyHeight())
+		case "pgdown":
+			m.previewScroll = scrolledOffset(m.previewScroll, max(1, m.previewBodyHeight()-2), len(m.previewContentLines()), m.previewBodyHeight())
+		case "pgup":
+			m.previewScroll = scrolledOffset(m.previewScroll, -max(1, m.previewBodyHeight()-2), len(m.previewContentLines()), m.previewBodyHeight())
+		case "home":
+			m.previewScroll = 0
+		case "end":
+			m.previewScroll = clampScrollOffset(len(m.previewContentLines()), m.previewBodyHeight(), len(m.previewContentLines()))
+		}
+		return m, nil
+	}
+	if m.screen == screenProfiles {
+		switch key.String() {
+		case "j", "down":
+			if m.profile+1 < len(m.data.Profiles) {
+				m.profile++
+			}
+		case "k", "up":
+			if m.profile > 0 {
+				m.profile--
+			}
+		case " ", "enter":
+			m.toggleProfile()
+		case "esc", "p":
+			m.screen = screenList
+		}
+		return m, nil
+	}
+	if m.screen == screenDetail {
+		switch key.String() {
+		case "esc", "left", "d":
+			m.detailScroll = 0
+			m.screen = screenList
+		case "j", "down":
+			m.detailScroll = scrolledOffset(m.detailScroll, 1, len(m.detailContentLines()), m.detailBodyHeight())
+		case "k", "up":
+			m.detailScroll = scrolledOffset(m.detailScroll, -1, len(m.detailContentLines()), m.detailBodyHeight())
+		case "pgdown":
+			m.detailScroll = scrolledOffset(m.detailScroll, max(1, m.detailBodyHeight()-2), len(m.detailContentLines()), m.detailBodyHeight())
+		case "pgup":
+			m.detailScroll = scrolledOffset(m.detailScroll, -max(1, m.detailBodyHeight()-2), len(m.detailContentLines()), m.detailBodyHeight())
+		case "home":
+			m.detailScroll = 0
+		case "end":
+			m.detailScroll = clampScrollOffset(len(m.detailContentLines()), m.detailBodyHeight(), len(m.detailContentLines()))
+		}
+		return m, nil
+	}
+	switch key.String() {
+	case "j", "down":
+		if m.cursor+1 < len(m.visibleTags()) {
+			m.cursor++
+		}
+	case "k", "up":
+		if m.cursor > 0 {
+			m.cursor--
+		}
+	case " ":
+		visible := m.visibleTags()
+		if m.cursor >= 0 && m.cursor < len(visible) {
+			i := visible[m.cursor]
+			m.selected[i] = !m.selected[i]
+		}
+	case "/":
+		m.screen = screenSearch
+		m.query = ""
+		m.cursor = 0
+	case "p":
+		m.screen = screenProfiles
+		m.profile = 0
+	case "d", "right":
+		visible := m.visibleTags()
+		if m.cursor >= 0 && m.cursor < len(visible) {
+			m.detail = visible[m.cursor]
+			m.detailScroll = 0
+			m.screen = screenDetail
+		}
+	case "enter":
+		return m.startPreview()
+	case "esc":
+		return m.cancel(), tea.Quit
+	}
+	return m, nil
+}
+
+func (m Model) startPreview() (tea.Model, tea.Cmd) {
+	tags := m.SelectedTags()
+	m.nextRequest++
+	request := previewRequest{
+		id:          m.nextRequest,
+		fingerprint: fingerprint(tags),
+		tags:        append([]string(nil), tags...),
+	}
+	m.pending = &request
+	m.accepted = Preview{}
+	m.previewTags = nil
+	m.previewError = ""
+	m.previewScroll = 0
+	m.screen = screenLoading
+	provider := m.previewFunc
+	return m, func() tea.Msg {
+		if provider == nil {
+			return previewResponse{id: request.id, fingerprint: request.fingerprint, err: errors.New("preview is unavailable")}
+		}
+		input := append([]string(nil), request.tags...)
+		preview, err := provider(input)
+		return previewResponse{id: request.id, fingerprint: request.fingerprint, preview: preview, err: err}
+	}
+}
+
+func (m Model) acceptPreview(response previewResponse) Model {
+	if m.pending == nil || m.canceled || response.id != m.pending.id || response.fingerprint != m.pending.fingerprint {
+		return m
+	}
+	request := *m.pending
+	m.pending = nil
+	if response.err != nil {
+		m.previewError = response.err.Error()
+		m.screen = screenList
+		return m
+	}
+	m.accepted = response.preview
+	m.previewTags = cloneStrings(request.tags)
+	m.previewError = ""
+	m.previewScroll = 0
+	m.screen = screenPreview
+	return m
+}
+
+func (m Model) cancel() Model {
+	m.pending = nil
+	m.accepted = Preview{}
+	m.previewTags = nil
+	m.canceled = true
+	m.finished = false
+	m.quitting = true
+	return m
+}
+
+func fingerprint(tags []string) string {
+	hash := sha256.New()
+	for _, tag := range tags {
+		fmt.Fprintf(hash, "%d:%s", len(tag), tag)
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func (m *Model) toggleProfile() {
+	if m.profile < 0 || m.profile >= len(m.data.Profiles) {
+		return
+	}
+	indices := make([]int, 0, len(m.data.Profiles[m.profile].Tags))
+	for _, name := range m.data.Profiles[m.profile].Tags {
+		for i, tag := range m.data.Tags {
+			if tag.Name == name {
+				indices = append(indices, i)
+				break
+			}
+		}
+	}
+	allSelected := len(indices) > 0
+	for _, i := range indices {
+		if !m.selected[i] {
+			allSelected = false
+			break
+		}
+	}
+	for _, i := range indices {
+		m.selected[i] = !allSelected
+	}
+}
+
+func (m Model) visibleTags() []int {
+	query := strings.ToLower(m.query)
+	visible := make([]int, 0, len(m.data.Tags))
+	for i, tag := range m.data.Tags {
+		if query == "" || strings.Contains(strings.ToLower(tag.Name), query) || strings.Contains(strings.ToLower(tag.Description), query) {
+			visible = append(visible, i)
+		}
+	}
+	return visible
+}
+
+// SelectedTags returns a detached canonical-order snapshot of desired Tags.
+func (m Model) SelectedTags() []string {
+	out := make([]string, 0, len(m.data.Tags))
+	for i, tag := range m.data.Tags {
+		if m.selected[i] {
+			out = append(out, tag.Name)
+		}
+	}
+	return out
+}
+
+// Preview returns the immutable accepted preview value, if any.
+func (m Model) Preview() Preview {
+	if m.canceled {
+		return Preview{}
+	}
+	return m.accepted
+}
+
+// Result returns a detached successful result. Before confirmation or after
+// cancellation it returns the zero value.
+func (m Model) Result() Result {
+	if m.canceled || !m.finished {
+		return Result{}
+	}
+	return Result{Tags: cloneStrings(m.previewTags), Preview: m.accepted}
+}
+
+// Canceled reports whether the session ended without usable intent.
+func (m Model) Canceled() bool { return m.canceled }
+
+// View renders the current selection screen.
+func (m Model) View() string {
+	if m.quitting {
+		return ""
+	}
+	if m.screen == screenLoading {
+		return "dots · Loading preview…\n\nEsc returns to selection · q/ctrl+c cancel\n"
+	}
+	if m.screen == screenPreview {
+		return m.viewPreview()
+	}
+	if m.screen == screenProfiles {
+		return m.viewProfiles()
+	}
+	if m.screen == screenDetail {
+		return m.viewDetail()
+	}
+	return m.viewList()
+}
+
+func (m Model) viewList() string {
+	header := []string{"dots · select Tags"}
+	if m.screen == screenSearch {
+		header = append(header, "Search: "+m.query)
+	} else if m.query != "" {
+		header = append(header, "Filter: "+m.query)
+	}
+	if m.previewError != "" {
+		header = append(header, "Preview error: "+m.previewError)
+	}
+
+	help := "/ search · space toggle · p profiles · d details · enter preview · q cancel"
+	if m.screen == screenSearch {
+		help = "type to search · enter accept · esc clear · ctrl+c cancel"
+	}
+	footer := []string{"", help}
+	lines, cursorLine := m.listLines()
+
+	var detail []string
+	visible := m.visibleTags()
+	if m.width >= 100 && m.cursor >= 0 && m.cursor < len(visible) {
+		detail = append([]string{""}, splitRendered(m.viewDetailFor(visible[m.cursor]))...)
+		if m.height > 0 && len(detail) > m.height/2 {
+			detail = scrollPage(detail, 0, max(1, m.height/2))
+		}
+	}
+	bodyHeight := availableBodyHeight(m.height, len(header)+len(footer)+len(detail))
+	if bodyHeight < 3 && len(detail) > 0 {
+		detail = nil
+		bodyHeight = availableBodyHeight(m.height, len(header)+len(footer))
+	}
+	body := cursorPage(lines, cursorLine, bodyHeight)
+	return renderLines(append(append(append(header, body...), footer...), detail...))
+}
+
+func (m Model) listLines() ([]string, int) {
+	lines := []string{}
+	cursorLine := 0
+	lastGroup := ""
+	for position, i := range m.visibleTags() {
+		tag := m.data.Tags[i]
+		if tag.Group != lastGroup {
+			lines = append(lines, "", tag.Group)
+			lastGroup = tag.Group
+		}
+		cursor := "  "
+		if position == m.cursor {
+			cursor = "> "
+			cursorLine = len(lines)
+		}
+		checkbox := " "
+		if m.selected[i] {
+			checkbox = "x"
+		}
+		row := fmt.Sprintf("%s[%s] %s", cursor, checkbox, tag.Name)
+		if tag.Description != "" {
+			row += " — " + tag.Description
+		}
+		if tag.State != "" {
+			row += fmt.Sprintf(" (%s)", tag.State)
+		}
+		lines = append(lines, row)
+	}
+	if len(lines) == 0 {
+		return []string{"", "No matching Tags."}, 1
+	}
+	return lines, cursorLine
+}
+
+func (m Model) viewPreview() string {
+	header := []string{"dots · selection preview", ""}
+	footer := []string{"", "j/k scroll · pgup/pgdown · enter confirm · esc back · q/ctrl+c cancel"}
+	body := scrollPage(m.previewContentLines(), m.previewScroll, m.previewBodyHeight())
+	return renderLines(append(append(header, body...), footer...))
+}
+
+func (m Model) viewProfiles() string {
+	header := []string{"dots · Profile presets", ""}
+	lines := []string{}
+	cursorLine := 0
+	for i, profile := range m.data.Profiles {
+		cursor := "  "
+		if i == m.profile {
+			cursor = "> "
+			cursorLine = len(lines)
+		}
+		lines = append(lines,
+			fmt.Sprintf("%s[%s] %s — %s", cursor, m.profileMark(profile), profile.Name, profile.Description),
+			"    Tags: "+strings.Join(profile.Tags, ", "),
+		)
+	}
+	if len(lines) == 0 {
+		lines = []string{"No Profile presets available."}
+	}
+	footer := []string{"", "space/enter apply preset · esc return · ctrl+c cancel"}
+	body := cursorPage(lines, cursorLine, availableBodyHeight(m.height, len(header)+len(footer)))
+	return renderLines(append(append(header, body...), footer...))
+}
+
+func (m Model) profileMark(profile Profile) string {
+	valid, selected := 0, 0
+	for _, name := range profile.Tags {
+		for i, tag := range m.data.Tags {
+			if tag.Name == name {
+				valid++
+				if m.selected[i] {
+					selected++
+				}
+				break
+			}
+		}
+	}
+	if valid > 0 && selected == valid {
+		return "x"
+	}
+	if selected > 0 {
+		return "-"
+	}
+	return " "
+}
+
+func (m Model) viewDetail() string {
+	header := []string{"dots · Tag details", ""}
+	footer := []string{"", "j/k scroll · pgup/pgdown · esc/left/d return · ctrl+c cancel"}
+	body := scrollPage(m.detailContentLines(), m.detailScroll, m.detailBodyHeight())
+	return renderLines(append(append(header, body...), footer...))
+}
+
+func (m Model) previewContentLines() []string {
+	lines := splitRendered(m.accepted.Text)
+	if m.accepted.ForwardOnly {
+		lines = append(lines, "", "[Forward-only]")
+	}
+	return lines
+}
+
+func (m Model) detailContentLines() []string {
+	return splitRendered(m.viewDetailFor(m.detail))
+}
+
+func (m Model) previewBodyHeight() int { return availableBodyHeight(m.height, 4) }
+
+func (m Model) detailBodyHeight() int { return availableBodyHeight(m.height, 4) }
+
+func (m Model) viewDetailFor(i int) string {
+	if i < 0 || i >= len(m.data.Tags) {
+		return ""
+	}
+	tag := m.data.Tags[i]
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s\n", tag.Name)
+	fmt.Fprintf(&b, "Description: %s\n", valueOrNone(tag.Description))
+	fmt.Fprintf(&b, "Profiles: %s\n", listOrNone(tag.Profiles))
+	fmt.Fprintf(&b, "Managed Entries: %s\n", listOrNone(tag.ManagedEntries))
+	fmt.Fprintf(&b, "Dependencies: %s\n", listOrNone(tag.Dependencies))
+	fmt.Fprintf(&b, "Provisioners: %s\n", listOrNone(tag.Provisioners))
+	fmt.Fprintf(&b, "Observed Status: %s\n", valueOrNone(string(tag.State)))
+	b.WriteString("Components:\n")
+	if len(tag.Components) == 0 {
+		b.WriteString("  none\n")
+	}
+	for _, component := range tag.Components {
+		fmt.Fprintf(&b, "  %s · %s · %s", component.Kind, component.Name, component.State)
+		if component.Detail != "" {
+			fmt.Fprintf(&b, " · %s", component.Detail)
+		}
+		b.WriteByte('\n')
+	}
+	if tag.ExternalEffectsPresent && m.initial[i] && !m.selected[i] {
+		b.WriteString("Retained External State [retained]\n")
+	} else if tag.ExternalEffectsPresent {
+		b.WriteString("External Effects Present\n")
+	} else {
+		b.WriteString("External Effects Present: none\n")
+	}
+	draft := "unchanged"
+	if m.selected[i] && !m.initial[i] {
+		draft = "add"
+	} else if !m.selected[i] && m.initial[i] {
+		draft = "remove"
+	}
+	fmt.Fprintf(&b, "Draft Change: %s\n", draft)
+	return b.String()
+}
+
+func availableBodyHeight(height, fixedLines int) int {
+	if height <= 0 {
+		return 0
+	}
+	return max(1, height-fixedLines)
+}
+
+func cursorPage(lines []string, cursorLine, height int) []string {
+	if height <= 0 || len(lines) <= height {
+		return append([]string(nil), lines...)
+	}
+	start := cursorLine - height/2
+	start = max(0, min(start, len(lines)-height))
+	page := append([]string(nil), lines[start:start+height]...)
+	if start > 0 {
+		page[0] = "↑ more"
+	}
+	if start+height < len(lines) {
+		page[len(page)-1] = "↓ more"
+	}
+	return page
+}
+
+func scrollPage(lines []string, offset, height int) []string {
+	if height <= 0 || len(lines) <= height {
+		return append([]string(nil), lines...)
+	}
+	offset = clampScrollOffset(offset, height, len(lines))
+	page := append([]string(nil), lines[offset:offset+height]...)
+	if offset > 0 {
+		page[0] = "↑ more"
+	}
+	if offset+height < len(lines) {
+		page[len(page)-1] = "↓ more"
+	}
+	return page
+}
+
+func scrolledOffset(current, delta, total, height int) int {
+	return clampScrollOffset(current+delta, height, total)
+}
+
+func clampScrollOffset(offset, height, total int) int {
+	if height <= 0 || total <= height {
+		return 0
+	}
+	return max(0, min(offset, total-height))
+}
+
+func splitRendered(value string) []string {
+	value = strings.TrimSuffix(value, "\n")
+	if value == "" {
+		return []string{}
+	}
+	return strings.Split(value, "\n")
+}
+
+func renderLines(lines []string) string {
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func listOrNone(values []string) string {
+	if len(values) == 0 {
+		return "none"
+	}
+	return strings.Join(values, ", ")
+}
+
+func valueOrNone(value string) string {
+	if value == "" {
+		return "none"
+	}
+	return value
+}
+
+func cloneStrings(values []string) []string {
+	out := make([]string, len(values))
+	copy(out, values)
+	return out
+}

--- a/internal/tui/tagselector/model_test.go
+++ b/internal/tui/tagselector/model_test.go
@@ -1,0 +1,522 @@
+package tagselector_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/yersonargotev/dots/internal/tui/tagselector"
+)
+
+func key(r rune) tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}}
+}
+
+func TestPreviewReceivesCanonicalSnapshotAndFinishesWithExactOpaqueValue(t *testing.T) {
+	wantPreview := tagselector.Preview{Text: "install zsh\nretain fzf", SemanticDigest: "sha256:opaque", ForwardOnly: true}
+	var received []string
+	model := tagselector.New(testBrowseData(), []string{"nvim", "zsh"}, func(tags []string) (tagselector.Preview, error) {
+		received = append([]string(nil), tags...)
+		tags[0] = "mutated-by-provider"
+		return wantPreview, nil
+	})
+
+	next, command := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(tagselector.Model)
+	if command == nil || !strings.Contains(model.View(), "Loading preview") {
+		t.Fatalf("enter should start asynchronous preview, view:\n%s", model.View())
+	}
+	message := command()
+	next, _ = model.Update(message)
+	model = next.(tagselector.Model)
+	if got, want := received, []string{"zsh", "nvim"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("preview input = %v, want canonical snapshot %v", got, want)
+	}
+	if got := model.Preview(); got != wantPreview {
+		t.Fatalf("Preview() = %#v, want exact opaque %#v", got, wantPreview)
+	}
+	view := model.View()
+	if !strings.Contains(view, wantPreview.Text) || !strings.Contains(view, "Forward-only") {
+		t.Fatalf("preview view missing opaque text or forward-only label:\n%s", view)
+	}
+	if got, want := model.SelectedTags(), []string{"zsh", "nvim"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("provider mutation leaked into desired Tags: %v, want %v", got, want)
+	}
+
+	next, quit := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(tagselector.Model)
+	if quit == nil {
+		t.Fatal("enter in preview should finish with a quit command")
+	}
+	result := model.Result()
+	if !reflect.DeepEqual(result.Tags, []string{"zsh", "nvim"}) || result.Preview != wantPreview {
+		t.Fatalf("Result() = %#v, want detached Tags and exact preview", result)
+	}
+	result.Tags[0] = "changed"
+	if got := model.Result().Tags[0]; got != "zsh" {
+		t.Fatalf("Result().Tags alias model storage, got %q", got)
+	}
+}
+
+func TestLoadingIgnoresRepeatedEnterSoEachRequestCallsPreviewOnce(t *testing.T) {
+	var calls atomic.Int32
+	model := tagselector.New(testBrowseData(), nil, func([]string) (tagselector.Preview, error) {
+		calls.Add(1)
+		return tagselector.Preview{Text: "ok"}, nil
+	})
+	next, command := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(tagselector.Model)
+	next, repeated := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(tagselector.Model)
+	if repeated != nil {
+		t.Fatal("enter while loading must not create another command for the same request")
+	}
+	message := command()
+	model = update(t, model, message)
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("preview calls = %d, want one for one request ID", got)
+	}
+}
+
+func TestPreviewErrorReturnsToDraftAndAllowsRetry(t *testing.T) {
+	var calls atomic.Int32
+	model := tagselector.New(testBrowseData(), []string{"zsh"}, func([]string) (tagselector.Preview, error) {
+		if calls.Add(1) == 1 {
+			return tagselector.Preview{}, errors.New("preview failed")
+		}
+		return tagselector.Preview{Text: "retry succeeded", SemanticDigest: "sha256:retry"}, nil
+	})
+
+	next, first := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(tagselector.Model)
+	model = update(t, model, first())
+	if view := model.View(); !strings.Contains(view, "Preview error: preview failed") || !strings.Contains(view, "[x] zsh") {
+		t.Fatalf("preview error should return to the unchanged draft:\n%s", view)
+	}
+	if got := model.Preview(); got != (tagselector.Preview{}) {
+		t.Fatalf("failed preview exposed usable value: %#v", got)
+	}
+
+	next, retry := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = update(t, next.(tagselector.Model), retry())
+	if got := model.Preview(); got.Text != "retry succeeded" || got.SemanticDigest != "sha256:retry" {
+		t.Fatalf("retry Preview() = %#v, want successful opaque preview", got)
+	}
+}
+
+func TestNewerPreviewWinsWhenBCompletesBeforeA(t *testing.T) {
+	aStarted := make(chan struct{})
+	aRelease := make(chan struct{})
+	preview := func(tags []string) (tagselector.Preview, error) {
+		if reflect.DeepEqual(tags, []string{"zsh"}) {
+			close(aStarted)
+			<-aRelease
+			return tagselector.Preview{Text: "A"}, nil
+		}
+		return tagselector.Preview{Text: "B", SemanticDigest: "b"}, nil
+	}
+	model := tagselector.New(testBrowseData(), []string{"zsh"}, preview)
+	next, commandA := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(tagselector.Model)
+	messagesA := make(chan tea.Msg, 1)
+	go func() { messagesA <- commandA() }()
+	<-aStarted
+
+	model = update(t, model, tea.KeyMsg{Type: tea.KeyEsc}, tea.KeyMsg{Type: tea.KeyDown}, key(' '))
+	next, commandB := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(tagselector.Model)
+	model = update(t, model, commandB())
+	if got := model.Preview().Text; got != "B" {
+		t.Fatalf("accepted Preview = %q, want B", got)
+	}
+
+	close(aRelease)
+	model = update(t, model, <-messagesA)
+	if got := model.Preview().Text; got != "B" {
+		t.Fatalf("stale A replaced accepted B, got %q", got)
+	}
+}
+
+func TestStalePreviewErrorAfterCancelCannotProduceUsableResult(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	model := tagselector.New(testBrowseData(), []string{"zsh"}, func([]string) (tagselector.Preview, error) {
+		close(started)
+		<-release
+		return tagselector.Preview{}, errors.New("late failure")
+	})
+	next, command := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(tagselector.Model)
+	messages := make(chan tea.Msg, 1)
+	go func() { messages <- command() }()
+	<-started
+	next, quit := model.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	model = next.(tagselector.Model)
+	if quit == nil || !model.Canceled() {
+		t.Fatal("ctrl+c while loading should cancel and quit immediately")
+	}
+	close(release)
+	model = update(t, model, <-messages)
+	if got := model.Result(); got.Tags != nil || got.Preview != (tagselector.Preview{}) {
+		t.Fatalf("canceled model exposed usable result: %#v", got)
+	}
+}
+
+func TestCtrlCCancelsFromEveryScreenAndClearsUsableValues(t *testing.T) {
+	preparations := map[string]func(t *testing.T) tagselector.Model{
+		"list": func(t *testing.T) tagselector.Model {
+			return tagselector.New(detailedBrowseData(), nil, nil)
+		},
+		"search": func(t *testing.T) tagselector.Model {
+			return update(t, tagselector.New(detailedBrowseData(), nil, nil), key('/'))
+		},
+		"profiles": func(t *testing.T) tagselector.Model {
+			browseData := detailedBrowseData()
+			browseData.Profiles = []tagselector.Profile{{Name: "core", Tags: []string{"zsh"}}}
+			return update(t, tagselector.New(browseData, nil, nil), key('p'))
+		},
+		"detail": func(t *testing.T) tagselector.Model {
+			return update(t, tagselector.New(detailedBrowseData(), nil, nil), tea.WindowSizeMsg{Width: 80}, key('d'))
+		},
+		"loading": func(t *testing.T) tagselector.Model {
+			model := tagselector.New(detailedBrowseData(), nil, func([]string) (tagselector.Preview, error) {
+				return tagselector.Preview{Text: "preview"}, nil
+			})
+			next, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			return next.(tagselector.Model)
+		},
+		"preview": func(t *testing.T) tagselector.Model {
+			model := tagselector.New(detailedBrowseData(), []string{"zsh"}, func([]string) (tagselector.Preview, error) {
+				return tagselector.Preview{Text: "preview"}, nil
+			})
+			next, command := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			return update(t, next.(tagselector.Model), command())
+		},
+	}
+	for name, prepare := range preparations {
+		t.Run(name, func(t *testing.T) {
+			model := prepare(t)
+			next, quit := model.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+			model = next.(tagselector.Model)
+			if quit == nil || !model.Canceled() {
+				t.Fatal("ctrl+c should cancel and quit")
+			}
+			if got := model.Result(); got.Tags != nil || got.Preview != (tagselector.Preview{}) {
+				t.Fatalf("canceled model exposed %#v", got)
+			}
+		})
+	}
+}
+
+func TestRunCancellationReturnsOnlyErrCanceled(t *testing.T) {
+	result, err := tagselector.Run(bytes.NewBuffer([]byte{3}), io.Discard, testBrowseData(), []string{"zsh"}, nil)
+	if !errors.Is(err, tagselector.ErrCanceled) {
+		t.Fatalf("Run() error = %v, want ErrCanceled", err)
+	}
+	if result.Tags != nil || result.Preview != (tagselector.Preview{}) {
+		t.Fatalf("Run() canceled result = %#v, want unusable zero value", result)
+	}
+}
+
+func TestRunCtrlCDoesNotWaitForInFlightPreview(t *testing.T) {
+	input, keys := io.Pipe()
+	defer input.Close()
+	defer keys.Close()
+	started := make(chan struct{})
+	release := make(chan struct{})
+	defer close(release)
+	type outcome struct {
+		result tagselector.Result
+		err    error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		result, err := tagselector.Run(input, io.Discard, testBrowseData(), []string{"zsh"}, func([]string) (tagselector.Preview, error) {
+			close(started)
+			<-release
+			return tagselector.Preview{Text: "too late"}, nil
+		})
+		done <- outcome{result: result, err: err}
+	}()
+	if _, err := keys.Write([]byte{'\r'}); err != nil {
+		t.Fatalf("write preview key: %v", err)
+	}
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("preview did not start")
+	}
+	if _, err := keys.Write([]byte{3}); err != nil {
+		t.Fatalf("write ctrl+c: %v", err)
+	}
+	select {
+	case got := <-done:
+		if !errors.Is(got.err, tagselector.ErrCanceled) || got.result.Tags != nil || got.result.Preview != (tagselector.Preview{}) {
+			t.Fatalf("Run() = (%#v, %v), want zero Result and ErrCanceled", got.result, got.err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run blocked on in-flight preview after ctrl+c")
+	}
+}
+
+func TestListGroupsTagsAndSearchesNameOrDescriptionCaseInsensitively(t *testing.T) {
+	model := tagselector.New(testBrowseData(), []string{"zsh"}, nil)
+	view := model.View()
+	for _, want := range []string{"Shell", "Development", "[x] zsh", "[ ] git"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("list view missing %q:\n%s", want, view)
+		}
+	}
+
+	model = update(t, model, key('/'), key('V'), key('E'), key('R'), key('S'), key('I'), key('O'), key('N'))
+	view = model.View()
+	if !strings.Contains(view, "git") || strings.Contains(view, "zsh") || strings.Contains(view, "nvim") {
+		t.Fatalf("description search should show only git:\n%s", view)
+	}
+
+	model = update(t, model, tea.KeyMsg{Type: tea.KeyEsc}, key('/'), key('N'), key('V'), key('I'), key('M'))
+	view = model.View()
+	if !strings.Contains(view, "nvim") || strings.Contains(view, "git") {
+		t.Fatalf("name search should show only nvim:\n%s", view)
+	}
+}
+
+func TestAcceptedSearchFilterTargetsTheVisibleTag(t *testing.T) {
+	model := tagselector.New(testBrowseData(), nil, nil)
+	model = update(t, model, key('/'), key('V'), key('E'), key('R'), tea.KeyMsg{Type: tea.KeyEnter}, key(' '))
+	if got, want := model.SelectedTags(), []string{"git"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("toggle after filtered search = %v, want visible Tag %v", got, want)
+	}
+}
+
+func update(t *testing.T, model tagselector.Model, messages ...tea.Msg) tagselector.Model {
+	t.Helper()
+	for _, message := range messages {
+		next, _ := model.Update(message)
+		model = next.(tagselector.Model)
+	}
+	return model
+}
+
+func testBrowseData() tagselector.BrowseData {
+	return tagselector.BrowseData{Tags: []tagselector.Tag{
+		{Name: "zsh", Description: "Shell setup", Group: "Shell"},
+		{Name: "git", Description: "Version control", Group: "Development"},
+		{Name: "nvim", Description: "Editor", Group: "Development"},
+	}}
+}
+
+func TestSelectedTagsStayInCanonicalBrowseOrderAndAreDetached(t *testing.T) {
+	browseData := testBrowseData()
+	model := tagselector.New(browseData, []string{"nvim", "unknown", "zsh"}, nil)
+
+	if got, want := model.SelectedTags(), []string{"zsh", "nvim"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("SelectedTags() = %v, want canonical %v", got, want)
+	}
+
+	first := model.SelectedTags()
+	first[0] = "changed"
+	browseData.Tags[0].Name = "also-changed"
+	if got, want := model.SelectedTags(), []string{"zsh", "nvim"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("SelectedTags() after caller mutation = %v, want detached %v", got, want)
+	}
+
+	model = update(t, model, key(' '), tea.KeyMsg{Type: tea.KeyDown}, key(' '))
+	if got, want := model.SelectedTags(), []string{"git", "nvim"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("SelectedTags() after reverse toggles = %v, want canonical browse order %v", got, want)
+	}
+}
+
+func TestProfilePresetSelectsOrDeselectsAllWithoutChangingUnrelatedTags(t *testing.T) {
+	browseData := testBrowseData()
+	browseData.Profiles = []tagselector.Profile{
+		{Name: "workstation", Description: "Everyday workstation", Tags: []string{"nvim", "zsh"}},
+		{Name: "agents", Description: "Agent tools", Tags: []string{"nvim", "git"}},
+	}
+	model := tagselector.New(browseData, []string{"git"}, nil)
+	model = update(t, model, key('p'))
+	if view := model.View(); !strings.Contains(view, "[ ] workstation") || !strings.Contains(view, "Everyday workstation") {
+		t.Fatalf("profiles view missing preset metadata:\n%s", view)
+	}
+
+	model = update(t, model, key(' '))
+	if view := model.View(); !strings.Contains(view, "[x] workstation") {
+		t.Fatalf("selected preset is not reflected in profile view:\n%s", view)
+	}
+	if got, want := model.SelectedTags(), []string{"zsh", "git", "nvim"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("first preset toggle = %v, want all preset Tags plus unrelated %v", got, want)
+	}
+	model = update(t, model, tea.KeyMsg{Type: tea.KeyEnter})
+	if view := model.View(); !strings.Contains(view, "[ ] workstation") {
+		t.Fatalf("deselected preset is not reflected in profile view:\n%s", view)
+	}
+	if got, want := model.SelectedTags(), []string{"git"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("second preset toggle = %v, want only unrelated %v", got, want)
+	}
+
+	model = update(t, model, tea.KeyMsg{Type: tea.KeyDown}, key(' '))
+	if got, want := model.SelectedTags(), []string{"git", "nvim"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("overlapping preset toggle = %v, want deterministic select-all %v", got, want)
+	}
+}
+
+func detailedBrowseData() tagselector.BrowseData {
+	return tagselector.BrowseData{Tags: []tagselector.Tag{{
+		Name:                   "zsh",
+		Description:            "Portable shell configuration",
+		Group:                  "Shell",
+		Profiles:               []string{"core", "workstation"},
+		ManagedEntries:         []string{"zshrc", "starship"},
+		Dependencies:           []string{"starship", "fzf"},
+		Provisioners:           []string{"zinit"},
+		State:                  tagselector.StateDrift,
+		ExternalEffectsPresent: true,
+		Components: []tagselector.Component{
+			{Kind: "Managed Entry", Name: "zshrc", State: tagselector.StateConflict, Detail: "local target differs"},
+			{Kind: "Dependency", Name: "fzf", State: tagselector.StateMissing, Detail: "command not found"},
+		},
+	}}}
+}
+
+func assertDetailFields(t *testing.T, view, draft, externalEffect string) {
+	t.Helper()
+	for _, want := range []string{
+		"Description: Portable shell configuration",
+		"Profiles: core, workstation",
+		"Managed Entries: zshrc, starship",
+		"Dependencies: starship, fzf",
+		"Provisioners: zinit",
+		"Observed Status: drift",
+		"Managed Entry · zshrc · conflict · local target differs",
+		"Dependency · fzf · missing · command not found",
+		externalEffect,
+		"Draft Change: " + draft,
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("detail view missing %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestWideListShowsDetailsAndDesiredCheckboxDoesNotReplaceObservedState(t *testing.T) {
+	model := tagselector.New(detailedBrowseData(), []string{"zsh"}, nil)
+	model = update(t, model, tea.WindowSizeMsg{Width: 100, Height: 30})
+	view := model.View()
+	if !strings.Contains(view, "[x] zsh") || !strings.Contains(view, "(drift)") {
+		t.Fatalf("desired checkbox and observed state must both be visible:\n%s", view)
+	}
+	assertDetailFields(t, view, "unchanged", "External Effects Present")
+	if strings.Contains(view, "Retained External State") {
+		t.Fatalf("unchanged Tag misclassified current external effects as selection residue:\n%s", view)
+	}
+
+	model = update(t, model, key(' '))
+	assertDetailFields(t, model.View(), "remove", "Retained External State [retained]")
+}
+
+func TestNarrowListOpensSeparateDetailWithDOrRight(t *testing.T) {
+	for _, open := range []tea.KeyMsg{key('d'), {Type: tea.KeyRight}} {
+		t.Run(open.String(), func(t *testing.T) {
+			model := tagselector.New(detailedBrowseData(), nil, nil)
+			model = update(t, model, tea.WindowSizeMsg{Width: 99, Height: 30})
+			if strings.Contains(model.View(), "Managed Entries:") {
+				t.Fatalf("narrow list should not inline details:\n%s", model.View())
+			}
+			model = update(t, model, key(' '), open)
+			assertDetailFields(t, model.View(), "add", "External Effects Present")
+			model = update(t, model, tea.KeyMsg{Type: tea.KeyEsc})
+			if strings.Contains(model.View(), "Managed Entries:") {
+				t.Fatalf("esc should return from narrow detail to list:\n%s", model.View())
+			}
+		})
+	}
+}
+
+func TestLargeCatalogKeepsCursorVisibleWithinTerminalHeight(t *testing.T) {
+	browseData := tagselector.BrowseData{}
+	for i := range 30 {
+		browseData.Tags = append(browseData.Tags, tagselector.Tag{
+			Name: fmt.Sprintf("tag-%02d", i), Group: fmt.Sprintf("Group %d", i/5), State: tagselector.StateAligned,
+		})
+	}
+	for _, width := range []int{80, 120} {
+		t.Run(fmt.Sprintf("width_%d", width), func(t *testing.T) {
+			model := tagselector.New(browseData, nil, nil)
+			model = update(t, model, tea.WindowSizeMsg{Width: width, Height: 10})
+			for range 21 {
+				model = update(t, model, tea.KeyMsg{Type: tea.KeyDown})
+			}
+			view := model.View()
+			if !strings.Contains(view, "> [ ] tag-21") {
+				t.Fatalf("cursor Tag is outside viewport:\n%s", view)
+			}
+			if strings.Contains(view, "tag-00") {
+				t.Fatalf("viewport still renders the beginning of a large catalog:\n%s", view)
+			}
+			if lines := renderedLineCount(view); lines > 10 {
+				t.Fatalf("rendered lines = %d, want at most terminal height 10\n%s", lines, view)
+			}
+		})
+	}
+}
+
+func TestLongPreviewScrollsWithinTerminalHeight(t *testing.T) {
+	var previewText strings.Builder
+	for i := 1; i <= 24; i++ {
+		fmt.Fprintf(&previewText, "plan line %02d\n", i)
+	}
+	model := tagselector.New(testBrowseData(), nil, func([]string) (tagselector.Preview, error) {
+		return tagselector.Preview{Text: previewText.String(), SemanticDigest: "sha256:long"}, nil
+	})
+	model = update(t, model, tea.WindowSizeMsg{Width: 80, Height: 8})
+	next, command := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = update(t, next.(tagselector.Model), command())
+	if view := model.View(); !strings.Contains(view, "plan line 01") || strings.Contains(view, "plan line 24") || !strings.Contains(view, "↓ more") {
+		t.Fatalf("preview should start at the first bounded page:\n%s", view)
+	}
+	for range 20 {
+		model = update(t, model, tea.KeyMsg{Type: tea.KeyPgDown})
+	}
+	view := model.View()
+	if !strings.Contains(view, "plan line 24") || strings.Contains(view, "plan line 01") || !strings.Contains(view, "↑ more") {
+		t.Fatalf("preview did not scroll to its final page:\n%s", view)
+	}
+	if lines := renderedLineCount(view); lines > 8 {
+		t.Fatalf("rendered preview lines = %d, want at most terminal height 8\n%s", lines, view)
+	}
+}
+
+func TestLongNarrowDetailScrollsWithinTerminalHeight(t *testing.T) {
+	browseData := detailedBrowseData()
+	for i := range 20 {
+		browseData.Tags[0].Components = append(browseData.Tags[0].Components, tagselector.Component{
+			Kind: "Dependency", Name: fmt.Sprintf("component-%02d", i), State: tagselector.StateAligned,
+		})
+	}
+	model := tagselector.New(browseData, nil, nil)
+	model = update(t, model, tea.WindowSizeMsg{Width: 80, Height: 8}, key('d'))
+	if view := model.View(); strings.Contains(view, "component-19") || !strings.Contains(view, "↓ more") {
+		t.Fatalf("detail should start at the first bounded page:\n%s", view)
+	}
+	for range 20 {
+		model = update(t, model, tea.KeyMsg{Type: tea.KeyPgDown})
+	}
+	view := model.View()
+	if !strings.Contains(view, "component-19") || !strings.Contains(view, "↑ more") {
+		t.Fatalf("detail did not scroll to its final page:\n%s", view)
+	}
+	if lines := renderedLineCount(view); lines > 8 {
+		t.Fatalf("rendered detail lines = %d, want at most terminal height 8\n%s", lines, view)
+	}
+}
+
+func renderedLineCount(view string) int {
+	return len(strings.Split(strings.TrimSuffix(view, "\n"), "\n"))
+}

--- a/internal/tui/tagselector/run.go
+++ b/internal/tui/tagselector/run.go
@@ -1,0 +1,33 @@
+package tagselector
+
+import (
+	"errors"
+	"io"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Run presents the selector on the provided streams. Cancellation always
+// returns a zero Result with ErrCanceled.
+func Run(in io.Reader, out io.Writer, browseData BrowseData, initial []string, preview PreviewFunc) (Result, error) {
+	program := tea.NewProgram(
+		New(browseData, initial, preview),
+		tea.WithInput(in),
+		tea.WithOutput(out),
+	)
+	final, err := program.Run()
+	if err != nil {
+		return Result{}, err
+	}
+	model, ok := final.(Model)
+	if !ok {
+		return Result{}, errors.New("tag selector returned unexpected model")
+	}
+	if model.Canceled() {
+		return Result{}, ErrCanceled
+	}
+	if !model.finished {
+		return Result{}, errors.New("tag selector ended without confirmation")
+	}
+	return model.Result(), nil
+}


### PR DESCRIPTION
Closes #468

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Add an interactive Bubble Tea browser for current atomic Tags, Profile presets, search, responsive details, and observed component state.
- Route selection-free interactive installs into an exact shared reconciliation preview while preserving non-interactive selection validation.
- Guarantee preview, cancellation, failure, and missing-repository paths do not prepare Git repositories or mutate Managed Entries, external tools, or Installation Metadata.

## Changes

| File | Change |
|------|--------|
| `internal/cli/install.go` | Route eligible interactive installs into the preview-only selector before repository preparation. |
| `internal/cli/install_tag_selector.go` | Build authoritative browse data and exact shared reconciliation previews, including portable OS-excluded details and historical Provisioner evidence. |
| `internal/tui/tagselector/` | Add the responsive Bubble Tea selection, detail, search, Profile preset, and asynchronous preview model. |
| `internal/cli/*_test.go`, `internal/tui/tagselector/model_test.go` | Cover routing, state projection, viewport behavior, stale responses, and byte-stable nonmutation. |
| `go.mod`, `go.sum` | Promote terminal detection to a direct dependency without changing its selected version. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile core --source-root "$PWD" --home <tmp>/home --state-root <tmp>/state`

Additional validation:

- [x] `git diff --check`
- [x] `go build ./...`
- [x] `go test -race ./internal/tui/tagselector -count=1`
- [x] `go test ./... -count=1`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked one issue with an admitted Delivery Contract using `Closes #468`.
- [x] Added exactly one `type:*` label.
- [x] Delivery Evidence records the Contract Source snapshot, Acceptance coverage, and Independent review.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed (not applicable; repository workflow did not change).
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

### Contract Source

- Kind: `composed-ticket`.
- Delivery ticket: GitHub node `I_kwDOSzLlmM8AAAABNwY30w`, https://github.com/yersonargotev/dots/issues/468, `updatedAt=2026-08-21T20:58:16Z`, raw UTF-8 SHA-256 `366bc3a97848b81180eddd02d44e67691427792e940ee0a1f3b966e7202e426b`.
- Parent specification: GitHub node `I_kwDOSzLlmM8AAAABNwWsmQ`, https://github.com/yersonargotev/dots/issues/459, `updatedAt=2026-08-21T20:59:00Z`, raw UTF-8 SHA-256 `85febbb601376376f0b74c2b155d6556d1f63d209272fdc033a0b178169dc556`.
- Composed Contract Source SHA-256: `34af0f2bd386b86aa835b866e606fee0dc948ae3e4b30ceadf4472805699903f`.
- Snapshot: category `enhancement`; readiness `ready-for-agent`; no comments on either source.
- Native relationships: parent #459 (open); no sub-issues under #468; `blockedBy` #465 (closed, `updatedAt=2026-08-22T16:36:06Z`); `blocking` #469 (open, `updatedAt=2026-08-21T20:58:19Z`). Parent #459 sub-issues are #465/#466/#467 closed and #468/#469 open, with membership, identity, state, and timestamps revalidated immediately before PR creation.

### Reviewed Candidate

- Base: `d687c2aa121741893f34c0340441e9de02a1ede3`.
- Head: `d0c6abe32ef0b842ebca2ffe16b06534b764ad01`.
- Binary diff SHA-256: `874da28abf1544d1abe7f79b8dde5db812fd48dc21dd74dc4c9d45160481da50`.
- `origin/main` remained exactly the fixed base and the worktree was clean before publication.

### Mutation Safety

- Classification: `required-mutation`; the selector intersects install selection authority even though this slice is preview-only.
- Invariant: selector completion, cancellation, and failure cannot prepare/fetch/checkout/stash the Installed Repository, apply Managed Entries, run Dependencies or Provisioners, or write Installation Metadata.
- Control matrix: no explicit selection + input/output TTY enters the preview-only selector; JSON, `--yes`, `--no-tui`, and non-TTY execution never enter it and retain explicit-selection validation.
- Fault and no-op evidence: real temporary Git repository byte/mode/path/symlink fingerprints stay identical after completion and cancellation; missing default repository is not bootstrapped; preview failure leaves home and metadata unchanged; stale asynchronous responses are rejected.
- Independent mutation-safety challenge on the reviewed head: PASS, zero actionable findings.

### Acceptance Coverage

- CLI routing tests cover the complete interactive/non-interactive matrix and exact completion/cancellation messages.
- Authoritative Installed Selection is normalized into an editable current-Tag draft; missing Installed Selection produces an empty, forward-only draft.
- Model tests cover deterministic group/Profile order, presets, search, checkbox-versus-observed state, component details, retained external evidence, responsive pagination, narrow detail, and long preview scrolling.
- Browse-data tests cover current and legacy Tags, current-OS and portable excluded surfaces, empty `not-applicable` Tags, Dependencies, Provisioners, Managed Entries, and the latest applicable historical Provisioner receipt across Profiles and legacy Tag aliases.
- Preview tests compare the opaque output/digest from the shared Selection Reconciliation Plan and reject stale asynchronous results.
- Cancellation, completion, and failure tests prove no filesystem, repository, external-tool, or metadata mutation; this slice never applies the draft.

### Automated Validation

All passed on the reviewed head:

- `test -z "$(gofmt -l .)"`
- `git diff --check`
- `go vet ./...`
- `go build ./...`
- `go test -race ./internal/tui/tagselector -count=1`
- `go test ./... -count=1`
- `go run ./cmd/dots manifest validate --file dots.yaml`
- sandboxed `go run ./cmd/dots plan ... --home <tmp>/home --state-root <tmp>/state`

### Manual Verification

- Built the candidate binary, launched the actual selector in a PTY with an explicit temporary manifest/source/home/state environment, canceled with Ctrl+C, observed `Tag selection canceled; nothing was applied.`, and verified the temporary home/state remained empty.

### Independent Review

- Spec: PASS, zero findings on `d0c6abe32ef0b842ebca2ffe16b06534b764ad01`.
- Standards: PASS, zero findings on `d0c6abe32ef0b842ebca2ffe16b06534b764ad01`.
<!-- delivery-issue:evidence:end -->
