### PR TITLE
feat(tui): apply confirmed tag selection changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,24 @@ Profiles are ordered convenience presets over atomic Tags, so the catalog also
 shows each independently meaningful capability. Select one directly with
 `dots install --tag <tag>`.
 
+In an interactive terminal, plain `dots install` opens the Tag selector from
+the current initialized Installed Repository. Profile presets can populate the
+draft, but the reviewed result is applied and recorded as an explicit list of
+current Tags. The preview covers Dependencies, the Install Plan, Selection
+Reconciliation, and Provisioners. Confirming the preview applies that exact
+candidate; `--dry-run` stops after the preview. Run `dots update` first when you
+want to refresh the Source of Truth, because opening the selector does not
+refresh its checkout.
+
+Removing selected Tags requires a second acknowledgement after the preview,
+separate from Conflict Resolution. Clearing every Tag requires typing the
+literal word `clear`. Declining either prompt, canceling the selector or
+Conflict Resolution, or encountering an apply failure leaves the prior
+Installed Selection authoritative. Dependencies and Provisioners that are no
+longer selected are reported as Retained External State; dots does not uninstall
+or reverse them. After terminal success, selection-aware status commands reuse
+the newly recorded explicit Tags.
+
 Explore the portable catalog before choosing, or compare two Profiles to see
 the exact declarative surface added and removed without inspecting machine
 state:
@@ -204,6 +222,13 @@ dots install --profile workstation --yes --backup-and-replace
 When replacing an existing Installed Selection and removing a recorded Profile
 or explicit extra Tag, add `--acknowledge-selection-change` after reviewing the
 reported delta. This acknowledgement is separate from Conflict Resolution.
+
+For the interactive equivalent, run `dots install` without selection flags,
+edit the Tag draft, and confirm its preview. Reductions receive their own
+acknowledgement, while an empty draft requires typing `clear`; cancellation or a
+mismatched phrase performs no mutation. Scripts and JSON consumers must keep
+using explicit `--profile`, `--tag`, or `--clear-selection` flags because the
+Tag selector is intentionally human-only.
 
 That mode creates Backup Sets before replacement, reports them in JSON as `data.backup_sets`, and still runs selected Provisioners after Managed Configuration is applied.
 

--- a/docs/agents/output-contract.md
+++ b/docs/agents/output-contract.md
@@ -210,6 +210,21 @@ prose the text surface prints:
   `--acknowledge-selection-change`. Successful reports keep the ordinary
   `data.selection` shape with empty `profiles`, `extra_tags`, and
   `effective_tags`; omitted selection flags never imply these empty arrays.
+- In a human interactive terminal, `install` with no selection flags opens the
+  Tag selector against the current initialized Installed Repository. Profile
+  presets edit the draft only; terminal success records the accepted current
+  Tags as explicit `extra_tags`, with empty `profiles`, and identical
+  `effective_tags`. The selector previews Dependencies, the Install Plan,
+  Selection Reconciliation, and Provisioners. An accepted reduction then uses
+  the ordinary Installed Selection change acknowledgement, independently from
+  Conflict Resolution; an empty accepted draft requires typing `clear`.
+  Cancellation, a mismatched clear phrase, or failure before terminal commit
+  preserves the prior authoritative Installed Selection.
+- The interactive Tag selector is not a JSON surface and does not refresh the
+  Source of Truth. `--output json`, `--yes`, `--no-tui`, and non-terminal input
+  continue to require explicit `--profile`, `--tag`, or `--clear-selection`
+  intent. Their existing JSON schemas are the machine-readable semantic
+  equivalent of the selector's reviewed plan and terminal result.
 - After a successful `install`, `update`, or `upgrade` finds sufficiently
   specific historical Installation Metadata evidence for retired Gentle AI or
   Codex delegation capabilities, `data.retirement` records portable `removed`

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -178,6 +178,23 @@ dots install --profile workstation --tag adaptive-theme
 
 ```
 
+Plain `dots install` in an interactive terminal provides the human workflow for
+editing the same complete selection. It starts from the authoritative Installed
+Selection, and Profile presets select their ordered current Tags in the draft.
+After the operator reviews and confirms the candidate, terminal success stores
+those current Tags explicitly rather than preserving Profile names. Removing
+Tags requires a separate Installed Selection reduction acknowledgement before
+Conflict Resolution. An empty draft additionally requires the literal `clear`;
+canceling or entering any other phrase leaves Managed Entries and the previous
+Installed Selection unchanged.
+
+The selector uses the current initialized Installed Repository and never
+refreshes the Source of Truth. Use `dots update` first when a refreshed checkout
+is intended. It remains a human-only surface: non-interactive and JSON commands
+must express the complete selection with `--profile`, `--tag`, or
+`--clear-selection`. Deselected Dependencies and Provisioners are Retained
+External State, not uninstall or rollback instructions.
+
 Tags are declarative selection only: they select Managed Entries, Dependencies,
 Provisioners, and source overrides, but never authorize hidden built-in cleanup
 or historical migration behavior. Historical retirement uses sufficiently

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -37,6 +37,9 @@ var (
 	commitInstallationMetadata               = func(commit install.MetadataCommit, installed state.InstalledSelection) error {
 		return commit.Commit(&installed)
 	}
+	commitSelectorInstallationMetadata = func(commit install.MetadataCommit, expected *state.InstalledSelection, installed state.InstalledSelection) error {
+		return commit.CommitTransition(expected, &installed)
+	}
 )
 
 func newInstallCommand() *cobra.Command {
@@ -59,7 +62,8 @@ func newInstallCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "install",
 		Short: "Install repository-managed dotfiles",
-		Long:  "install computes and shows an Install Plan, then applies safe create actions unless --dry-run is set.",
+		Long: "install computes and shows an Install Plan, then applies safe actions unless --dry-run is set. " +
+			"Without selection flags, an interactive terminal opens the Tag selector; scripts and non-interactive runs must pass --profile, --tag, or --clear-selection explicitly.",
 		// Domain installation failures are user-facing conflicts, not command misuse.
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -104,7 +108,14 @@ func newInstallCommand() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				return runInstallTagSelectorPreview(cmd, *m, meta, paths, prep.SourceReadRoot, prep.LegacyMigrations)
+				return runInstallTagSelector(cmd, *m, meta, paths, prep.SourceReadRoot, prep.LegacyMigrations, installTagSelectorOptions{
+					ManifestPath:       resolveManifestPath(cmd, file, paths.SourceRoot),
+					RequestedStateRoot: stateRoot,
+					DryRun:             dryRun,
+					SkipDependencies:   skipDeps,
+					NoTUI:              noTUI,
+					BackupAndReplace:   backupAndReplace,
+				})
 			}
 
 			var effective selection.Effective

--- a/internal/cli/install_tag_selector.go
+++ b/internal/cli/install_tag_selector.go
@@ -7,22 +7,32 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
+	"reflect"
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/charmbracelet/x/term"
 	"github.com/spf13/cobra"
+	"github.com/yersonargotev/dots/internal/backups"
 	"github.com/yersonargotev/dots/internal/catalog"
+	"github.com/yersonargotev/dots/internal/codexconfig"
 	"github.com/yersonargotev/dots/internal/deps"
+	"github.com/yersonargotev/dots/internal/deps/pkgmgr"
+	"github.com/yersonargotev/dots/internal/install"
 	"github.com/yersonargotev/dots/internal/manifest"
 	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/provision"
 	"github.com/yersonargotev/dots/internal/selection"
+	"github.com/yersonargotev/dots/internal/selectionreconciliation"
+	"github.com/yersonargotev/dots/internal/selectionretirement"
 	"github.com/yersonargotev/dots/internal/state"
 	"github.com/yersonargotev/dots/internal/status"
 	tagselectortui "github.com/yersonargotev/dots/internal/tui/tagselector"
+	"github.com/yersonargotev/dots/internal/version"
 )
 
 type installTagSelectorRunnerFunc func(io.Reader, io.Writer, tagselectortui.BrowseData, []string, tagselectortui.PreviewFunc) (tagselectortui.Result, error)
@@ -46,7 +56,206 @@ func installTagSelectorRequested(cmd *cobra.Command, yes, noTUI bool) bool {
 	return !yes && !noTUI && !wantsJSON(cmd) && installTagSelectorTerminal(cmd.InOrStdin(), cmd.OutOrStdout())
 }
 
-func runInstallTagSelectorPreview(cmd *cobra.Command, m manifest.Manifest, meta state.Metadata, paths resolvedPaths, sourceReadRoot string, legacyMigrations map[string]plan.LegacyMigration) error {
+type installTagSelectorOptions struct {
+	ManifestPath       string
+	RequestedStateRoot string
+	DryRun             bool
+	SkipDependencies   bool
+	NoTUI              bool
+	BackupAndReplace   bool
+}
+
+type installTagSelectorCandidate struct {
+	Manifest            manifest.Manifest
+	Metadata            state.Metadata
+	Paths               resolvedPaths
+	Effective           selection.Effective
+	Dependencies        *deps.PreparedInstall
+	DependencyOptions   deps.Options
+	DependencyLookup    deps.Lookup
+	BrewDetection       pkgmgr.HomebrewDetection
+	PackageManagerSetup *pkgmgr.Report
+	Plan                plan.Plan
+	CapturedSources     map[install.SourceCaptureKey]install.CapturedSource
+	Provisioners        provision.Plan
+	Retirement          selectionretirement.Plan
+	RetirementBlock     string
+	RetirementOptions   selectionretirement.Options
+	ManifestPath        string
+	RequestedStateRoot  string
+	Preview             tagselectortui.Preview
+}
+
+func (c installTagSelectorCandidate) releaseCapturedSources() error {
+	return install.ReleaseCapturedSources(c.CapturedSources)
+}
+
+type installTagSelectorCandidateStore struct {
+	mu          sync.Mutex
+	closed      bool
+	latestID    uint64
+	latestToken string
+	candidate   *installTagSelectorCandidate
+	release     func(installTagSelectorCandidate) error
+}
+
+func newInstallTagSelectorCandidateStore() *installTagSelectorCandidateStore {
+	return &installTagSelectorCandidateStore{release: func(candidate installTagSelectorCandidate) error {
+		return candidate.releaseCapturedSources()
+	}}
+}
+
+func (s *installTagSelectorCandidateStore) activate(requestID uint64) (string, bool, error) {
+	s.mu.Lock()
+	if s.closed || requestID == 0 || requestID <= s.latestID {
+		s.mu.Unlock()
+		return "", false, nil
+	}
+	token := fmt.Sprintf("selector-preview-%d", requestID)
+	previous := s.candidate
+	s.candidate = nil
+	s.latestID = requestID
+	s.latestToken = token
+	s.mu.Unlock()
+	if previous != nil {
+		if err := s.releaseCandidate(*previous); err != nil {
+			return token, true, fmt.Errorf("release superseded Tag selector candidate: %w", err)
+		}
+	}
+	return token, true, nil
+}
+
+func (s *installTagSelectorCandidateStore) put(requestID uint64, token string, candidate installTagSelectorCandidate) (bool, error) {
+	s.mu.Lock()
+	if s.closed || requestID != s.latestID || token == "" || token != s.latestToken {
+		s.mu.Unlock()
+		if err := s.releaseCandidate(candidate); err != nil {
+			return false, fmt.Errorf("release rejected Tag selector candidate: %w", err)
+		}
+		return false, nil
+	}
+	previous := s.candidate
+	s.candidate = &candidate
+	s.mu.Unlock()
+	if previous != nil {
+		if err := s.releaseCandidate(*previous); err != nil {
+			return true, fmt.Errorf("release replaced Tag selector candidate: %w", err)
+		}
+	}
+	return true, nil
+}
+
+func (s *installTagSelectorCandidateStore) take(token string) (installTagSelectorCandidate, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed || token == "" || token != s.latestToken || s.candidate == nil {
+		return installTagSelectorCandidate{}, false
+	}
+	candidate := *s.candidate
+	s.candidate = nil
+	return candidate, true
+}
+
+type installTagSelectorPreviewProvider struct {
+	store      *installTagSelectorCandidateStore
+	buildMu    sync.Mutex
+	releaseMu  sync.Mutex
+	releaseErr error
+	closed     bool
+	lateError  func(error)
+	build      func([]string) (installTagSelectorCandidate, error)
+}
+
+func (p *installTagSelectorPreviewProvider) preview(requestID uint64, tags []string) (tagselectortui.Preview, error) {
+	p.buildMu.Lock()
+	defer p.buildMu.Unlock()
+
+	token, ok, releaseErr := p.store.activate(requestID)
+	reportedLate := p.recordReleaseError(releaseErr)
+	if releaseErr != nil {
+		if reportedLate {
+			return tagselectortui.Preview{}, errors.New("Tag selector preview provider closed during cleanup")
+		}
+		return tagselectortui.Preview{}, releaseErr
+	}
+	if !ok {
+		return tagselectortui.Preview{}, fmt.Errorf("Tag selector preview request is stale or the candidate store is closed")
+	}
+	candidate, err := p.build(tags)
+	if err != nil {
+		return tagselectortui.Preview{}, err
+	}
+	candidate.Preview.CandidateToken = token
+	stored, releaseErr := p.store.put(requestID, token, candidate)
+	reportedLate = p.recordReleaseError(releaseErr)
+	if releaseErr != nil {
+		if reportedLate {
+			return tagselectortui.Preview{}, errors.New("Tag selector preview provider closed during cleanup")
+		}
+		return tagselectortui.Preview{}, releaseErr
+	}
+	if !stored {
+		return tagselectortui.Preview{}, fmt.Errorf("Tag selector preview request was superseded")
+	}
+	return candidate.Preview, nil
+}
+
+func (p *installTagSelectorPreviewProvider) recordReleaseError(err error) bool {
+	if err == nil {
+		return false
+	}
+	p.releaseMu.Lock()
+	if p.closed {
+		report := p.lateError
+		p.releaseMu.Unlock()
+		if report != nil {
+			report(err)
+		} else {
+			slog.Error("late Tag selector cleanup failed", "error", err)
+		}
+		return true
+	}
+	p.releaseErr = errors.Join(p.releaseErr, err)
+	p.releaseMu.Unlock()
+	return false
+}
+
+func (p *installTagSelectorPreviewProvider) close() error {
+	closeErr := p.store.close()
+	p.releaseMu.Lock()
+	defer p.releaseMu.Unlock()
+	result := errors.Join(p.releaseErr, closeErr)
+	p.releaseErr = nil
+	p.closed = true
+	return result
+}
+
+func (s *installTagSelectorCandidateStore) releaseCandidate(candidate installTagSelectorCandidate) error {
+	if s.release == nil {
+		return candidate.releaseCapturedSources()
+	}
+	return s.release(candidate)
+}
+
+func (s *installTagSelectorCandidateStore) close() error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil
+	}
+	s.closed = true
+	candidate := s.candidate
+	s.candidate = nil
+	s.mu.Unlock()
+	if candidate != nil {
+		if err := s.releaseCandidate(*candidate); err != nil {
+			return fmt.Errorf("release stored Tag selector candidate: %w", err)
+		}
+	}
+	return nil
+}
+
+func runInstallTagSelector(cmd *cobra.Command, m manifest.Manifest, meta state.Metadata, paths resolvedPaths, sourceReadRoot string, legacyMigrations map[string]plan.LegacyMigration, opts installTagSelectorOptions) (resultErr error) {
 	initial, err := resolveInstallTagSelectorInitial(m, meta.InstalledSelection)
 	if err != nil {
 		return err
@@ -66,10 +275,19 @@ func runInstallTagSelectorPreview(cmd *cobra.Command, m manifest.Manifest, meta 
 	if err != nil {
 		return err
 	}
-	preview := func(tags []string) (tagselectortui.Preview, error) {
-		return buildInstallTagSelectorPreview(m, meta, paths, sourceReadRoot, legacyMigrations, installHostOS, tags)
+	candidates := newInstallTagSelectorCandidateStore()
+	provider := &installTagSelectorPreviewProvider{
+		store: candidates,
+		build: func(tags []string) (installTagSelectorCandidate, error) {
+			return buildInstallTagSelectorCandidate(m, meta, paths, sourceReadRoot, legacyMigrations, installHostOS, tags, opts)
+		},
 	}
-	result, err := installTagSelectorRunner(cmd.InOrStdin(), cmd.OutOrStdout(), browseData, initial, preview)
+	defer func() {
+		if err := provider.close(); err != nil {
+			resultErr = errors.Join(resultErr, fmt.Errorf("close Tag selector preview provider: %w", err))
+		}
+	}()
+	result, err := installTagSelectorRunner(cmd.InOrStdin(), cmd.OutOrStdout(), browseData, initial, provider.preview)
 	if errors.Is(err, tagselectortui.ErrCanceled) {
 		fmt.Fprintln(cmd.OutOrStdout(), "Tag selection canceled; nothing was applied.")
 		return nil
@@ -77,17 +295,35 @@ func runInstallTagSelectorPreview(cmd *cobra.Command, m manifest.Manifest, meta 
 	if err != nil {
 		return fmt.Errorf("run Tag selector: %w", err)
 	}
-	if result.Preview.SemanticDigest == "" {
+	if result.Preview.SemanticDigest == "" || result.Preview.CandidateToken == "" {
 		return fmt.Errorf("run Tag selector: completed without an accepted preview")
 	}
-	if result.Preview.Text != "" {
-		fmt.Fprint(cmd.OutOrStdout(), result.Preview.Text)
-		if !strings.HasSuffix(result.Preview.Text, "\n") {
+	candidate, ok := candidates.take(result.Preview.CandidateToken)
+	if !ok {
+		return fmt.Errorf("run Tag selector: accepted preview does not match its immutable candidate")
+	}
+	defer func() {
+		if err := candidate.releaseCapturedSources(); err != nil {
+			resultErr = errors.Join(resultErr, fmt.Errorf("release accepted Tag selector candidate: %w", err))
+		}
+	}()
+	if err := provider.close(); err != nil {
+		return fmt.Errorf("close Tag selector preview provider: %w", err)
+	}
+	if !reflect.DeepEqual(result.Preview, candidate.Preview) || !slices.Equal(result.Tags, candidate.Effective.Selection.Tags) {
+		return fmt.Errorf("run Tag selector: accepted preview does not match its immutable candidate")
+	}
+	if candidate.Preview.Text != "" {
+		fmt.Fprint(cmd.OutOrStdout(), candidate.Preview.Text)
+		if !strings.HasSuffix(candidate.Preview.Text, "\n") {
 			fmt.Fprintln(cmd.OutOrStdout())
 		}
 	}
-	fmt.Fprintln(cmd.OutOrStdout(), "Selection preview only; nothing was applied.")
-	return nil
+	if opts.DryRun {
+		fmt.Fprintln(cmd.OutOrStdout(), "Dry run complete; nothing was applied.")
+		return nil
+	}
+	return applyInstallTagSelectorCandidate(cmd, candidate, opts, result.AcknowledgementAccepted)
 }
 
 type tagSelectorBrowseOptions struct {
@@ -512,28 +748,89 @@ func resolveInstallTagSelectorInitial(m manifest.Manifest, installed *state.Inst
 	return append([]string(nil), effective.Selection.Tags...), nil
 }
 
-func buildInstallTagSelectorPreview(m manifest.Manifest, meta state.Metadata, paths resolvedPaths, sourceReadRoot string, legacyMigrations map[string]plan.LegacyMigration, hostOS string, tags []string) (tagselectortui.Preview, error) {
+func buildInstallTagSelectorCandidate(m manifest.Manifest, meta state.Metadata, paths resolvedPaths, sourceReadRoot string, legacyMigrations map[string]plan.LegacyMigration, hostOS string, tags []string, opts installTagSelectorOptions) (installTagSelectorCandidate, error) {
 	effective, err := selection.ResolveIntent(m, selection.Intent{
 		Source:     selection.SourceExplicit,
 		ExtraTags:  append([]string(nil), tags...),
 		AllowEmpty: len(tags) == 0,
 	})
 	if err != nil {
-		return tagselectortui.Preview{}, fmt.Errorf("resolve Tag selector draft: %w", err)
+		return installTagSelectorCandidate{}, fmt.Errorf("resolve Tag selector draft: %w", err)
 	}
 	effective = selection.CompareInstalled(m, effective, meta.InstalledSelection, hostOS)
+
+	depTier, err := resolveInstallTier(hostOS)
+	if err != nil {
+		return installTagSelectorCandidate{}, err
+	}
+	depOptions := deps.Options{
+		Selection: &effective.Selection,
+		OS:        hostOS, Arch: installHostArch, Home: paths.Home, StateRoot: paths.StateRoot,
+		AppLookup: appInstalled(hostOS, paths.Home), HTTPClient: depsHTTPClient, RollingReleaseURL: depsRollingReleaseURL,
+	}
+	brewDetection := packageManagerDetector.DetectHomebrew()
+	depLookup := packageManagerLookup(brewDetection)
+	var preparedDependencies *deps.PreparedInstall
+	var packageManagerSetup *pkgmgr.Report
+	if !opts.SkipDependencies {
+		prepared, prepareErr := deps.PrepareInstall(m, depOptions, depLookup, fontInstalled(hostOS, paths.Home), depTier)
+		if prepareErr != nil {
+			return installTagSelectorCandidate{}, fmt.Errorf("prepare Tag selector Dependencies: %w", prepareErr)
+		}
+		setup := pkgmgr.HomebrewSetupNeed(hostOS, prepared.Report, brewDetection)
+		if setup.Status != pkgmgr.StatusNotNeeded || setup.Detection.NeedsPATH {
+			packageManagerSetup = &setup
+		}
+		if setup.Status == pkgmgr.StatusWouldOffer {
+			// The accepted candidate must already contain the exact actions that
+			// become runnable after the separately reviewed setup step succeeds.
+			available := brewDetection
+			available.Found = true
+			prepared, prepareErr = deps.PrepareInstall(m, depOptions, packageManagerLookup(available), fontInstalled(hostOS, paths.Home), depTier)
+			if prepareErr != nil {
+				return installTagSelectorCandidate{}, fmt.Errorf("prepare post-setup Tag selector Dependencies: %w", prepareErr)
+			}
+		}
+		preparedDependencies = &prepared
+	}
+
 	p, provisionPlan, err := buildInstallPlanAndProvisioners(m, meta, effective.Selection, hostOS, paths, sourceReadRoot, legacyMigrations)
 	if err != nil {
-		return tagselectortui.Preview{}, fmt.Errorf("build Tag selector preview: %w", err)
+		return installTagSelectorCandidate{}, fmt.Errorf("build Tag selector preview: %w", err)
 	}
 	p.Selection = &effective.Report
 	p.SelectionReconciliation, err = buildSelectionReconciliation(m, meta, effective, p, hostOS, paths, sourceReadRoot, true)
 	if err != nil {
-		return tagselectortui.Preview{}, fmt.Errorf("build Tag selector reconciliation preview: %w", err)
+		return installTagSelectorCandidate{}, fmt.Errorf("build Tag selector reconciliation preview: %w", err)
+	}
+	retirementOptions := selectionretirement.Options{SourceRoot: paths.SourceRoot, Home: paths.Home, StateRoot: paths.StateRoot, ForwardPlan: &p}
+	var retirementPlan selectionretirement.Plan
+	var retirementBlock string
+	if p.SelectionReconciliation != nil {
+		retirementPlan, err = selectionretirement.Build(*p.SelectionReconciliation, meta, retirementOptions)
+		if err != nil {
+			retirementBlock = err.Error()
+			retirementPlan = selectionretirement.Plan{}
+		}
+	}
+	capturedSources, err := install.CaptureManagedSources(p, install.Options{
+		SourceRoot: paths.SourceRoot, Home: paths.Home, StateRoot: paths.StateRoot,
+		ConflictDecisions: replaceAllConflictDecisions(p),
+	})
+	if err != nil {
+		return installTagSelectorCandidate{}, fmt.Errorf("capture Tag selector Source of Truth inputs: %w", err)
 	}
 
 	forwardOnly := meta.InstalledSelection == nil
 	var rendered bytes.Buffer
+	if preparedDependencies != nil {
+		renderPackageManagerSetup(&rendered, packageManagerSetup)
+		renderDepsInstallPreview(&rendered, preparedDependencies.Report)
+		fmt.Fprintln(&rendered)
+	} else {
+		fmt.Fprintln(&rendered, "Dependency provisioning skipped (--skip-deps).")
+		fmt.Fprintln(&rendered)
+	}
 	if forwardOnly {
 		fmt.Fprintln(&rendered, "Forward-only selection preview")
 		fmt.Fprintln(&rendered, "No Installed Selection is recorded; no retirement is authorized.")
@@ -543,19 +840,430 @@ func buildInstallTagSelectorPreview(m manifest.Manifest, meta state.Metadata, pa
 	renderProvisionPlan(&rendered, provisionPlan)
 
 	semantic := struct {
-		ForwardOnly  bool             `json:"forward_only"`
-		Selection    selection.Report `json:"selection"`
-		Plan         plan.Plan        `json:"plan"`
-		Provisioners provision.Plan   `json:"provisioners"`
+		Manifest             manifest.Manifest                `json:"manifest"`
+		Metadata             state.Metadata                   `json:"metadata"`
+		Paths                resolvedPaths                    `json:"paths"`
+		SourceReadRoot       string                           `json:"source_read_root"`
+		LegacyMigrations     map[string]plan.LegacyMigration  `json:"legacy_migrations"`
+		ForwardOnly          bool                             `json:"forward_only"`
+		Selection            selection.Report                 `json:"selection"`
+		Dependencies         *deps.PreparedInstall            `json:"dependencies,omitempty"`
+		PackageManagerSetup  *pkgmgr.Report                   `json:"package_manager_setup,omitempty"`
+		Plan                 plan.Plan                        `json:"plan"`
+		PlanAuthority        []tagSelectorPlanAuthority       `json:"plan_authority"`
+		CapturedSources      []install.SourceCaptureAuthority `json:"captured_sources"`
+		Provisioners         provision.Plan                   `json:"provisioners"`
+		Retirement           selectionretirement.Plan         `json:"retirement"`
+		RetirementBlock      string                           `json:"retirement_block,omitempty"`
+		HistoricalRetirement string                           `json:"historical_retirement"`
 	}{
-		ForwardOnly: forwardOnly, Selection: effective.Report, Plan: p, Provisioners: provisionPlan,
+		Manifest: m, Metadata: meta, Paths: paths, SourceReadRoot: sourceReadRoot, LegacyMigrations: legacyMigrations,
+		ForwardOnly: forwardOnly, Selection: effective.Report, Dependencies: preparedDependencies, PackageManagerSetup: packageManagerSetup,
+		Plan: p, PlanAuthority: tagSelectorPlanAuthorities(p), CapturedSources: install.SourceCaptureAuthorities(capturedSources),
+		Provisioners: provisionPlan, Retirement: retirementPlan, RetirementBlock: retirementBlock,
+		HistoricalRetirement: "not-run-selector",
 	}
 	encoded, err := json.Marshal(semantic)
 	if err != nil {
-		return tagselectortui.Preview{}, fmt.Errorf("encode Tag selector preview: %w", err)
+		return installTagSelectorCandidate{}, errors.Join(fmt.Errorf("encode Tag selector preview: %w", err), install.ReleaseCapturedSources(capturedSources))
 	}
 	digest := sha256.Sum256(encoded)
-	return tagselectortui.Preview{
+	preview := tagselectortui.Preview{
 		Text: rendered.String(), SemanticDigest: fmt.Sprintf("sha256:%x", digest), ForwardOnly: forwardOnly,
+	}
+	if len(effective.Selection.Tags) == 0 {
+		preview.Confirmation = tagselectortui.ConfirmationClear
+	} else if effective.Report.Change != nil && effective.Report.Change.AcknowledgementRequired {
+		preview.Confirmation = tagselectortui.ConfirmationReduction
+	}
+	return installTagSelectorCandidate{
+		Manifest: m, Metadata: meta, Paths: paths,
+		Effective: effective, Dependencies: preparedDependencies, DependencyOptions: depOptions,
+		DependencyLookup: depLookup, BrewDetection: brewDetection, PackageManagerSetup: packageManagerSetup,
+		Plan: p, CapturedSources: capturedSources, Provisioners: provisionPlan, Retirement: retirementPlan,
+		RetirementBlock: retirementBlock, RetirementOptions: retirementOptions,
+		ManifestPath: opts.ManifestPath, RequestedStateRoot: opts.RequestedStateRoot, Preview: preview,
 	}, nil
+}
+
+type tagSelectorPlanAuthority struct {
+	ResolvedSource                string
+	ResolvedSources               []string
+	Contributions                 []plan.Contribution
+	Content                       []byte
+	PreviousContent               []byte
+	PreviousHash                  string
+	PreviousRecordFingerprint     string
+	PreviousReconciliationReceipt *state.ReconciliationReceipt
+	Ownership                     string
+	Migration                     *plan.LegacyMigration
+	LegacyParent                  string
+}
+
+func tagSelectorPlanAuthorities(p plan.Plan) []tagSelectorPlanAuthority {
+	result := make([]tagSelectorPlanAuthority, 0, len(p.Actions))
+	for _, action := range p.Actions {
+		result = append(result, tagSelectorPlanAuthority{
+			ResolvedSource: action.ResolvedSource, ResolvedSources: action.ResolvedSources, Contributions: action.Contributions,
+			Content: action.Content, PreviousContent: action.PreviousContent, PreviousHash: action.PreviousHash,
+			PreviousRecordFingerprint: action.PreviousRecordFingerprint, PreviousReconciliationReceipt: action.PreviousReconciliationReceipt,
+			Ownership: action.Ownership, Migration: action.Migration, LegacyParent: action.LegacyParent,
+		})
+	}
+	return result
+}
+
+func applyInstallTagSelectorCandidate(cmd *cobra.Command, candidate installTagSelectorCandidate, opts installTagSelectorOptions, acknowledgementAccepted bool) (resultErr error) {
+	effective := candidate.Effective
+	if effective.Report.Change != nil {
+		change := *effective.Report.Change
+		effective.Report.Change = &change
+	}
+	clearSelection := len(candidate.Effective.Selection.Tags) == 0
+	proceed, _, err := guardSelectionChange(cmd, &effective, selectionChangePolicy{ClearSelection: clearSelection, AlreadyAccepted: acknowledgementAccepted})
+	if err != nil {
+		return err
+	}
+	if !proceed {
+		return nil
+	}
+	if candidate.RetirementBlock != "" {
+		return fmt.Errorf("accepted Tag selector reduction is blocked: %s", candidate.RetirementBlock)
+	}
+
+	conflictDecisions, proceed, err := resolveConflictDecisions(cmd, candidate.Plan, candidate.Paths, false, opts.NoTUI, opts.BackupAndReplace)
+	if err != nil {
+		return err
+	}
+	if !proceed {
+		return nil
+	}
+	installOptions := install.Options{
+		SourceRoot: candidate.Paths.SourceRoot, Home: candidate.Paths.Home, StateRoot: candidate.Paths.StateRoot,
+		ConflictDecisions: conflictDecisions,
+		CapturedSources:   selectorCapturedSourcesForDecisions(candidate.CapturedSources, conflictDecisions),
+	}
+	adoptSnapshots, err := install.CaptureAdoptSnapshots(candidate.Plan, installOptions)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := install.ReleaseAdoptSnapshots(adoptSnapshots); err != nil {
+			resultErr = errors.Join(resultErr, fmt.Errorf("release Tag selector adopt snapshots: %w", err))
+		}
+	}()
+	installOptions.AdoptSnapshots = adoptSnapshots
+	if err := install.ValidateManagedEntries(candidate.Plan, installOptions); err != nil {
+		return err
+	}
+	if err := validateInstallTagSelectorAuthority(candidate); err != nil {
+		return err
+	}
+
+	dependencyEnvironment, dependenciesReport, err := applyInstallTagSelectorDependencies(cmd, candidate)
+	if err != nil {
+		return err
+	}
+	if candidate.Dependencies != nil && dependenciesReport == nil {
+		return nil
+	}
+
+	beforeBackups, err := backups.Load(backups.Path(candidate.Paths.StateRoot))
+	if err != nil {
+		return err
+	}
+	metadataCommit, err := install.ApplyManagedEntries(candidate.Plan, installOptions)
+	if err != nil {
+		return err
+	}
+	createdBackups, err := createdBackupSetReports(candidate.Paths.StateRoot, beforeBackups)
+	if err != nil {
+		return err
+	}
+
+	provisionerReport, err := applyAcceptedTagSelectorProvisioners(cmd, candidate, dependencyEnvironment)
+	if err != nil {
+		return err
+	}
+	var retirementResult *selectionretirement.Result
+	if len(candidate.Retirement.Actions) > 0 {
+		result, applyErr := selectionretirement.Apply(candidate.Retirement, candidate.RetirementOptions)
+		retirementResult = &result
+		if applyErr != nil {
+			return applyErr
+		}
+	}
+
+	installedSelection := candidate.Effective.InstalledSelection(state.CaptureProvenance(candidate.Paths.SourceRoot, version.Value))
+	if err := commitSelectorInstallationMetadata(metadataCommit, candidate.Metadata.InstalledSelection, installedSelection); err != nil {
+		return err
+	}
+	renderTagSelectorFinalResult(cmd.OutOrStdout(), candidate, conflictDecisions, dependenciesReport, provisionerReport, retirementResult, len(createdBackups))
+	return nil
+}
+
+func renderTagSelectorFinalResult(w io.Writer, candidate installTagSelectorCandidate, conflictDecisions map[string]install.ConflictDecision, dependencyReport *deps.InstallReport, provisionerReport provision.Report, retirement *selectionretirement.Result, backupSets int) {
+	fmt.Fprintf(w, "Tag selection applied: tags=%s\n", renderSelectionValues(candidate.Effective.Selection.Tags))
+	fmt.Fprintf(w, "  Managed Entries: %d planned action(s)\n", len(candidate.Plan.Actions))
+	dependencyResults := 0
+	if dependencyReport != nil {
+		dependencyResults = len(dependencyReport.Items)
+	}
+	fmt.Fprintf(w, "  Dependencies: %d result(s)\n", dependencyResults)
+	fmt.Fprintf(w, "  Provisioners: %d result(s)\n", len(provisionerReport.Items))
+	removed, retained := 0, 0
+	if retirement != nil {
+		removed, retained = len(retirement.Removed), len(retirement.Retained)
+	}
+	fmt.Fprintf(w, "  Selection retirement: %d removed, %d retained\n", removed, retained)
+	fmt.Fprintf(w, "  Backup Sets: %d created\n", backupSets)
+	fmt.Fprintln(w, "  Historical retirement: not run (Tag selector path)")
+	renderTagSelectorManagedEntryResults(w, candidate.Plan, conflictDecisions)
+	renderTagSelectorRetainedExternalState(w, candidate.Plan.SelectionReconciliation)
+	renderSelectionRetirement(w, retirement)
+}
+
+func renderTagSelectorManagedEntryResults(w io.Writer, p plan.Plan, conflictDecisions map[string]install.ConflictDecision) {
+	if len(p.Actions) == 0 {
+		return
+	}
+	fmt.Fprintln(w, "\nManaged Entry results:")
+	for _, action := range p.Actions {
+		fmt.Fprintf(w, "  %-10s %s\n", tagSelectorManagedEntryOutcome(action, p.SelectionReconciliation, conflictDecisions), action.Target)
+	}
+}
+
+func tagSelectorManagedEntryOutcome(action plan.Action, report *selectionreconciliation.Report, conflictDecisions map[string]install.ConflictDecision) string {
+	if action.Status == plan.StatusConflict {
+		switch conflictDecisions[action.Target] {
+		case install.DecisionReplace:
+			return "replaced"
+		case install.DecisionAdopt:
+			return "adopted"
+		default:
+			return "skipped"
+		}
+	}
+	if action.Status == plan.StatusMigrate {
+		return "migrated"
+	}
+	if report != nil {
+		for _, semantic := range report.Actions {
+			if semantic.Scope != selectionreconciliation.ScopeManagedEntry || semantic.ResolvedTarget != action.Target {
+				continue
+			}
+			switch semantic.Outcome {
+			case selectionreconciliation.OutcomeCreate:
+				return "created"
+			case selectionreconciliation.OutcomeUpdate:
+				return "updated"
+			case selectionreconciliation.OutcomePreserve:
+				return "preserved"
+			case selectionreconciliation.OutcomeReconcile:
+				return "reconciled"
+			}
+		}
+	}
+	switch action.Status {
+	case plan.StatusCreate:
+		return "created"
+	case plan.StatusUpdate:
+		return "updated"
+	case plan.StatusUnchanged:
+		return "preserved"
+	case plan.StatusMissingSource:
+		return "not-applied"
+	default:
+		return "unknown"
+	}
+}
+
+func renderTagSelectorRetainedExternalState(w io.Writer, report *selectionreconciliation.Report) {
+	if report == nil {
+		return
+	}
+	printedHeading := false
+	for _, action := range report.Actions {
+		if action.Outcome != selectionreconciliation.OutcomeRetainedExternalState {
+			continue
+		}
+		if !printedHeading {
+			fmt.Fprintln(w, "\nRetained External State:")
+			printedHeading = true
+		}
+		subject := strings.Join(action.Names, ", ")
+		if action.Identity != "" {
+			subject += " [" + action.Identity + "]"
+		}
+		fmt.Fprintf(w, "  %-12s %s\n", action.Scope, subject)
+	}
+}
+
+func selectorCapturedSourcesForDecisions(captures map[install.SourceCaptureKey]install.CapturedSource, decisions map[string]install.ConflictDecision) map[install.SourceCaptureKey]install.CapturedSource {
+	selected := make(map[install.SourceCaptureKey]install.CapturedSource, len(captures))
+	for key, capture := range captures {
+		if decisions[key.Target] == install.DecisionAdopt {
+			continue
+		}
+		selected[key] = capture
+	}
+	return selected
+}
+
+func validateInstallTagSelectorAuthority(candidate installTagSelectorCandidate) error {
+	if candidate.ManifestPath != "" {
+		current, err := manifest.LoadFile(candidate.ManifestPath)
+		if err != nil {
+			return fmt.Errorf("revalidate accepted Tag selector Install Manifest: %w", err)
+		}
+		if !reflect.DeepEqual(*current, candidate.Manifest) {
+			return fmt.Errorf("accepted Tag selector candidate is stale: Install Manifest changed before mutation")
+		}
+	}
+	currentMetadata, err := loadInstallationMetadata(candidate.Paths, candidate.RequestedStateRoot)
+	if err != nil {
+		return fmt.Errorf("revalidate accepted Tag selector Installation Metadata: %w", err)
+	}
+	if !reflect.DeepEqual(currentMetadata, candidate.Metadata) {
+		return fmt.Errorf("accepted Tag selector candidate is stale: Installation Metadata changed before mutation")
+	}
+	return nil
+}
+
+func applyInstallTagSelectorDependencies(cmd *cobra.Command, candidate installTagSelectorCandidate) ([]string, *deps.InstallReport, error) {
+	if candidate.Dependencies == nil {
+		return nil, &deps.InstallReport{}, nil
+	}
+	var setup *pkgmgr.Report
+	if candidate.PackageManagerSetup != nil {
+		copy := *candidate.PackageManagerSetup
+		setup = &copy
+	}
+	brewDetection := candidate.BrewDetection
+	brewPath := brewDetection.Path
+	if setup != nil && setup.Status == pkgmgr.StatusWouldOffer {
+		confirmed, err := confirmPackageManagerSetup(cmd.InOrStdin(), cmd.OutOrStdout(), *setup)
+		if err != nil {
+			return nil, nil, err
+		}
+		if !confirmed {
+			setup.Status = pkgmgr.StatusDeclined
+			fmt.Fprintln(cmd.OutOrStdout(), "Package Manager Setup declined; install canceled before Managed Configuration.")
+			return nil, nil, nil
+		}
+		if err := pkgmgr.RunHomebrewSetup(cmd.Context(), packageManagerSetupRunner, cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr()); err != nil {
+			setup.Status = pkgmgr.StatusFailed
+			return nil, nil, fmt.Errorf("Homebrew Package Manager Setup failed: %w", err)
+		}
+		brewDetection = packageManagerDetector.DetectHomebrew()
+		if !brewDetection.Found {
+			setup.Status = pkgmgr.StatusUnavailable
+			return nil, nil, fmt.Errorf("Homebrew Package Manager Setup completed but brew was not found on PATH, /opt/homebrew/bin/brew, or /usr/local/bin/brew")
+		}
+		setup.Status = pkgmgr.StatusInstalled
+		brewPath = brewDetection.Path
+	}
+
+	prepared := *candidate.Dependencies
+	if hasRequiredInstallablePreviewAction(prepared.Report) {
+		confirmed, err := confirmDepsInstall(cmd.InOrStdin(), cmd.OutOrStdout())
+		if err != nil {
+			return nil, nil, err
+		}
+		if !confirmed {
+			fmt.Fprintln(cmd.OutOrStdout(), "Dependency installation cancelled.")
+			return nil, nil, nil
+		}
+	} else if hasInstallablePreviewAction(prepared.Report) {
+		report, err := unresolvedInstallReportFromPreview(prepared.Report)
+		renderDepsInstall(cmd.OutOrStdout(), report)
+		return nil, &report, err
+	}
+
+	depOptions := pinResolvedUserLocal(candidate.DependencyOptions, prepared.Report)
+	runner := &depsExecRunner{
+		ctx: cmd.Context(), stdin: cmd.InOrStdin(), stdout: cmd.OutOrStdout(), stderr: cmd.ErrOrStderr(),
+		home: candidate.Paths.Home, stateRoot: depOptions.StateRoot, brewPath: brewPath,
+	}
+	report, err := deps.InstallPrepared(prepared, depOptions, candidate.DependencyLookup, fontInstalled(depOptions.OS, candidate.Paths.Home), runner)
+	renderDepsInstall(cmd.OutOrStdout(), report)
+	return runner.Environment(), &report, err
+}
+
+func applyAcceptedTagSelectorProvisioners(cmd *cobra.Command, candidate installTagSelectorCandidate, baseEnv []string) (provision.Report, error) {
+	report := provision.Report{
+		Profile: candidate.Provisioners.Profile, Profiles: append([]string(nil), candidate.Provisioners.Profiles...),
+		Tags: append([]string(nil), candidate.Provisioners.Tags...), Items: []provision.RunItem{},
+	}
+	selected, err := provision.Select(candidate.Manifest, provision.Options{Selection: &candidate.Effective.Selection, OS: candidate.DependencyOptions.OS})
+	if err != nil {
+		return report, err
+	}
+	if len(selected) != len(candidate.Provisioners.Steps) {
+		return report, fmt.Errorf("accepted Tag selector Provisioner Plan changed shape: %d declarations for %d steps", len(selected), len(candidate.Provisioners.Steps))
+	}
+	ctx := cmd.Context()
+	stdout := cmd.OutOrStdout()
+	runner := provisionExecRunner{ctx: ctx, home: candidate.Paths.Home, stdin: cmd.InOrStdin(), stdout: stdout, stderr: cmd.ErrOrStderr(), baseEnv: baseEnv}
+	for index, step := range candidate.Provisioners.Steps {
+		declaration := selected[index]
+		executable, args := provision.RenderCommand(declaration)
+		if declaration.Tool != step.Tool || executable != step.Executable || !slices.Equal(args, step.Args) {
+			return report, fmt.Errorf("accepted Tag selector Provisioner step %d no longer matches its declaration", index)
+		}
+		item := provision.RunItem{Tool: step.Tool, Executable: step.Executable, Args: append([]string(nil), step.Args...)}
+		if missing := missingAcceptedTagSelectorProvisionerDependencies(declaration, candidate, runner); len(missing) > 0 {
+			item.Status = provision.RunStatusMissingDeps
+			item.Missing = missing
+			report.Items = append(report.Items, item)
+			renderProvisionReport(cmd.OutOrStdout(), report)
+			if recordErr := recordProvisionerMetadata(candidate.Paths.StateRoot, candidate.Paths.SourceRoot, report); recordErr != nil {
+				return report, errors.Join(fmt.Errorf("provisioner %q is missing dependencies: %v", step.Tool, missing), recordErr)
+			}
+			return report, fmt.Errorf("provisioner %q is missing dependencies: %v", step.Tool, missing)
+		}
+		if err := runner.Run(step.Executable, step.Args); err != nil {
+			item.Status = provision.RunStatusFailed
+			report.Items = append(report.Items, item)
+			renderProvisionReport(cmd.OutOrStdout(), report)
+			if recordErr := recordProvisionerMetadata(candidate.Paths.StateRoot, candidate.Paths.SourceRoot, report); recordErr != nil {
+				return report, errors.Join(fmt.Errorf("provisioner %q failed: %w", step.Tool, err), recordErr)
+			}
+			return report, fmt.Errorf("provisioner %q failed: %w", step.Tool, err)
+		}
+		item.Status = provision.RunStatusProvisioned
+		report.Items = append(report.Items, item)
+	}
+	if len(report.Items) > 0 {
+		renderProvisionReport(cmd.OutOrStdout(), report)
+		if err := recordProvisionerMetadata(candidate.Paths.StateRoot, candidate.Paths.SourceRoot, report); err != nil {
+			return report, err
+		}
+	}
+	if agents := selectedCodeGraphAgents(selected); len(agents) > 0 {
+		if err := codexconfig.EnsureCodeGraphMode(candidate.Paths.Home, agents...); err != nil {
+			return report, err
+		}
+	}
+	return report, nil
+}
+
+func missingAcceptedTagSelectorProvisionerDependencies(declaration manifest.Provisioner, candidate installTagSelectorCandidate, runner provisionExecRunner) []string {
+	probeOptions := deps.Options{OS: candidate.DependencyOptions.OS, AppLookup: candidate.DependencyOptions.AppLookup}
+	fontLookup := fontInstalled(candidate.DependencyOptions.OS, candidate.Paths.Home)
+	var missing []string
+	for _, dependency := range declaration.Dependencies {
+		if deps.DependencyPresent(dependency, probeOptions, runner.Lookup, fontLookup) {
+			continue
+		}
+		if dependency.IsFont() {
+			matches := dependency.FontMatches()
+			if len(matches) > 0 {
+				missing = append(missing, matches[0])
+			}
+			continue
+		}
+		missing = append(missing, dependency.Probe())
+	}
+	return missing
 }

--- a/internal/cli/install_tag_selector_apply_internal_test.go
+++ b/internal/cli/install_tag_selector_apply_internal_test.go
@@ -1,0 +1,621 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/install"
+	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/plan"
+	"github.com/yersonargotev/dots/internal/provision"
+	"github.com/yersonargotev/dots/internal/selectionreconciliation"
+	"github.com/yersonargotev/dots/internal/selectionretirement"
+	"github.com/yersonargotev/dots/internal/state"
+	tagselectortui "github.com/yersonargotev/dots/internal/tui/tagselector"
+)
+
+func TestInstallTagSelectorProfilePresetPersistsExplicitCurrentTags(t *testing.T) {
+	manifestPath, sourceRoot, home, stateRoot := writeTagSelectorTestManifest(t)
+	setInstallTagSelectorTestHooks(t, true, func(_ io.Reader, _ io.Writer, browse tagselectortui.BrowseData, initial []string, preview tagselectortui.PreviewFunc) (tagselectortui.Result, error) {
+		if len(initial) != 0 {
+			t.Fatalf("initial Tags = %#v, want empty", initial)
+		}
+		var preset []string
+		for _, profile := range browse.Profiles {
+			if profile.Name == "default" {
+				preset = append([]string(nil), profile.Tags...)
+				break
+			}
+		}
+		if want := []string{"one"}; !reflect.DeepEqual(preset, want) {
+			t.Fatalf("default Profile preset = %#v, want %#v", preset, want)
+		}
+		built, err := preview(1, preset)
+		return tagselectortui.Result{Tags: preset, Preview: built}, err
+	})
+
+	out, err := executeAcceptedSelector(t, "", manifestPath, sourceRoot, home, stateRoot)
+	if err != nil {
+		t.Fatalf("Execute() error = %v\n%s", err, out)
+	}
+	got := loadSelectorSelection(t, stateRoot)
+	if len(got.Profiles) != 0 || !reflect.DeepEqual(got.ExtraTags, []string{"one"}) || !reflect.DeepEqual(got.ResolvedTags, []string{"one"}) {
+		t.Fatalf("Installed Selection = %#v, want Profile flattened to explicit current Tag one", got)
+	}
+}
+
+func TestInstallTagSelectorConflictResolutionCancelPreservesInstalledSelection(t *testing.T) {
+	manifestPath, sourceRoot, home, stateRoot := writeTagSelectorTestManifest(t)
+	runExplicitTagSelectorSeed(t, manifestPath, sourceRoot, home, stateRoot, "one")
+	previous := *loadSelectorSelection(t, stateRoot)
+	target := filepath.Join(home, ".one")
+	if err := os.Remove(target); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("operator-owned\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	setInstallTagSelectorTestHooks(t, true, acceptedSelectorTags("one", "two"))
+	out, err := executeAcceptedSelector(t, "q", manifestPath, sourceRoot, home, stateRoot)
+	if err != nil {
+		t.Fatalf("Execute() error = %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "Conflict resolution canceled; no changes applied.") {
+		t.Fatalf("output missing shared Conflict Resolution cancellation\n%s", out)
+	}
+	if got, readErr := os.ReadFile(target); readErr != nil || string(got) != "operator-owned\n" {
+		t.Fatalf("conflict target = %q, %v; want operator content", got, readErr)
+	}
+	if _, statErr := os.Lstat(filepath.Join(home, ".two")); !os.IsNotExist(statErr) {
+		t.Fatalf("Conflict Resolution cancellation applied later Managed Entry: %v", statErr)
+	}
+	if got := loadSelectorSelection(t, stateRoot); !reflect.DeepEqual(*got, previous) {
+		t.Fatalf("Installed Selection = %#v, want previous %#v", got, previous)
+	}
+}
+
+func TestInstallTagSelectorApplyFailurePreservesInstalledSelection(t *testing.T) {
+	manifestPath, sourceRoot, home, stateRoot := writeTagSelectorTestManifest(t)
+	runExplicitTagSelectorSeed(t, manifestPath, sourceRoot, home, stateRoot, "one")
+	previous := *loadSelectorSelection(t, stateRoot)
+	setInstallTagSelectorTestHooks(t, true, func(_ io.Reader, _ io.Writer, _ tagselectortui.BrowseData, _ []string, preview tagselectortui.PreviewFunc) (tagselectortui.Result, error) {
+		built, err := preview(1, []string{"one", "two"})
+		if err != nil {
+			return tagselectortui.Result{}, err
+		}
+		replacement := filepath.Join(sourceRoot, "config", "two-replacement")
+		if err := os.WriteFile(replacement, []byte("stale\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Rename(replacement, filepath.Join(sourceRoot, "config", "two")); err != nil {
+			t.Fatal(err)
+		}
+		return tagselectortui.Result{Tags: []string{"one", "two"}, Preview: built}, nil
+	})
+
+	out, err := executeAcceptedSelector(t, "", manifestPath, sourceRoot, home, stateRoot)
+	if err == nil || !strings.Contains(err.Error(), "changed identity") {
+		t.Fatalf("Execute() error = %v, want stale apply authority failure\n%s", err, out)
+	}
+	if _, statErr := os.Lstat(filepath.Join(home, ".two")); !os.IsNotExist(statErr) {
+		t.Fatalf("failed apply created .two: %v", statErr)
+	}
+	if got := loadSelectorSelection(t, stateRoot); !reflect.DeepEqual(*got, previous) {
+		t.Fatalf("Installed Selection = %#v, want previous %#v", got, previous)
+	}
+}
+
+func TestInstallTagSelectorTerminalCASPreservesConcurrentInstalledSelection(t *testing.T) {
+	manifestPath, sourceRoot, home, stateRoot := writeTagSelectorProvisionerFixture(t)
+	runExplicitTagSelectorSeed(t, manifestPath, sourceRoot, home, stateRoot, "one")
+	concurrentMetadata, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	concurrent := &state.InstalledSelection{
+		Profiles: []string{}, ExtraTags: []string{"two"}, ResolvedTags: []string{"two"},
+		Provenance: state.Provenance{SourceRoot: sourceRoot, DotsVersion: "concurrent-writer"},
+	}
+	concurrentMetadata.InstalledSelection = concurrent
+	concurrentPath := filepath.Join(t.TempDir(), "concurrent.json")
+	if err := state.Save(concurrentPath, concurrentMetadata); err != nil {
+		t.Fatal(err)
+	}
+	stubDir := t.TempDir()
+	writeSelectorExecutable(t, filepath.Join(stubDir, "claude"), fmt.Sprintf("#!/bin/sh\n[ \"$1\" = plugin ] || exit 0\ncp %q %q\n", concurrentPath, state.Path(stateRoot)))
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	setInstallTagSelectorTestHooks(t, true, acceptedSelectorTags("one", "two"))
+
+	out, err := executeAcceptedSelector(t, "", manifestPath, sourceRoot, home, stateRoot)
+	if err == nil || !strings.Contains(err.Error(), "installed selection changed concurrently") {
+		t.Fatalf("Execute() error = %v, want terminal CAS rejection\n%s", err, out)
+	}
+	if got := loadSelectorSelection(t, stateRoot); !reflect.DeepEqual(got, concurrent) {
+		t.Fatalf("Installed Selection = %#v, want concurrent authority %#v", got, concurrent)
+	}
+}
+
+func TestInstallTagSelectorPartialFailureRerunConverges(t *testing.T) {
+	manifestPath, sourceRoot, home, stateRoot := writeTagSelectorProvisionerFixture(t)
+	runExplicitTagSelectorSeed(t, manifestPath, sourceRoot, home, stateRoot, "one")
+	previous := *loadSelectorSelection(t, stateRoot)
+	stubDir := t.TempDir()
+	marker := filepath.Join(stubDir, "failed-once")
+	writeSelectorExecutable(t, filepath.Join(stubDir, "claude"), fmt.Sprintf("#!/bin/sh\n[ \"$1\" = plugin ] || exit 0\nif [ ! -e %q ]; then : > %q; exit 17; fi\nexit 0\n", marker, marker))
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	setInstallTagSelectorTestHooks(t, true, acceptedSelectorTags("one", "two"))
+	firstOut, firstErr := executeAcceptedSelector(t, "", manifestPath, sourceRoot, home, stateRoot)
+	if firstErr == nil || !strings.Contains(firstErr.Error(), `provisioner "claude" failed`) {
+		t.Fatalf("first Execute() error = %v, want injected partial failure\n%s", firstErr, firstOut)
+	}
+	if got := loadSelectorSelection(t, stateRoot); !reflect.DeepEqual(*got, previous) {
+		t.Fatalf("Installed Selection after partial failure = %#v, want previous %#v", got, previous)
+	}
+
+	setInstallTagSelectorTestHooks(t, true, acceptedSelectorTags("one", "two"))
+	secondOut, secondErr := executeAcceptedSelector(t, "", manifestPath, sourceRoot, home, stateRoot)
+	if secondErr != nil {
+		t.Fatalf("rerun Execute() error = %v\n%s", secondErr, secondOut)
+	}
+	if _, err := os.Lstat(filepath.Join(home, ".two")); err != nil {
+		t.Fatalf("rerun did not converge Managed Entry: %v", err)
+	}
+	got := loadSelectorSelection(t, stateRoot)
+	if !reflect.DeepEqual(got.ExtraTags, []string{"one", "two"}) || !reflect.DeepEqual(got.ResolvedTags, []string{"one", "two"}) {
+		t.Fatalf("rerun Installed Selection = %#v, want explicit Tags one,two", got)
+	}
+}
+
+func TestInstallTagSelectorMixedPreviewMatchesExplicitJSONSemanticsAndGolden(t *testing.T) {
+	manifestPath, sourceRoot, home, stateRoot := writeTagSelectorMixedFixture(t)
+	stubDir := t.TempDir()
+	writeSelectorExecutable(t, filepath.Join(stubDir, "claude"), "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	runExplicitTagSelectorSeed(t, manifestPath, sourceRoot, home, stateRoot, "base", "retired")
+
+	m, err := manifest.LoadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	paths, err := resolvePaths(home, sourceRoot, stateRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidate, err := buildInstallTagSelectorCandidate(*m, meta, paths, sourceRoot, nil, installHostOS, []string{"base", "next"}, installTagSelectorOptions{SkipDependencies: true})
+	if err != nil {
+		t.Fatalf("build selector candidate: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := candidate.releaseCapturedSources(); err != nil {
+			t.Errorf("release selector candidate: %v", err)
+		}
+	})
+	assertSelectorReconciliationAction(t, candidate.Plan.SelectionReconciliation, selectionreconciliation.ScopeSelection, selectionreconciliation.OutcomeRemove, "retired")
+	assertSelectorReconciliationAction(t, candidate.Plan.SelectionReconciliation, selectionreconciliation.ScopeSelection, selectionreconciliation.OutcomeCreate, "next")
+	assertSelectorReconciliationAction(t, candidate.Plan.SelectionReconciliation, selectionreconciliation.ScopeManagedEntry, selectionreconciliation.OutcomeReconcile, ".shared.json")
+	assertSelectorReconciliationAction(t, candidate.Plan.SelectionReconciliation, selectionreconciliation.ScopeManagedEntry, selectionreconciliation.OutcomeRemove, ".retired")
+	assertSelectorReconciliationAction(t, candidate.Plan.SelectionReconciliation, selectionreconciliation.ScopeManagedEntry, selectionreconciliation.OutcomeCreate, ".next")
+	assertSelectorReconciliationAction(t, candidate.Plan.SelectionReconciliation, selectionreconciliation.ScopeDependency, selectionreconciliation.OutcomeRetainedExternalState, "retired-tool")
+	assertSelectorReconciliationAction(t, candidate.Plan.SelectionReconciliation, selectionreconciliation.ScopeProvisioner, selectionreconciliation.OutcomeRetainedExternalState, "claude")
+
+	cmd := NewRootCommand()
+	var jsonOut bytes.Buffer
+	cmd.SetOut(&jsonOut)
+	cmd.SetErr(&jsonOut)
+	cmd.SetArgs([]string{
+		"--output", "json", "install", "--dry-run", "--skip-deps", "--tag", "base", "--tag", "next",
+		"--file", manifestPath, "--source-root", sourceRoot, "--home", home, "--state-root", stateRoot,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("explicit JSON dry-run error = %v\n%s", err, jsonOut.String())
+	}
+	var envelope struct {
+		Data struct {
+			Plan struct {
+				SelectionReconciliation *selectionreconciliation.Report `json:"selection_reconciliation"`
+			} `json:"plan"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(jsonOut.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode explicit JSON: %v\n%s", err, jsonOut.String())
+	}
+	if !reflect.DeepEqual(envelope.Data.Plan.SelectionReconciliation, candidate.Plan.SelectionReconciliation) {
+		t.Fatalf("selector and explicit JSON reconciliation differ\nselector: %#v\nJSON: %#v", candidate.Plan.SelectionReconciliation, envelope.Data.Plan.SelectionReconciliation)
+	}
+
+	goldenText := strings.ReplaceAll(candidate.Preview.Text, home, "/home/test")
+	goldenText = strings.ReplaceAll(goldenText, sourceRoot, "/source")
+	assertGolden(t, "install_tag_selector_mixed_preview.golden", []byte(goldenText))
+
+	setInstallTagSelectorTestHooks(t, true, func(_ io.Reader, _ io.Writer, _ tagselectortui.BrowseData, _ []string, preview tagselectortui.PreviewFunc) (tagselectortui.Result, error) {
+		built, previewErr := preview(1, []string{"base", "next"})
+		return tagselectortui.Result{
+			Tags: []string{"base", "next"}, Preview: built, AcknowledgementAccepted: true,
+		}, previewErr
+	})
+	resultText, err := executeAcceptedSelector(t, "", manifestPath, sourceRoot, home, stateRoot)
+	if err != nil {
+		t.Fatalf("mixed selector apply error = %v\n%s", err, resultText)
+	}
+	for _, want := range []string{
+		"Tag selection applied: tags=base,next",
+		"Managed Entry results:",
+		"reconciled",
+		filepath.Join(home, ".shared.json"),
+		"created",
+		filepath.Join(home, ".next"),
+		"Retained External State:",
+		"dependency",
+		"retired-tool",
+		"provisioner",
+		"claude",
+		"Selection retirement:",
+		filepath.Join(home, ".retired"),
+	} {
+		if !strings.Contains(resultText, want) {
+			t.Fatalf("mixed selector result missing %q\n%s", want, resultText)
+		}
+	}
+	var shared map[string]any
+	sharedData, err := os.ReadFile(filepath.Join(home, ".shared.json"))
+	if err != nil {
+		t.Fatalf("read reconciled shared target: %v", err)
+	}
+	if err := json.Unmarshal(sharedData, &shared); err != nil {
+		t.Fatalf("decode reconciled shared target: %v\n%s", err, sharedData)
+	}
+	if len(shared) != 1 || shared["base"] != true {
+		t.Fatalf("reconciled shared target = %#v, want only selected base contribution", shared)
+	}
+	if _, err := os.Lstat(filepath.Join(home, ".retired")); !os.IsNotExist(err) {
+		t.Fatalf("whole retired target still exists: %v", err)
+	}
+	if destination, err := os.Readlink(filepath.Join(home, ".next")); err != nil || destination != filepath.Join(sourceRoot, "config", "next") {
+		t.Fatalf("added target destination = %q, %v", destination, err)
+	}
+	installed := loadSelectorSelection(t, stateRoot)
+	if len(installed.Profiles) != 0 || !reflect.DeepEqual(installed.ExtraTags, []string{"base", "next"}) || !reflect.DeepEqual(installed.ResolvedTags, []string{"base", "next"}) {
+		t.Fatalf("mixed Installed Selection = %#v, want explicit current Tags base,next", installed)
+	}
+	resultGolden := strings.ReplaceAll(resultText, home, "/home/test")
+	resultGolden = strings.ReplaceAll(resultGolden, sourceRoot, "/source")
+	assertGolden(t, "install_tag_selector_mixed_result.golden", []byte(resultGolden))
+}
+
+func TestRenderTagSelectorFinalResultReportsEffectiveConflictAndRetirementOutcomes(t *testing.T) {
+	replaced := "/home/test/.replaced"
+	adopted := "/home/test/.adopted"
+	skipped := "/home/test/.skipped"
+	drifted := "/home/test/.drifted"
+	candidate := installTagSelectorCandidate{Plan: plan.Plan{
+		Actions: []plan.Action{
+			{Target: replaced, Status: plan.StatusConflict},
+			{Target: adopted, Status: plan.StatusConflict},
+			{Target: skipped, Status: plan.StatusConflict},
+		},
+		SelectionReconciliation: &selectionreconciliation.Report{Actions: []selectionreconciliation.Action{
+			{Scope: selectionreconciliation.ScopeManagedEntry, Outcome: selectionreconciliation.OutcomeBlocked, ResolvedTarget: replaced},
+			{Scope: selectionreconciliation.ScopeManagedEntry, Outcome: selectionreconciliation.OutcomeBlocked, ResolvedTarget: adopted},
+			{Scope: selectionreconciliation.ScopeManagedEntry, Outcome: selectionreconciliation.OutcomeBlocked, ResolvedTarget: skipped},
+			{Scope: selectionreconciliation.ScopeDependency, Outcome: selectionreconciliation.OutcomeRetainedExternalState, Names: []string{"old-tool"}},
+		}},
+	}}
+	decisions := map[string]install.ConflictDecision{
+		replaced: install.DecisionReplace,
+		adopted:  install.DecisionAdopt,
+		skipped:  install.DecisionSkip,
+	}
+	retirement := &selectionretirement.Result{Retained: []string{drifted}}
+
+	var out bytes.Buffer
+	renderTagSelectorFinalResult(&out, candidate, decisions, nil, provision.Report{}, retirement, 0)
+	text := out.String()
+	for _, want := range []string{
+		"Managed Entry results:",
+		"replaced   " + replaced,
+		"adopted    " + adopted,
+		"skipped    " + skipped,
+		"Retained External State:",
+		"dependency   old-tool",
+		"retained " + drifted + " and released dots ownership",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("effective selector result missing %q\n%s", want, text)
+		}
+	}
+	for _, contradicted := range []string{"Selection reconciliation result:", "blocked", "removed " + drifted} {
+		if strings.Contains(text, contradicted) {
+			t.Fatalf("effective selector result contains stale plan outcome %q\n%s", contradicted, text)
+		}
+	}
+}
+
+func TestInstallTagSelectorReductionFindingsGolden(t *testing.T) {
+	var out bytes.Buffer
+	renderPlan(&out, plan.Plan{
+		Profile:  "tags only",
+		Profiles: []string{},
+		Tags:     []string{"kept"},
+		Actions: []plan.Action{
+			{Source: "config/kept", Target: "/home/test/.kept", Strategy: "symlink", Status: plan.StatusUnchanged},
+		},
+		SelectionReconciliation: &selectionreconciliation.Report{
+			PreviousIntent:  selectionreconciliation.Intent{Authority: selectionreconciliation.AuthorityRecorded, ExtraTags: []string{"kept", "removed"}, ResolvedTags: []string{"kept", "removed"}},
+			RequestedIntent: selectionreconciliation.Intent{Authority: selectionreconciliation.AuthorityExplicitRequest, ExtraTags: []string{"kept"}, ResolvedTags: []string{"kept"}},
+			Actions: []selectionreconciliation.Action{
+				{Scope: selectionreconciliation.ScopeSelection, Outcome: selectionreconciliation.OutcomeRemove, Names: []string{"removed"}, PreviousSources: []string{}, CurrentSources: []string{}},
+				{Scope: selectionreconciliation.ScopeManagedEntry, Outcome: selectionreconciliation.OutcomeRemove, ResolvedTarget: "/home/test/.removed", PreviousSources: []string{"config/removed"}, CurrentSources: []string{}},
+				{Scope: selectionreconciliation.ScopeManagedEntry, Outcome: selectionreconciliation.OutcomeRetain, Reason: selectionreconciliation.ReasonWholeTargetDrift, ResolvedTarget: "/home/test/.retained", PreviousSources: []string{"config/retained"}, CurrentSources: []string{}},
+				{Scope: selectionreconciliation.ScopeManagedEntry, Outcome: selectionreconciliation.OutcomeBlocked, Reason: selectionreconciliation.ReasonAmbiguousPartialOwnership, ResolvedTarget: "/home/test/.shared.json", PreviousSources: []string{"config/base.json", "config/removed.json"}, CurrentSources: []string{"config/base.json"}},
+				{Scope: selectionreconciliation.ScopeDependency, Outcome: selectionreconciliation.OutcomeRetainedExternalState, Names: []string{"removed-tool"}, PreviousSources: []string{}, CurrentSources: []string{}},
+				{Scope: selectionreconciliation.ScopeProvisioner, Outcome: selectionreconciliation.OutcomeRetainedExternalState, Names: []string{"claude"}, Identity: "sha256:example", PreviousSources: []string{}, CurrentSources: []string{}},
+			},
+		},
+	})
+	assertGolden(t, "install_tag_selector_reduction_findings.golden", out.Bytes())
+}
+
+func TestInstallTagSelectorBlockedReductionPreviewSurfacesFinding(t *testing.T) {
+	manifestPath, sourceRoot, home, stateRoot := writeTagSelectorMixedFixture(t)
+	stubDir := t.TempDir()
+	writeSelectorExecutable(t, filepath.Join(stubDir, "claude"), "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	runExplicitTagSelectorSeed(t, manifestPath, sourceRoot, home, stateRoot, "base", "retired")
+	if err := os.WriteFile(filepath.Join(home, ".shared.json"), []byte("{\"base\":true,\"retired\":\"operator-change\"}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	m, err := manifest.LoadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	paths, err := resolvePaths(home, sourceRoot, stateRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidate, err := buildInstallTagSelectorCandidate(*m, meta, paths, sourceRoot, nil, installHostOS, []string{"base", "next"}, installTagSelectorOptions{SkipDependencies: true})
+	if err != nil {
+		t.Fatalf("blocked reduction preview error = %v, want a renderable non-mutating finding", err)
+	}
+	t.Cleanup(func() {
+		if err := candidate.releaseCapturedSources(); err != nil {
+			t.Errorf("release selector candidate: %v", err)
+		}
+	})
+	for _, want := range []string{"blocked", selectionreconciliation.ReasonAmbiguousPartialOwnership, filepath.Join(home, ".shared.json")} {
+		if !strings.Contains(candidate.Preview.Text, want) {
+			t.Fatalf("blocked reduction preview missing %q\n%s", want, candidate.Preview.Text)
+		}
+	}
+	previousSelection := *loadSelectorSelection(t, stateRoot)
+	sharedBefore, err := os.ReadFile(filepath.Join(home, ".shared.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	setInstallTagSelectorTestHooks(t, true, func(_ io.Reader, _ io.Writer, _ tagselectortui.BrowseData, _ []string, preview tagselectortui.PreviewFunc) (tagselectortui.Result, error) {
+		built, previewErr := preview(1, []string{"base", "next"})
+		return tagselectortui.Result{Tags: []string{"base", "next"}, Preview: built, AcknowledgementAccepted: true}, previewErr
+	})
+	out, err := executeAcceptedSelector(t, "", manifestPath, sourceRoot, home, stateRoot)
+	if err == nil || !strings.Contains(err.Error(), "accepted Tag selector reduction is blocked") || !strings.Contains(err.Error(), selectionreconciliation.ReasonAmbiguousPartialOwnership) {
+		t.Fatalf("acknowledged blocked apply error = %v, want fail-closed finding\n%s", err, out)
+	}
+	if !strings.Contains(out, "blocked") || !strings.Contains(out, selectionreconciliation.ReasonAmbiguousPartialOwnership) {
+		t.Fatalf("acknowledged blocked apply did not render finding\n%s", out)
+	}
+	if got := loadSelectorSelection(t, stateRoot); !reflect.DeepEqual(*got, previousSelection) {
+		t.Fatalf("blocked apply Installed Selection = %#v, want previous %#v", got, previousSelection)
+	}
+	if got, readErr := os.ReadFile(filepath.Join(home, ".shared.json")); readErr != nil || !bytes.Equal(got, sharedBefore) {
+		t.Fatalf("blocked apply shared target = %q, %v; want unchanged %q", got, readErr, sharedBefore)
+	}
+	if _, statErr := os.Lstat(filepath.Join(home, ".next")); !os.IsNotExist(statErr) {
+		t.Fatalf("blocked apply created forward Managed Entry: %v", statErr)
+	}
+	if _, statErr := os.Lstat(filepath.Join(home, ".retired")); statErr != nil {
+		t.Fatalf("blocked apply retired previous Managed Entry: %v", statErr)
+	}
+}
+
+func acceptedSelectorTags(tags ...string) installTagSelectorRunnerFunc {
+	selected := append([]string(nil), tags...)
+	return func(_ io.Reader, _ io.Writer, _ tagselectortui.BrowseData, _ []string, preview tagselectortui.PreviewFunc) (tagselectortui.Result, error) {
+		built, err := preview(1, selected)
+		return tagselectortui.Result{Tags: append([]string(nil), selected...), Preview: built}, err
+	}
+}
+
+func executeAcceptedSelector(t *testing.T, input, manifestPath, sourceRoot, home, stateRoot string) (string, error) {
+	t.Helper()
+	cmd := NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetIn(strings.NewReader(input))
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"install", "--skip-deps", "--file", manifestPath,
+		"--source-root", sourceRoot, "--home", home, "--state-root", stateRoot,
+	})
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+func loadSelectorSelection(t *testing.T, stateRoot string) *state.InstalledSelection {
+	t.Helper()
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.InstalledSelection == nil {
+		t.Fatal("Installed Selection = nil")
+	}
+	return meta.InstalledSelection
+}
+
+func writeTagSelectorProvisionerFixture(t *testing.T) (manifestPath, sourceRoot, home, stateRoot string) {
+	t.Helper()
+	home = t.TempDir()
+	sourceRoot = t.TempDir()
+	stateRoot = t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	if err := os.MkdirAll(filepath.Join(sourceRoot, "config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"one", "two"} {
+		if err := os.WriteFile(filepath.Join(sourceRoot, "config", name), []byte(name+"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	manifestPath = filepath.Join(sourceRoot, "dots.yaml")
+	manifest := `version: 1
+tags:
+  one:
+    description: Existing surface.
+    kind: surface
+    status: current
+  two:
+    description: Added surface with a Provisioner.
+    kind: surface
+    status: current
+profiles:
+  default:
+    tags: [one]
+entries:
+  - source: config/one
+    target: ~/.one
+    strategy: symlink
+    tags: [one]
+  - source: config/two
+    target: ~/.two
+    strategy: symlink
+    tags: [two]
+provisioners:
+  - tool: claude
+    tags: [two]
+    spec:
+      marketplace: example/tools
+    dependencies:
+      - name: claude
+`
+	if err := os.WriteFile(manifestPath, []byte(manifest), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return manifestPath, sourceRoot, home, stateRoot
+}
+
+func writeTagSelectorMixedFixture(t *testing.T) (manifestPath, sourceRoot, home, stateRoot string) {
+	t.Helper()
+	home = t.TempDir()
+	sourceRoot = t.TempDir()
+	stateRoot = t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	for relative, content := range map[string]string{
+		"config/base.json":    "{\"base\":true}\n",
+		"config/retired.json": "{\"retired\":true}\n",
+		"config/retired":      "retired\n",
+		"config/next":         "next\n",
+	} {
+		path := filepath.Join(sourceRoot, relative)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	manifestPath = filepath.Join(sourceRoot, "dots.yaml")
+	data := `version: 1
+tags:
+  base:
+    description: Shared retained contribution.
+    kind: surface
+    status: current
+  retired:
+    description: Retired contribution and whole target.
+    kind: surface
+    status: current
+  next:
+    description: New forward surface.
+    kind: surface
+    status: current
+profiles:
+  old:
+    tags: [base, retired]
+  next:
+    tags: [base, next]
+entries:
+  - source: config/base.json
+    target: ~/.shared.json
+    strategy: copy
+    ownership: json-subset
+    tags: [base]
+  - source: config/retired.json
+    target: ~/.shared.json
+    strategy: copy
+    ownership: json-subset
+    tags: [retired]
+  - source: config/retired
+    target: ~/.retired
+    strategy: copy
+    tags: [retired]
+  - source: config/next
+    target: ~/.next
+    strategy: symlink
+    tags: [next]
+dependencies:
+  - tags: [retired]
+    dependencies:
+      - name: retired-tool
+        command: retired-tool
+        manual: retained outside dots
+provisioners:
+  - tool: claude
+    tags: [retired]
+    spec:
+      marketplace: example/tools
+    dependencies:
+      - name: claude
+`
+	if err := os.WriteFile(manifestPath, []byte(data), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return manifestPath, sourceRoot, home, stateRoot
+}
+
+func assertSelectorReconciliationAction(t *testing.T, report *selectionreconciliation.Report, scope selectionreconciliation.Scope, outcome selectionreconciliation.Outcome, evidence string) {
+	t.Helper()
+	if report == nil {
+		t.Fatal("Selection Reconciliation Plan = nil")
+	}
+	for _, action := range report.Actions {
+		encoded, _ := json.Marshal(action)
+		if action.Scope == scope && action.Outcome == outcome && strings.Contains(string(encoded), evidence) {
+			return
+		}
+	}
+	t.Fatalf("missing %s/%s containing %q in %#v", scope, outcome, evidence, report.Actions)
+}
+
+func writeSelectorExecutable(t *testing.T, path, script string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/cli/install_tag_selector_internal_test.go
+++ b/internal/cli/install_tag_selector_internal_test.go
@@ -11,16 +11,343 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/yersonargotev/dots/internal/backups"
 	"github.com/yersonargotev/dots/internal/deps"
+	"github.com/yersonargotev/dots/internal/install"
 	"github.com/yersonargotev/dots/internal/manifest"
+	"github.com/yersonargotev/dots/internal/plan"
 	"github.com/yersonargotev/dots/internal/provision"
 	"github.com/yersonargotev/dots/internal/selection"
 	"github.com/yersonargotev/dots/internal/state"
 	"github.com/yersonargotev/dots/internal/status"
 	tagselectortui "github.com/yersonargotev/dots/internal/tui/tagselector"
 )
+
+func TestInstallTagSelectorCandidateStoreRejectsLatePreviewAndTransfersAcceptedLease(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	source := filepath.Join(sourceRoot, "tool.conf")
+	target := filepath.Join(home, ".tool.conf")
+	if err := os.WriteFile(source, []byte("reviewed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	p := plan.Plan{Actions: []plan.Action{{Source: "tool.conf", Target: target, Strategy: "copy", Status: plan.StatusCreate}}}
+	opts := install.Options{Home: home, SourceRoot: sourceRoot}
+	capturesA, err := install.CaptureManagedSources(p, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := install.ReleaseCapturedSources(capturesA); err != nil {
+			t.Errorf("release first captures: %v", err)
+		}
+	})
+	store := newInstallTagSelectorCandidateStore()
+	t.Cleanup(func() {
+		if err := store.close(); err != nil {
+			t.Errorf("candidate store cleanup: %v", err)
+		}
+	})
+	tokenA, ok, err := store.activate(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("candidate store rejected first preview")
+	}
+	candidateA := installTagSelectorCandidate{CapturedSources: capturesA, Preview: tagselectortui.Preview{SemanticDigest: "sha256:same", CandidateToken: tokenA}}
+	stored, err := store.put(1, tokenA, candidateA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !stored {
+		t.Fatal("candidate store rejected current first preview")
+	}
+
+	tokenB, ok, err := store.activate(2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("candidate store rejected second preview")
+	}
+	opts.CapturedSources = capturesA
+	if err := install.ValidateManagedEntries(p, opts); err == nil || !strings.Contains(err.Error(), "released") {
+		t.Fatalf("superseded candidate error = %v, want released authority", err)
+	}
+
+	capturesB, err := install.CaptureManagedSources(p, install.Options{Home: home, SourceRoot: sourceRoot})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := install.ReleaseCapturedSources(capturesB); err != nil {
+			t.Errorf("release second captures: %v", err)
+		}
+	})
+	candidateB := installTagSelectorCandidate{CapturedSources: capturesB, Preview: tagselectortui.Preview{SemanticDigest: "sha256:same", CandidateToken: tokenB}}
+	stored, err = store.put(2, tokenB, candidateB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !stored {
+		t.Fatal("candidate store rejected current second preview")
+	}
+
+	lateCaptures, err := install.CaptureManagedSources(p, install.Options{Home: home, SourceRoot: sourceRoot})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := install.ReleaseCapturedSources(lateCaptures); err != nil {
+			t.Errorf("release late captures: %v", err)
+		}
+	})
+	lateA := installTagSelectorCandidate{CapturedSources: lateCaptures, Preview: tagselectortui.Preview{SemanticDigest: "sha256:same", CandidateToken: tokenA}}
+	stored, err = store.put(1, tokenA, lateA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored {
+		t.Fatal("candidate store accepted stale first preview after second preview")
+	}
+	opts.CapturedSources = lateCaptures
+	if err := install.ValidateManagedEntries(p, opts); err == nil || !strings.Contains(err.Error(), "released") {
+		t.Fatalf("late candidate error = %v, want released authority", err)
+	}
+
+	leased, ok := store.take(tokenB)
+	if !ok {
+		t.Fatal("candidate store did not transfer accepted second preview")
+	}
+	if err := store.close(); err != nil {
+		t.Fatal(err)
+	}
+	opts.CapturedSources = leased.CapturedSources
+	if err := install.ValidateManagedEntries(p, opts); err != nil {
+		t.Fatalf("accepted lease was closed by store: %v", err)
+	}
+	if err := leased.releaseCapturedSources(); err != nil {
+		t.Fatal(err)
+	}
+	if err := install.ValidateManagedEntries(p, opts); err == nil || !strings.Contains(err.Error(), "released") {
+		t.Fatalf("released lease error = %v, want fail-closed authority", err)
+	}
+}
+
+func TestInstallTagSelectorCandidateStoreSerializesLatePreviewAndCancellation(t *testing.T) {
+	store := newInstallTagSelectorCandidateStore()
+	start := make(chan struct{})
+	var workers sync.WaitGroup
+	for i := range 100 {
+		requestID := uint64(i + 1)
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			<-start
+			token, ok, err := store.activate(requestID)
+			if err != nil {
+				t.Errorf("activate(%d): %v", requestID, err)
+				return
+			}
+			if !ok {
+				return
+			}
+			if _, err := store.put(requestID, token, installTagSelectorCandidate{Preview: tagselectortui.Preview{SemanticDigest: fmt.Sprintf("sha256:%d", i), CandidateToken: token}}); err != nil {
+				t.Errorf("put(%d): %v", requestID, err)
+			}
+		}()
+	}
+	workers.Add(1)
+	go func() {
+		defer workers.Done()
+		<-start
+		if err := store.close(); err != nil {
+			t.Errorf("close candidate store: %v", err)
+		}
+	}()
+	close(start)
+	workers.Wait()
+	if err := store.close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, err := store.activate(101); err != nil || ok {
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Fatal("candidate store reopened after concurrent cancellation")
+	}
+}
+
+func TestInstallTagSelectorCandidateStoreUsesUIRequestOrder(t *testing.T) {
+	store := newInstallTagSelectorCandidateStore()
+	t.Cleanup(func() {
+		if err := store.close(); err != nil {
+			t.Errorf("candidate store cleanup: %v", err)
+		}
+	})
+
+	tokenB, ok, err := store.activate(2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("candidate store rejected newer request")
+	}
+	if _, ok, err := store.activate(1); err != nil || ok {
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Fatal("candidate store accepted an older request that arrived later")
+	}
+	candidateB := installTagSelectorCandidate{Preview: tagselectortui.Preview{SemanticDigest: "sha256:b", CandidateToken: tokenB}}
+	stored, err := store.put(2, tokenB, candidateB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !stored {
+		t.Fatal("candidate store rejected the newest request")
+	}
+	if _, ok := store.take(tokenB); !ok {
+		t.Fatal("candidate store lost the newest request after scheduling inversion")
+	}
+}
+
+func TestInstallTagSelectorPreviewProviderSerializesCandidateBuilds(t *testing.T) {
+	store := newInstallTagSelectorCandidateStore()
+	t.Cleanup(func() {
+		if err := store.close(); err != nil {
+			t.Errorf("candidate store cleanup: %v", err)
+		}
+	})
+	entered := make(chan string, 2)
+	release := make(chan struct{})
+	var statsMu sync.Mutex
+	inFlight := 0
+	maxInFlight := 0
+	provider := &installTagSelectorPreviewProvider{
+		store: store,
+		build: func(tags []string) (installTagSelectorCandidate, error) {
+			statsMu.Lock()
+			inFlight++
+			if inFlight > maxInFlight {
+				maxInFlight = inFlight
+			}
+			statsMu.Unlock()
+			entered <- tags[0]
+			<-release
+			statsMu.Lock()
+			inFlight--
+			statsMu.Unlock()
+			return installTagSelectorCandidate{Preview: tagselectortui.Preview{SemanticDigest: "sha256:" + tags[0]}}, nil
+		},
+	}
+
+	type previewResult struct {
+		preview tagselectortui.Preview
+		err     error
+	}
+	first := make(chan previewResult, 1)
+	second := make(chan previewResult, 1)
+	go func() {
+		preview, err := provider.preview(1, []string{"first"})
+		first <- previewResult{preview: preview, err: err}
+	}()
+	if got := <-entered; got != "first" {
+		t.Fatalf("first build = %q, want first", got)
+	}
+	go func() {
+		preview, err := provider.preview(2, []string{"second"})
+		second <- previewResult{preview: preview, err: err}
+	}()
+	select {
+	case got := <-entered:
+		t.Fatalf("build %q entered while the first capture-bearing build was blocked", got)
+	case <-time.After(50 * time.Millisecond):
+	}
+	release <- struct{}{}
+	if result := <-first; result.err != nil {
+		t.Fatalf("first preview error = %v", result.err)
+	}
+	if got := <-entered; got != "second" {
+		t.Fatalf("second build = %q, want second", got)
+	}
+	release <- struct{}{}
+	if result := <-second; result.err != nil {
+		t.Fatalf("second preview error = %v", result.err)
+	}
+	statsMu.Lock()
+	defer statsMu.Unlock()
+	if maxInFlight != 1 {
+		t.Fatalf("maximum concurrent candidate builds = %d, want 1", maxInFlight)
+	}
+}
+
+func TestInstallTagSelectorPreviewProviderClosesWithoutWaitingForActiveBuild(t *testing.T) {
+	store := newInstallTagSelectorCandidateStore()
+	store.release = func(installTagSelectorCandidate) error {
+		return errors.New("injected late release failure")
+	}
+	entered := make(chan string, 2)
+	release := make(chan struct{})
+	lateErrors := make(chan error, 1)
+	provider := &installTagSelectorPreviewProvider{
+		store:     store,
+		lateError: func(err error) { lateErrors <- err },
+		build: func(tags []string) (installTagSelectorCandidate, error) {
+			entered <- tags[0]
+			<-release
+			return installTagSelectorCandidate{Preview: tagselectortui.Preview{SemanticDigest: "sha256:" + tags[0]}}, nil
+		},
+	}
+	first := make(chan error, 1)
+	second := make(chan error, 1)
+	go func() {
+		_, err := provider.preview(1, []string{"first"})
+		first <- err
+	}()
+	if got := <-entered; got != "first" {
+		t.Fatalf("first build = %q, want first", got)
+	}
+	go func() {
+		_, err := provider.preview(2, []string{"second"})
+		second <- err
+	}()
+	closed := make(chan error, 1)
+	go func() { closed <- provider.close() }()
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatalf("close preview provider: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("preview provider close waited for the active build")
+	}
+	release <- struct{}{}
+	if err := <-first; err == nil || !strings.Contains(err.Error(), "closed during cleanup") {
+		t.Fatalf("active preview error = %v, want closed cleanup response", err)
+	}
+	select {
+	case err := <-lateErrors:
+		if !strings.Contains(err.Error(), "injected late release failure") {
+			t.Fatalf("late cleanup sink error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("late release failure was not reported to the asynchronous cleanup sink")
+	}
+	if err := <-second; err == nil || !strings.Contains(err.Error(), "closed") {
+		t.Fatalf("queued preview error = %v, want closed store rejection", err)
+	}
+	select {
+	case got := <-entered:
+		t.Fatalf("queued build %q entered after provider close", got)
+	default:
+	}
+}
 
 func TestInstallTagSelectorRouting(t *testing.T) {
 	manifestPath, sourceRoot, home, stateRoot := writeTagSelectorTestManifest(t)
@@ -33,7 +360,7 @@ func TestInstallTagSelectorRouting(t *testing.T) {
 			if len(initial) != 0 {
 				t.Fatalf("initial Tags = %v, want empty without Installed Selection", initial)
 			}
-			built, err := preview([]string{"one"})
+			built, err := preview(1, []string{"one"})
 			return tagselectortui.Result{Tags: []string{"one"}, Preview: built}, err
 		})
 		cmd := NewRootCommand()
@@ -48,7 +375,7 @@ func TestInstallTagSelectorRouting(t *testing.T) {
 		if called != 1 {
 			t.Fatalf("selector calls = %d, want 1", called)
 		}
-		for _, want := range []string{"Forward-only selection preview", "Selection preview only; nothing was applied."} {
+		for _, want := range []string{"Forward-only selection preview", "Dry run complete; nothing was applied."} {
 			if !strings.Contains(out.String(), want) {
 				t.Fatalf("output missing %q\n%s", want, out.String())
 			}
@@ -107,6 +434,579 @@ func TestInstallTagSelectorRouting(t *testing.T) {
 	})
 }
 
+func TestInstallTagSelectorPreviewIncludesPreparedDependencies(t *testing.T) {
+	manifestPath, sourceRoot, home, stateRoot := writeTagSelectorTestManifest(t)
+	setInstallTagSelectorTestHooks(t, true, func(_ io.Reader, _ io.Writer, _ tagselectortui.BrowseData, _ []string, preview tagselectortui.PreviewFunc) (tagselectortui.Result, error) {
+		built, err := preview(1, []string{"one"})
+		return tagselectortui.Result{Tags: []string{"one"}, Preview: built}, err
+	})
+	stubDir := t.TempDir()
+	t.Setenv("PATH", stubDir)
+
+	cmd := NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"install", "--dry-run", "--file", manifestPath,
+		"--source-root", sourceRoot, "--home", home, "--state-root", stateRoot,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\n%s", err, out.String())
+	}
+	for _, want := range []string{"Dependency install preview", "install one manually (required)", "Plan for tags only", "Dry run complete; nothing was applied."} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("selector preview missing %q\n%s", want, out.String())
+		}
+	}
+	if _, err := os.Stat(state.Path(stateRoot)); !os.IsNotExist(err) {
+		t.Fatalf("dry-run selector wrote Installation Metadata: %v", err)
+	}
+}
+
+func TestInstallTagSelectorAcceptedAdditionAppliesAndPersistsExplicitTags(t *testing.T) {
+	manifestPath, sourceRoot, home, stateRoot := writeTagSelectorTestManifest(t)
+	setInstallTagSelectorTestHooks(t, true, func(_ io.Reader, _ io.Writer, _ tagselectortui.BrowseData, initial []string, preview tagselectortui.PreviewFunc) (tagselectortui.Result, error) {
+		if len(initial) != 0 {
+			t.Fatalf("initial Tags = %v, want empty without Installed Selection", initial)
+		}
+		built, err := preview(1, []string{"one"})
+		return tagselectortui.Result{Tags: []string{"one"}, Preview: built}, err
+	})
+
+	cmd := NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetIn(strings.NewReader(""))
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"install", "--skip-deps", "--file", manifestPath,
+		"--source-root", sourceRoot, "--home", home, "--state-root", stateRoot,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\n%s", err, out.String())
+	}
+	if _, err := os.Readlink(filepath.Join(home, ".one")); err != nil {
+		t.Fatalf("accepted Tag selection did not apply Managed Entry: %v\n%s", err, out.String())
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatalf("load Installation Metadata: %v", err)
+	}
+	if meta.InstalledSelection == nil {
+		t.Fatal("Installed Selection = nil")
+	}
+	if got := meta.InstalledSelection.Profiles; len(got) != 0 {
+		t.Fatalf("Profiles = %#v, want none", got)
+	}
+	if got, want := meta.InstalledSelection.ExtraTags, []string{"one"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ExtraTags = %#v, want %#v", got, want)
+	}
+	if got, want := meta.InstalledSelection.ResolvedTags, []string{"one"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ResolvedTags = %#v, want %#v", got, want)
+	}
+	for _, want := range []string{
+		"Tag selection applied: tags=one",
+		"Historical retirement: not run (Tag selector path)",
+		"Managed Entry results:",
+		"created    " + filepath.Join(home, ".one"),
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("final result missing %q\n%s", want, out.String())
+		}
+	}
+}
+
+func TestInstallTagSelectorProfilePresetResultIsPersistedAsExplicitCurrentTags(t *testing.T) {
+	manifestPath, sourceRoot, home, stateRoot := writeTagSelectorTestManifest(t)
+	setInstallTagSelectorTestHooks(t, true, func(_ io.Reader, _ io.Writer, browse tagselectortui.BrowseData, _ []string, preview tagselectortui.PreviewFunc) (tagselectortui.Result, error) {
+		var preset []string
+		for _, profile := range browse.Profiles {
+			if profile.Name == "default" {
+				preset = append([]string(nil), profile.Tags...)
+			}
+		}
+		if !reflect.DeepEqual(preset, []string{"one"}) {
+			t.Fatalf("default preset Tags = %#v, want one", preset)
+		}
+		built, err := preview(1, preset)
+		return tagselectortui.Result{Tags: preset, Preview: built}, err
+	})
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{
+		"install", "--skip-deps", "--file", manifestPath,
+		"--source-root", sourceRoot, "--home", home, "--state-root", stateRoot,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.InstalledSelection == nil || len(meta.InstalledSelection.Profiles) != 0 ||
+		!reflect.DeepEqual(meta.InstalledSelection.ExtraTags, []string{"one"}) ||
+		!reflect.DeepEqual(meta.InstalledSelection.ResolvedTags, []string{"one"}) {
+		t.Fatalf("Installed Selection = %#v, want flattened explicit current Tag intent", meta.InstalledSelection)
+	}
+}
+
+func TestInstallTagSelectorRejectsAcceptedCandidateWhenSourceIdentityChanges(t *testing.T) {
+	manifestPath, sourceRoot, home, stateRoot := writeTagSelectorTestManifest(t)
+	setInstallTagSelectorTestHooks(t, true, func(_ io.Reader, _ io.Writer, _ tagselectortui.BrowseData, _ []string, preview tagselectortui.PreviewFunc) (tagselectortui.Result, error) {
+		built, err := preview(1, []string{"one"})
+		if err != nil {
+			return tagselectortui.Result{}, err
+		}
+		replacement := filepath.Join(sourceRoot, "config", "replacement")
+		if err := os.WriteFile(replacement, []byte("changed\n"), 0o600); err != nil {
+			t.Fatalf("write replacement source: %v", err)
+		}
+		if err := os.Rename(replacement, filepath.Join(sourceRoot, "config", "one")); err != nil {
+			t.Fatalf("replace source identity: %v", err)
+		}
+		return tagselectortui.Result{Tags: []string{"one"}, Preview: built}, nil
+	})
+
+	cmd := NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"install", "--skip-deps", "--file", manifestPath,
+		"--source-root", sourceRoot, "--home", home, "--state-root", stateRoot,
+	})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "source") || !strings.Contains(err.Error(), "changed identity") {
+		t.Fatalf("Execute() error = %v, want stale source identity rejection\n%s", err, out.String())
+	}
+	if _, statErr := os.Lstat(filepath.Join(home, ".one")); !os.IsNotExist(statErr) {
+		t.Fatalf("Managed Entry changed after stale candidate: %v", statErr)
+	}
+	if _, statErr := os.Stat(state.Path(stateRoot)); !os.IsNotExist(statErr) {
+		t.Fatalf("Installation Metadata changed after stale candidate: %v", statErr)
+	}
+}
+
+func TestInstallTagSelectorRejectsManifestAndMetadataStalenessBeforeMutation(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		mutate func(t *testing.T, manifestPath, stateRoot string)
+	}{
+		{
+			name: "Install Manifest",
+			mutate: func(t *testing.T, manifestPath, _ string) {
+				data, err := os.ReadFile(manifestPath)
+				if err != nil {
+					t.Fatal(err)
+				}
+				data = bytes.Replace(data, []byte("One selectable capability."), []byte("Changed selectable capability."), 1)
+				if err := os.WriteFile(manifestPath, data, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "Installation Metadata",
+			mutate: func(t *testing.T, _ string, stateRoot string) {
+				concurrent := &state.InstalledSelection{Profiles: []string{}, ExtraTags: []string{"two"}, ResolvedTags: []string{"two"}}
+				if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, Entries: []state.Record{}, InstalledSelection: concurrent}); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			manifestPath, sourceRoot, home, stateRoot := writeTagSelectorTestManifest(t)
+			setInstallTagSelectorTestHooks(t, true, func(_ io.Reader, _ io.Writer, _ tagselectortui.BrowseData, _ []string, preview tagselectortui.PreviewFunc) (tagselectortui.Result, error) {
+				built, err := preview(1, []string{"one"})
+				if err != nil {
+					return tagselectortui.Result{}, err
+				}
+				tc.mutate(t, manifestPath, stateRoot)
+				return tagselectortui.Result{Tags: []string{"one"}, Preview: built}, nil
+			})
+
+			cmd := NewRootCommand()
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs([]string{
+				"install", "--skip-deps", "--file", manifestPath,
+				"--source-root", sourceRoot, "--home", home, "--state-root", stateRoot,
+			})
+			err := cmd.Execute()
+			if err == nil || !strings.Contains(err.Error(), "candidate is stale") || !strings.Contains(err.Error(), tc.name) {
+				t.Fatalf("Execute() error = %v, want %s staleness rejection\n%s", err, tc.name, out.String())
+			}
+			if _, statErr := os.Lstat(filepath.Join(home, ".one")); !os.IsNotExist(statErr) {
+				t.Fatalf("Managed Entry changed after stale candidate: %v", statErr)
+			}
+		})
+	}
+}
+
+func TestInstallTagSelectorOrdinaryReductionRequiresDistinctConfirmation(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		answer        string
+		acknowledged  bool
+		wantTags      []string
+		wantTwoExists bool
+	}{
+		{name: "decline", answer: "n\n", wantTags: []string{"one", "two"}, wantTwoExists: true},
+		{name: "accept", answer: "y\n", wantTags: []string{"one"}},
+		{name: "accepted in selector is not prompted twice", acknowledged: true, wantTags: []string{"one"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			manifestPath, sourceRoot, home, stateRoot := writeTagSelectorTestManifest(t)
+			runExplicitTagSelectorSeed(t, manifestPath, sourceRoot, home, stateRoot, "one", "two")
+			setInstallTagSelectorTestHooks(t, true, func(_ io.Reader, _ io.Writer, _ tagselectortui.BrowseData, initial []string, preview tagselectortui.PreviewFunc) (tagselectortui.Result, error) {
+				if want := []string{"one", "two"}; !reflect.DeepEqual(initial, want) {
+					t.Fatalf("initial Tags = %#v, want %#v", initial, want)
+				}
+				built, err := preview(1, []string{"one"})
+				return tagselectortui.Result{Tags: []string{"one"}, Preview: built, AcknowledgementAccepted: tc.acknowledged}, err
+			})
+
+			cmd := NewRootCommand()
+			var out bytes.Buffer
+			cmd.SetIn(strings.NewReader(tc.answer))
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs([]string{
+				"install", "--skip-deps", "--file", manifestPath,
+				"--source-root", sourceRoot, "--home", home, "--state-root", stateRoot,
+			})
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v\n%s", err, out.String())
+			}
+			if !tc.acknowledged && !strings.Contains(out.String(), "Apply this Installed Selection reduction? This is separate from Conflict Resolution.") {
+				t.Fatalf("output missing distinct reduction confirmation\n%s", out.String())
+			}
+			if tc.acknowledged && strings.Contains(out.String(), "Apply this Installed Selection reduction?") {
+				t.Fatalf("selector acknowledgement was prompted twice\n%s", out.String())
+			}
+			_, twoErr := os.Lstat(filepath.Join(home, ".two"))
+			if tc.wantTwoExists && twoErr != nil {
+				t.Fatalf("declined reduction changed .two: %v", twoErr)
+			}
+			if !tc.wantTwoExists && !os.IsNotExist(twoErr) {
+				t.Fatalf("accepted reduction retained .two: %v", twoErr)
+			}
+			meta, err := state.Load(state.Path(stateRoot))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if meta.InstalledSelection == nil || !reflect.DeepEqual(meta.InstalledSelection.ExtraTags, tc.wantTags) {
+				t.Fatalf("Installed Selection = %#v, want explicit Tags %#v", meta.InstalledSelection, tc.wantTags)
+			}
+		})
+	}
+}
+
+func TestInstallTagSelectorAcceptedBlockedReductionStopsBeforeMutation(t *testing.T) {
+	manifestPath, sourceRoot, home, stateRoot := writeTagSelectorMixedFixture(t)
+	stubDir := t.TempDir()
+	writeSelectorExecutable(t, filepath.Join(stubDir, "claude"), "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	runExplicitTagSelectorSeed(t, manifestPath, sourceRoot, home, stateRoot, "base", "retired")
+	previous := *loadSelectorSelection(t, stateRoot)
+	if err := os.WriteFile(filepath.Join(home, ".shared.json"), []byte("{\"base\":true,\"retired\":\"operator-change\"}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	setInstallTagSelectorTestHooks(t, true, func(_ io.Reader, _ io.Writer, _ tagselectortui.BrowseData, _ []string, preview tagselectortui.PreviewFunc) (tagselectortui.Result, error) {
+		tags := []string{"base", "next"}
+		built, err := preview(1, tags)
+		return tagselectortui.Result{Tags: tags, Preview: built, AcknowledgementAccepted: true}, err
+	})
+
+	out, err := executeAcceptedSelector(t, "", manifestPath, sourceRoot, home, stateRoot)
+	if err == nil || !strings.Contains(err.Error(), "accepted Tag selector reduction is blocked") {
+		t.Fatalf("Execute() error = %v, want blocked reduction rejection\n%s", err, out)
+	}
+	if _, statErr := os.Lstat(filepath.Join(home, ".next")); !os.IsNotExist(statErr) {
+		t.Fatalf("blocked reduction created next Managed Entry: %v", statErr)
+	}
+	if got := loadSelectorSelection(t, stateRoot); !reflect.DeepEqual(*got, previous) {
+		t.Fatalf("Installed Selection = %#v, want previous %#v", got, previous)
+	}
+}
+
+func TestInstallTagSelectorEmptyResultAlwaysRequiresLiteralClear(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		seed         string
+		answer       string
+		wantTags     []string
+		wantOne      bool
+		wantMetadata bool
+	}{
+		{name: "mismatch preserves prior authority", seed: "one", answer: "CLEAR\n", wantTags: []string{"one"}, wantOne: true, wantMetadata: true},
+		{name: "clear succeeds", seed: "one", answer: "clear\n", wantTags: []string{}, wantMetadata: true},
+		{name: "nil authority still prompts and records empty", answer: "clear\n", wantTags: []string{}, wantMetadata: true},
+		{name: "already empty still prompts", seed: "empty", answer: "clear\n", wantTags: []string{}, wantMetadata: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			manifestPath, sourceRoot, home, stateRoot := writeTagSelectorTestManifest(t)
+			switch tc.seed {
+			case "one":
+				runExplicitTagSelectorSeed(t, manifestPath, sourceRoot, home, stateRoot, "one")
+			case "empty":
+				empty := &state.InstalledSelection{Profiles: []string{}, ExtraTags: []string{}, ResolvedTags: []string{}}
+				if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, Entries: []state.Record{}, InstalledSelection: empty}); err != nil {
+					t.Fatalf("seed explicit empty Installed Selection: %v", err)
+				}
+			}
+			setInstallTagSelectorTestHooks(t, true, func(_ io.Reader, _ io.Writer, _ tagselectortui.BrowseData, _ []string, preview tagselectortui.PreviewFunc) (tagselectortui.Result, error) {
+				built, err := preview(1, []string{})
+				return tagselectortui.Result{Tags: []string{}, Preview: built}, err
+			})
+
+			cmd := NewRootCommand()
+			var out bytes.Buffer
+			cmd.SetIn(strings.NewReader(tc.answer))
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs([]string{
+				"install", "--skip-deps", "--file", manifestPath,
+				"--source-root", sourceRoot, "--home", home, "--state-root", stateRoot,
+			})
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v\n%s", err, out.String())
+			}
+			if !strings.Contains(out.String(), "Type clear to remove every selected Managed Entry from dots management:") {
+				t.Fatalf("output missing literal clear prompt\n%s", out.String())
+			}
+			_, oneErr := os.Lstat(filepath.Join(home, ".one"))
+			if tc.wantOne && oneErr != nil {
+				t.Fatalf("clear mismatch changed .one: %v", oneErr)
+			}
+			if !tc.wantOne && tc.seed == "one" && !os.IsNotExist(oneErr) {
+				t.Fatalf("successful clear retained .one: %v", oneErr)
+			}
+			meta, err := state.Load(state.Path(stateRoot))
+			if err != nil {
+				t.Fatal(err)
+			}
+			matchesTags := meta.InstalledSelection != nil && reflect.DeepEqual(meta.InstalledSelection.ExtraTags, tc.wantTags)
+			if len(tc.wantTags) == 0 {
+				matchesTags = meta.InstalledSelection != nil && len(meta.InstalledSelection.ExtraTags) == 0 && len(meta.InstalledSelection.ResolvedTags) == 0
+			}
+			if tc.wantMetadata && !matchesTags {
+				t.Fatalf("Installed Selection = %#v, want explicit Tags %#v", meta.InstalledSelection, tc.wantTags)
+			}
+		})
+	}
+}
+
+func TestInstallTagSelectorAcceptedSelectionUsesExistingConflictResolution(t *testing.T) {
+	manifestPath, sourceRoot, home, stateRoot := writeTagSelectorTestManifest(t)
+	target := filepath.Join(home, ".one")
+	if err := os.WriteFile(target, []byte("local\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	setInstallTagSelectorTestHooks(t, true, func(_ io.Reader, _ io.Writer, _ tagselectortui.BrowseData, _ []string, preview tagselectortui.PreviewFunc) (tagselectortui.Result, error) {
+		built, err := preview(1, []string{"one"})
+		return tagselectortui.Result{Tags: []string{"one"}, Preview: built}, err
+	})
+
+	cmd := NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetIn(strings.NewReader("r\r"))
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"install", "--skip-deps", "--file", manifestPath,
+		"--source-root", sourceRoot, "--home", home, "--state-root", stateRoot,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\n%s", err, out.String())
+	}
+	if _, err := os.Readlink(target); err != nil {
+		t.Fatalf("existing Conflict Resolution did not replace target: %v", err)
+	}
+	backupMeta, err := backups.Load(backups.Path(stateRoot))
+	if err != nil || len(backupMeta.Sets) != 1 {
+		t.Fatalf("Backup Sets = %#v, error = %v, want one protected replacement", backupMeta.Sets, err)
+	}
+}
+
+func TestInstallTagSelectorAdoptUsesPostConflictSnapshots(t *testing.T) {
+	manifestPath, sourceRoot, home, stateRoot := writeTagSelectorTestManifest(t)
+	target := filepath.Join(home, ".one")
+	if err := os.WriteFile(target, []byte("adopted-local\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	setInstallTagSelectorTestHooks(t, true, func(_ io.Reader, _ io.Writer, _ tagselectortui.BrowseData, _ []string, preview tagselectortui.PreviewFunc) (tagselectortui.Result, error) {
+		built, err := preview(1, []string{"one"})
+		return tagselectortui.Result{Tags: []string{"one"}, Preview: built}, err
+	})
+
+	cmd := NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetIn(strings.NewReader("a\r"))
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"install", "--skip-deps", "--file", manifestPath,
+		"--source-root", sourceRoot, "--home", home, "--state-root", stateRoot,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\n%s", err, out.String())
+	}
+	gotSource, err := os.ReadFile(filepath.Join(sourceRoot, "config", "one"))
+	if err != nil || string(gotSource) != "adopted-local\n" {
+		t.Fatalf("adopted Source of Truth = %q, %v", gotSource, err)
+	}
+	if _, err := os.Readlink(target); err != nil {
+		t.Fatalf("adopt did not install managed symlink: %v", err)
+	}
+}
+
+func TestInstallTagSelectorCommitFailureThenPublicRerunConverges(t *testing.T) {
+	manifestPath, sourceRoot, home, stateRoot := writeTagSelectorTestManifest(t)
+	runner := func(_ io.Reader, _ io.Writer, _ tagselectortui.BrowseData, _ []string, preview tagselectortui.PreviewFunc) (tagselectortui.Result, error) {
+		built, err := preview(1, []string{"one"})
+		return tagselectortui.Result{Tags: []string{"one"}, Preview: built}, err
+	}
+	setInstallTagSelectorTestHooks(t, true, runner)
+	originalCommit := commitSelectorInstallationMetadata
+	commitSelectorInstallationMetadata = func(install.MetadataCommit, *state.InstalledSelection, state.InstalledSelection) error {
+		return errors.New("injected selector terminal commit failure")
+	}
+	t.Cleanup(func() { commitSelectorInstallationMetadata = originalCommit })
+
+	run := func() error {
+		cmd := NewRootCommand()
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+		cmd.SetArgs([]string{
+			"install", "--skip-deps", "--file", manifestPath,
+			"--source-root", sourceRoot, "--home", home, "--state-root", stateRoot,
+		})
+		return cmd.Execute()
+	}
+	if err := run(); err == nil || !strings.Contains(err.Error(), "injected selector terminal commit failure") {
+		t.Fatalf("first Execute() error = %v, want injected commit failure", err)
+	}
+	partial, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if partial.InstalledSelection != nil {
+		t.Fatalf("Installed Selection = %#v after failed commit, want prior nil authority", partial.InstalledSelection)
+	}
+	if _, err := os.Readlink(filepath.Join(home, ".one")); err != nil {
+		t.Fatalf("Managed Entry was not staged before commit failure: %v", err)
+	}
+
+	commitSelectorInstallationMetadata = originalCommit
+	if err := run(); err != nil {
+		t.Fatalf("public rerun did not converge: %v", err)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.InstalledSelection == nil || !reflect.DeepEqual(meta.InstalledSelection.ExtraTags, []string{"one"}) {
+		t.Fatalf("Installed Selection = %#v, want converged explicit Tag one", meta.InstalledSelection)
+	}
+	if len(meta.Entries) != 1 || len(meta.Entries[0].Contributions) == 0 {
+		t.Fatalf("Installation Metadata = %#v, want terminal contribution evidence", meta.Entries)
+	}
+}
+
+func TestInstallTagSelectorLeavesHistoricalRetirementEvidenceUntouched(t *testing.T) {
+	manifestPath, sourceRoot, home, stateRoot := writeTagSelectorTestManifest(t)
+	if err := state.Save(state.Path(stateRoot), state.Metadata{
+		Version: state.CurrentVersion,
+		Entries: []state.Record{},
+		Provisioners: []state.ProvisionerRecord{{
+			Profile: "agents", Tool: "gentle-ai", Executable: "gentle-ai", Args: []string{"install", "--scope", "global"}, Status: "provisioned",
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	instructions := filepath.Join(home, ".codex", "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(instructions), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	legacy := "before\n<!-- gentle-ai:trigger-rules -->\nretired\n<!-- /gentle-ai:trigger-rules -->\nafter\n"
+	if err := os.WriteFile(instructions, []byte(legacy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	setInstallTagSelectorTestHooks(t, true, func(_ io.Reader, _ io.Writer, _ tagselectortui.BrowseData, _ []string, preview tagselectortui.PreviewFunc) (tagselectortui.Result, error) {
+		built, err := preview(1, []string{"one"})
+		return tagselectortui.Result{Tags: []string{"one"}, Preview: built}, err
+	})
+
+	cmd := NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"install", "--skip-deps", "--file", manifestPath,
+		"--source-root", sourceRoot, "--home", home, "--state-root", stateRoot,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\n%s", err, out.String())
+	}
+	got, err := os.ReadFile(instructions)
+	if err != nil || string(got) != legacy {
+		t.Fatalf("selector path changed historical state: %q, %v", got, err)
+	}
+	if !strings.Contains(out.String(), "Historical retirement: not run (Tag selector path)") {
+		t.Fatalf("final result does not disclose historical-retirement exclusion\n%s", out.String())
+	}
+}
+
+func TestInstallTagSelectorSkipsAcceptedProvisionerWhenDependencyIsMissing(t *testing.T) {
+	manifestPath, sourceRoot, home, stateRoot := writeTagSelectorProvisionerFixture(t)
+	manifestData, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestData = bytes.Replace(manifestData, []byte("      - name: claude\n"), []byte("      - name: selector-missing-tool\n"), 1)
+	if err := os.WriteFile(manifestPath, manifestData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stubDir := t.TempDir()
+	marker := filepath.Join(stubDir, "provisioner-invoked")
+	writeSelectorExecutable(t, filepath.Join(stubDir, "claude"), fmt.Sprintf("#!/bin/sh\n: > %q\n", marker))
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	setInstallTagSelectorTestHooks(t, true, acceptedSelectorTags("two"))
+
+	out, err := executeAcceptedSelector(t, "", manifestPath, sourceRoot, home, stateRoot)
+	if err == nil || !strings.Contains(err.Error(), `provisioner "claude" is missing dependencies`) {
+		t.Fatalf("Execute() error = %v, want missing Provisioner Dependency gate\n%s", err, out)
+	}
+	if _, statErr := os.Stat(marker); !os.IsNotExist(statErr) {
+		t.Fatalf("Provisioner ran despite missing Dependency: %v", statErr)
+	}
+	if !strings.Contains(out, "missing-dependencies") || !strings.Contains(out, "selector-missing-tool") {
+		t.Fatalf("Provisioner result missing dependency finding\n%s", out)
+	}
+}
+
+func runExplicitTagSelectorSeed(t *testing.T, manifestPath, sourceRoot, home, stateRoot string, tags ...string) {
+	t.Helper()
+	args := []string{
+		"install", "--yes", "--skip-deps", "--file", manifestPath,
+		"--source-root", sourceRoot, "--home", home, "--state-root", stateRoot,
+	}
+	for _, tag := range tags {
+		args = append(args, "--tag", tag)
+	}
+	cmd := NewRootCommand()
+	cmd.SetArgs(args)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("seed explicit Installed Selection: %v", err)
+	}
+}
+
 func TestInstallTagSelectorCancelIsSuccessfulAndNonMutating(t *testing.T) {
 	manifestPath, sourceRoot, home, stateRoot := writeTagSelectorTestManifest(t)
 	setInstallTagSelectorTestHooks(t, true, func(io.Reader, io.Writer, tagselectortui.BrowseData, []string, tagselectortui.PreviewFunc) (tagselectortui.Result, error) {
@@ -130,13 +1030,15 @@ func TestInstallTagSelectorCancelIsSuccessfulAndNonMutating(t *testing.T) {
 
 func TestInstallTagSelectorDefaultRepositoryIsByteStable(t *testing.T) {
 	for _, tc := range []struct {
-		name   string
-		runner installTagSelectorRunnerFunc
+		name          string
+		expectApplied bool
+		runner        installTagSelectorRunnerFunc
 	}{
 		{
-			name: "completed preview",
+			name:          "completed selection applies from current checkout",
+			expectApplied: true,
 			runner: func(_ io.Reader, _ io.Writer, _ tagselectortui.BrowseData, _ []string, preview tagselectortui.PreviewFunc) (tagselectortui.Result, error) {
-				built, err := preview([]string{"one"})
+				built, err := preview(1, []string{"one"})
 				return tagselectortui.Result{Tags: []string{"one"}, Preview: built}, err
 			},
 		},
@@ -150,7 +1052,8 @@ func TestInstallTagSelectorDefaultRepositoryIsByteStable(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			home, sourceRoot := writeTagSelectorGitRepository(t)
 			t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".xdg-state"))
-			before := fingerprintTree(t, home)
+			beforeSource := fingerprintTree(t, sourceRoot)
+			beforeHome := fingerprintTree(t, home)
 			setInstallTagSelectorTestHooks(t, true, tc.runner)
 
 			cmd := NewRootCommand()
@@ -161,14 +1064,21 @@ func TestInstallTagSelectorDefaultRepositoryIsByteStable(t *testing.T) {
 			if err := cmd.Execute(); err != nil {
 				t.Fatalf("Execute() error = %v\n%s", err, out.String())
 			}
-			if after := fingerprintTree(t, home); after != before {
-				t.Fatalf("home fingerprint changed after selector path: before %s, after %s", before, after)
+			if afterSource := fingerprintTree(t, sourceRoot); afterSource != beforeSource {
+				t.Fatalf("Installed Repository changed after selector path: before %s, after %s", beforeSource, afterSource)
 			}
-			if _, err := os.Stat(filepath.Join(home, ".one")); !os.IsNotExist(err) {
-				t.Fatalf("Managed Entry exists after selector path: %v", err)
-			}
-			if _, err := os.Stat(state.Path(defaultStateRoot(home))); !os.IsNotExist(err) {
-				t.Fatalf("Installation Metadata exists after selector path: %v", err)
+			if tc.expectApplied {
+				if _, err := os.Readlink(filepath.Join(home, ".one")); err != nil {
+					t.Fatalf("Managed Entry missing after accepted selector path: %v", err)
+				}
+				meta, err := state.Load(state.Path(defaultStateRoot(home)))
+				if err != nil || meta.InstalledSelection == nil || !reflect.DeepEqual(meta.InstalledSelection.ExtraTags, []string{"one"}) {
+					t.Fatalf("Installed Selection = %#v, error = %v, want explicit Tag one", meta.InstalledSelection, err)
+				}
+			} else {
+				if afterHome := fingerprintTree(t, home); afterHome != beforeHome {
+					t.Fatalf("home fingerprint changed after canceled selector: before %s, after %s", beforeHome, afterHome)
+				}
 			}
 			if !strings.HasPrefix(sourceRoot, home+string(filepath.Separator)) {
 				t.Fatalf("test Installed Repository %q is outside temporary home %q", sourceRoot, home)
@@ -203,7 +1113,7 @@ func TestInstallTagSelectorMissingDefaultRepositoryDoesNotBootstrap(t *testing.T
 func TestInstallTagSelectorPreviewFailureIsNonMutating(t *testing.T) {
 	manifestPath, sourceRoot, home, stateRoot := writeTagSelectorTestManifest(t)
 	setInstallTagSelectorTestHooks(t, true, func(_ io.Reader, _ io.Writer, _ tagselectortui.BrowseData, _ []string, preview tagselectortui.PreviewFunc) (tagselectortui.Result, error) {
-		_, err := preview([]string{"unknown"})
+		_, err := preview(1, []string{"unknown"})
 		return tagselectortui.Result{}, err
 	})
 
@@ -245,11 +1155,18 @@ func writeTagSelectorTestManifest(t *testing.T) (manifestPath, sourceRoot, home,
 	if err := os.WriteFile(filepath.Join(configDir, "one"), []byte("one\n"), 0o600); err != nil {
 		t.Fatalf("write selector source: %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(configDir, "two"), []byte("two\n"), 0o600); err != nil {
+		t.Fatalf("write second selector source: %v", err)
+	}
 	manifestPath = filepath.Join(sourceRoot, "dots.yaml")
 	data := []byte(`version: 1
 tags:
   one:
     description: One selectable capability.
+    kind: surface
+    status: current
+  two:
+    description: Second selectable capability.
     kind: surface
     status: current
 profiles:
@@ -266,6 +1183,10 @@ entries:
     target: ~/.one
     strategy: symlink
     tags: [one]
+  - source: config/two
+    target: ~/.two
+    strategy: symlink
+    tags: [two]
 `)
 	if err := os.WriteFile(manifestPath, data, 0o600); err != nil {
 		t.Fatalf("write selector manifest: %v", err)
@@ -373,6 +1294,33 @@ func fingerprintTree(t *testing.T, root string) string {
 	return fmt.Sprintf("sha256:%x", hash.Sum(nil))
 }
 
+func TestInstallTagSelectorRejectsAcceptedPreviewWithDifferentCandidateToken(t *testing.T) {
+	manifestPath, sourceRoot, home, stateRoot := writeTagSelectorTestManifest(t)
+	setInstallTagSelectorTestHooks(t, true, func(_ io.Reader, _ io.Writer, _ tagselectortui.BrowseData, _ []string, preview tagselectortui.PreviewFunc) (tagselectortui.Result, error) {
+		built, err := preview(1, []string{"one"})
+		if err != nil {
+			return tagselectortui.Result{}, err
+		}
+		built.CandidateToken = "selector-preview-forged"
+		return tagselectortui.Result{Tags: []string{"one"}, Preview: built}, nil
+	})
+
+	out, err := executeAcceptedSelector(t, "", manifestPath, sourceRoot, home, stateRoot)
+	if err == nil || !strings.Contains(err.Error(), "accepted preview does not match its immutable candidate") {
+		t.Fatalf("Execute() error = %v, want candidate-token rejection\n%s", err, out)
+	}
+	if _, statErr := os.Lstat(filepath.Join(home, ".one")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("forged candidate token mutated Managed Entry: %v", statErr)
+	}
+	meta, loadErr := state.Load(state.Path(stateRoot))
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	if meta.InstalledSelection != nil {
+		t.Fatalf("forged candidate token committed Installed Selection: %#v", meta.InstalledSelection)
+	}
+}
+
 func TestBuildInstallTagSelectorPreviewUsesSharedReconciliationReport(t *testing.T) {
 	home := t.TempDir()
 	sourceRoot := t.TempDir()
@@ -390,12 +1338,18 @@ func TestBuildInstallTagSelectorPreviewUsesSharedReconciliationReport(t *testing
 	}
 	meta := state.Metadata{InstalledSelection: &state.InstalledSelection{ExtraTags: []string{"old"}, ResolvedTags: []string{"old"}}}
 	tags := []string{"new"}
-	preview, err := buildInstallTagSelectorPreview(m, meta, resolvedPaths{
+	candidate, err := buildInstallTagSelectorCandidate(m, meta, resolvedPaths{
 		Home: home, SourceRoot: sourceRoot, StateRoot: stateRoot, XDGStateHome: filepath.Join(home, ".local", "state"),
-	}, sourceRoot, nil, "linux", tags)
+	}, sourceRoot, nil, "linux", tags, installTagSelectorOptions{SkipDependencies: true})
 	if err != nil {
-		t.Fatalf("buildInstallTagSelectorPreview() error = %v", err)
+		t.Fatalf("buildInstallTagSelectorCandidate() error = %v", err)
 	}
+	t.Cleanup(func() {
+		if err := candidate.releaseCapturedSources(); err != nil {
+			t.Errorf("release selector candidate: %v", err)
+		}
+	})
+	preview := candidate.Preview
 	if preview.ForwardOnly {
 		t.Fatal("Preview.ForwardOnly = true, want shared reconciliation preview")
 	}
@@ -427,12 +1381,18 @@ func TestBuildInstallTagSelectorPreviewWithoutInstalledSelectionIsForwardOnly(t 
 		}},
 	}
 	meta := state.Metadata{Entries: []state.Record{{Target: filepath.Join(home, ".historical"), Source: "historical", Tags: []string{"old"}}}}
-	preview, err := buildInstallTagSelectorPreview(m, meta, resolvedPaths{
+	candidate, err := buildInstallTagSelectorCandidate(m, meta, resolvedPaths{
 		Home: home, SourceRoot: sourceRoot, StateRoot: t.TempDir(), XDGStateHome: filepath.Join(home, ".local", "state"),
-	}, sourceRoot, nil, "linux", []string{"new"})
+	}, sourceRoot, nil, "linux", []string{"new"}, installTagSelectorOptions{SkipDependencies: true})
 	if err != nil {
-		t.Fatalf("buildInstallTagSelectorPreview() error = %v", err)
+		t.Fatalf("buildInstallTagSelectorCandidate() error = %v", err)
 	}
+	t.Cleanup(func() {
+		if err := candidate.releaseCapturedSources(); err != nil {
+			t.Errorf("release selector candidate: %v", err)
+		}
+	})
+	preview := candidate.Preview
 	if !preview.ForwardOnly {
 		t.Fatal("Preview.ForwardOnly = false, want forward-only without Installed Selection")
 	}

--- a/internal/cli/testdata/install_tag_selector_mixed_preview.golden
+++ b/internal/cli/testdata/install_tag_selector_mixed_preview.golden
@@ -1,0 +1,18 @@
+Dependency provisioning skipped (--skip-deps).
+
+Plan for tags only (tags: base, next) [selection: explicit]
+
+  update          copy      config/base.json -> /home/test/.shared.json
+  create          symlink   config/next -> /home/test/.next
+
+Summary: 1 create, 1 update, 0 migrate, 0 conflict, 0 unchanged, 0 missing-source
+
+Selection reconciliation:
+  remove                   selection      retired
+  create                   selection      next
+  reconcile                managed-entry  /home/test/.shared.json
+  create                   managed-entry  /home/test/.next
+  remove                   managed-entry  /home/test/.retired
+  retained-external-state  dependency     retired-tool
+  retained-external-state  dependency     claude
+  retained-external-state  provisioner    claude [sha256:5ad1ba026bb241cda935498a093942a764ade70f9f396b81cae8f709cf5fffeb]

--- a/internal/cli/testdata/install_tag_selector_mixed_result.golden
+++ b/internal/cli/testdata/install_tag_selector_mixed_result.golden
@@ -1,0 +1,37 @@
+Dependency provisioning skipped (--skip-deps).
+
+Plan for tags only (tags: base, next) [selection: explicit]
+
+  update          copy      config/base.json -> /home/test/.shared.json
+  create          symlink   config/next -> /home/test/.next
+
+Summary: 1 create, 1 update, 0 migrate, 0 conflict, 0 unchanged, 0 missing-source
+
+Selection reconciliation:
+  remove                   selection      retired
+  create                   selection      next
+  reconcile                managed-entry  /home/test/.shared.json
+  create                   managed-entry  /home/test/.next
+  remove                   managed-entry  /home/test/.retired
+  retained-external-state  dependency     retired-tool
+  retained-external-state  dependency     claude
+  retained-external-state  provisioner    claude [sha256:5ad1ba026bb241cda935498a093942a764ade70f9f396b81cae8f709cf5fffeb]
+Tag selection applied: tags=base,next
+  Managed Entries: 2 planned action(s)
+  Dependencies: 0 result(s)
+  Provisioners: 0 result(s)
+  Selection retirement: 1 removed, 0 retained
+  Backup Sets: 1 created
+  Historical retirement: not run (Tag selector path)
+
+Managed Entry results:
+  reconciled /home/test/.shared.json
+  created    /home/test/.next
+
+Retained External State:
+  dependency   retired-tool
+  dependency   claude
+  provisioner  claude [sha256:5ad1ba026bb241cda935498a093942a764ade70f9f396b81cae8f709cf5fffeb]
+Selection retirement:
+  removed /home/test/.retired and released dots ownership
+

--- a/internal/cli/testdata/install_tag_selector_reduction_findings.golden
+++ b/internal/cli/testdata/install_tag_selector_reduction_findings.golden
@@ -1,0 +1,13 @@
+Plan for profile "tags only" (tags: kept)
+
+  unchanged       symlink   config/kept -> /home/test/.kept
+
+Summary: 0 create, 0 conflict, 1 unchanged, 0 missing-source
+
+Selection reconciliation:
+  remove                   selection      removed
+  remove                   managed-entry  /home/test/.removed
+  retain                   managed-entry  /home/test/.retained [reason=whole-target-drift]
+  blocked                  managed-entry  /home/test/.shared.json [reason=ambiguous-partial-ownership]
+  retained-external-state  dependency     removed-tool
+  retained-external-state  provisioner    claude [sha256:example]

--- a/internal/deps/install.go
+++ b/internal/deps/install.go
@@ -43,6 +43,14 @@ type InstallDryRunReport struct {
 	Items    []InstallPreview `json:"items"`
 }
 
+// PreparedInstall binds the exact dependency actions accepted during preview
+// to their public dry-run representation. InstallPrepared executes Plan as-is;
+// it never resolves providers or artifacts again.
+type PreparedInstall struct {
+	Plan   PlanReport
+	Report InstallDryRunReport
+}
+
 // Runner executes one argv-shaped install action.
 type Runner interface {
 	Run(executable string, args []string) error
@@ -102,9 +110,19 @@ type InstallReport struct {
 // InstallDryRun computes the install preview for missing Dependencies without
 // executing package managers.
 func InstallDryRun(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup, tier Tier) (InstallDryRunReport, error) {
-	plan, err := Plan(m, opts, look, fontLook, tier)
+	prepared, err := PrepareInstall(m, opts, look, fontLook, tier)
 	if err != nil {
 		return InstallDryRunReport{}, err
+	}
+	return prepared.Report, nil
+}
+
+// PrepareInstall computes the dependency Plan once and derives the public
+// preview from those exact actions.
+func PrepareInstall(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup, tier Tier) (PreparedInstall, error) {
+	plan, err := Plan(m, opts, look, fontLook, tier)
+	if err != nil {
+		return PreparedInstall{}, err
 	}
 
 	report := InstallDryRunReport{Profile: plan.Profile, Profiles: plan.Profiles, Tags: plan.Tags, Tier: plan.Tier}
@@ -128,17 +146,24 @@ func InstallDryRun(m manifest.Manifest, opts Options, look Lookup, fontLook Font
 			UserLocal:    action.UserLocal,
 		})
 	}
-	return report, nil
+	return PreparedInstall{Plan: plan, Report: report}, nil
 }
 
 // Install executes missing executable install actions and re-probes each
 // dependency after a successful package-manager command.
 func Install(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup, tier Tier, runner Runner) (InstallReport, error) {
-	plan, err := Plan(m, opts, look, fontLook, tier)
+	prepared, err := PrepareInstall(m, opts, look, fontLook, tier)
 	if err != nil {
 		return InstallReport{}, err
 	}
+	return InstallPrepared(prepared, opts, look, fontLook, runner)
+}
 
+// InstallPrepared executes the exact actions selected by PrepareInstall. It
+// may re-probe presence to avoid redundant work, but does not re-resolve an
+// action's provider, package, artifact, or command.
+func InstallPrepared(prepared PreparedInstall, opts Options, look Lookup, fontLook FontLookup, runner Runner) (InstallReport, error) {
+	plan := prepared.Plan
 	report := InstallReport{Profile: plan.Profile, Profiles: plan.Profiles, Tags: plan.Tags, Tier: plan.Tier}
 	requiredUnresolved := false
 	executionLook := look
@@ -146,12 +171,11 @@ func Install(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup
 	if hasToolchainEnvironment {
 		executionLook = toolchainEnvironment.Lookup
 	}
-	environmentActivated := false
 	for _, action := range plan.Actions {
-		// Toolchain activation can satisfy a later action that was missing when
-		// the Install Plan was built (for example npx after fnm activates Node).
-		// Re-probe before honoring that stale plan status.
-		if environmentActivated && actionPresent(action, opts, executionLook, fontLook) {
+		// A dependency can become present between preview and execution (or after
+		// an earlier toolchain action). It is safe to skip, but never to replace,
+		// the reviewed action.
+		if actionPresent(action, opts, executionLook, fontLook) {
 			continue
 		}
 		if !actionExecutable(action) {
@@ -206,7 +230,6 @@ func Install(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup
 			if pathRunner, ok := runner.(HomebrewFormulaPATHRunner); ok {
 				if err := pathRunner.AddHomebrewFormulaToPATH(action.Package); err == nil {
 					executionLook = pathRunner.Lookup
-					environmentActivated = true
 				}
 			}
 		}
@@ -256,7 +279,7 @@ func Install(m manifest.Manifest, opts Options, look Lookup, fontLook FontLookup
 			// Activation failure is represented as unresolved below: a successful
 			// bootstrap is not proof that the selected runtime is executable.
 			if err := toolchainEnvironment.ActivateToolchain(action.Toolchain); err == nil {
-				environmentActivated = true
+				executionLook = toolchainEnvironment.Lookup
 			}
 		}
 		if !actionPresent(action, opts, executionLook, fontLook) {

--- a/internal/deps/install_prepared_test.go
+++ b/internal/deps/install_prepared_test.go
@@ -1,0 +1,59 @@
+package deps_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/deps"
+)
+
+func TestInstallPreparedUsesExactProviderSelectedDuringPrepare(t *testing.T) {
+	present := map[string]bool{"tmux": true, "brew": true}
+	look := func(command string) bool { return present[command] }
+	prepared, err := deps.PrepareInstall(planManifest(), deps.Options{Profile: "default", OS: "darwin"}, look, fontLookupSet(), deps.TierHomebrew)
+	if err != nil {
+		t.Fatalf("PrepareInstall() error = %v", err)
+	}
+
+	// Provider availability changes after review. The accepted action remains
+	// the Homebrew action and must not be resolved again to the newly available
+	// Debian provider.
+	present["brew"] = false
+	present["sudo"] = true
+	present["apt-get"] = true
+	runner := &recordingRunner{afterRun: func() { present["starship"] = true }}
+	report, err := deps.InstallPrepared(prepared, deps.Options{Profile: "default", OS: "darwin"}, look, fontLookupSet(), runner)
+	if err != nil {
+		t.Fatalf("InstallPrepared() error = %v", err)
+	}
+
+	wantCalls := []runnerCall{{executable: "brew", args: []string{"install", "starship"}}}
+	if !reflect.DeepEqual(runner.calls, wantCalls) {
+		t.Fatalf("runner calls = %#v, want exact prepared calls %#v", runner.calls, wantCalls)
+	}
+	if len(report.Items) != 1 || report.Items[0].Provider != deps.TierHomebrew || report.Items[0].Status != deps.InstallStatusInstalled {
+		t.Fatalf("report items = %#v, want prepared Homebrew action installed", report.Items)
+	}
+}
+
+func TestInstallPreparedSkipsActionThatBecamePresent(t *testing.T) {
+	present := map[string]bool{"tmux": true, "brew": true}
+	look := func(command string) bool { return present[command] }
+	prepared, err := deps.PrepareInstall(planManifest(), deps.Options{Profile: "default", OS: "darwin"}, look, fontLookupSet(), deps.TierHomebrew)
+	if err != nil {
+		t.Fatalf("PrepareInstall() error = %v", err)
+	}
+
+	present["starship"] = true
+	runner := &recordingRunner{}
+	report, err := deps.InstallPrepared(prepared, deps.Options{Profile: "default", OS: "darwin"}, look, fontLookupSet(), runner)
+	if err != nil {
+		t.Fatalf("InstallPrepared() error = %v", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runner calls = %#v, want no calls for dependency that became present", runner.calls)
+	}
+	if len(report.Items) != 0 {
+		t.Fatalf("report items = %#v, want skipped action omitted", report.Items)
+	}
+}

--- a/internal/deps/install_test.go
+++ b/internal/deps/install_test.go
@@ -219,8 +219,8 @@ func TestInstallYesReprobesAfterSuccessAndErrorsWhenStillMissing(t *testing.T) {
 	if len(report.Items) != 1 || report.Items[0].Status != deps.InstallStatusUnresolved {
 		t.Fatalf("report items = %#v, want one unresolved item", report.Items)
 	}
-	if !reflect.DeepEqual(probes, []string{"starship", "brew", "tmux", "starship"}) {
-		t.Fatalf("probes = %#v, want initial plan probes then starship re-probe", probes)
+	if !reflect.DeepEqual(probes, []string{"starship", "brew", "tmux", "starship", "starship"}) {
+		t.Fatalf("probes = %#v, want initial plan, pre-execution, then post-install starship probes", probes)
 	}
 }
 

--- a/internal/deps/rolling_user_local_test.go
+++ b/internal/deps/rolling_user_local_test.go
@@ -372,6 +372,47 @@ func TestPlanSkipsRollingResolutionWhenCodexIsPresent(t *testing.T) {
 	}
 }
 
+func TestInstallPreparedKeepsResolvedRollingUserLocalArtifact(t *testing.T) {
+	server := rollingReleaseServer(t, []githubRelease{{TagName: "rust-v0.147.0", Assets: releaseAssets("SERVER")}})
+	defer server.Close()
+	present := false
+	look := func(command string) bool { return command == "codex" && present }
+	prepareOpts := Options{Profile: "default", OS: "linux", Arch: "amd64", Home: "/tmp/home", HTTPClient: server.Client(), RollingReleaseURL: server.URL + "/releases"}
+	prepared, err := PrepareInstall(rollingCodexManifest(), prepareOpts, look, func(string) bool { return false }, TierDebian)
+	if err != nil {
+		t.Fatalf("PrepareInstall() error = %v", err)
+	}
+
+	runner := &preparedUserLocalRunner{afterRun: func() { present = true }}
+	executionOpts := prepareOpts
+	executionOpts.ResolvedUserLocal = map[string]UserLocalArtifact{"codex": {Version: "rust-v9.999.0", Artifact: "different.tar.gz"}}
+	if _, err := InstallPrepared(prepared, executionOpts, look, func(string) bool { return false }, runner); err != nil {
+		t.Fatalf("InstallPrepared() error = %v", err)
+	}
+	if len(runner.actions) != 1 || runner.actions[0].UserLocal == nil {
+		t.Fatalf("user-local actions = %#v, want one prepared artifact", runner.actions)
+	}
+	artifact := runner.actions[0].UserLocal
+	if artifact.Version != "rust-v0.147.0" || artifact.Artifact != "codex-package-x86_64-unknown-linux-musl.tar.gz" {
+		t.Fatalf("executed artifact = %#v, want originally prepared rolling artifact", artifact)
+	}
+}
+
+type preparedUserLocalRunner struct {
+	actions  []InstallAction
+	afterRun func()
+}
+
+func (r *preparedUserLocalRunner) Run(string, []string) error { return nil }
+
+func (r *preparedUserLocalRunner) RunUserLocal(action InstallAction) error {
+	r.actions = append(r.actions, action)
+	r.afterRun()
+	return nil
+}
+
+func (r *preparedUserLocalRunner) RecordUserLocal(InstallAction) error { return nil }
+
 func TestPlanSkipsRollingResolutionWhenClaudeIsPresent(t *testing.T) {
 	var requests atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -8,6 +8,9 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/yersonargotev/dots/internal/backups"
@@ -17,6 +20,7 @@ import (
 	"github.com/yersonargotev/dots/internal/state"
 	"github.com/yersonargotev/dots/internal/textblock"
 	"github.com/yersonargotev/dots/internal/version"
+	"golang.org/x/sys/unix"
 )
 
 // ConflictDecision describes the explicit per-target action selected for a
@@ -40,6 +44,158 @@ type Options struct {
 	// ConflictDecisions contains explicit per-target decisions. Missing conflict
 	// targets default to skip; there is deliberately no global adopt policy.
 	ConflictDecisions map[string]ConflictDecision
+	// CapturedSources binds selector-driven actions to the exact confined Source
+	// of Truth objects reviewed before dependency and provisioner effects.
+	// Explicit installs may leave this nil to retain their historical behavior.
+	CapturedSources map[SourceCaptureKey]CapturedSource
+	// AdoptSnapshots binds explicit adopt decisions to post-conflict snapshots.
+	AdoptSnapshots map[string]AdoptSnapshot
+}
+
+// SourceCaptureKey identifies one Source of Truth input for one target. Target
+// is included because the same source can legitimately participate in actions
+// with different selector authority.
+type SourceCaptureKey struct {
+	Target string
+	Source string
+}
+
+// CapturedSource is an immutable snapshot produced by CaptureManagedSources.
+// Explicit presence flags preserve empty content and zero-valued metadata.
+type CapturedSource struct {
+	Content             []byte
+	ContentPresent      bool
+	Mode                os.FileMode
+	ModePresent         bool
+	IdentityFingerprint string
+	IdentityPresent     bool
+	identity            *capturedFileIdentity
+}
+
+type capturedFileIdentity struct {
+	mu   sync.Mutex
+	file *os.File
+}
+
+func (i *capturedFileIdentity) stat() (os.FileInfo, error) {
+	if i == nil {
+		return nil, fmt.Errorf("captured identity is unavailable")
+	}
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.file == nil {
+		return nil, fmt.Errorf("captured identity was released")
+	}
+	info, err := i.file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat captured identity: %w", err)
+	}
+	return info, nil
+}
+
+func (i *capturedFileIdentity) release() error {
+	if i == nil {
+		return nil
+	}
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.file == nil {
+		return nil
+	}
+	file := i.file
+	i.file = nil
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close captured identity: %w", err)
+	}
+	return nil
+}
+
+// SourceCaptureAuthority is the stable, serializable projection of one opaque
+// captured Source of Truth input. It is suitable for semantic digests; apply
+// authority remains the process-local CapturedSource identity.
+type SourceCaptureAuthority struct {
+	Target              string `json:"target"`
+	Source              string `json:"source"`
+	Content             []byte `json:"content"`
+	ContentPresent      bool   `json:"content_present"`
+	Mode                uint32 `json:"mode"`
+	ModePresent         bool   `json:"mode_present"`
+	IdentityFingerprint string `json:"identity_fingerprint"`
+	IdentityPresent     bool   `json:"identity_present"`
+}
+
+// SourceCaptureAuthorities returns a detached, deterministic projection of
+// captures without exposing their opaque filesystem identities.
+func SourceCaptureAuthorities(captures map[SourceCaptureKey]CapturedSource) []SourceCaptureAuthority {
+	keys := make([]SourceCaptureKey, 0, len(captures))
+	for key := range captures {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].Target != keys[j].Target {
+			return keys[i].Target < keys[j].Target
+		}
+		return keys[i].Source < keys[j].Source
+	})
+	result := make([]SourceCaptureAuthority, 0, len(keys))
+	for _, key := range keys {
+		capture := captures[key]
+		result = append(result, SourceCaptureAuthority{
+			Target: key.Target, Source: key.Source, Content: append([]byte(nil), capture.Content...), ContentPresent: capture.ContentPresent,
+			Mode: uint32(capture.Mode), ModePresent: capture.ModePresent,
+			IdentityFingerprint: capture.IdentityFingerprint, IdentityPresent: capture.IdentityPresent,
+		})
+	}
+	return result
+}
+
+// ReleaseCapturedSources releases the process-local descriptors that pin
+// reviewed Source of Truth identities. It is safe to call more than once and
+// must be deferred immediately after a successful CaptureManagedSources call.
+func ReleaseCapturedSources(captures map[SourceCaptureKey]CapturedSource) error {
+	identities := make(map[*capturedFileIdentity]struct{}, len(captures))
+	for _, capture := range captures {
+		if capture.identity != nil {
+			identities[capture.identity] = struct{}{}
+		}
+	}
+	var errs []error
+	for identity := range identities {
+		if err := identity.release(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// AdoptSnapshot is an immutable post-conflict snapshot produced by
+// CaptureAdoptSnapshots. Its fields are opaque so only confined capture can
+// grant authority to overwrite the Source of Truth.
+type AdoptSnapshot struct {
+	target CapturedSource
+	source CapturedSource
+}
+
+// ReleaseAdoptSnapshots releases the descriptors that pin reviewed adopt
+// target and Source of Truth identities. It is safe to call more than once and
+// must be deferred immediately after CaptureAdoptSnapshots succeeds.
+func ReleaseAdoptSnapshots(snapshots map[string]AdoptSnapshot) error {
+	identities := make(map[*capturedFileIdentity]struct{}, len(snapshots)*2)
+	for _, snapshot := range snapshots {
+		if snapshot.target.identity != nil {
+			identities[snapshot.target.identity] = struct{}{}
+		}
+		if snapshot.source.identity != nil {
+			identities[snapshot.source.identity] = struct{}{}
+		}
+	}
+	var errs []error
+	for identity := range identities {
+		if err := identity.release(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // MetadataCommit finalizes exact contribution evidence after every terminal
@@ -96,6 +252,10 @@ func applyManagedEntriesWithApply(p plan.Plan, opts Options, applyAction managed
 	appliedActions := append([]plan.Action(nil), p.Actions...)
 	appliedReceipts := make([]*state.ReconciliationReceipt, len(p.Actions))
 	for i, action := range p.Actions {
+		action, err = prepareCapturedAction(action, resolvedSources[i], opts)
+		if err != nil {
+			return MetadataCommit{}, err
+		}
 		source := resolvedSources[i][0]
 		prepared, receipt, err := applyActionWithReconciliationReceipt(action, source, resolvedSources[i], opts, applyAction)
 		if err != nil {
@@ -126,7 +286,7 @@ func applyManagedAction(action plan.Action, source string, opts Options) (manage
 	case plan.StatusUnchanged:
 		return managedActionResult{}, nil
 	case plan.StatusCreate:
-		return managedActionResult{}, applyCreate(action, source)
+		return managedActionResult{}, applyCreate(action, source, opts)
 	case plan.StatusUpdate:
 		return applyUpdate(action, source, opts)
 	case plan.StatusMigrate:
@@ -232,47 +392,244 @@ func snapshotReconciliationSources(action plan.Action, resolvedSources []string,
 }
 
 func readConfinedRegularFile(path, rootPath string) ([]byte, error) {
+	captured, err := captureConfinedSource(path, rootPath, true)
+	if err != nil {
+		return nil, err
+	}
+	data := append([]byte(nil), captured.Content...)
+	return data, captured.identity.release()
+}
+
+// CaptureManagedSources snapshots selector-driven Source of Truth inputs under
+// os.Root confinement. Callers pass the result back in Options for both early
+// validation and per-action apply revalidation.
+func CaptureManagedSources(p plan.Plan, opts Options) (result map[SourceCaptureKey]CapturedSource, resultErr error) {
+	captureOpts := opts
+	captureOpts.CapturedSources = nil
+	resolvedSources, err := validatePlan(p, captureOpts)
+	if err != nil {
+		return nil, err
+	}
+	captures := make(map[SourceCaptureKey]CapturedSource)
+	defer func() {
+		if resultErr != nil {
+			resultErr = errors.Join(resultErr, ReleaseCapturedSources(captures))
+		}
+	}()
+	for i, action := range p.Actions {
+		decision := conflictDecision(action, opts)
+		if !recordsMetadata(action, decision) || decision == DecisionAdopt {
+			continue
+		}
+		sourceNames := actionSourceList(action)
+		for j, source := range resolvedSources[i] {
+			captured, err := captureConfinedSource(source, opts.SourceRoot, action.Strategy == "copy")
+			if err != nil {
+				return nil, fmt.Errorf("capture source %s for %s: %w", sourceNames[j], action.Target, err)
+			}
+			key := SourceCaptureKey{Target: action.Target, Source: sourceNames[j]}
+			if previous, ok := captures[key]; ok {
+				if err := previous.identity.release(); err != nil {
+					return nil, errors.Join(err, captured.identity.release())
+				}
+			}
+			captures[key] = captured
+		}
+	}
+	return captures, nil
+}
+
+// CaptureAdoptSnapshots captures the post-conflict target and Source of Truth
+// authority for every explicit adopt decision. It must run after conflict
+// selection and before any unrelated external effects.
+func CaptureAdoptSnapshots(p plan.Plan, opts Options) (result map[string]AdoptSnapshot, resultErr error) {
+	captureOpts := opts
+	captureOpts.AdoptSnapshots = nil
+	resolvedSources, err := validatePlan(p, captureOpts)
+	if err != nil {
+		return nil, err
+	}
+	snapshots := make(map[string]AdoptSnapshot)
+	defer func() {
+		if resultErr != nil {
+			resultErr = errors.Join(resultErr, ReleaseAdoptSnapshots(snapshots))
+		}
+	}()
+	for i, action := range p.Actions {
+		if action.Status != plan.StatusConflict || conflictDecision(action, opts) != DecisionAdopt {
+			continue
+		}
+		target, err := captureConfinedSource(action.Target, opts.Home, true)
+		if err != nil {
+			return nil, fmt.Errorf("capture adopt target %s: %w", action.Target, err)
+		}
+		source, err := captureConfinedSource(resolvedSources[i][0], opts.SourceRoot, true)
+		if err != nil {
+			return nil, errors.Join(fmt.Errorf("capture adopt source %s: %w", action.Source, err), target.identity.release())
+		}
+		if previous, ok := snapshots[action.Target]; ok {
+			if err := errors.Join(previous.target.identity.release(), previous.source.identity.release()); err != nil {
+				return nil, errors.Join(err, target.identity.release(), source.identity.release())
+			}
+		}
+		snapshots[action.Target] = AdoptSnapshot{target: target, source: source}
+	}
+	return snapshots, nil
+}
+
+func captureConfinedSource(path, rootPath string, contentRequired bool) (CapturedSource, error) {
 	rootAbs, err := cleanAbs(rootPath)
 	if err != nil {
-		return nil, fmt.Errorf("resolve source root %s: %w", rootPath, err)
+		return CapturedSource{}, fmt.Errorf("resolve source root %s: %w", rootPath, err)
 	}
 	pathAbs, err := cleanAbs(path)
 	if err != nil {
-		return nil, fmt.Errorf("resolve source %s: %w", path, err)
+		return CapturedSource{}, fmt.Errorf("resolve source %s: %w", path, err)
 	}
 	relative, err := filepath.Rel(rootAbs, pathAbs)
 	if err != nil || !filepath.IsLocal(relative) || relative == "." {
-		return nil, fmt.Errorf("confine source %s beneath source root %s", path, rootAbs)
+		return CapturedSource{}, fmt.Errorf("confine source %s beneath source root %s", path, rootAbs)
 	}
 	root, err := os.OpenRoot(rootAbs)
 	if err != nil {
-		return nil, fmt.Errorf("open source root %s: %w", rootAbs, err)
+		return CapturedSource{}, fmt.Errorf("open source root %s: %w", rootAbs, err)
 	}
 	defer root.Close()
 	observed, err := root.Stat(relative)
 	if err != nil {
-		return nil, fmt.Errorf("inspect confined source %s: %w", path, err)
+		return CapturedSource{}, fmt.Errorf("inspect confined source %s: %w", path, err)
 	}
-	if !observed.Mode().IsRegular() {
-		return nil, fmt.Errorf("confined source %s does not resolve to a regular file", path)
+	if contentRequired && !observed.Mode().IsRegular() {
+		return CapturedSource{}, fmt.Errorf("confined source %s does not resolve to a regular file", path)
 	}
 	file, err := root.OpenFile(relative, os.O_RDONLY, 0)
 	if err != nil {
-		return nil, fmt.Errorf("open confined source %s: %w", path, err)
+		return CapturedSource{}, fmt.Errorf("open confined source %s: %w", path, err)
 	}
-	defer file.Close()
 	info, err := file.Stat()
 	if err != nil {
-		return nil, fmt.Errorf("stat confined source %s: %w", path, err)
+		return CapturedSource{}, errors.Join(fmt.Errorf("stat confined source %s: %w", path, err), file.Close())
 	}
-	if !info.Mode().IsRegular() || !os.SameFile(observed, info) {
-		return nil, fmt.Errorf("install plan is stale: source %s changed identity before snapshot", path)
+	if (contentRequired && !info.Mode().IsRegular()) || !os.SameFile(observed, info) {
+		return CapturedSource{}, errors.Join(fmt.Errorf("install plan is stale: source %s changed identity before snapshot", path), file.Close())
 	}
-	data, err := io.ReadAll(file)
+	captured := CapturedSource{
+		Mode:                info.Mode(),
+		ModePresent:         true,
+		IdentityFingerprint: fmt.Sprintf("%s:%d:%d:%d", info.Name(), info.Size(), info.Mode(), info.ModTime().UnixNano()),
+		IdentityPresent:     true,
+		identity:            &capturedFileIdentity{file: file},
+	}
+	if contentRequired {
+		data, err := io.ReadAll(file)
+		if err != nil {
+			return CapturedSource{}, errors.Join(fmt.Errorf("read confined source %s: %w", path, err), captured.identity.release())
+		}
+		captured.Content = append([]byte{}, data...)
+		captured.ContentPresent = true
+	}
+	return captured, nil
+}
+
+func prepareCapturedAction(action plan.Action, resolvedSources []string, opts Options) (plan.Action, error) {
+	if len(opts.CapturedSources) == 0 {
+		return action, nil
+	}
+	sourceNames := actionSourceList(action)
+	hasTargetCapture := false
+	for key := range opts.CapturedSources {
+		if key.Target == action.Target {
+			hasTargetCapture = true
+			break
+		}
+	}
+	if !hasTargetCapture {
+		return action, nil
+	}
+	contents := make([][]byte, len(sourceNames))
+	for i, sourceName := range sourceNames {
+		captured, ok := opts.CapturedSources[SourceCaptureKey{Target: action.Target, Source: sourceName}]
+		if !ok {
+			return action, fmt.Errorf("captured source %q is missing for %s", sourceName, action.Target)
+		}
+		current, err := captureConfinedSource(resolvedSources[i], opts.SourceRoot, captured.ContentPresent)
+		if err != nil {
+			return action, fmt.Errorf("revalidate captured source %s for %s: %w", sourceName, action.Target, err)
+		}
+		label := fmt.Sprintf("captured source %s for %s", sourceName, action.Target)
+		if err := validateCapturedSource(captured, current, label, func(component string) error {
+			return fmt.Errorf("install plan is stale: captured source %s changed %s for %s", sourceName, component, action.Target)
+		}); err != nil {
+			return action, err
+		}
+		if captured.ContentPresent {
+			contents[i] = append([]byte{}, captured.Content...)
+		}
+	}
+	if action.Strategy != "copy" {
+		return action, nil
+	}
+	prepared := action
+	if len(contents) == 1 {
+		prepared.Content = contents[0]
+		return prepared, nil
+	}
+	composed := append([]byte{}, contents[0]...)
+	for i := 1; i < len(contents); i++ {
+		merged, err := configsubset.MergeJSON(composed, contents[i])
+		if err != nil {
+			return action, fmt.Errorf("compose captured source %s for %s: %w", sourceNames[i], action.Target, err)
+		}
+		composed = merged
+	}
+	prepared.Content = composed
+	return prepared, nil
+}
+
+func validateCapturedFile(path, rootPath, label string, expected CapturedSource) error {
+	current, err := captureConfinedSource(path, rootPath, true)
 	if err != nil {
-		return nil, fmt.Errorf("read confined source %s: %w", path, err)
+		return fmt.Errorf("validate %s: %w", label, err)
 	}
-	return data, nil
+	return validateCapturedSource(expected, current, label, func(component string) error {
+		return fmt.Errorf("%s changed %s", label, component)
+	})
+}
+
+func validateCapturedSource(expected, current CapturedSource, label string, changed func(string) error) (resultErr error) {
+	defer func() {
+		if err := current.identity.release(); err != nil {
+			resultErr = errors.Join(resultErr, fmt.Errorf("release current %s identity: %w", label, err))
+		}
+	}()
+	if expected.IdentityPresent {
+		same, err := sameCapturedIdentity(expected, current)
+		if err != nil {
+			return fmt.Errorf("%s identity authority: %w", label, err)
+		}
+		if !same {
+			return changed("identity")
+		}
+	}
+	if expected.ModePresent && current.Mode.Perm() != expected.Mode.Perm() {
+		return changed("mode")
+	}
+	if expected.ContentPresent && (!current.ContentPresent || !bytes.Equal(current.Content, expected.Content)) {
+		return changed("content")
+	}
+	return nil
+}
+
+func sameCapturedIdentity(expected, current CapturedSource) (bool, error) {
+	expectedInfo, err := expected.identity.stat()
+	if err != nil {
+		return false, err
+	}
+	currentInfo, err := current.identity.stat()
+	if err != nil {
+		return false, err
+	}
+	return os.SameFile(expectedInfo, currentInfo), nil
 }
 
 func actionSourceList(action plan.Action) []string {
@@ -294,11 +651,25 @@ func ValidateManagedEntries(p plan.Plan, opts Options) error {
 // Commit revalidates sources and live targets, then atomically records exact
 // contribution evidence and, when supplied, the authoritative selection.
 func (c MetadataCommit) Commit(installed *state.InstalledSelection) error {
+	return c.commitSelection(nil, installed, false)
+}
+
+// CommitTransition atomically records terminal evidence and replaces the
+// Installed Selection only when its exact prior value still matches expected.
+// In particular, nil authority is distinct from an explicitly empty selection.
+func (c MetadataCommit) CommitTransition(expected, installed *state.InstalledSelection) error {
+	return c.commitSelection(expected, installed, true)
+}
+
+func (c MetadataCommit) commitSelection(expected, installed *state.InstalledSelection, transition bool) error {
 	if c.opts.StateRoot == "" {
 		return nil
 	}
 	path := state.Path(c.opts.StateRoot)
 	return state.Update(path, func(meta *state.Metadata) error {
+		if transition && !reflect.DeepEqual(meta.InstalledSelection, expected) {
+			return fmt.Errorf("installed selection changed concurrently")
+		}
 		if err := c.validateTerminalPaths(); err != nil {
 			return err
 		}
@@ -344,12 +715,24 @@ func (c MetadataCommit) Commit(installed *state.InstalledSelection) error {
 		for target := range legacyTargets {
 			*meta = meta.Remove(target)
 		}
-		if installed != nil {
-			selection := *installed
-			meta.InstalledSelection = &selection
+		if transition {
+			meta.InstalledSelection = cloneInstalledSelection(installed)
+		} else if installed != nil {
+			meta.InstalledSelection = cloneInstalledSelection(installed)
 		}
 		return nil
 	})
+}
+
+func cloneInstalledSelection(installed *state.InstalledSelection) *state.InstalledSelection {
+	if installed == nil {
+		return nil
+	}
+	cloned := *installed
+	cloned.Profiles = append([]string(nil), installed.Profiles...)
+	cloned.ExtraTags = append([]string(nil), installed.ExtraTags...)
+	cloned.ResolvedTags = append([]string(nil), installed.ResolvedTags...)
+	return &cloned
 }
 
 func (c *MetadataCommit) captureStagedEvidence() error {
@@ -613,6 +996,21 @@ func cloneOptions(opts Options) Options {
 			cloned.ConflictDecisions[target] = decision
 		}
 	}
+	if opts.CapturedSources != nil {
+		cloned.CapturedSources = make(map[SourceCaptureKey]CapturedSource, len(opts.CapturedSources))
+		for key, capture := range opts.CapturedSources {
+			capture.Content = append([]byte(nil), capture.Content...)
+			cloned.CapturedSources[key] = capture
+		}
+	}
+	if opts.AdoptSnapshots != nil {
+		cloned.AdoptSnapshots = make(map[string]AdoptSnapshot, len(opts.AdoptSnapshots))
+		for target, snapshot := range opts.AdoptSnapshots {
+			snapshot.target.Content = append([]byte(nil), snapshot.target.Content...)
+			snapshot.source.Content = append([]byte(nil), snapshot.source.Content...)
+			cloned.AdoptSnapshots[target] = snapshot
+		}
+	}
 	return cloned
 }
 
@@ -726,6 +1124,9 @@ func validatePlan(p plan.Plan, opts Options) ([][]string, error) {
 		seenTargets[targetKey] = struct{}{}
 		resolvedSources[i], err = validateActionSources(action, sourceRoot, nil)
 		if err != nil {
+			return nil, err
+		}
+		if _, err := prepareCapturedAction(action, resolvedSources[i], opts); err != nil {
 			return nil, err
 		}
 		source := resolvedSources[i][0]
@@ -855,6 +1256,14 @@ func validatePlan(p plan.Plan, opts Options) ([][]string, error) {
 				}
 				if err := validateAdoptableSource(source, sourceRoot); err != nil {
 					return nil, err
+				}
+				if snapshot, ok := opts.AdoptSnapshots[action.Target]; ok {
+					if err := validateCapturedFile(action.Target, home, "adopt target", snapshot.target); err != nil {
+						return nil, fmt.Errorf("install plan is stale: %w", err)
+					}
+					if err := validateCapturedFile(source, sourceRoot, "adopt source", snapshot.source); err != nil {
+						return nil, fmt.Errorf("install plan is stale: %w", err)
+					}
 				}
 				if action.Strategy == "symlink" {
 					if opts.StateRoot == "" {
@@ -1055,19 +1464,26 @@ func supportedStrategy(strategy string) bool {
 	}
 }
 
-func applyCreate(action plan.Action, source string) error {
-	if err := os.MkdirAll(filepath.Dir(action.Target), 0o755); err != nil {
+func applyCreate(action plan.Action, source string, opts Options) error {
+	if err := createConfinedParent(opts.Home, action.Target); err != nil {
 		return fmt.Errorf("create parent directory for %s: %w", action.Target, err)
 	}
 
 	switch action.Strategy {
 	case "symlink":
-		if err := os.Symlink(source, action.Target); err != nil {
+		if err := createCapturedSymlink(action, source, opts); err != nil {
 			return fmt.Errorf("create symlink %s: %w", action.Target, err)
 		}
 		return nil
 	case "copy":
-		if len(action.Content) > 0 {
+		firstSource := actionSourceList(action)[0]
+		if captured, ok := opts.CapturedSources[SourceCaptureKey{Target: action.Target, Source: firstSource}]; ok && captured.ContentPresent {
+			if err := writeNewFileWithMode(opts.Home, action.Target, action.Content, captured.Mode.Perm()); err != nil {
+				return fmt.Errorf("write captured source to %s: %w", action.Target, err)
+			}
+			return nil
+		}
+		if action.Content != nil {
 			if err := writeNewFileFromSourceMode(source, action.Target, action.Content); err != nil {
 				return fmt.Errorf("write composed JSON to %s: %w", action.Target, err)
 			}
@@ -1082,6 +1498,180 @@ func applyCreate(action plan.Action, source string) error {
 	}
 }
 
+func createCapturedSymlink(action plan.Action, source string, opts Options) error {
+	return createCapturedSymlinkWithHook(action, source, opts, nil)
+}
+
+func createCapturedSymlinkWithHook(action plan.Action, source string, opts Options, afterCreate func() error) error {
+	sourceName := actionSourceList(action)[0]
+	captured, hasCapture := opts.CapturedSources[SourceCaptureKey{Target: action.Target, Source: sourceName}]
+	if hasCapture {
+		if _, err := prepareCapturedAction(action, []string{source}, opts); err != nil {
+			return err
+		}
+	}
+	homeAbs, err := cleanAbs(opts.Home)
+	if err != nil {
+		return fmt.Errorf("resolve home: %w", err)
+	}
+	targetAbs, err := cleanAbs(action.Target)
+	if err != nil {
+		return fmt.Errorf("resolve target %s: %w", action.Target, err)
+	}
+	relative, err := filepath.Rel(homeAbs, targetAbs)
+	if err != nil || !filepath.IsLocal(relative) || relative == "." {
+		return fmt.Errorf("confine target %s beneath home %s", action.Target, homeAbs)
+	}
+	root, err := os.OpenRoot(homeAbs)
+	if err != nil {
+		return fmt.Errorf("open home root %s: %w", homeAbs, err)
+	}
+	defer root.Close()
+	if err := symlinkAtRoot(root, relative, source); err != nil {
+		return err
+	}
+	created, err := root.Lstat(relative)
+	if err != nil {
+		return fmt.Errorf("inspect created symlink: %w", err)
+	}
+	if afterCreate != nil {
+		if err := afterCreate(); err != nil {
+			return errors.Join(fmt.Errorf("after symlink creation: %w", err), removeCreatedSymlinkIfMatching(root, relative, source, created))
+		}
+	}
+	if !hasCapture {
+		return nil
+	}
+	resolved, resolveErr := statSymlinkTargetAtRoot(root, relative)
+	capturedInfo, capturedInfoErr := captured.identity.stat()
+	if resolveErr == nil && capturedInfoErr == nil && os.SameFile(resolved, capturedInfo) {
+		// After terminal commit, a managed symlink intentionally follows later
+		// Source of Truth checkout changes. This identity check only closes the
+		// selector review-to-creation window.
+		return nil
+	}
+	cleanupErr := removeCreatedSymlinkIfMatching(root, relative, source, created)
+	if capturedInfoErr != nil {
+		return errors.Join(fmt.Errorf("resolve captured source identity: %w", capturedInfoErr), cleanupErr)
+	}
+	if resolveErr != nil {
+		return errors.Join(fmt.Errorf("resolve created symlink: %w", resolveErr), cleanupErr)
+	}
+	return errors.Join(fmt.Errorf("created symlink resolved to a different source identity"), cleanupErr)
+}
+
+func createConfinedParent(rootPath, target string) error {
+	root, relative, err := openConfinedRoot(rootPath, target)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+	parent := filepath.Dir(relative)
+	if parent == "." {
+		return nil
+	}
+	current := ""
+	for _, component := range strings.Split(parent, string(os.PathSeparator)) {
+		if component == "" || component == "." {
+			continue
+		}
+		current = filepath.Join(current, component)
+		if err := root.Mkdir(current, 0o755); err != nil && !errors.Is(err, os.ErrExist) {
+			return err
+		}
+		info, err := root.Stat(current)
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("parent %s is not a directory", current)
+		}
+	}
+	return nil
+}
+
+func symlinkAtRoot(root *os.Root, relative, destination string) (resultErr error) {
+	parent, base, err := openRootParent(root, relative)
+	if err != nil {
+		return fmt.Errorf("open symlink parent: %w", err)
+	}
+	defer func() { resultErr = errors.Join(resultErr, parent.Close()) }()
+	if err := unix.Symlinkat(destination, int(parent.Fd()), base); err != nil {
+		return fmt.Errorf("create confined symlink: %w", err)
+	}
+	return nil
+}
+
+func openRootParent(root *os.Root, relative string) (*os.File, string, error) {
+	parent, err := root.OpenFile(filepath.Dir(relative), os.O_RDONLY, 0)
+	if err != nil {
+		return nil, "", err
+	}
+	return parent, filepath.Base(relative), nil
+}
+
+func statSymlinkTargetAtRoot(root *os.Root, relative string) (result os.FileInfo, resultErr error) {
+	parent, base, err := openRootParent(root, relative)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { resultErr = errors.Join(resultErr, parent.Close()) }()
+	fd, err := unix.Openat(int(parent.Fd()), base, unix.O_RDONLY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, err
+	}
+	resolved := os.NewFile(uintptr(fd), relative)
+	if resolved == nil {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("open resolved symlink descriptor")
+	}
+	defer func() { resultErr = errors.Join(resultErr, resolved.Close()) }()
+	return resolved.Stat()
+}
+
+func readlinkAtRoot(root *os.Root, relative string) (result string, resultErr error) {
+	parent, base, err := openRootParent(root, relative)
+	if err != nil {
+		return "", err
+	}
+	defer func() { resultErr = errors.Join(resultErr, parent.Close()) }()
+	for size := 256; size <= 1<<20; size *= 2 {
+		buffer := make([]byte, size)
+		n, err := unix.Readlinkat(int(parent.Fd()), base, buffer)
+		if err != nil {
+			return "", err
+		}
+		if n < len(buffer) {
+			return string(buffer[:n]), nil
+		}
+	}
+	return "", fmt.Errorf("symlink destination exceeds supported length")
+}
+
+func removeCreatedSymlinkIfMatching(root *os.Root, relative, destination string, created os.FileInfo) error {
+	current, err := root.Lstat(relative)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("inspect created symlink for compensation: %w", err)
+	}
+	if current.Mode()&os.ModeSymlink == 0 || !os.SameFile(current, created) {
+		return fmt.Errorf("created symlink changed before compensation; refusing removal")
+	}
+	currentDestination, err := readlinkAtRoot(root, relative)
+	if err != nil {
+		return fmt.Errorf("read created symlink for compensation: %w", err)
+	}
+	if currentDestination != destination {
+		return fmt.Errorf("created symlink destination changed before compensation; refusing removal")
+	}
+	if err := root.Remove(relative); err != nil {
+		return fmt.Errorf("remove created symlink during compensation: %w", err)
+	}
+	return nil
+}
+
 func applyReplace(action plan.Action, source string, opts Options) error {
 	if err := createBackupSet(opts, action.Target); err != nil {
 		return err
@@ -1089,7 +1679,7 @@ func applyReplace(action plan.Action, source string, opts Options) error {
 	if err := removeConflictingTarget(action.Target); err != nil {
 		return fmt.Errorf("remove conflicting target %s: %w", action.Target, err)
 	}
-	if err := applyCreate(action, source); err != nil {
+	if err := applyCreate(action, source, opts); err != nil {
 		return err
 	}
 	return nil
@@ -1452,6 +2042,9 @@ func removeConflictingTarget(target string) error {
 }
 
 func applyAdopt(action plan.Action, source string, opts Options) error {
+	if snapshot, ok := opts.AdoptSnapshots[action.Target]; ok {
+		return applyCapturedAdopt(action, source, opts, snapshot)
+	}
 	if err := copyAdoptedTargetToSource(action.Target, source); err != nil {
 		return err
 	}
@@ -1464,10 +2057,162 @@ func applyAdopt(action plan.Action, source string, opts Options) error {
 	if err := os.Remove(action.Target); err != nil {
 		return fmt.Errorf("remove adopted target %s: %w", action.Target, err)
 	}
-	if err := applyCreate(action, source); err != nil {
+	if err := applyCreate(action, source, opts); err != nil {
 		return err
 	}
 	return nil
+}
+
+func applyCapturedAdopt(action plan.Action, source string, opts Options, snapshot AdoptSnapshot) (resultErr error) {
+	if err := validateCapturedFile(action.Target, opts.Home, "adopt target", snapshot.target); err != nil {
+		return fmt.Errorf("install plan is stale: %w", err)
+	}
+	if err := validateCapturedFile(source, opts.SourceRoot, "adopt source", snapshot.source); err != nil {
+		return fmt.Errorf("install plan is stale: %w", err)
+	}
+
+	sourceRoot, sourceRelative, err := openConfinedRoot(opts.SourceRoot, source)
+	if err != nil {
+		return fmt.Errorf("open adopt source root: %w", err)
+	}
+	defer func() { resultErr = errors.Join(resultErr, sourceRoot.Close()) }()
+	sourceFile, err := sourceRoot.OpenFile(sourceRelative, os.O_RDWR, 0)
+	if err != nil {
+		return fmt.Errorf("open adopt source %s: %w", source, err)
+	}
+	defer func() { resultErr = errors.Join(resultErr, sourceFile.Close()) }()
+	sourceInfo, sourceData, err := readCapturedDescriptor(sourceFile, "adopt source", snapshot.source)
+	if err != nil {
+		return err
+	}
+
+	homeRoot, targetRelative, err := openConfinedRoot(opts.Home, action.Target)
+	if err != nil {
+		return fmt.Errorf("open adopt target root: %w", err)
+	}
+	defer func() { resultErr = errors.Join(resultErr, homeRoot.Close()) }()
+	targetFile, err := homeRoot.OpenFile(targetRelative, os.O_RDONLY, 0)
+	if err != nil {
+		return fmt.Errorf("open adopt target %s: %w", action.Target, err)
+	}
+	_, targetData, targetReadErr := readCapturedDescriptor(targetFile, "adopt target", snapshot.target)
+	targetCloseErr := targetFile.Close()
+	if err := errors.Join(targetReadErr, targetCloseErr); err != nil {
+		return err
+	}
+
+	if err := rewriteOpenedRegularFile(sourceFile, source, targetData, sourceData); err != nil {
+		return fmt.Errorf("write captured adopt source %s: %w", source, err)
+	}
+	if action.Strategy != "symlink" {
+		return nil
+	}
+	rollbackSource := func() error {
+		if _, err := sourceFile.Seek(0, io.SeekStart); err != nil {
+			return fmt.Errorf("seek adopt source for rollback: %w", err)
+		}
+		current, err := io.ReadAll(sourceFile)
+		if err != nil {
+			return fmt.Errorf("read adopt source for rollback: %w", err)
+		}
+		if !bytes.Equal(current, targetData) {
+			return fmt.Errorf("adopt source changed after write; refusing rollback")
+		}
+		return rewriteOpenedRegularFile(sourceFile, source, sourceData, targetData)
+	}
+	if _, err := backups.CreateContentSet(opts.StateRoot, action.Target, targetData, snapshot.target.Mode, backups.CreateOptions{
+		Reason: "pre-install conflict protection", Machine: backups.MachineName(), Repo: opts.SourceRoot,
+	}); err != nil {
+		return errors.Join(err, rollbackSource())
+	}
+	if err := validateCapturedFile(action.Target, opts.Home, "adopt target", snapshot.target); err != nil {
+		return errors.Join(fmt.Errorf("install plan is stale: %w", err), rollbackSource())
+	}
+	if err := homeRoot.Remove(targetRelative); err != nil {
+		return errors.Join(fmt.Errorf("remove adopted target %s: %w", action.Target, err), rollbackSource())
+	}
+
+	adoptedSource := CapturedSource{
+		Content: append([]byte{}, targetData...), ContentPresent: true,
+		Mode: sourceInfo.Mode(), ModePresent: true,
+		IdentityFingerprint: snapshot.source.IdentityFingerprint, IdentityPresent: true, identity: snapshot.source.identity,
+	}
+	createOpts := opts
+	createOpts.CapturedSources = map[SourceCaptureKey]CapturedSource{
+		{Target: action.Target, Source: action.Source}: adoptedSource,
+	}
+	if err := applyCreate(action, source, createOpts); err != nil {
+		restoreErr := restoreCapturedTargetIfAbsent(homeRoot, targetRelative, snapshot.target)
+		return errors.Join(err, restoreErr, rollbackSource())
+	}
+	return nil
+}
+
+func openConfinedRoot(rootPath, path string) (*os.Root, string, error) {
+	rootAbs, err := cleanAbs(rootPath)
+	if err != nil {
+		return nil, "", err
+	}
+	pathAbs, err := cleanAbs(path)
+	if err != nil {
+		return nil, "", err
+	}
+	relative, err := filepath.Rel(rootAbs, pathAbs)
+	if err != nil || !filepath.IsLocal(relative) || relative == "." {
+		return nil, "", fmt.Errorf("confine %s beneath %s", path, rootAbs)
+	}
+	root, err := os.OpenRoot(rootAbs)
+	if err != nil {
+		return nil, "", err
+	}
+	return root, relative, nil
+}
+
+func readCapturedDescriptor(file *os.File, label string, expected CapturedSource) (os.FileInfo, []byte, error) {
+	info, err := file.Stat()
+	if err != nil {
+		return nil, nil, fmt.Errorf("stat %s descriptor: %w", label, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, nil, fmt.Errorf("%s descriptor is not a regular file", label)
+	}
+	if expected.IdentityPresent {
+		expectedInfo, err := expected.identity.stat()
+		if err != nil {
+			return nil, nil, fmt.Errorf("install plan is stale: %s identity authority: %w", label, err)
+		}
+		if !os.SameFile(info, expectedInfo) {
+			return nil, nil, fmt.Errorf("install plan is stale: %s changed identity", label)
+		}
+	}
+	if expected.ModePresent && info.Mode().Perm() != expected.Mode.Perm() {
+		return nil, nil, fmt.Errorf("install plan is stale: %s changed mode", label)
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return nil, nil, fmt.Errorf("seek %s descriptor: %w", label, err)
+	}
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read %s descriptor: %w", label, err)
+	}
+	if expected.ContentPresent && !bytes.Equal(data, expected.Content) {
+		return nil, nil, fmt.Errorf("install plan is stale: %s changed content", label)
+	}
+	return info, data, nil
+}
+
+func restoreCapturedTargetIfAbsent(root *os.Root, relative string, snapshot CapturedSource) error {
+	file, err := root.OpenFile(relative, os.O_WRONLY|os.O_CREATE|os.O_EXCL, snapshot.Mode.Perm())
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return fmt.Errorf("adopt target was replaced after removal; refusing compensation")
+		}
+		return fmt.Errorf("restore adopted target: %w", err)
+	}
+	writeErr := writeAll(file, snapshot.Content)
+	chmodErr := file.Chmod(snapshot.Mode.Perm())
+	closeErr := file.Close()
+	return errors.Join(writeErr, chmodErr, closeErr)
 }
 
 func validateAdoptableTarget(target, home string) error {
@@ -1573,6 +2318,58 @@ func writeNewFileFromSourceMode(source, target string, data []byte) error {
 	if err := file.Close(); err != nil {
 		_ = os.Remove(target)
 		return err
+	}
+	return nil
+}
+
+func writeNewFileWithMode(rootPath, target string, data []byte, mode os.FileMode) error {
+	return writeNewFileWithModeAtRoot(rootPath, target, data, mode, nil)
+}
+
+func writeNewFileWithModeAtRoot(rootPath, target string, data []byte, mode os.FileMode, beforeOpen func() error) (resultErr error) {
+	root, relative, err := openConfinedRoot(rootPath, target)
+	if err != nil {
+		return err
+	}
+	defer func() { resultErr = errors.Join(resultErr, root.Close()) }()
+	if beforeOpen != nil {
+		if err := beforeOpen(); err != nil {
+			return fmt.Errorf("before confined target create: %w", err)
+		}
+	}
+	file, err := root.OpenFile(relative, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode.Perm())
+	if err != nil {
+		return err
+	}
+	created, err := file.Stat()
+	if err != nil {
+		return errors.Join(fmt.Errorf("stat created target: %w", err), file.Close())
+	}
+	if err := writeAll(file, data); err != nil {
+		return errors.Join(err, file.Close(), removeCreatedFileIfMatching(root, relative, created))
+	}
+	if err := file.Chmod(mode.Perm()); err != nil {
+		return errors.Join(err, file.Close(), removeCreatedFileIfMatching(root, relative, created))
+	}
+	if err := file.Close(); err != nil {
+		return errors.Join(err, removeCreatedFileIfMatching(root, relative, created))
+	}
+	return nil
+}
+
+func removeCreatedFileIfMatching(root *os.Root, relative string, created os.FileInfo) error {
+	current, err := root.Lstat(relative)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("inspect created target for compensation: %w", err)
+	}
+	if !current.Mode().IsRegular() || !os.SameFile(current, created) {
+		return fmt.Errorf("created target changed before compensation; refusing removal")
+	}
+	if err := root.Remove(relative); err != nil {
+		return fmt.Errorf("remove created target during compensation: %w", err)
 	}
 	return nil
 }

--- a/internal/install/mutation_safety_internal_test.go
+++ b/internal/install/mutation_safety_internal_test.go
@@ -1,0 +1,604 @@
+package install
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/plan"
+	"github.com/yersonargotev/dots/internal/state"
+)
+
+func TestSourceCaptureAuthoritiesAreDetachedAndDeterministic(t *testing.T) {
+	captures := map[SourceCaptureKey]CapturedSource{
+		{Target: "/home/.z", Source: "z"}: {Content: []byte("z"), ContentPresent: true, Mode: 0o640, ModePresent: true, IdentityFingerprint: "z-id", IdentityPresent: true},
+		{Target: "/home/.a", Source: "b"}: {Content: []byte("b"), ContentPresent: true},
+		{Target: "/home/.a", Source: "a"}: {Content: []byte{}, ContentPresent: true},
+	}
+
+	got := SourceCaptureAuthorities(captures)
+	wantKeys := []SourceCaptureKey{
+		{Target: "/home/.a", Source: "a"},
+		{Target: "/home/.a", Source: "b"},
+		{Target: "/home/.z", Source: "z"},
+	}
+	for i, want := range wantKeys {
+		if got[i].Target != want.Target || got[i].Source != want.Source {
+			t.Fatalf("authority[%d] = %s/%s, want %s/%s", i, got[i].Target, got[i].Source, want.Target, want.Source)
+		}
+	}
+	captures[SourceCaptureKey{Target: "/home/.z", Source: "z"}] = CapturedSource{Content: []byte("changed"), ContentPresent: true}
+	if string(got[2].Content) != "z" {
+		t.Fatalf("authority content changed through source map: %q", got[2].Content)
+	}
+}
+
+func TestValidateCapturedSourceJoinsAuthorityAndReleaseErrors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "source")
+	if err := os.WriteFile(path, []byte("reviewed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	expected := CapturedSource{IdentityPresent: true, identity: &capturedFileIdentity{}}
+	current := CapturedSource{identity: &capturedFileIdentity{file: file}}
+	err = validateCapturedSource(expected, current, "test source", func(component string) error {
+		return fmt.Errorf("test source changed %s", component)
+	})
+	if err == nil {
+		t.Fatal("validateCapturedSource() error = nil, want joined authority and release failures")
+	}
+	for _, want := range []string{"captured identity was released", "close captured identity"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("validateCapturedSource() error = %v, want %q", err, want)
+		}
+	}
+}
+
+func TestMetadataCommitTransitionComparesExactInstalledSelection(t *testing.T) {
+	tests := []struct {
+		name     string
+		current  *state.InstalledSelection
+		expected *state.InstalledSelection
+		wantOK   bool
+	}{
+		{name: "nil matches nil", wantOK: true},
+		{name: "nil differs from explicit empty", expected: &state.InstalledSelection{}},
+		{name: "explicit empty differs from nil", current: &state.InstalledSelection{}},
+		{
+			name:     "provenance differs",
+			current:  &state.InstalledSelection{Profiles: []string{"core"}, Provenance: state.Provenance{SourceRevision: "S1"}},
+			expected: &state.InstalledSelection{Profiles: []string{"core"}, Provenance: state.Provenance{SourceRevision: "S0"}},
+		},
+		{
+			name:     "nonempty exact match",
+			current:  &state.InstalledSelection{Profiles: []string{"core"}, ExtraTags: []string{"git"}, ResolvedTags: []string{"core", "git"}},
+			expected: &state.InstalledSelection{Profiles: []string{"core"}, ExtraTags: []string{"git"}, ResolvedTags: []string{"core", "git"}},
+			wantOK:   true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			home := t.TempDir()
+			sourceRoot := t.TempDir()
+			stateRoot := t.TempDir()
+			if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, InstalledSelection: test.current}); err != nil {
+				t.Fatal(err)
+			}
+			commit := MetadataCommit{opts: Options{Home: home, SourceRoot: sourceRoot, StateRoot: stateRoot}}
+			updated := &state.InstalledSelection{Profiles: []string{"desktop"}, ResolvedTags: []string{"desktop"}}
+			err := commit.CommitTransition(test.expected, updated)
+			if test.wantOK && err != nil {
+				t.Fatalf("CommitTransition() error = %v", err)
+			}
+			if !test.wantOK && (err == nil || !strings.Contains(err.Error(), "installed selection changed concurrently")) {
+				t.Fatalf("CommitTransition() error = %v, want exact CAS rejection", err)
+			}
+			meta, err := state.Load(state.Path(stateRoot))
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := test.current
+			if test.wantOK {
+				want = updated
+			}
+			if !reflect.DeepEqual(meta.InstalledSelection, want) {
+				t.Fatalf("InstalledSelection = %#v, want %#v", meta.InstalledSelection, want)
+			}
+		})
+	}
+}
+
+func TestCapturedCopySourcePreservesExplicitEmptyBytesAndMode(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	source := filepath.Join(sourceRoot, "empty.conf")
+	target := filepath.Join(home, ".empty.conf")
+	if err := os.WriteFile(source, []byte{}, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	p := plan.Plan{Actions: []plan.Action{{Source: "empty.conf", Target: target, Strategy: "copy", Status: plan.StatusCreate}}}
+	opts := Options{Home: home, SourceRoot: sourceRoot}
+	captures, err := CaptureManagedSources(p, opts)
+	if err != nil {
+		t.Fatalf("CaptureManagedSources() error = %v", err)
+	}
+	releaseCapturedSourcesForTest(t, captures)
+	captured := captures[SourceCaptureKey{Target: target, Source: "empty.conf"}]
+	if !captured.ContentPresent || captured.Content == nil || len(captured.Content) != 0 || !captured.ModePresent {
+		t.Fatalf("captured source = %#v, want explicitly present empty bytes and mode", captured)
+	}
+	opts.CapturedSources = captures
+	if err := ValidateManagedEntries(p, opts); err != nil {
+		t.Fatalf("ValidateManagedEntries() error = %v", err)
+	}
+	if _, err := ApplyManagedEntries(p, opts); err != nil {
+		t.Fatalf("ApplyManagedEntries() error = %v", err)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil || !bytes.Equal(got, []byte{}) {
+		t.Fatalf("target content = %q, %v; want explicit empty", got, err)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o640 {
+		t.Fatalf("target mode = %o, want 0640", info.Mode().Perm())
+	}
+}
+
+func TestCapturedCopySourceRejectsContentAndModeChanges(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(string) error
+		want   string
+	}{
+		{name: "content", mutate: func(path string) error { return os.WriteFile(path, []byte("changed\n"), 0o600) }, want: "changed content"},
+		{name: "mode", mutate: func(path string) error { return os.Chmod(path, 0o640) }, want: "changed mode"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			home := t.TempDir()
+			sourceRoot := t.TempDir()
+			source := filepath.Join(sourceRoot, "tool.conf")
+			target := filepath.Join(home, ".tool.conf")
+			if err := os.WriteFile(source, []byte("reviewed\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			p := plan.Plan{Actions: []plan.Action{{Source: "tool.conf", Target: target, Strategy: "copy", Status: plan.StatusCreate}}}
+			opts := Options{Home: home, SourceRoot: sourceRoot}
+			captures, err := CaptureManagedSources(p, opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+			releaseCapturedSourcesForTest(t, captures)
+			opts.CapturedSources = captures
+			if err := test.mutate(source); err != nil {
+				t.Fatal(err)
+			}
+			if err := ValidateManagedEntries(p, opts); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("ValidateManagedEntries() error = %v, want %q", err, test.want)
+			}
+			if _, err := ApplyManagedEntries(p, opts); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("ApplyManagedEntries() error = %v, want %q", err, test.want)
+			}
+			if _, err := os.Lstat(target); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("target lstat error = %v, want no mutation", err)
+			}
+		})
+	}
+}
+
+func TestReleasedCapturedSourceFailsClosedAndReleaseIsIdempotent(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	source := filepath.Join(sourceRoot, "tool.conf")
+	target := filepath.Join(home, ".tool.conf")
+	if err := os.WriteFile(source, []byte("reviewed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	p := plan.Plan{Actions: []plan.Action{{Source: "tool.conf", Target: target, Strategy: "copy", Status: plan.StatusCreate}}}
+	opts := Options{Home: home, SourceRoot: sourceRoot}
+	captures, err := CaptureManagedSources(p, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ReleaseCapturedSources(captures); err != nil {
+		t.Fatalf("ReleaseCapturedSources() error = %v", err)
+	}
+	if err := ReleaseCapturedSources(captures); err != nil {
+		t.Fatalf("second ReleaseCapturedSources() error = %v, want idempotent release", err)
+	}
+	opts.CapturedSources = captures
+	if err := ValidateManagedEntries(p, opts); err == nil || !strings.Contains(err.Error(), "released") {
+		t.Fatalf("ValidateManagedEntries() error = %v, want released authority rejection", err)
+	}
+}
+
+func TestCapturedAdoptRejectsTargetOrSourceSubstitution(t *testing.T) {
+	tests := []struct {
+		name       string
+		substitute func(target, source string) error
+		want       string
+	}{
+		{
+			name: "target",
+			substitute: func(target, _ string) error {
+				if err := os.Remove(target); err != nil {
+					return err
+				}
+				return os.WriteFile(target, []byte("local\n"), 0o640)
+			},
+			want: "adopt target changed identity",
+		},
+		{
+			name: "source",
+			substitute: func(_, source string) error {
+				if err := os.Remove(source); err != nil {
+					return err
+				}
+				return os.WriteFile(source, []byte("managed\n"), 0o600)
+			},
+			want: "adopt source changed identity",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			home := t.TempDir()
+			sourceRoot := t.TempDir()
+			source := filepath.Join(sourceRoot, "gitconfig")
+			target := filepath.Join(home, ".gitconfig")
+			if err := os.WriteFile(source, []byte("managed\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(target, []byte("local\n"), 0o640); err != nil {
+				t.Fatal(err)
+			}
+			p := plan.Plan{Actions: []plan.Action{{Source: "gitconfig", Target: target, Strategy: "copy", Status: plan.StatusConflict}}}
+			opts := Options{Home: home, SourceRoot: sourceRoot, ConflictDecisions: map[string]ConflictDecision{target: DecisionAdopt}}
+			snapshots, err := CaptureAdoptSnapshots(p, opts)
+			if err != nil {
+				t.Fatalf("CaptureAdoptSnapshots() error = %v", err)
+			}
+			releaseAdoptSnapshotsForTest(t, snapshots)
+			opts.AdoptSnapshots = snapshots
+			if err := test.substitute(target, source); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := ApplyManagedEntries(p, opts); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("ApplyManagedEntries() error = %v, want %q", err, test.want)
+			}
+			got, err := os.ReadFile(source)
+			if err != nil || string(got) != "managed\n" {
+				t.Fatalf("source = %q, %v; want unchanged managed content", got, err)
+			}
+		})
+	}
+}
+
+func TestReleasedAdoptSnapshotFailsClosedAndReleaseIsIdempotent(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	source := filepath.Join(sourceRoot, "gitconfig")
+	target := filepath.Join(home, ".gitconfig")
+	if err := os.WriteFile(source, []byte("managed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("local\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	p := plan.Plan{Actions: []plan.Action{{Source: "gitconfig", Target: target, Strategy: "copy", Status: plan.StatusConflict}}}
+	opts := Options{Home: home, SourceRoot: sourceRoot, ConflictDecisions: map[string]ConflictDecision{target: DecisionAdopt}}
+	snapshots, err := CaptureAdoptSnapshots(p, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	releaseAdoptSnapshotsForTest(t, snapshots)
+	if err := ReleaseAdoptSnapshots(snapshots); err != nil {
+		t.Fatalf("ReleaseAdoptSnapshots() error = %v", err)
+	}
+	if err := ReleaseAdoptSnapshots(snapshots); err != nil {
+		t.Fatalf("second ReleaseAdoptSnapshots() error = %v, want idempotent release", err)
+	}
+	opts.AdoptSnapshots = snapshots
+	if err := ValidateManagedEntries(p, opts); err == nil || !strings.Contains(err.Error(), "released") {
+		t.Fatalf("ValidateManagedEntries() error = %v, want released authority rejection", err)
+	}
+}
+
+func TestCapturedAdoptWritesReviewedBytesAndRecordsTerminalEvidence(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	source := filepath.Join(sourceRoot, "gitconfig")
+	target := filepath.Join(home, ".gitconfig")
+	if err := os.WriteFile(source, []byte("managed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("local\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	action := plan.Action{Source: "gitconfig", Target: target, Strategy: "copy", Status: plan.StatusConflict, Contributions: []plan.Contribution{{Source: "gitconfig"}}}
+	p := plan.Plan{Actions: []plan.Action{action}}
+	opts := Options{Home: home, SourceRoot: sourceRoot, StateRoot: stateRoot, ConflictDecisions: map[string]ConflictDecision{target: DecisionAdopt}}
+	snapshots, err := CaptureAdoptSnapshots(p, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	releaseAdoptSnapshotsForTest(t, snapshots)
+	opts.AdoptSnapshots = snapshots
+	commit, err := ApplyManagedEntries(p, opts)
+	if err != nil {
+		t.Fatalf("ApplyManagedEntries() error = %v", err)
+	}
+	if err := commit.Commit(nil); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	got, err := os.ReadFile(source)
+	if err != nil || string(got) != "local\n" {
+		t.Fatalf("source = %q, %v; want reviewed adopted bytes", got, err)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, ok := meta.FindByTarget(target)
+	if !ok || record.Hash != state.HashBytes([]byte("local\n")) || len(record.Contributions) != 1 || record.Contributions[0].Hash != state.HashBytes([]byte("local\n")) {
+		t.Fatalf("terminal evidence = %#v, want adopted content hashes", record)
+	}
+}
+
+func TestCapturedSymlinkSourceRejectsEscapeBeforeCreate(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	source := filepath.Join(sourceRoot, "tool.conf")
+	target := filepath.Join(home, ".tool.conf")
+	outside := filepath.Join(t.TempDir(), "outside.conf")
+	if err := os.WriteFile(source, []byte("reviewed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(outside, []byte("outside\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	p := plan.Plan{Actions: []plan.Action{{Source: "tool.conf", Target: target, Strategy: "symlink", Status: plan.StatusCreate}}}
+	opts := Options{Home: home, SourceRoot: sourceRoot}
+	captures, err := CaptureManagedSources(p, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	releaseCapturedSourcesForTest(t, captures)
+	opts.CapturedSources = captures
+	if err := os.Remove(source); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, source); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ApplyManagedEntries(p, opts); err == nil {
+		t.Fatal("ApplyManagedEntries() accepted a captured symlink source escaping Source of Truth")
+	}
+	if _, err := os.Lstat(target); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("target lstat = %v, want absent", err)
+	}
+}
+
+func TestCapturedSymlinkCompensatesSourceSubstitution(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	source := filepath.Join(sourceRoot, "tool.conf")
+	target := filepath.Join(home, ".tool.conf")
+	if err := os.WriteFile(source, []byte("reviewed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	action := plan.Action{Source: "tool.conf", Target: target, Strategy: "symlink", Status: plan.StatusCreate}
+	p := plan.Plan{Actions: []plan.Action{action}}
+	opts := Options{Home: home, SourceRoot: sourceRoot}
+	captures, err := CaptureManagedSources(p, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	releaseCapturedSourcesForTest(t, captures)
+	opts.CapturedSources = captures
+	err = createCapturedSymlinkWithHook(action, source, opts, func() error {
+		moved := source + ".reviewed"
+		if err := os.Rename(source, moved); err != nil {
+			return err
+		}
+		return os.WriteFile(source, []byte("substituted\n"), 0o600)
+	})
+	if err == nil || !strings.Contains(err.Error(), "different source identity") {
+		t.Fatalf("createCapturedSymlinkWithHook() error = %v, want identity rejection", err)
+	}
+	if _, err := os.Lstat(target); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("target lstat = %v, want compensated link removal", err)
+	}
+}
+
+func TestCapturedSymlinkCompensationPreservesExternalReplacement(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	source := filepath.Join(sourceRoot, "tool.conf")
+	target := filepath.Join(home, ".tool.conf")
+	if err := os.WriteFile(source, []byte("reviewed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	action := plan.Action{Source: "tool.conf", Target: target, Strategy: "symlink", Status: plan.StatusCreate}
+	p := plan.Plan{Actions: []plan.Action{action}}
+	opts := Options{Home: home, SourceRoot: sourceRoot}
+	captures, err := CaptureManagedSources(p, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	releaseCapturedSourcesForTest(t, captures)
+	opts.CapturedSources = captures
+	err = createCapturedSymlinkWithHook(action, source, opts, func() error {
+		if err := os.Remove(target); err != nil {
+			return err
+		}
+		return os.WriteFile(target, []byte("external\n"), 0o600)
+	})
+	if err == nil || !strings.Contains(err.Error(), "refusing removal") {
+		t.Fatalf("createCapturedSymlinkWithHook() error = %v, want conditional compensation refusal", err)
+	}
+	got, readErr := os.ReadFile(target)
+	if readErr != nil || string(got) != "external\n" {
+		t.Fatalf("target = %q, %v; want external replacement preserved", got, readErr)
+	}
+}
+
+func TestOrdinaryCreateFailureDoesNotClaimOwnershipAndExternalEditFailsClosed(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	firstSource := filepath.Join(sourceRoot, "first.conf")
+	secondSource := filepath.Join(sourceRoot, "second.conf")
+	for path, content := range map[string]string{firstSource: "first\n", secondSource: "second\n"} {
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	firstTarget := filepath.Join(home, ".first.conf")
+	secondTarget := filepath.Join(home, ".second.conf")
+	p := plan.Plan{Actions: []plan.Action{
+		{Source: "first.conf", Target: firstTarget, Strategy: "copy", Status: plan.StatusCreate},
+		{Source: "second.conf", Target: secondTarget, Strategy: "copy", Status: plan.StatusCreate},
+	}}
+	opts := Options{Home: home, SourceRoot: sourceRoot, StateRoot: stateRoot}
+	injected := errors.New("injected second action failure")
+	_, err := applyManagedEntriesWithApply(p, opts, func(action plan.Action, source string, applyOpts Options) (managedActionResult, error) {
+		if action.Target == secondTarget {
+			return managedActionResult{}, injected
+		}
+		return applyManagedAction(action, source, applyOpts)
+	})
+	if !errors.Is(err, injected) {
+		t.Fatalf("applyManagedEntriesWithApply() error = %v, want injected failure", err)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, owned := meta.FindByTarget(firstTarget); owned {
+		t.Fatalf("metadata = %#v, must not claim ordinary create after later failure", meta)
+	}
+	if err := os.WriteFile(firstTarget, []byte("external\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateManagedEntries(p, opts); err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("ValidateManagedEntries() error = %v, want stale create rejection", err)
+	}
+	got, err := os.ReadFile(firstTarget)
+	if err != nil || string(got) != "external\n" {
+		t.Fatalf("first target = %q, %v; want external edit preserved", got, err)
+	}
+}
+
+func TestCapturedCopyCreateRejectsParentSymlinkSubstitution(t *testing.T) {
+	home := t.TempDir()
+	outside := t.TempDir()
+	parent := filepath.Join(home, ".config")
+	if err := os.Mkdir(parent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(parent, "tool.conf")
+	err := writeNewFileWithModeAtRoot(home, target, []byte("reviewed\n"), 0o600, func() error {
+		if err := os.Rename(parent, parent+".reviewed"); err != nil {
+			return err
+		}
+		return os.Symlink(outside, parent)
+	})
+	if err == nil {
+		t.Fatal("writeNewFileWithModeAtRoot() accepted a parent symlink escape")
+	}
+	if _, err := os.Lstat(filepath.Join(outside, "tool.conf")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("outside target lstat = %v, want no escaped write", err)
+	}
+}
+
+func TestCapturedSymlinkVerificationRejectsParentEscape(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	outside := t.TempDir()
+	parent := filepath.Join(home, ".config")
+	if err := os.Mkdir(parent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	source := filepath.Join(sourceRoot, "tool.conf")
+	if err := os.WriteFile(source, []byte("reviewed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(parent, "tool.conf")
+	action := plan.Action{Source: "tool.conf", Target: target, Strategy: "symlink", Status: plan.StatusCreate}
+	opts := Options{Home: home, SourceRoot: sourceRoot}
+	captures, err := CaptureManagedSources(plan.Plan{Actions: []plan.Action{action}}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	releaseCapturedSourcesForTest(t, captures)
+	opts.CapturedSources = captures
+	err = createCapturedSymlinkWithHook(action, source, opts, func() error {
+		if err := os.Rename(parent, parent+".reviewed"); err != nil {
+			return err
+		}
+		return os.Symlink(outside, parent)
+	})
+	if err == nil {
+		t.Fatal("createCapturedSymlinkWithHook() accepted a parent symlink escape during verification")
+	}
+	if _, err := os.Lstat(filepath.Join(outside, "tool.conf")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("outside target lstat = %v, want no escaped verification or compensation", err)
+	}
+}
+
+func releaseCapturedSourcesForTest(t *testing.T, captures map[SourceCaptureKey]CapturedSource) {
+	t.Helper()
+	t.Cleanup(func() {
+		if err := ReleaseCapturedSources(captures); err != nil {
+			t.Errorf("ReleaseCapturedSources() error = %v", err)
+		}
+	})
+}
+
+func releaseAdoptSnapshotsForTest(t *testing.T, snapshots map[string]AdoptSnapshot) {
+	t.Helper()
+	t.Cleanup(func() {
+		if err := ReleaseAdoptSnapshots(snapshots); err != nil {
+			t.Errorf("ReleaseAdoptSnapshots() error = %v", err)
+		}
+	})
+}
+
+func TestMetadataCommitTransitionPreservesConcurrentSelection(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	s1 := &state.InstalledSelection{Profiles: []string{"S1"}, ResolvedTags: []string{"S1"}}
+	s2 := &state.InstalledSelection{Profiles: []string{"S2"}, ResolvedTags: []string{"S2"}}
+	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, InstalledSelection: s2}); err != nil {
+		t.Fatal(err)
+	}
+	commit := MetadataCommit{opts: Options{Home: home, SourceRoot: sourceRoot, StateRoot: stateRoot}}
+	err := commit.CommitTransition(s1, &state.InstalledSelection{Profiles: []string{"S3"}})
+	if err == nil || !strings.Contains(err.Error(), "installed selection changed concurrently") {
+		t.Fatalf("CommitTransition() error = %v, want concurrent transition rejection", err)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(meta.InstalledSelection, s2) {
+		t.Fatalf("InstalledSelection = %#v, want concurrent S2 %#v", meta.InstalledSelection, s2)
+	}
+}

--- a/internal/tui/tagselector/model.go
+++ b/internal/tui/tagselector/model.go
@@ -59,20 +59,38 @@ type BrowseData struct {
 	Profiles []Profile
 }
 
+// Confirmation identifies the acknowledgement required after reviewing a
+// preview. The preview provider derives this from the shared selection domain
+// decision rather than the model inferring it from visible Tags.
+type Confirmation string
+
+const (
+	ConfirmationNone      Confirmation = ""
+	ConfirmationReduction Confirmation = "reduction"
+	ConfirmationClear     Confirmation = "clear"
+)
+
 // Preview is the opaque preview value returned across the CLI seam.
 type Preview struct {
 	Text           string
 	SemanticDigest string
+	// CandidateToken binds an accepted UI value to one process-local candidate.
+	// It is opaque presentation data and is not part of the semantic digest.
+	CandidateToken string
 	ForwardOnly    bool
+	Confirmation   Confirmation
 }
 
-// PreviewFunc computes a preview for a detached canonical Tag snapshot.
-type PreviewFunc func([]string) (Preview, error)
+// PreviewFunc computes a preview for a detached canonical Tag snapshot. The
+// request ID is assigned synchronously in UI request order and is opaque to the
+// presentation layer.
+type PreviewFunc func(uint64, []string) (Preview, error)
 
 // Result is a successfully confirmed selection and its accepted preview.
 type Result struct {
-	Tags    []string
-	Preview Preview
+	Tags                    []string
+	Preview                 Preview
+	AcknowledgementAccepted bool
 }
 
 // ErrCanceled means the operator canceled without producing usable intent.
@@ -87,6 +105,8 @@ const (
 	screenDetail
 	screenLoading
 	screenPreview
+	screenReductionConfirmation
+	screenClearConfirmation
 )
 
 // Model is the Bubble Tea model for selecting Tags.
@@ -110,6 +130,9 @@ type Model struct {
 	accepted     Preview
 	previewTags  []string
 	previewError string
+	clearInput   string
+	clearError   string
+	acknowledged bool
 	canceled     bool
 	finished     bool
 	quitting     bool
@@ -225,23 +248,53 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			m.previewScroll = 0
 			m.screen = screenList
 		case tea.KeyEnter:
+			switch m.confirmation() {
+			case ConfirmationReduction:
+				m.screen = screenReductionConfirmation
+				return m, nil
+			case ConfirmationClear:
+				m.screen = screenClearConfirmation
+				return m, nil
+			}
 			m.finished = true
 			m.quitting = true
 			return m, tea.Quit
 		}
+		return m.scrollPreview(key), nil
+	}
+	if m.screen == screenReductionConfirmation {
+		switch key.Type {
+		case tea.KeyEnter:
+			return m.finishAcknowledged(), tea.Quit
+		case tea.KeyEsc:
+			return m.abandonPreview(), nil
+		}
 		switch key.String() {
-		case "j", "down":
-			m.previewScroll = scrolledOffset(m.previewScroll, 1, len(m.previewContentLines()), m.previewBodyHeight())
-		case "k", "up":
-			m.previewScroll = scrolledOffset(m.previewScroll, -1, len(m.previewContentLines()), m.previewBodyHeight())
-		case "pgdown":
-			m.previewScroll = scrolledOffset(m.previewScroll, max(1, m.previewBodyHeight()-2), len(m.previewContentLines()), m.previewBodyHeight())
-		case "pgup":
-			m.previewScroll = scrolledOffset(m.previewScroll, -max(1, m.previewBodyHeight()-2), len(m.previewContentLines()), m.previewBodyHeight())
-		case "home":
-			m.previewScroll = 0
-		case "end":
-			m.previewScroll = clampScrollOffset(len(m.previewContentLines()), m.previewBodyHeight(), len(m.previewContentLines()))
+		case "y":
+			return m.finishAcknowledged(), tea.Quit
+		case "n":
+			return m.abandonPreview(), nil
+		}
+		return m.scrollPreview(key), nil
+	}
+	if m.screen == screenClearConfirmation {
+		switch key.Type {
+		case tea.KeyEsc:
+			return m.abandonPreview(), nil
+		case tea.KeyEnter:
+			if m.clearInput == string(ConfirmationClear) {
+				return m.finishAcknowledged(), tea.Quit
+			}
+			m.clearError = `Confirmation did not match; type exactly "clear".`
+		case tea.KeyBackspace, tea.KeyDelete:
+			if len(m.clearInput) > 0 {
+				runes := []rune(m.clearInput)
+				m.clearInput = string(runes[:len(runes)-1])
+			}
+			m.clearError = ""
+		case tea.KeyRunes:
+			m.clearInput += string(key.Runes)
+			m.clearError = ""
 		}
 		return m, nil
 	}
@@ -319,6 +372,26 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+func (m Model) scrollPreview(key tea.KeyMsg) Model {
+	bodyHeight := m.previewBodyHeight()
+	contentLines := len(m.previewContentLines())
+	switch key.String() {
+	case "j", "down":
+		m.previewScroll = scrolledOffset(m.previewScroll, 1, contentLines, bodyHeight)
+	case "k", "up":
+		m.previewScroll = scrolledOffset(m.previewScroll, -1, contentLines, bodyHeight)
+	case "pgdown":
+		m.previewScroll = scrolledOffset(m.previewScroll, max(1, bodyHeight-2), contentLines, bodyHeight)
+	case "pgup":
+		m.previewScroll = scrolledOffset(m.previewScroll, -max(1, bodyHeight-2), contentLines, bodyHeight)
+	case "home":
+		m.previewScroll = 0
+	case "end":
+		m.previewScroll = clampScrollOffset(contentLines, bodyHeight, contentLines)
+	}
+	return m
+}
+
 func (m Model) startPreview() (tea.Model, tea.Cmd) {
 	tags := m.SelectedTags()
 	m.nextRequest++
@@ -331,6 +404,9 @@ func (m Model) startPreview() (tea.Model, tea.Cmd) {
 	m.accepted = Preview{}
 	m.previewTags = nil
 	m.previewError = ""
+	m.clearInput = ""
+	m.clearError = ""
+	m.acknowledged = false
 	m.previewScroll = 0
 	m.screen = screenLoading
 	provider := m.previewFunc
@@ -339,7 +415,7 @@ func (m Model) startPreview() (tea.Model, tea.Cmd) {
 			return previewResponse{id: request.id, fingerprint: request.fingerprint, err: errors.New("preview is unavailable")}
 		}
 		input := append([]string(nil), request.tags...)
-		preview, err := provider(input)
+		preview, err := provider(request.id, input)
 		return previewResponse{id: request.id, fingerprint: request.fingerprint, preview: preview, err: err}
 	}
 }
@@ -363,10 +439,38 @@ func (m Model) acceptPreview(response previewResponse) Model {
 	return m
 }
 
+func (m Model) confirmation() Confirmation {
+	if len(m.previewTags) == 0 {
+		return ConfirmationClear
+	}
+	return m.accepted.Confirmation
+}
+
+func (m Model) finishAcknowledged() Model {
+	m.acknowledged = true
+	m.finished = true
+	m.quitting = true
+	return m
+}
+
+func (m Model) abandonPreview() Model {
+	m.accepted = Preview{}
+	m.previewTags = nil
+	m.previewScroll = 0
+	m.clearInput = ""
+	m.clearError = ""
+	m.acknowledged = false
+	m.screen = screenList
+	return m
+}
+
 func (m Model) cancel() Model {
 	m.pending = nil
 	m.accepted = Preview{}
 	m.previewTags = nil
+	m.clearInput = ""
+	m.clearError = ""
+	m.acknowledged = false
 	m.canceled = true
 	m.finished = false
 	m.quitting = true
@@ -442,7 +546,7 @@ func (m Model) Result() Result {
 	if m.canceled || !m.finished {
 		return Result{}
 	}
-	return Result{Tags: cloneStrings(m.previewTags), Preview: m.accepted}
+	return Result{Tags: cloneStrings(m.previewTags), Preview: m.accepted, AcknowledgementAccepted: m.acknowledged}
 }
 
 // Canceled reports whether the session ended without usable intent.
@@ -458,6 +562,12 @@ func (m Model) View() string {
 	}
 	if m.screen == screenPreview {
 		return m.viewPreview()
+	}
+	if m.screen == screenReductionConfirmation {
+		return m.viewReductionConfirmation()
+	}
+	if m.screen == screenClearConfirmation {
+		return m.viewClearConfirmation()
 	}
 	if m.screen == screenProfiles {
 		return m.viewProfiles()
@@ -541,6 +651,23 @@ func (m Model) viewPreview() string {
 	header := []string{"dots · selection preview", ""}
 	footer := []string{"", "j/k scroll · pgup/pgdown · enter confirm · esc back · q/ctrl+c cancel"}
 	body := scrollPage(m.previewContentLines(), m.previewScroll, m.previewBodyHeight())
+	return renderLines(append(append(header, body...), footer...))
+}
+
+func (m Model) viewReductionConfirmation() string {
+	header := []string{"dots · confirm selection reduction", ""}
+	footer := []string{"", "y/enter acknowledge · n/esc back · q/ctrl+c cancel"}
+	body := scrollPage(m.previewContentLines(), m.previewScroll, availableBodyHeight(m.height, len(header)+len(footer)))
+	return renderLines(append(append(header, body...), footer...))
+}
+
+func (m Model) viewClearConfirmation() string {
+	header := []string{"dots · confirm clear selection", ""}
+	body := append(m.previewContentLines(), "", `Type "clear" to remove every selected Managed Entry from dots management: `+m.clearInput)
+	if m.clearError != "" {
+		body = append(body, m.clearError)
+	}
+	footer := []string{"", "enter acknowledge · esc back · q/ctrl+c cancel"}
 	return renderLines(append(append(header, body...), footer...))
 }
 

--- a/internal/tui/tagselector/model_test.go
+++ b/internal/tui/tagselector/model_test.go
@@ -20,9 +20,11 @@ func key(r rune) tea.KeyMsg {
 }
 
 func TestPreviewReceivesCanonicalSnapshotAndFinishesWithExactOpaqueValue(t *testing.T) {
-	wantPreview := tagselector.Preview{Text: "install zsh\nretain fzf", SemanticDigest: "sha256:opaque", ForwardOnly: true}
+	wantPreview := tagselector.Preview{Text: "install zsh\nretain fzf", SemanticDigest: "sha256:opaque", CandidateToken: "selector-preview-1", ForwardOnly: true}
 	var received []string
-	model := tagselector.New(testBrowseData(), []string{"nvim", "zsh"}, func(tags []string) (tagselector.Preview, error) {
+	var receivedRequestID uint64
+	model := tagselector.New(testBrowseData(), []string{"nvim", "zsh"}, func(requestID uint64, tags []string) (tagselector.Preview, error) {
+		receivedRequestID = requestID
 		received = append([]string(nil), tags...)
 		tags[0] = "mutated-by-provider"
 		return wantPreview, nil
@@ -38,6 +40,9 @@ func TestPreviewReceivesCanonicalSnapshotAndFinishesWithExactOpaqueValue(t *test
 	model = next.(tagselector.Model)
 	if got, want := received, []string{"zsh", "nvim"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("preview input = %v, want canonical snapshot %v", got, want)
+	}
+	if receivedRequestID != 1 {
+		t.Fatalf("preview request ID = %d, want 1", receivedRequestID)
 	}
 	if got := model.Preview(); got != wantPreview {
 		t.Fatalf("Preview() = %#v, want exact opaque %#v", got, wantPreview)
@@ -56,7 +61,7 @@ func TestPreviewReceivesCanonicalSnapshotAndFinishesWithExactOpaqueValue(t *test
 		t.Fatal("enter in preview should finish with a quit command")
 	}
 	result := model.Result()
-	if !reflect.DeepEqual(result.Tags, []string{"zsh", "nvim"}) || result.Preview != wantPreview {
+	if !reflect.DeepEqual(result.Tags, []string{"zsh", "nvim"}) || result.Preview != wantPreview || result.AcknowledgementAccepted {
 		t.Fatalf("Result() = %#v, want detached Tags and exact preview", result)
 	}
 	result.Tags[0] = "changed"
@@ -65,9 +70,167 @@ func TestPreviewReceivesCanonicalSnapshotAndFinishesWithExactOpaqueValue(t *test
 	}
 }
 
+func TestReductionPreviewTransitionsToDistinctConfirmationBeforeFinishing(t *testing.T) {
+	wantPreview := tagselector.Preview{
+		Text:         "Removed:\n  nvim\nRetained External State:\n  neovim",
+		Confirmation: tagselector.ConfirmationReduction,
+	}
+	model := tagselector.New(testBrowseData(), []string{"zsh", "nvim"}, func(uint64, []string) (tagselector.Preview, error) {
+		return wantPreview, nil
+	})
+	model = update(t, model, tea.KeyMsg{Type: tea.KeyDown}, tea.KeyMsg{Type: tea.KeyDown}, key(' '))
+
+	next, command := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = update(t, next.(tagselector.Model), command())
+	model = update(t, model, tea.KeyMsg{Type: tea.KeyEnter})
+
+	view := model.View()
+	for _, want := range []string{"dots · confirm selection reduction", "Removed:", "nvim", "Retained External State:"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("reduction confirmation missing %q:\n%s", want, view)
+		}
+	}
+	if got := model.Result(); got.Tags != nil || got.Preview != (tagselector.Preview{}) || got.AcknowledgementAccepted {
+		t.Fatalf("reduction was usable before dedicated acknowledgement: %#v", got)
+	}
+}
+
+func TestReductionAcknowledgementAcceptsReviewedPreview(t *testing.T) {
+	for name, accept := range map[string]tea.KeyMsg{
+		"yes":   key('y'),
+		"enter": {Type: tea.KeyEnter},
+	} {
+		t.Run(name, func(t *testing.T) {
+			wantPreview := tagselector.Preview{Text: "remove nvim", SemanticDigest: "sha256:reduction", Confirmation: tagselector.ConfirmationReduction}
+			model := reviewedPreview(t, []string{"zsh", "nvim"}, []tea.KeyMsg{{Type: tea.KeyDown}, {Type: tea.KeyDown}, key(' ')}, wantPreview)
+			model = update(t, model, tea.KeyMsg{Type: tea.KeyEnter})
+
+			next, quit := model.Update(accept)
+			model = next.(tagselector.Model)
+			if quit == nil {
+				t.Fatal("accepted reduction should quit")
+			}
+			if got := model.Result(); !reflect.DeepEqual(got.Tags, []string{"zsh"}) || got.Preview != wantPreview || !got.AcknowledgementAccepted {
+				t.Fatalf("accepted reduction Result() = %#v", got)
+			}
+		})
+	}
+}
+
+func TestReductionAcknowledgementDeclineReturnsToDraftWithoutUsableResult(t *testing.T) {
+	for name, decline := range map[string]tea.KeyMsg{
+		"no":  key('n'),
+		"esc": {Type: tea.KeyEsc},
+	} {
+		t.Run(name, func(t *testing.T) {
+			preview := tagselector.Preview{Text: "remove nvim", Confirmation: tagselector.ConfirmationReduction}
+			model := reviewedPreview(t, []string{"zsh", "nvim"}, []tea.KeyMsg{{Type: tea.KeyDown}, {Type: tea.KeyDown}, key(' ')}, preview)
+			model = update(t, model, tea.KeyMsg{Type: tea.KeyEnter}, decline)
+
+			if view := model.View(); !strings.Contains(view, "dots · select Tags") || !strings.Contains(view, "[ ] nvim") {
+				t.Fatalf("declined reduction should return to unchanged draft:\n%s", view)
+			}
+			if got := model.Preview(); got != (tagselector.Preview{}) {
+				t.Fatalf("declined reduction exposed accepted Preview: %#v", got)
+			}
+			if got := model.Result(); !reflect.DeepEqual(got, tagselector.Result{}) {
+				t.Fatalf("declined reduction exposed Result: %#v", got)
+			}
+		})
+	}
+}
+
+func TestReductionAcknowledgementCancelClearsReviewedPreview(t *testing.T) {
+	preview := tagselector.Preview{Text: "remove nvim", Confirmation: tagselector.ConfirmationReduction}
+	model := reviewedPreview(t, []string{"zsh", "nvim"}, []tea.KeyMsg{{Type: tea.KeyDown}, {Type: tea.KeyDown}, key(' ')}, preview)
+	model = update(t, model, tea.KeyMsg{Type: tea.KeyEnter})
+
+	next, quit := model.Update(key('q'))
+	model = next.(tagselector.Model)
+	if quit == nil || !model.Canceled() {
+		t.Fatal("q should cancel from reduction acknowledgement")
+	}
+	if got := model.Result(); !reflect.DeepEqual(got, tagselector.Result{}) {
+		t.Fatalf("canceled reduction exposed Result: %#v", got)
+	}
+}
+
+func TestEmptySelectionRequiresLiteralClearAndSupportsBackspace(t *testing.T) {
+	wantPreview := tagselector.Preview{Text: "Removed:\n  zsh", SemanticDigest: "sha256:clear", Confirmation: tagselector.ConfirmationClear}
+	model := reviewedPreview(t, []string{"zsh"}, []tea.KeyMsg{key(' ')}, wantPreview)
+	model = update(t, model, tea.KeyMsg{Type: tea.KeyEnter})
+	if view := model.View(); !strings.Contains(view, "dots · confirm clear selection") || !strings.Contains(view, `Type "clear"`) {
+		t.Fatalf("empty preview did not enter strong clear confirmation:\n%s", view)
+	}
+	if got := model.Result(); !reflect.DeepEqual(got, tagselector.Result{}) {
+		t.Fatalf("empty selection was usable before typing clear: %#v", got)
+	}
+
+	model = update(t, model,
+		key('c'), key('l'), key('e'), key('a'), key('r'), key('r'),
+		tea.KeyMsg{Type: tea.KeyBackspace},
+	)
+	if view := model.View(); !strings.Contains(view, `management: clear`) || strings.Contains(view, `management: clearr`) {
+		t.Fatalf("clear confirmation did not reflect typed phrase and backspace:\n%s", view)
+	}
+	next, quit := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(tagselector.Model)
+	if quit == nil {
+		t.Fatal("literal clear should finish and quit")
+	}
+	if got := model.Result(); got.Tags == nil || len(got.Tags) != 0 || got.Preview != wantPreview || !got.AcknowledgementAccepted {
+		t.Fatalf("clear Result() = %#v, want accepted explicit empty Tags", got)
+	}
+}
+
+func TestClearConfirmationMismatchShowsErrorWithoutUsableResult(t *testing.T) {
+	preview := tagselector.Preview{Text: "remove everything", Confirmation: tagselector.ConfirmationClear}
+	model := reviewedPreview(t, []string{"zsh"}, []tea.KeyMsg{key(' ')}, preview)
+	model = update(t, model, tea.KeyMsg{Type: tea.KeyEnter}, key('C'), key('L'), key('E'), key('A'), key('R'), tea.KeyMsg{Type: tea.KeyEnter})
+
+	view := model.View()
+	if !strings.Contains(view, `Confirmation did not match; type exactly "clear".`) || !strings.Contains(view, "management: CLEAR") {
+		t.Fatalf("mismatched clear phrase should remain visible with an error:\n%s", view)
+	}
+	if got := model.Result(); !reflect.DeepEqual(got, tagselector.Result{}) {
+		t.Fatalf("mismatched clear phrase exposed Result: %#v", got)
+	}
+}
+
+func TestClearConfirmationDeclineReturnsToDraftAndCancelClearsIntent(t *testing.T) {
+	preview := tagselector.Preview{Text: "remove everything", Confirmation: tagselector.ConfirmationClear}
+
+	t.Run("decline", func(t *testing.T) {
+		model := reviewedPreview(t, []string{"zsh"}, []tea.KeyMsg{key(' ')}, preview)
+		model = update(t, model, tea.KeyMsg{Type: tea.KeyEnter}, key('c'), tea.KeyMsg{Type: tea.KeyEsc})
+		if view := model.View(); !strings.Contains(view, "dots · select Tags") || !strings.Contains(view, "[ ] zsh") {
+			t.Fatalf("declined clear should return to unchanged draft:\n%s", view)
+		}
+		if got := model.Preview(); got != (tagselector.Preview{}) {
+			t.Fatalf("declined clear exposed Preview: %#v", got)
+		}
+		if got := model.Result(); !reflect.DeepEqual(got, tagselector.Result{}) {
+			t.Fatalf("declined clear exposed Result: %#v", got)
+		}
+	})
+
+	t.Run("cancel", func(t *testing.T) {
+		model := reviewedPreview(t, []string{"zsh"}, []tea.KeyMsg{key(' ')}, preview)
+		model = update(t, model, tea.KeyMsg{Type: tea.KeyEnter}, key('c'))
+		next, quit := model.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+		model = next.(tagselector.Model)
+		if quit == nil || !model.Canceled() {
+			t.Fatal("ctrl+c should cancel clear confirmation")
+		}
+		if got := model.Result(); !reflect.DeepEqual(got, tagselector.Result{}) {
+			t.Fatalf("canceled clear exposed Result: %#v", got)
+		}
+	})
+}
+
 func TestLoadingIgnoresRepeatedEnterSoEachRequestCallsPreviewOnce(t *testing.T) {
 	var calls atomic.Int32
-	model := tagselector.New(testBrowseData(), nil, func([]string) (tagselector.Preview, error) {
+	model := tagselector.New(testBrowseData(), nil, func(uint64, []string) (tagselector.Preview, error) {
 		calls.Add(1)
 		return tagselector.Preview{Text: "ok"}, nil
 	})
@@ -87,7 +250,7 @@ func TestLoadingIgnoresRepeatedEnterSoEachRequestCallsPreviewOnce(t *testing.T) 
 
 func TestPreviewErrorReturnsToDraftAndAllowsRetry(t *testing.T) {
 	var calls atomic.Int32
-	model := tagselector.New(testBrowseData(), []string{"zsh"}, func([]string) (tagselector.Preview, error) {
+	model := tagselector.New(testBrowseData(), []string{"zsh"}, func(uint64, []string) (tagselector.Preview, error) {
 		if calls.Add(1) == 1 {
 			return tagselector.Preview{}, errors.New("preview failed")
 		}
@@ -114,7 +277,9 @@ func TestPreviewErrorReturnsToDraftAndAllowsRetry(t *testing.T) {
 func TestNewerPreviewWinsWhenBCompletesBeforeA(t *testing.T) {
 	aStarted := make(chan struct{})
 	aRelease := make(chan struct{})
-	preview := func(tags []string) (tagselector.Preview, error) {
+	requestIDs := make(chan uint64, 2)
+	preview := func(requestID uint64, tags []string) (tagselector.Preview, error) {
+		requestIDs <- requestID
 		if reflect.DeepEqual(tags, []string{"zsh"}) {
 			close(aStarted)
 			<-aRelease
@@ -142,12 +307,15 @@ func TestNewerPreviewWinsWhenBCompletesBeforeA(t *testing.T) {
 	if got := model.Preview().Text; got != "B" {
 		t.Fatalf("stale A replaced accepted B, got %q", got)
 	}
+	if first, second := <-requestIDs, <-requestIDs; first != 1 || second != 2 {
+		t.Fatalf("preview request IDs = %d, %d, want UI order 1, 2", first, second)
+	}
 }
 
 func TestStalePreviewErrorAfterCancelCannotProduceUsableResult(t *testing.T) {
 	started := make(chan struct{})
 	release := make(chan struct{})
-	model := tagselector.New(testBrowseData(), []string{"zsh"}, func([]string) (tagselector.Preview, error) {
+	model := tagselector.New(testBrowseData(), []string{"zsh"}, func(uint64, []string) (tagselector.Preview, error) {
 		close(started)
 		<-release
 		return tagselector.Preview{}, errors.New("late failure")
@@ -186,14 +354,14 @@ func TestCtrlCCancelsFromEveryScreenAndClearsUsableValues(t *testing.T) {
 			return update(t, tagselector.New(detailedBrowseData(), nil, nil), tea.WindowSizeMsg{Width: 80}, key('d'))
 		},
 		"loading": func(t *testing.T) tagselector.Model {
-			model := tagselector.New(detailedBrowseData(), nil, func([]string) (tagselector.Preview, error) {
+			model := tagselector.New(detailedBrowseData(), nil, func(uint64, []string) (tagselector.Preview, error) {
 				return tagselector.Preview{Text: "preview"}, nil
 			})
 			next, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
 			return next.(tagselector.Model)
 		},
 		"preview": func(t *testing.T) tagselector.Model {
-			model := tagselector.New(detailedBrowseData(), []string{"zsh"}, func([]string) (tagselector.Preview, error) {
+			model := tagselector.New(detailedBrowseData(), []string{"zsh"}, func(uint64, []string) (tagselector.Preview, error) {
 				return tagselector.Preview{Text: "preview"}, nil
 			})
 			next, command := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -238,7 +406,7 @@ func TestRunCtrlCDoesNotWaitForInFlightPreview(t *testing.T) {
 	}
 	done := make(chan outcome, 1)
 	go func() {
-		result, err := tagselector.Run(input, io.Discard, testBrowseData(), []string{"zsh"}, func([]string) (tagselector.Preview, error) {
+		result, err := tagselector.Run(input, io.Discard, testBrowseData(), []string{"zsh"}, func(uint64, []string) (tagselector.Preview, error) {
 			close(started)
 			<-release
 			return tagselector.Preview{Text: "too late"}, nil
@@ -303,6 +471,18 @@ func update(t *testing.T, model tagselector.Model, messages ...tea.Msg) tagselec
 		model = next.(tagselector.Model)
 	}
 	return model
+}
+
+func reviewedPreview(t *testing.T, initial []string, draftKeys []tea.KeyMsg, preview tagselector.Preview) tagselector.Model {
+	t.Helper()
+	model := tagselector.New(testBrowseData(), initial, func(uint64, []string) (tagselector.Preview, error) {
+		return preview, nil
+	})
+	for _, draftKey := range draftKeys {
+		model = update(t, model, draftKey)
+	}
+	next, command := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	return update(t, next.(tagselector.Model), command())
 }
 
 func testBrowseData() tagselector.BrowseData {
@@ -472,7 +652,7 @@ func TestLongPreviewScrollsWithinTerminalHeight(t *testing.T) {
 	for i := 1; i <= 24; i++ {
 		fmt.Fprintf(&previewText, "plan line %02d\n", i)
 	}
-	model := tagselector.New(testBrowseData(), nil, func([]string) (tagselector.Preview, error) {
+	model := tagselector.New(testBrowseData(), nil, func(uint64, []string) (tagselector.Preview, error) {
 		return tagselector.Preview{Text: previewText.String(), SemanticDigest: "sha256:long"}, nil
 	})
 	model = update(t, model, tea.WindowSizeMsg{Width: 80, Height: 8})


### PR DESCRIPTION
Closes #469

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Apply a confirmed interactive Tag draft from one immutable prepared candidate and commit the explicit current Tags only at terminal success.
- Add distinct reduction and literal `clear` confirmations while reusing the existing Conflict Resolution flow.
- Report effective Managed Entry, retirement, and Retained External State results, with complete sandboxed recovery and mutation-safety coverage.

## Changes

| File | Change |
|------|--------|
| `internal/cli/install_tag_selector.go` | Builds, validates, applies, and reports the exact accepted selector candidate. |
| `internal/tui/tagselector/model.go` | Adds reduction and literal clear confirmation states with safe cancellation. |
| `internal/install/install.go` | Adds confined source/adopt snapshots, conditional compensation, and terminal Installed Selection CAS. |
| `internal/deps/install.go` | Separates Dependency preparation from exact prepared execution. |
| `internal/cli/*_test.go`, `internal/install/*_test.go`, `internal/tui/tagselector/*_test.go` | Covers mixed apply, conflicts, Drift, stale authority, failures, reruns, model transitions, goldens, and Temporary Homes. |
| `README.md`, `docs/agents/output-contract.md`, `docs/manifest.md` | Documents interactive selection, confirmations, results, cancellation, and retained state. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan only when dotfiles behavior changes: `go run ./cmd/dots plan --file dots.yaml --profile core --source-root "$PWD" --home <tmp>`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked one issue with an admitted Delivery Contract using `Closes #<issue-number>`.
- [x] Added exactly one `type:*` label.
- [x] Delivery Evidence records the Contract Source snapshot, Acceptance coverage, and Independent review.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

### Contract Source snapshot

- Kind: delivery ticket body composed with its native parent specification and native relationships.
- Ticket: issue `I_kwDOSzLlmM8AAAABNwY47w`, https://github.com/yersonargotev/dots/issues/469, `updatedAt=2026-08-21T20:58:19Z`, body SHA-256 `751f3bf0ffb91b8f04e76846b79e194db4461f2121c9aa78ea4824cf839455f8`.
- Parent specification: issue `I_kwDOSzLlmM8AAAABNwWsmQ`, https://github.com/yersonargotev/dots/issues/459, `updatedAt=2026-08-21T20:59:00Z`, body SHA-256 `85febbb601376376f0b74c2b155d6556d1f63d209272fdc033a0b178169dc556`.
- Admission: category `enhancement`; triage state `ready-for-agent`; both source issues open with zero comments.
- Native relationships: parent #459 open; blocked by #467 closed (`updatedAt=2026-08-22T20:19:05Z`) and #468 closed (`updatedAt=2026-08-22T23:02:42Z`); no sub-issues and no blocking issues.
- Revalidated immediately before PR creation; no concurrent closing PR and `origin/main=2d4d067097a90601d98f2badac2afaf9c3188ee2`.

### Reviewed head

- Base: `2d4d067097a90601d98f2badac2afaf9c3188ee2`.
- Head: `f6e4848af9bf6dcbab8a13d64cc3431178dd63df`.

### Mutation safety

- Result: `required-mutation`; safety case bound to the base and the two Contract Source digests above.
- Operation invariant: only the exact accepted candidate, captured beneath the approved Source of Truth/Home roots and still matching the accepted Install Manifest plus exact prior Installed Selection, may mutate Managed Entries. Prepared Dependencies and Provisioners consume that candidate; safe retirement follows; exact Installed Selection CAS is the terminal commit. Failures preserve prior authority, and compensation removes only a still-matching postimage produced by this run.
- Compatibility coverage: interactive routing, JSON/non-interactive behavior, persisted metadata schema, global uninstall semantics, empty captured bytes, file modes, confined symlinks, source overrides, Backup Sets, and external state are preserved.
- Matrix coverage: create/update/reconcile, conflict replace/adopt/skip/cancel, whole-target remove versus Drift retain, shared-target block, source/manifest/metadata staleness, symlink/parent substitution and path escape, partial failure, terminal CAS, and convergent rerun.
- Fault seams and evidence: prepared-provider changes, dependency appearance, source identity/content/mode changes, parent symlink substitution, postimage compensation with external replacement, Provisioner failure, metadata persistence/CAS, mixed Temporary Home application, and model/golden confirmation tests.
- Remote Linux validation exposed immediate inode reuse after source replacement; captured identities now remain pinned by confined descriptors, release idempotently on every exit, and fail closed after release.
- Follow-up adversarial review found and closed two preview-lifecycle risks: UI request IDs are assigned synchronously before asynchronous commands, stale IDs cannot replace newer candidates, and capture-bearing candidate builds are serialized to one in flight.
- Final Standards review also drove explicit propagation of every descriptor-release failure: candidate, store, provider, and adopt cleanup join their errors with the primary result, while one shared validator preserves simultaneous authority and release failures.
- Independent design challenge: PASS on `f6e4848af9bf6dcbab8a13d64cc3431178dd63df`, zero actionable findings; focused race-detector validation passed for CLI, selector, and install authority paths.

### Acceptance coverage

1. Addition-only apply and terminal explicit Tags: `TestInstallTagSelectorAcceptedAdditionAppliesAndPersistsExplicitTags` plus forward-only real-TUI verification.
2. Distinct reduction confirmation and complete findings: model reduction tests and `TestInstallTagSelectorReductionFindingsGolden`.
3. Literal `clear`, mismatch, and cancellation: model/CLI clear tests plus real-TUI `CLEAR` rejection and `clear` success.
4. Existing Conflict Resolution reuse: conflict cancel/adopt tests and effective replace/adopt/skip result coverage.
5. Profile presets flatten to explicit current Tags: profile preset CLI and Temporary Home tests.
6. Prior authoritative selection survives cancellation/failure: preview, conflict, source-staleness, apply, Provisioner, and terminal-CAS tests.
7. Mixed add/reconcile/retire/retain parity: full Temporary Home apply, filesystem/Installed Selection assertions, explicit JSON semantic comparison, and human golden.
8. Partial failure recovery: injected Provisioner and terminal commit failures followed by convergent public reruns.
9. Documentation: README, manifest guide, install help, and Agent Output Contract updated.
10. Complete safe coverage: Bubble Tea Model Tests, Golden Output Tests, confined mutation tests, and explicit Temporary Home/source/state roots with stubbed executables and no network.

### Automated validation

- PASS: `gofmt -l .` (no output).
- PASS: `go vet ./...`.
- PASS: `go build ./...`.
- PASS: `go test ./...`.
- PASS: `go test -race ./internal/install -count=1`.
- PASS: focused `go test -race ./internal/cli ./internal/tui/tagselector` lifecycle and apply coverage.
- PASS: `go run ./cmd/dots manifest validate --file dots.yaml`.
- PASS: sandboxed `go run ./cmd/dots plan --file dots.yaml --profile core --source-root "$PWD" --home <tmp>`.

### Manual verification

- Built one real binary with `go build -o <tmp>/dots ./cmd/dots`.
- PASS in explicit Temporary Homes with `--skip-deps --file <tmp>/source/dots.yaml --source-root <tmp>/source --home <tmp>/home --state-root <tmp>/state`: forward-only addition created the symlink and reported `created`; accepted addition persisted explicit Tags; selector cancellation changed neither files nor metadata; `CLEAR` was rejected without mutation; literal `clear` removed only the Managed Entry and persisted an explicit empty Installed Selection.
- No real home files, package managers, Provisioners, or network were used.

### Independent review

- Standards: PASS on `f6e4848af9bf6dcbab8a13d64cc3431178dd63df`, zero actionable findings and no scope creep.
- Spec: PASS on `f6e4848af9bf6dcbab8a13d64cc3431178dd63df`, zero actionable findings and no scope creep.
<!-- delivery-issue:evidence:end -->
