### PR TITLE
fix(reliability): propagate selector cleanup failures

### DIFF
--- a/internal/cli/install_tag_selector.go
+++ b/internal/cli/install_tag_selector.go
@@ -113,13 +113,14 @@ func (s *installTagSelectorCandidateStore) activate(requestID uint64) (string, b
 	}
 	token := fmt.Sprintf("selector-preview-%d", requestID)
 	previous := s.candidate
+	previousToken := s.latestToken
 	s.candidate = nil
 	s.latestID = requestID
 	s.latestToken = token
 	s.mu.Unlock()
 	if previous != nil {
 		if err := s.releaseCandidate(*previous); err != nil {
-			return token, true, fmt.Errorf("release superseded Tag selector candidate: %w", err)
+			return token, true, fmt.Errorf("release superseded tag selector candidate %q: %w", previousToken, err)
 		}
 	}
 	return token, true, nil
@@ -130,7 +131,7 @@ func (s *installTagSelectorCandidateStore) put(requestID uint64, token string, c
 	if s.closed || requestID != s.latestID || token == "" || token != s.latestToken {
 		s.mu.Unlock()
 		if err := s.releaseCandidate(candidate); err != nil {
-			return false, fmt.Errorf("release rejected Tag selector candidate: %w", err)
+			return false, fmt.Errorf("release rejected tag selector candidate %q: %w", token, err)
 		}
 		return false, nil
 	}
@@ -139,7 +140,7 @@ func (s *installTagSelectorCandidateStore) put(requestID uint64, token string, c
 	s.mu.Unlock()
 	if previous != nil {
 		if err := s.releaseCandidate(*previous); err != nil {
-			return true, fmt.Errorf("release replaced Tag selector candidate: %w", err)
+			return true, fmt.Errorf("release replaced tag selector candidate %q: %w", token, err)
 		}
 	}
 	return true, nil
@@ -157,13 +158,12 @@ func (s *installTagSelectorCandidateStore) take(token string) (installTagSelecto
 }
 
 type installTagSelectorPreviewProvider struct {
-	store      *installTagSelectorCandidateStore
-	buildMu    sync.Mutex
-	releaseMu  sync.Mutex
-	releaseErr error
-	closed     bool
-	lateError  func(error)
-	build      func([]string) (installTagSelectorCandidate, error)
+	store     *installTagSelectorCandidateStore
+	buildMu   sync.Mutex
+	releaseMu sync.Mutex
+	closed    bool
+	lateError func(error)
+	build     func([]string) (installTagSelectorCandidate, error)
 }
 
 func (p *installTagSelectorPreviewProvider) preview(requestID uint64, tags []string) (tagselectortui.Preview, error) {
@@ -171,15 +171,17 @@ func (p *installTagSelectorPreviewProvider) preview(requestID uint64, tags []str
 	defer p.buildMu.Unlock()
 
 	token, ok, releaseErr := p.store.activate(requestID)
-	reportedLate := p.recordReleaseError(releaseErr)
 	if releaseErr != nil {
-		if reportedLate {
-			return tagselectortui.Preview{}, errors.New("Tag selector preview provider closed during cleanup")
+		if p.reportCleanupErrorIfClosed(releaseErr) {
+			return tagselectortui.Preview{}, errors.New("tag selector preview provider is closed")
 		}
 		return tagselectortui.Preview{}, releaseErr
 	}
 	if !ok {
-		return tagselectortui.Preview{}, fmt.Errorf("Tag selector preview request is stale or the candidate store is closed")
+		if p.isClosed() {
+			return tagselectortui.Preview{}, errors.New("tag selector preview provider is closed")
+		}
+		return tagselectortui.Preview{}, errors.New("tag selector preview request is stale")
 	}
 	candidate, err := p.build(tags)
 	if err != nil {
@@ -187,47 +189,55 @@ func (p *installTagSelectorPreviewProvider) preview(requestID uint64, tags []str
 	}
 	candidate.Preview.CandidateToken = token
 	stored, releaseErr := p.store.put(requestID, token, candidate)
-	reportedLate = p.recordReleaseError(releaseErr)
 	if releaseErr != nil {
-		if reportedLate {
-			return tagselectortui.Preview{}, errors.New("Tag selector preview provider closed during cleanup")
+		if p.reportCleanupErrorIfClosed(releaseErr) {
+			return tagselectortui.Preview{}, errors.New("tag selector preview provider is closed")
 		}
 		return tagselectortui.Preview{}, releaseErr
 	}
 	if !stored {
-		return tagselectortui.Preview{}, fmt.Errorf("Tag selector preview request was superseded")
+		if p.isClosed() {
+			return tagselectortui.Preview{}, errors.New("tag selector preview provider is closed")
+		}
+		return tagselectortui.Preview{}, errors.New("tag selector preview request was superseded")
 	}
 	return candidate.Preview, nil
 }
 
-func (p *installTagSelectorPreviewProvider) recordReleaseError(err error) bool {
+func (p *installTagSelectorPreviewProvider) reportCleanupErrorIfClosed(err error) bool {
 	if err == nil {
 		return false
 	}
 	p.releaseMu.Lock()
-	if p.closed {
-		report := p.lateError
-		p.releaseMu.Unlock()
-		if report != nil {
-			report(err)
-		} else {
-			slog.Error("late Tag selector cleanup failed", "error", err)
-		}
-		return true
-	}
-	p.releaseErr = errors.Join(p.releaseErr, err)
+	closed := p.closed
+	report := p.lateError
 	p.releaseMu.Unlock()
-	return false
+	if !closed {
+		return false
+	}
+	if report != nil {
+		report(err)
+	} else {
+		slog.Error("late tag selector cleanup failed", "error", err)
+	}
+	return true
+}
+
+func (p *installTagSelectorPreviewProvider) isClosed() bool {
+	p.releaseMu.Lock()
+	defer p.releaseMu.Unlock()
+	return p.closed
 }
 
 func (p *installTagSelectorPreviewProvider) close() error {
-	closeErr := p.store.close()
 	p.releaseMu.Lock()
-	defer p.releaseMu.Unlock()
-	result := errors.Join(p.releaseErr, closeErr)
-	p.releaseErr = nil
+	if p.closed {
+		p.releaseMu.Unlock()
+		return nil
+	}
 	p.closed = true
-	return result
+	p.releaseMu.Unlock()
+	return p.store.close()
 }
 
 func (s *installTagSelectorCandidateStore) releaseCandidate(candidate installTagSelectorCandidate) error {
@@ -249,7 +259,7 @@ func (s *installTagSelectorCandidateStore) close() error {
 	s.mu.Unlock()
 	if candidate != nil {
 		if err := s.releaseCandidate(*candidate); err != nil {
-			return fmt.Errorf("release stored Tag selector candidate: %w", err)
+			return fmt.Errorf("release stored tag selector candidate %q: %w", s.latestToken, err)
 		}
 	}
 	return nil
@@ -284,7 +294,7 @@ func runInstallTagSelector(cmd *cobra.Command, m manifest.Manifest, meta state.M
 	}
 	defer func() {
 		if err := provider.close(); err != nil {
-			resultErr = errors.Join(resultErr, fmt.Errorf("close Tag selector preview provider: %w", err))
+			resultErr = errors.Join(resultErr, fmt.Errorf("close tag selector preview provider: %w", err))
 		}
 	}()
 	result, err := installTagSelectorRunner(cmd.InOrStdin(), cmd.OutOrStdout(), browseData, initial, provider.preview)
@@ -304,11 +314,11 @@ func runInstallTagSelector(cmd *cobra.Command, m manifest.Manifest, meta state.M
 	}
 	defer func() {
 		if err := candidate.releaseCapturedSources(); err != nil {
-			resultErr = errors.Join(resultErr, fmt.Errorf("release accepted Tag selector candidate: %w", err))
+			resultErr = errors.Join(resultErr, fmt.Errorf("release accepted tag selector candidate %q: %w", candidate.Preview.CandidateToken, err))
 		}
 	}()
 	if err := provider.close(); err != nil {
-		return fmt.Errorf("close Tag selector preview provider: %w", err)
+		return fmt.Errorf("close tag selector preview provider: %w", err)
 	}
 	if !reflect.DeepEqual(result.Preview, candidate.Preview) || !slices.Equal(result.Tags, candidate.Effective.Selection.Tags) {
 		return fmt.Errorf("run Tag selector: accepted preview does not match its immutable candidate")
@@ -1020,7 +1030,13 @@ func renderTagSelectorFinalResult(w io.Writer, candidate installTagSelectorCandi
 	fmt.Fprintln(w, "  Historical retirement: not run (Tag selector path)")
 	renderTagSelectorManagedEntryResults(w, candidate.Plan, conflictDecisions)
 	renderTagSelectorRetainedExternalState(w, candidate.Plan.SelectionReconciliation)
-	renderSelectionRetirement(w, retirement)
+	renderTagSelectorSelectionRetirement(w, retirement)
+}
+
+func renderTagSelectorSelectionRetirement(w io.Writer, result *selectionretirement.Result) {
+	var rendered strings.Builder
+	renderSelectionRetirement(&rendered, result)
+	fmt.Fprint(w, strings.TrimSuffix(rendered.String(), "\n"))
 }
 
 func renderTagSelectorManagedEntryResults(w io.Writer, p plan.Plan, conflictDecisions map[string]install.ConflictDecision) {

--- a/internal/cli/install_tag_selector_internal_test.go
+++ b/internal/cli/install_tag_selector_internal_test.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -217,6 +218,254 @@ func TestInstallTagSelectorCandidateStoreUsesUIRequestOrder(t *testing.T) {
 	}
 }
 
+func TestInstallTagSelectorCandidateStoreCleanupErrorsDeliveredOnce(t *testing.T) {
+	t.Run("superseded", func(t *testing.T) {
+		injected := errors.New("injected superseded release failure")
+		store := newInstallTagSelectorCandidateStore()
+		var releases int
+		store.release = func(candidate installTagSelectorCandidate) error {
+			releases++
+			if candidate.Preview.SemanticDigest == "sha256:first" {
+				return injected
+			}
+			return nil
+		}
+
+		token, ok, err := store.activate(1)
+		if err != nil || !ok {
+			t.Fatalf("activate first candidate = (%q, %t, %v)", token, ok, err)
+		}
+		if stored, err := store.put(1, token, installTagSelectorCandidate{Preview: tagselectortui.Preview{SemanticDigest: "sha256:first"}}); err != nil || !stored {
+			t.Fatalf("put first candidate = (%t, %v)", stored, err)
+		}
+		_, ok, err = store.activate(2)
+		if !ok || !errors.Is(err, injected) || !strings.Contains(err.Error(), `release superseded tag selector candidate "selector-preview-1"`) {
+			t.Fatalf("activate replacement = (%t, %v), want contextual wrapped cleanup failure", ok, err)
+		}
+		if err := store.close(); err != nil {
+			t.Fatalf("close replayed superseded cleanup failure: %v", err)
+		}
+		if err := store.close(); err != nil {
+			t.Fatalf("second close replayed superseded cleanup failure: %v", err)
+		}
+		if releases != 1 {
+			t.Fatalf("release calls = %d, want 1", releases)
+		}
+	})
+
+	t.Run("rejected", func(t *testing.T) {
+		injected := errors.New("injected rejected release failure")
+		store := newInstallTagSelectorCandidateStore()
+		var releases int
+		store.release = func(installTagSelectorCandidate) error {
+			releases++
+			return injected
+		}
+
+		token, ok, err := store.activate(1)
+		if err != nil || !ok {
+			t.Fatalf("activate first candidate = (%q, %t, %v)", token, ok, err)
+		}
+		if _, ok, err := store.activate(2); err != nil || !ok {
+			t.Fatalf("activate newer candidate = (%t, %v)", ok, err)
+		}
+		stored, err := store.put(1, token, installTagSelectorCandidate{})
+		if stored || !errors.Is(err, injected) || !strings.Contains(err.Error(), `release rejected tag selector candidate "selector-preview-1"`) {
+			t.Fatalf("put rejected candidate = (%t, %v), want contextual wrapped cleanup failure", stored, err)
+		}
+		if err := store.close(); err != nil {
+			t.Fatalf("close replayed rejected cleanup failure: %v", err)
+		}
+		if err := store.close(); err != nil {
+			t.Fatalf("second close replayed rejected cleanup failure: %v", err)
+		}
+		if releases != 1 {
+			t.Fatalf("release calls = %d, want 1", releases)
+		}
+	})
+
+	t.Run("replaced", func(t *testing.T) {
+		injected := errors.New("injected replaced release failure")
+		store := newInstallTagSelectorCandidateStore()
+		releases := make(map[string]int)
+		store.release = func(candidate installTagSelectorCandidate) error {
+			digest := candidate.Preview.SemanticDigest
+			releases[digest]++
+			if digest == "sha256:first" {
+				return injected
+			}
+			return nil
+		}
+
+		token, ok, err := store.activate(1)
+		if err != nil || !ok {
+			t.Fatalf("activate candidate = (%q, %t, %v)", token, ok, err)
+		}
+		if stored, err := store.put(1, token, installTagSelectorCandidate{Preview: tagselectortui.Preview{SemanticDigest: "sha256:first"}}); err != nil || !stored {
+			t.Fatalf("put first candidate = (%t, %v)", stored, err)
+		}
+		stored, err := store.put(1, token, installTagSelectorCandidate{Preview: tagselectortui.Preview{SemanticDigest: "sha256:second"}})
+		if !stored || !errors.Is(err, injected) || !strings.Contains(err.Error(), `release replaced tag selector candidate "selector-preview-1"`) {
+			t.Fatalf("put replacement candidate = (%t, %v), want contextual wrapped cleanup failure", stored, err)
+		}
+		if err := store.close(); err != nil {
+			t.Fatalf("close replayed replaced cleanup failure: %v", err)
+		}
+		if err := store.close(); err != nil {
+			t.Fatalf("second close replayed replaced cleanup failure: %v", err)
+		}
+		if releases["sha256:first"] != 1 || releases["sha256:second"] != 1 {
+			t.Fatalf("release calls = %v, want each candidate once", releases)
+		}
+	})
+
+	t.Run("stored close", func(t *testing.T) {
+		injected := errors.New("injected stored release failure")
+		store := newInstallTagSelectorCandidateStore()
+		var releases int
+		store.release = func(installTagSelectorCandidate) error {
+			releases++
+			return injected
+		}
+
+		token, ok, err := store.activate(1)
+		if err != nil || !ok {
+			t.Fatalf("activate candidate = (%q, %t, %v)", token, ok, err)
+		}
+		if stored, err := store.put(1, token, installTagSelectorCandidate{}); err != nil || !stored {
+			t.Fatalf("put candidate = (%t, %v)", stored, err)
+		}
+		err = store.close()
+		if !errors.Is(err, injected) || !strings.Contains(err.Error(), `release stored tag selector candidate "selector-preview-1"`) {
+			t.Fatalf("close error = %v, want contextual wrapped cleanup failure", err)
+		}
+		if err := store.close(); err != nil {
+			t.Fatalf("second close replayed stored cleanup failure: %v", err)
+		}
+		if releases != 1 {
+			t.Fatalf("release calls = %d, want 1", releases)
+		}
+	})
+}
+
+func TestInstallTagSelectorPreviewProviderReturnsSynchronousCleanupOnce(t *testing.T) {
+	t.Run("superseded", func(t *testing.T) {
+		injected := errors.New("injected synchronous supersede failure")
+		store := newInstallTagSelectorCandidateStore()
+		var releases int
+		store.release = func(installTagSelectorCandidate) error {
+			releases++
+			return injected
+		}
+		lateErrors := make(chan error, 1)
+		var builds int
+		provider := &installTagSelectorPreviewProvider{
+			store:     store,
+			lateError: func(err error) { lateErrors <- err },
+			build: func([]string) (installTagSelectorCandidate, error) {
+				builds++
+				return installTagSelectorCandidate{Preview: tagselectortui.Preview{SemanticDigest: "sha256:candidate"}}, nil
+			},
+		}
+		if _, err := provider.preview(1, []string{"first"}); err != nil {
+			t.Fatal(err)
+		}
+		_, err := provider.preview(2, []string{"second"})
+		if !errors.Is(err, injected) || !strings.Contains(err.Error(), `release superseded tag selector candidate "selector-preview-1"`) {
+			t.Fatalf("preview error = %v, want synchronous contextual cleanup failure", err)
+		}
+		if err := provider.close(); err != nil {
+			t.Fatalf("close replayed synchronous cleanup failure: %v", err)
+		}
+		if err := provider.close(); err != nil {
+			t.Fatalf("second close replayed synchronous cleanup failure: %v", err)
+		}
+		select {
+		case err := <-lateErrors:
+			t.Fatalf("synchronous cleanup was also sent to late sink: %v", err)
+		default:
+		}
+		if releases != 1 || builds != 1 {
+			t.Fatalf("release calls = %d, builds = %d, want 1 and 1", releases, builds)
+		}
+	})
+
+	t.Run("rejected", func(t *testing.T) {
+		injected := errors.New("injected synchronous reject failure")
+		store := newInstallTagSelectorCandidateStore()
+		var releases int
+		store.release = func(installTagSelectorCandidate) error {
+			releases++
+			return injected
+		}
+		lateErrors := make(chan error, 1)
+		provider := &installTagSelectorPreviewProvider{
+			store:     store,
+			lateError: func(err error) { lateErrors <- err },
+			build: func([]string) (installTagSelectorCandidate, error) {
+				if _, ok, err := store.activate(2); err != nil || !ok {
+					t.Fatalf("supersede active request = (%t, %v)", ok, err)
+				}
+				return installTagSelectorCandidate{Preview: tagselectortui.Preview{SemanticDigest: "sha256:rejected"}}, nil
+			},
+		}
+		_, err := provider.preview(1, []string{"first"})
+		if !errors.Is(err, injected) || !strings.Contains(err.Error(), `release rejected tag selector candidate "selector-preview-1"`) {
+			t.Fatalf("preview error = %v, want synchronous contextual cleanup failure", err)
+		}
+		if err := provider.close(); err != nil {
+			t.Fatalf("close replayed synchronous cleanup failure: %v", err)
+		}
+		if err := provider.close(); err != nil {
+			t.Fatalf("second close replayed synchronous cleanup failure: %v", err)
+		}
+		select {
+		case err := <-lateErrors:
+			t.Fatalf("synchronous cleanup was also sent to late sink: %v", err)
+		default:
+		}
+		if releases != 1 {
+			t.Fatalf("release calls = %d, want 1", releases)
+		}
+	})
+}
+
+func TestInstallTagSelectorPreviewProviderReturnsStoredCloseCleanupOnce(t *testing.T) {
+	injected := errors.New("injected stored close failure")
+	store := newInstallTagSelectorCandidateStore()
+	var releases int
+	store.release = func(installTagSelectorCandidate) error {
+		releases++
+		return injected
+	}
+	lateErrors := make(chan error, 1)
+	provider := &installTagSelectorPreviewProvider{
+		store:     store,
+		lateError: func(err error) { lateErrors <- err },
+		build: func([]string) (installTagSelectorCandidate, error) {
+			return installTagSelectorCandidate{Preview: tagselectortui.Preview{SemanticDigest: "sha256:stored"}}, nil
+		},
+	}
+	if _, err := provider.preview(1, []string{"stored"}); err != nil {
+		t.Fatal(err)
+	}
+	err := provider.close()
+	if !errors.Is(err, injected) || !strings.Contains(err.Error(), `release stored tag selector candidate "selector-preview-1"`) {
+		t.Fatalf("close error = %v, want contextual wrapped cleanup failure", err)
+	}
+	if err := provider.close(); err != nil {
+		t.Fatalf("second close replayed stored cleanup failure: %v", err)
+	}
+	select {
+	case err := <-lateErrors:
+		t.Fatalf("stored close cleanup was also sent to late sink: %v", err)
+	default:
+	}
+	if releases != 1 {
+		t.Fatalf("release calls = %d, want 1", releases)
+	}
+}
+
 func TestInstallTagSelectorPreviewProviderSerializesCandidateBuilds(t *testing.T) {
 	store := newInstallTagSelectorCandidateStore()
 	t.Cleanup(func() {
@@ -289,16 +538,24 @@ func TestInstallTagSelectorPreviewProviderSerializesCandidateBuilds(t *testing.T
 
 func TestInstallTagSelectorPreviewProviderClosesWithoutWaitingForActiveBuild(t *testing.T) {
 	store := newInstallTagSelectorCandidateStore()
+	var releaseCount atomic.Int32
 	store.release = func(installTagSelectorCandidate) error {
+		releaseCount.Add(1)
 		return errors.New("injected late release failure")
 	}
 	entered := make(chan string, 2)
 	release := make(chan struct{})
-	lateErrors := make(chan error, 1)
+	lateErrors := make(chan error, 2)
+	var lateErrorCount atomic.Int32
+	var buildCount atomic.Int32
 	provider := &installTagSelectorPreviewProvider{
-		store:     store,
-		lateError: func(err error) { lateErrors <- err },
+		store: store,
+		lateError: func(err error) {
+			lateErrorCount.Add(1)
+			lateErrors <- err
+		},
 		build: func(tags []string) (installTagSelectorCandidate, error) {
+			buildCount.Add(1)
 			entered <- tags[0]
 			<-release
 			return installTagSelectorCandidate{Preview: tagselectortui.Preview{SemanticDigest: "sha256:" + tags[0]}}, nil
@@ -328,24 +585,41 @@ func TestInstallTagSelectorPreviewProviderClosesWithoutWaitingForActiveBuild(t *
 		t.Fatal("preview provider close waited for the active build")
 	}
 	release <- struct{}{}
-	if err := <-first; err == nil || !strings.Contains(err.Error(), "closed during cleanup") {
-		t.Fatalf("active preview error = %v, want closed cleanup response", err)
+	if err := <-first; err == nil || err.Error() != "tag selector preview provider is closed" {
+		t.Fatalf("active preview error = %v, want generic closed response", err)
 	}
 	select {
 	case err := <-lateErrors:
-		if !strings.Contains(err.Error(), "injected late release failure") {
-			t.Fatalf("late cleanup sink error = %v", err)
+		if !strings.Contains(err.Error(), `release rejected tag selector candidate "selector-preview-1"`) || !strings.Contains(err.Error(), "injected late release failure") {
+			t.Fatalf("late cleanup sink error = %v, want candidate and operation context", err)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("late release failure was not reported to the asynchronous cleanup sink")
 	}
-	if err := <-second; err == nil || !strings.Contains(err.Error(), "closed") {
-		t.Fatalf("queued preview error = %v, want closed store rejection", err)
+	if err := <-second; err == nil || err.Error() != "tag selector preview provider is closed" {
+		t.Fatalf("queued preview error = %v, want generic closed response", err)
 	}
 	select {
 	case got := <-entered:
 		t.Fatalf("queued build %q entered after provider close", got)
 	default:
+	}
+	if err := provider.close(); err != nil {
+		t.Fatalf("second close replayed late cleanup failure: %v", err)
+	}
+	select {
+	case err := <-lateErrors:
+		t.Fatalf("late cleanup was delivered more than once: %v", err)
+	default:
+	}
+	if got := releaseCount.Load(); got != 1 {
+		t.Fatalf("release calls = %d, want 1", got)
+	}
+	if got := lateErrorCount.Load(); got != 1 {
+		t.Fatalf("late sink calls = %d, want 1", got)
+	}
+	if got := buildCount.Load(); got != 1 {
+		t.Fatalf("build calls = %d, want 1", got)
 	}
 }
 

--- a/internal/cli/testdata/install_tag_selector_mixed_result.golden
+++ b/internal/cli/testdata/install_tag_selector_mixed_result.golden
@@ -34,4 +34,3 @@ Retained External State:
   provisioner  claude [sha256:5ad1ba026bb241cda935498a093942a764ade70f9f396b81cae8f709cf5fffeb]
 Selection retirement:
   removed /home/test/.retired and released dots ownership
-

--- a/internal/install/cleanup_internal_test.go
+++ b/internal/install/cleanup_internal_test.go
@@ -1,0 +1,997 @@
+package install
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yersonargotev/dots/internal/backups"
+	"github.com/yersonargotev/dots/internal/plan"
+	"github.com/yersonargotev/dots/internal/state"
+)
+
+type typedInjectedCleanupError struct {
+	lifecycle string
+}
+
+func (e *typedInjectedCleanupError) Error() string {
+	return "typed injected cleanup for " + e.lifecycle
+}
+
+type typedInjectedPrimaryError struct {
+	lifecycle string
+}
+
+func (e *typedInjectedPrimaryError) Error() string {
+	return "typed injected primary failure for " + e.lifecycle
+}
+
+func TestWithoutCompletedActionMarkerPreservesEveryJoinedCleanup(t *testing.T) {
+	first := errors.New("first cleanup")
+	second := errors.New("second cleanup")
+	joined := errors.Join(
+		completedActionCleanup(first),
+		fmt.Errorf("wrapped cleanup: %w", completedActionCleanup(second)),
+	)
+
+	stripped := withoutCompletedActionMarker(joined)
+	if !errors.Is(stripped, first) || !errors.Is(stripped, second) {
+		t.Fatalf("stripped cleanup = %v, want both cleanup errors", stripped)
+	}
+	if !strings.Contains(stripped.Error(), "wrapped cleanup: second cleanup") {
+		t.Fatalf("stripped cleanup = %q, want outer operation context preserved", stripped)
+	}
+	if isCompletedActionCleanup(stripped) {
+		t.Fatalf("stripped cleanup = %v, completed-action marker remains", stripped)
+	}
+	if !isCleanupFailure(stripped) {
+		t.Fatalf("stripped cleanup = %v, cleanup classification was lost", stripped)
+	}
+}
+
+func TestDecisionReplaceCompletedCreateCleanupRetainsBackupAndPrefix(t *testing.T) {
+	home, sourceRoot, stateRoot := t.TempDir(), t.TempDir(), t.TempDir()
+	source, laterSource := filepath.Join(sourceRoot, "replacement"), filepath.Join(sourceRoot, "later")
+	target, laterTarget := filepath.Join(home, "target"), filepath.Join(home, "later")
+	if err := os.WriteFile(source, []byte("replacement\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(laterSource, []byte("later\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("original\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	oldSelection := &state.InstalledSelection{Profiles: []string{"old"}}
+	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, InstalledSelection: oldSelection}); err != nil {
+		t.Fatal(err)
+	}
+	p := plan.Plan{Profiles: []string{"new"}, Actions: []plan.Action{
+		{Source: "replacement", Target: target, Strategy: "copy", Status: plan.StatusConflict},
+		{Source: "later", Target: laterTarget, Strategy: "copy", Status: plan.StatusCreate},
+	}}
+	opts := Options{Home: home, SourceRoot: sourceRoot, StateRoot: stateRoot, ConflictDecisions: map[string]ConflictDecision{target: DecisionReplace}}
+	captures, err := CaptureManagedSources(p, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer releaseCapturedSourcesForTest(t, captures)
+	opts.CapturedSources = captures
+
+	originalRoot, originalFile := closeRootOperation, closeFileOperation
+	defer func() { closeRootOperation, closeFileOperation = originalRoot, originalFile }()
+	fault := errors.New("injected replace create root close fault")
+	targetClosed, calls := false, 0
+	closeFileOperation = func(file *os.File) error {
+		err := originalFile(file)
+		if file.Name() == target {
+			targetClosed = true
+		}
+		return err
+	}
+	closeRootOperation = func(root *os.Root) error {
+		err := originalRoot(root)
+		if root.Name() == home && targetClosed && calls == 0 {
+			calls++
+			return errors.Join(err, fault)
+		}
+		return err
+	}
+	_, err = ApplyManagedEntries(p, opts)
+	if !errors.Is(err, fault) || calls != 1 || !strings.Contains(err.Error(), "close filesystem root "+home) {
+		t.Fatalf("replace cleanup = %v, calls %d", err, calls)
+	}
+	if got, readErr := os.ReadFile(target); readErr != nil || string(got) != "replacement\n" {
+		t.Fatalf("replacement target = %q, %v", got, readErr)
+	}
+	if _, statErr := os.Lstat(laterTarget); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("later action ran: %v", statErr)
+	}
+	backupMeta, err := backups.Load(backups.Path(stateRoot))
+	if err != nil || len(backupMeta.Sets) != 1 {
+		t.Fatalf("Backup Sets = %#v, %v", backupMeta.Sets, err)
+	}
+	backup, err := os.ReadFile(backups.FilePath(stateRoot, backupMeta.Sets[0].ID, 1, target))
+	if err != nil || string(backup) != "original\n" {
+		t.Fatalf("replacement backup = %q, %v", backup, err)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record, ok := meta.FindByTarget(target); !ok || record.Hash != state.HashBytes([]byte("replacement\n")) || len(record.Contributions) != 0 {
+		t.Fatalf("replacement partial inventory = %#v", record)
+	}
+	if meta.InstalledSelection == nil || meta.InstalledSelection.Profiles[0] != "old" {
+		t.Fatalf("InstalledSelection = %#v", meta.InstalledSelection)
+	}
+
+	closeRootOperation, closeFileOperation = originalRoot, originalFile
+	commit, err := ApplyManagedEntries(p, opts)
+	if err != nil {
+		t.Fatalf("safe replace rerun = %v", err)
+	}
+	if err := commit.Commit(nil); err != nil {
+		t.Fatal(err)
+	}
+	if got, readErr := os.ReadFile(laterTarget); readErr != nil || string(got) != "later\n" {
+		t.Fatalf("safe replace rerun later target = %q, %v", got, readErr)
+	}
+}
+
+func TestExternalEditDuringCompletedCreateCleanupIsPreservedAndUnclaimed(t *testing.T) {
+	home, sourceRoot, stateRoot := t.TempDir(), t.TempDir(), t.TempDir()
+	source, laterSource := filepath.Join(sourceRoot, "source"), filepath.Join(sourceRoot, "later")
+	target, laterTarget := filepath.Join(home, "target"), filepath.Join(home, "later")
+	if err := os.WriteFile(source, []byte("managed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(laterSource, []byte("later\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	oldSelection := &state.InstalledSelection{Profiles: []string{"old"}}
+	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, InstalledSelection: oldSelection}); err != nil {
+		t.Fatal(err)
+	}
+	p := plan.Plan{Profiles: []string{"new"}, Actions: []plan.Action{
+		{Source: "source", Target: target, Strategy: "copy", Status: plan.StatusCreate},
+		{Source: "later", Target: laterTarget, Strategy: "copy", Status: plan.StatusCreate},
+	}}
+	opts := Options{Home: home, SourceRoot: sourceRoot, StateRoot: stateRoot}
+	captures, err := CaptureManagedSources(p, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer releaseCapturedSourcesForTest(t, captures)
+	opts.CapturedSources = captures
+	originalRoot := closeRootOperation
+	defer func() { closeRootOperation = originalRoot }()
+	fault := errors.New("injected create root close fault after external edit")
+	calls := 0
+	closeRootOperation = func(root *os.Root) error {
+		err := originalRoot(root)
+		if root.Name() == home && calls == 0 {
+			if _, statErr := os.Lstat(target); statErr == nil {
+				if editErr := os.WriteFile(target, []byte("external\n"), 0o600); editErr != nil {
+					t.Fatalf("inject external edit: %v", editErr)
+				}
+				calls++
+				return errors.Join(err, fault)
+			}
+		}
+		return err
+	}
+	_, err = ApplyManagedEntries(p, opts)
+	if !errors.Is(err, fault) || calls != 1 || !strings.Contains(err.Error(), "capture completed install prefix evidence") {
+		t.Fatalf("ApplyManagedEntries() = %v, calls %d; want cleanup plus fail-closed evidence", err, calls)
+	}
+	if got, readErr := os.ReadFile(target); readErr != nil || string(got) != "external\n" {
+		t.Fatalf("external target = %q, %v; want preserved", got, readErr)
+	}
+	if _, statErr := os.Lstat(laterTarget); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("later action ran: %v", statErr)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := meta.FindByTarget(target); ok {
+		t.Fatal("cleanup recovery claimed externally edited bytes")
+	}
+	if meta.InstalledSelection == nil || meta.InstalledSelection.Profiles[0] != "old" {
+		t.Fatalf("InstalledSelection = %#v", meta.InstalledSelection)
+	}
+
+	closeRootOperation = originalRoot
+	_, rerunErr := ApplyManagedEntries(p, opts)
+	if rerunErr == nil {
+		t.Fatal("rerun accepted stale create plan over external target")
+	}
+	if got, readErr := os.ReadFile(target); readErr != nil || string(got) != "external\n" {
+		t.Fatalf("rerun changed external target = %q, %v", got, readErr)
+	}
+	if _, statErr := os.Lstat(laterTarget); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("rerun reached later action: %v", statErr)
+	}
+}
+
+func TestLaterCreateParentRootCleanupPersistsEarlierPrefixAndReruns(t *testing.T) {
+	home, sourceRoot, stateRoot := t.TempDir(), t.TempDir(), t.TempDir()
+	for _, name := range []string{"one", "two", "three"} {
+		if err := os.WriteFile(filepath.Join(sourceRoot, name), []byte(name+"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	targetOne := filepath.Join(home, "one")
+	targetTwo := filepath.Join(home, "nested", "two")
+	targetThree := filepath.Join(home, "three")
+	p := plan.Plan{Actions: []plan.Action{
+		{Source: "one", Target: targetOne, Strategy: "copy", Status: plan.StatusCreate},
+		{Source: "two", Target: targetTwo, Strategy: "copy", Status: plan.StatusCreate},
+		{Source: "three", Target: targetThree, Strategy: "copy", Status: plan.StatusCreate},
+	}}
+	opts := Options{Home: home, SourceRoot: sourceRoot, StateRoot: stateRoot}
+	captures, err := CaptureManagedSources(p, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer releaseCapturedSourcesForTest(t, captures)
+	opts.CapturedSources = captures
+	originalRoot := closeRootOperation
+	defer func() { closeRootOperation = originalRoot }()
+	fault := errors.New("injected later create parent root close fault")
+	homeCloses, faults := 0, 0
+	closeRootOperation = func(root *os.Root) error {
+		err := originalRoot(root)
+		if root.Name() == home {
+			homeCloses++
+			if homeCloses == 3 {
+				faults++
+				return errors.Join(err, fault)
+			}
+		}
+		return err
+	}
+	_, err = ApplyManagedEntries(p, opts)
+	if !errors.Is(err, fault) || faults != 1 || !strings.Contains(err.Error(), "create parent directory for "+targetTwo) {
+		t.Fatalf("ApplyManagedEntries() = %v, faults %d; want action-two parent cleanup", err, faults)
+	}
+	if got, readErr := os.ReadFile(targetOne); readErr != nil || string(got) != "one\n" {
+		t.Fatalf("first target = %q, %v", got, readErr)
+	}
+	for _, target := range []string{targetTwo, targetThree} {
+		if _, statErr := os.Lstat(target); !errors.Is(statErr, os.ErrNotExist) {
+			t.Fatalf("uncompleted target %s exists: %v", target, statErr)
+		}
+	}
+	if info, statErr := os.Stat(filepath.Dir(targetTwo)); statErr != nil || !info.IsDir() {
+		t.Fatalf("non-owned empty parent may remain, got %v, %v", info, statErr)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := meta.FindByTarget(targetOne); !ok {
+		t.Fatal("partial inventory missing earlier completed action")
+	}
+	if _, ok := meta.FindByTarget(targetTwo); ok {
+		t.Fatal("partial inventory includes current uncompleted action")
+	}
+
+	closeRootOperation = originalRoot
+	rerun := p
+	rerun.Actions = append([]plan.Action(nil), p.Actions...)
+	rerun.Actions[0].Status = plan.StatusUnchanged
+	commit, err := ApplyManagedEntries(rerun, opts)
+	if err != nil {
+		t.Fatalf("safe rerun = %v", err)
+	}
+	if err := commit.Commit(nil); err != nil {
+		t.Fatal(err)
+	}
+	for target, want := range map[string]string{targetTwo: "two\n", targetThree: "three\n"} {
+		if got, readErr := os.ReadFile(target); readErr != nil || string(got) != want {
+			t.Fatalf("rerun target %s = %q, %v", target, got, readErr)
+		}
+	}
+}
+
+func TestCompletedCreateRootCleanupPersistsExactPrefix(t *testing.T) {
+	home, sourceRoot, stateRoot := t.TempDir(), t.TempDir(), t.TempDir()
+	sourceOne, sourceTwo := filepath.Join(sourceRoot, "one"), filepath.Join(sourceRoot, "two")
+	targetOne, targetTwo := filepath.Join(home, "one"), filepath.Join(home, "two")
+	if err := os.WriteFile(sourceOne, []byte("one\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(sourceTwo, []byte("two\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	oldSelection := &state.InstalledSelection{Profiles: []string{"old"}, ResolvedTags: []string{"old"}}
+	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, InstalledSelection: oldSelection}); err != nil {
+		t.Fatal(err)
+	}
+	p := plan.Plan{Profiles: []string{"next"}, Actions: []plan.Action{
+		{Source: "one", Target: targetOne, Strategy: "copy", Status: plan.StatusCreate},
+		{Source: "two", Target: targetTwo, Strategy: "copy", Status: plan.StatusCreate},
+	}}
+	opts := Options{Home: home, SourceRoot: sourceRoot, StateRoot: stateRoot}
+	captures, err := CaptureManagedSources(p, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer releaseCapturedSourcesForTest(t, captures)
+	opts.CapturedSources = captures
+
+	originalRoot, originalFile := closeRootOperation, closeFileOperation
+	defer func() { closeRootOperation, closeFileOperation = originalRoot, originalFile }()
+	cleanupFault := errors.New("injected completed create root close fault")
+	targetClosed := false
+	rootFaults := 0
+	closeFileOperation = func(file *os.File) error {
+		err := originalFile(file)
+		if file.Name() == targetOne {
+			targetClosed = true
+		}
+		return err
+	}
+	closeRootOperation = func(root *os.Root) error {
+		err := originalRoot(root)
+		if targetClosed && root.Name() == home && rootFaults == 0 {
+			rootFaults++
+			return errors.Join(err, cleanupFault)
+		}
+		return err
+	}
+
+	_, err = ApplyManagedEntries(p, opts)
+	if !errors.Is(err, cleanupFault) || !isCompletedActionCleanup(err) {
+		t.Fatalf("ApplyManagedEntries() error = %v, want completed cleanup", err)
+	}
+	if rootFaults != 1 {
+		t.Fatalf("injected root cleanup count = %d, want one", rootFaults)
+	}
+	if got, readErr := os.ReadFile(targetOne); readErr != nil || string(got) != "one\n" {
+		t.Fatalf("completed target = %q, %v", got, readErr)
+	}
+	if _, statErr := os.Lstat(targetTwo); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("later target exists or stat failed unexpectedly: %v", statErr)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, ok := meta.FindByTarget(targetOne)
+	if !ok || len(record.Contributions) != 0 || record.Hash != state.HashBytes([]byte("one\n")) {
+		t.Fatalf("partial inventory = %#v, want exact completed first action without terminal contributions", record)
+	}
+	if _, ok := meta.FindByTarget(targetTwo); ok {
+		t.Fatalf("partial inventory includes unapplied later target %s", targetTwo)
+	}
+	if meta.InstalledSelection == nil || len(meta.InstalledSelection.Profiles) != 1 || meta.InstalledSelection.Profiles[0] != "old" {
+		t.Fatalf("InstalledSelection = %#v, want previous selection", meta.InstalledSelection)
+	}
+
+	closeRootOperation, closeFileOperation = originalRoot, originalFile
+	rerun := p
+	rerun.Actions = append([]plan.Action(nil), p.Actions...)
+	rerun.Actions[0].Status = plan.StatusUnchanged
+	commit, err := ApplyManagedEntries(rerun, opts)
+	if err != nil {
+		t.Fatalf("safe rerun ApplyManagedEntries() error = %v", err)
+	}
+	if err := commit.Commit(nil); err != nil {
+		t.Fatalf("safe rerun Commit() error = %v", err)
+	}
+	if got, readErr := os.ReadFile(targetTwo); readErr != nil || string(got) != "two\n" {
+		t.Fatalf("safe rerun later target = %q, %v", got, readErr)
+	}
+}
+
+func TestUpdateCleanupReturnsExactPostimageAndJoinsPrimary(t *testing.T) {
+	home := t.TempDir()
+	target := filepath.Join(home, "target")
+	if err := os.WriteFile(target, []byte("old\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fileFault := errors.New("injected update file close fault")
+	rootFault := errors.New("injected update root close fault")
+	originalRoot, originalFile := closeRootOperation, closeFileOperation
+	defer func() { closeRootOperation, closeFileOperation = originalRoot, originalFile }()
+	fileCalls, rootCalls := 0, 0
+	closeFileOperation = func(file *os.File) error {
+		err := originalFile(file)
+		if file.Name() == target {
+			fileCalls++
+			return errors.Join(err, fileFault)
+		}
+		return err
+	}
+	closeRootOperation = func(root *os.Root) error {
+		err := originalRoot(root)
+		if root.Name() == home {
+			rootCalls++
+			return errors.Join(err, rootFault)
+		}
+		return err
+	}
+	result, err := updateConfinedRegularFile(target, home, func([]byte) ([]byte, bool, error) {
+		return []byte("new\n"), true, nil
+	})
+	if !errors.Is(err, fileFault) || !errors.Is(err, rootFault) || !isCompletedActionCleanup(err) {
+		t.Fatalf("update cleanup error = %v", err)
+	}
+	if !result.ExactTargetContent || string(result.PreviousTargetContent) != "old\n" || string(result.TargetContent) != "new\n" {
+		t.Fatalf("update result = %#v, want exact preimage and postimage", result)
+	}
+	if fileCalls != 1 || rootCalls != 1 {
+		t.Fatalf("update close calls = file %d, root %d; want one each", fileCalls, rootCalls)
+	}
+
+	closeFileOperation, closeRootOperation = originalFile, originalRoot
+	primaryFault := errors.New("injected update transform fault")
+	closeFileOperation = func(file *os.File) error { return errors.Join(originalFile(file), fileFault) }
+	closeRootOperation = func(root *os.Root) error { return errors.Join(originalRoot(root), rootFault) }
+	_, err = updateConfinedRegularFile(target, home, func([]byte) ([]byte, bool, error) {
+		return nil, false, primaryFault
+	})
+	if !errors.Is(err, primaryFault) || !errors.Is(err, fileFault) || !errors.Is(err, rootFault) || isCompletedActionCleanup(err) {
+		t.Fatalf("primary plus cleanup error = %v", err)
+	}
+}
+
+func TestWriteNewFileCloseFailureCompensatesWithoutRetry(t *testing.T) {
+	home := t.TempDir()
+	target := filepath.Join(home, "target")
+	fault := errors.New("injected new file close fault")
+	originalFile := closeFileOperation
+	defer func() { closeFileOperation = originalFile }()
+	calls := 0
+	closeFileOperation = func(file *os.File) error {
+		calls++
+		return errors.Join(originalFile(file), fault)
+	}
+	err := writeNewFileWithMode(home, target, []byte("content\n"), 0o600)
+	if !errors.Is(err, fault) || !strings.Contains(err.Error(), "close file "+target) {
+		t.Fatalf("writeNewFileWithMode() error = %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("new file close calls = %d, want exactly one", calls)
+	}
+	if _, statErr := os.Lstat(target); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("target remains after file-close compensation: %v", statErr)
+	}
+}
+
+func TestCompletedReconciliationCleanupPersistsReceiptAndPriorSelection(t *testing.T) {
+	home, sourceRoot, stateRoot := t.TempDir(), t.TempDir(), t.TempDir()
+	sourceName := "shared.json"
+	source := filepath.Join(sourceRoot, sourceName)
+	target := filepath.Join(home, "shared.json")
+	previous := []byte(`{"old":true}`)
+	current := []byte(`{"new":true}`)
+	live := []byte(`{"old":true,"external":true}`)
+	if err := os.WriteFile(source, current, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, live, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	record := recoveryAuthorityRecord(target, sourceName, previous)
+	oldSelection := &state.InstalledSelection{Profiles: []string{"old"}}
+	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, Entries: []state.Record{record}, InstalledSelection: oldSelection}); err != nil {
+		t.Fatal(err)
+	}
+	fingerprint, err := state.RecordEvidenceFingerprint(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	action := recoveryAuthorityAction(target, sourceName, previous, fingerprint)
+	fault := errors.New("injected reconciliation file close fault")
+	originalFile := closeFileOperation
+	defer func() { closeFileOperation = originalFile }()
+	calls := 0
+	closeFileOperation = func(file *os.File) error {
+		err := originalFile(file)
+		if file.Name() == target {
+			calls++
+			return errors.Join(err, fault)
+		}
+		return err
+	}
+	_, err = ApplyManagedEntries(plan.Plan{Profiles: []string{"new"}, Actions: []plan.Action{action}}, Options{
+		Home: home, SourceRoot: sourceRoot, StateRoot: stateRoot,
+	})
+	if !errors.Is(err, fault) || !isCompletedActionCleanup(err) || calls != 1 {
+		t.Fatalf("ApplyManagedEntries() = %v, close calls %d; want completed reconciliation cleanup once", err, calls)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated, ok := meta.FindByTarget(target)
+	if !ok || updated.PendingReconciliation == nil || updated.PendingReconciliation.TargetHash != state.HashBytes(got) {
+		t.Fatalf("reconciliation receipt = %#v, want exact postimage %q", updated.PendingReconciliation, got)
+	}
+	if len(updated.Contributions) != 1 || updated.Contributions[0].Hash != state.HashBytes(previous) {
+		t.Fatalf("committed contribution evidence changed on cleanup failure: %#v", updated.Contributions)
+	}
+	if meta.InstalledSelection == nil || len(meta.InstalledSelection.Profiles) != 1 || meta.InstalledSelection.Profiles[0] != "old" {
+		t.Fatalf("InstalledSelection = %#v, want prior selection", meta.InstalledSelection)
+	}
+}
+
+func TestCompletedCapturedAdoptionCleanupPersistsRecoveryInventory(t *testing.T) {
+	home, sourceRoot, stateRoot := t.TempDir(), t.TempDir(), t.TempDir()
+	source := filepath.Join(sourceRoot, "adopt")
+	target := filepath.Join(home, "adopt")
+	later := filepath.Join(home, "later")
+	if err := os.WriteFile(source, []byte("source\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("adopted\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceRoot, "later"), []byte("later\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	oldSelection := &state.InstalledSelection{Profiles: []string{"old"}}
+	if err := state.Save(state.Path(stateRoot), state.Metadata{Version: state.CurrentVersion, InstalledSelection: oldSelection}); err != nil {
+		t.Fatal(err)
+	}
+	p := plan.Plan{Profiles: []string{"new"}, Actions: []plan.Action{
+		{Source: "adopt", Target: target, Strategy: "copy", Status: plan.StatusConflict},
+		{Source: "later", Target: later, Strategy: "copy", Status: plan.StatusCreate},
+	}}
+	opts := Options{Home: home, SourceRoot: sourceRoot, StateRoot: stateRoot, ConflictDecisions: map[string]ConflictDecision{target: DecisionAdopt}}
+	snapshots, err := CaptureAdoptSnapshots(p, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	opts.AdoptSnapshots = snapshots
+	fault := errors.New("injected completed adoption source close fault")
+	originalFile := closeFileOperation
+	calls := 0
+	closeFileOperation = func(file *os.File) error {
+		err := originalFile(file)
+		if file.Name() == source {
+			content, readErr := os.ReadFile(source)
+			if readErr == nil && string(content) == "adopted\n" {
+				calls++
+				return errors.Join(err, fault)
+			}
+		}
+		return err
+	}
+	_, applyErr := ApplyManagedEntries(p, opts)
+	closeFileOperation = originalFile
+	if releaseErr := ReleaseAdoptSnapshots(snapshots); releaseErr != nil {
+		t.Fatal(releaseErr)
+	}
+	if !errors.Is(applyErr, fault) || !isCompletedActionCleanup(applyErr) || calls != 1 {
+		t.Fatalf("ApplyManagedEntries() = %v, close calls %d; want completed adoption cleanup once", applyErr, calls)
+	}
+	if got, readErr := os.ReadFile(source); readErr != nil || string(got) != "adopted\n" {
+		t.Fatalf("adopted source = %q, %v", got, readErr)
+	}
+	if _, statErr := os.Lstat(later); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("later action ran: %v", statErr)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, ok := meta.FindByTarget(target)
+	if !ok || record.Hash != state.HashBytes([]byte("adopted\n")) || len(record.Contributions) != 0 {
+		t.Fatalf("adoption recovery inventory = %#v", record)
+	}
+	if meta.InstalledSelection == nil || meta.InstalledSelection.Profiles[0] != "old" {
+		t.Fatalf("InstalledSelection = %#v, want prior selection", meta.InstalledSelection)
+	}
+}
+
+func TestLaterPrepareCaptureCleanupPersistsEarlierPrefix(t *testing.T) {
+	home, sourceRoot, stateRoot := t.TempDir(), t.TempDir(), t.TempDir()
+	for _, name := range []string{"one", "two", "three"} {
+		if err := os.WriteFile(filepath.Join(sourceRoot, name), []byte(name+"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	p := plan.Plan{Actions: []plan.Action{
+		{Source: "one", Target: filepath.Join(home, "one"), Strategy: "copy", Status: plan.StatusCreate},
+		{Source: "two", Target: filepath.Join(home, "two"), Strategy: "copy", Status: plan.StatusCreate},
+		{Source: "three", Target: filepath.Join(home, "three"), Strategy: "copy", Status: plan.StatusCreate},
+	}}
+	opts := Options{Home: home, SourceRoot: sourceRoot, StateRoot: stateRoot}
+	captures, err := CaptureManagedSources(p, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer releaseCapturedSourcesForTest(t, captures)
+	opts.CapturedSources = captures
+	originalRoot := closeRootOperation
+	defer func() { closeRootOperation = originalRoot }()
+	fault := errors.New("injected later prepare capture root cleanup")
+	faults := 0
+	closeRootOperation = func(root *os.Root) error {
+		err := originalRoot(root)
+		if root.Name() == sourceRoot {
+			if _, statErr := os.Lstat(filepath.Join(home, "one")); statErr == nil && faults == 0 {
+				faults++
+				return errors.Join(err, fault)
+			}
+		}
+		return err
+	}
+	_, err = ApplyManagedEntries(p, opts)
+	if !errors.Is(err, fault) || isCompletedActionCleanup(err) || faults != 1 {
+		t.Fatalf("ApplyManagedEntries() = %v, faults %d; want later prepare cleanup", err, faults)
+	}
+	meta, err := state.Load(state.Path(stateRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := meta.FindByTarget(filepath.Join(home, "one")); !ok {
+		t.Fatal("partial inventory missing completed first action")
+	}
+	for _, name := range []string{"two", "three"} {
+		if _, statErr := os.Lstat(filepath.Join(home, name)); !errors.Is(statErr, os.ErrNotExist) {
+			t.Fatalf("action %s ran after cleanup failure: %v", name, statErr)
+		}
+		if _, ok := meta.FindByTarget(filepath.Join(home, name)); ok {
+			t.Fatalf("partial inventory includes unapplied action %s", name)
+		}
+	}
+}
+
+func TestCaptureManagedSourcesReportsRootAndIdentityCleanupExactlyOnce(t *testing.T) {
+	sourceRoot := t.TempDir()
+	home := t.TempDir()
+	source := filepath.Join(sourceRoot, "source")
+	target := filepath.Join(home, "target")
+	if err := os.WriteFile(source, []byte("content\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	p := plan.Plan{Actions: []plan.Action{{Source: "source", Target: target, Strategy: "copy", Status: plan.StatusCreate}}}
+	rootFault := errors.New("injected root close fault")
+	identityFault := errors.New("injected identity close fault")
+
+	t.Run("root close invalidates capture", func(t *testing.T) {
+		originalRoot := closeRootOperation
+		defer func() { closeRootOperation = originalRoot }()
+		calls := 0
+		closeRootOperation = func(root *os.Root) error {
+			calls++
+			return errors.Join(originalRoot(root), rootFault)
+		}
+		captures, err := CaptureManagedSources(p, Options{SourceRoot: sourceRoot, Home: home})
+		if !errors.Is(err, rootFault) || captures != nil {
+			t.Fatalf("CaptureManagedSources() = %#v, %v; want no live capture and root fault", captures, err)
+		}
+		if calls != 1 {
+			t.Fatalf("root close calls = %d, want exactly one", calls)
+		}
+	})
+
+	t.Run("identity release closes once", func(t *testing.T) {
+		originalFile := closeFileOperation
+		defer func() { closeFileOperation = originalFile }()
+		calls := 0
+		closeFileOperation = func(file *os.File) error {
+			calls++
+			return errors.Join(originalFile(file), identityFault)
+		}
+		captures, err := CaptureManagedSources(p, Options{SourceRoot: sourceRoot, Home: home})
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = ReleaseCapturedSources(captures)
+		if !errors.Is(err, identityFault) {
+			t.Fatalf("ReleaseCapturedSources() error = %v, want identity fault", err)
+		}
+		if calls != 1 {
+			t.Fatalf("identity close calls = %d, want exactly one", calls)
+		}
+		if err := ReleaseCapturedSources(captures); err != nil || calls != 1 {
+			t.Fatalf("second release = %v, calls = %d; genuine close must never be retried after possible fd reuse", err, calls)
+		}
+	})
+
+	t.Run("simultaneous root and identity cleanup", func(t *testing.T) {
+		originalRoot, originalFile := closeRootOperation, closeFileOperation
+		defer func() { closeRootOperation, closeFileOperation = originalRoot, originalFile }()
+		rootCalls, fileCalls := 0, 0
+		closeRootOperation = func(root *os.Root) error {
+			rootCalls++
+			return errors.Join(originalRoot(root), rootFault)
+		}
+		closeFileOperation = func(file *os.File) error {
+			fileCalls++
+			return errors.Join(originalFile(file), identityFault)
+		}
+		captures, err := CaptureManagedSources(p, Options{SourceRoot: sourceRoot, Home: home})
+		if captures != nil || !errors.Is(err, rootFault) || !errors.Is(err, identityFault) {
+			t.Fatalf("CaptureManagedSources() = %#v, %v; want both faults and no live capture", captures, err)
+		}
+		if rootCalls != 1 || fileCalls != 1 {
+			t.Fatalf("close calls = root %d, identity %d; want one each", rootCalls, fileCalls)
+		}
+	})
+}
+
+func TestSymlinkDescriptorCleanupPreservesValidResults(t *testing.T) {
+	rootPath := t.TempDir()
+	resolvedPath := filepath.Join(rootPath, "source")
+	if err := os.WriteFile(resolvedPath, []byte("content\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	root, err := os.OpenRoot(rootPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := root.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
+	parentFault := errors.New("injected parent close fault")
+	resolvedFault := errors.New("injected resolved close fault")
+
+	originalFile := closeFileOperation
+	defer func() { closeFileOperation = originalFile }()
+	closeFileOperation = func(file *os.File) error {
+		err := originalFile(file)
+		return errors.Join(err, parentFault)
+	}
+	err = symlinkAtRoot(root, "link", "source")
+	if !errors.Is(err, parentFault) || !isCompletedActionCleanup(err) {
+		t.Fatalf("symlinkAtRoot() error = %v, want completed parent cleanup", err)
+	}
+	if destination, readErr := os.Readlink(filepath.Join(rootPath, "link")); readErr != nil || destination != "source" {
+		t.Fatalf("created symlink = %q, %v", destination, readErr)
+	}
+
+	for _, test := range []struct {
+		name         string
+		failParent   bool
+		failResolved bool
+		wantParent   bool
+		wantResolved bool
+	}{
+		{name: "parent", failParent: true, wantParent: true},
+		{name: "resolved", failResolved: true, wantResolved: true},
+		{name: "simultaneous", failParent: true, failResolved: true, wantParent: true, wantResolved: true},
+	} {
+		t.Run("stat "+test.name, func(t *testing.T) {
+			closeFileOperation = func(file *os.File) error {
+				err := originalFile(file)
+				if test.failParent && file.Name() != "link" {
+					return errors.Join(err, parentFault)
+				}
+				if test.failResolved && file.Name() == "link" {
+					return errors.Join(err, resolvedFault)
+				}
+				return err
+			}
+			info, err := statSymlinkTargetAtRoot(root, "link")
+			if info == nil || !info.Mode().IsRegular() {
+				t.Fatalf("stat result = %#v, want valid regular result", info)
+			}
+			if errors.Is(err, parentFault) != test.wantParent || errors.Is(err, resolvedFault) != test.wantResolved {
+				t.Fatalf("stat error = %v", err)
+			}
+			if err != nil && !strings.Contains(err.Error(), "close file") {
+				t.Fatalf("stat error lacks operation context: %v", err)
+			}
+		})
+	}
+
+	closeFileOperation = func(file *os.File) error {
+		err := originalFile(file)
+		return errors.Join(err, parentFault)
+	}
+	destination, err := readlinkAtRoot(root, "link")
+	if destination != "source" || !errors.Is(err, parentFault) || !strings.Contains(err.Error(), "close file") {
+		t.Fatalf("readlinkAtRoot() = %q, %v; want valid destination plus contextual cleanup", destination, err)
+	}
+}
+
+func TestStatSymlinkNewFileFailureClosesDescriptorOnce(t *testing.T) {
+	rootPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(rootPath, "source"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("source", filepath.Join(rootPath, "link")); err != nil {
+		t.Fatal(err)
+	}
+	root, err := os.OpenRoot(rootPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := root.Close(); err != nil {
+			t.Errorf("close test root %s: %v", rootPath, err)
+		}
+	})
+	originalNewFile, originalCloseFD := newFileOperation, closeFDOperation
+	defer func() { newFileOperation, closeFDOperation = originalNewFile, originalCloseFD }()
+	fdFault := errors.New("injected fd close fault")
+	closeCalls := 0
+	newFileOperation = func(uintptr, string) *os.File { return nil }
+	closeFDOperation = func(fd int) error {
+		closeCalls++
+		return errors.Join(originalCloseFD(fd), fdFault)
+	}
+	_, err = statSymlinkTargetAtRoot(root, "link")
+	if !errors.Is(err, fdFault) || !strings.Contains(err.Error(), "close descriptor for link") {
+		t.Fatalf("statSymlinkTargetAtRoot() error = %v", err)
+	}
+	if closeCalls != 1 {
+		t.Fatalf("unix close calls = %d, want exactly one because retry risks fd reuse", closeCalls)
+	}
+}
+
+func TestNewFileLifecyclesPreserveJoinedPrimaryAndTypedCloseFailures(t *testing.T) {
+	tests := []struct {
+		name        string
+		run         func(*testing.T, string) (string, error)
+		wantPresent bool
+		write       func(error)
+		wantPrimary func(string) string
+		wantContext func(string) string
+	}{
+		{
+			name: "copyRegularFile",
+			run: func(t *testing.T, dir string) (string, error) {
+				source, target := filepath.Join(dir, "copy-source"), filepath.Join(dir, "copy-target")
+				if err := os.WriteFile(source, []byte("copy\n"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				return target, copyRegularFile(source, target)
+			},
+			write: func(primary error) {
+				writeFileOperation = func(*os.File, []byte) (int, error) { return 0, primary }
+			},
+			wantPrimary: func(target string) string { return "write copy target " + target },
+			wantContext: func(target string) string { return "close file " + target },
+		},
+		{
+			name: "writeNewFileFromSourceMode",
+			run: func(t *testing.T, dir string) (string, error) {
+				source, target := filepath.Join(dir, "mode-source"), filepath.Join(dir, "mode-target")
+				if err := os.WriteFile(source, []byte("source\n"), 0o640); err != nil {
+					t.Fatal(err)
+				}
+				return target, writeNewFileFromSourceMode(source, target, []byte("written\n"))
+			},
+			write: func(primary error) {
+				writeFileOperation = func(*os.File, []byte) (int, error) { return 0, primary }
+			},
+			wantPrimary: func(target string) string { return "write new target " + target },
+			wantContext: func(target string) string { return "close file " + target },
+		},
+		{
+			name: "restoreCapturedTargetIfAbsent",
+			run: func(t *testing.T, dir string) (string, error) {
+				root, err := os.OpenRoot(dir)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer func() {
+					if err := root.Close(); err != nil {
+						t.Errorf("close restore test root %s: %v", dir, err)
+					}
+				}()
+				relative := "restored-target"
+				return filepath.Join(dir, relative), restoreCapturedTargetIfAbsent(root, relative, CapturedSource{
+					Content: []byte("restored\n"), Mode: 0o600,
+				})
+			},
+			wantPresent: true,
+			write: func(primary error) {
+				writeAllFileOperation = func(*os.File, []byte) error { return primary }
+			},
+			wantPrimary: func(string) string { return "restore adopted target restored-target: write" },
+			wantContext: func(string) string { return "close file restored-target" },
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			originalFile, originalWrite, originalWriteAll := closeFileOperation, writeFileOperation, writeAllFileOperation
+			defer func() {
+				closeFileOperation, writeFileOperation, writeAllFileOperation = originalFile, originalWrite, originalWriteAll
+			}()
+			primaryFault := &typedInjectedPrimaryError{lifecycle: test.name}
+			typedClose := &typedInjectedCleanupError{lifecycle: test.name}
+			calls := 0
+			test.write(primaryFault)
+			closeFileOperation = func(file *os.File) error {
+				calls++
+				return errors.Join(originalFile(file), typedClose)
+			}
+			target, err := test.run(t, t.TempDir())
+			if !errors.Is(err, primaryFault) || !isCleanupFailure(err) {
+				t.Fatalf("%s error = %v, want joined primary and cleanup classification", test.name, err)
+			}
+			var gotPrimary *typedInjectedPrimaryError
+			if !errors.As(err, &gotPrimary) || gotPrimary != primaryFault {
+				t.Fatalf("%s error = %v, want errors.As typed primary failure", test.name, err)
+			}
+			var gotTyped *typedInjectedCleanupError
+			if !errors.As(err, &gotTyped) || gotTyped != typedClose {
+				t.Fatalf("%s error = %v, want errors.As typed cleanup", test.name, err)
+			}
+			for _, context := range []string{test.wantPrimary(target), test.wantContext(target)} {
+				if !strings.Contains(err.Error(), context) {
+					t.Fatalf("%s error = %v, want context %q", test.name, err, context)
+				}
+			}
+			if calls != 1 {
+				t.Fatalf("%s close calls = %d, want exactly one", test.name, calls)
+			}
+			_, statErr := os.Lstat(target)
+			if test.wantPresent && statErr != nil {
+				t.Fatalf("%s target missing after restoration: %v", test.name, statErr)
+			}
+			if !test.wantPresent && !errors.Is(statErr, os.ErrNotExist) {
+				t.Fatalf("%s target remains after compensation: %v", test.name, statErr)
+			}
+		})
+	}
+}
+
+func TestCaptureConfinedSourceJoinsPrimaryAndTypedRootCloseFailures(t *testing.T) {
+	rootPath := t.TempDir()
+	directorySource := filepath.Join(rootPath, "directory")
+	if err := os.Mkdir(directorySource, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name        string
+		path        string
+		wantPrimary string
+		wantIs      error
+	}{
+		{name: "stat missing source", path: filepath.Join(rootPath, "missing"), wantPrimary: "inspect confined source", wantIs: os.ErrNotExist},
+		{name: "reject nonregular source", path: directorySource, wantPrimary: "does not resolve to a regular file"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			originalRoot := closeRootOperation
+			defer func() { closeRootOperation = originalRoot }()
+			typedClose := &typedInjectedCleanupError{lifecycle: test.name}
+			closeSentinel := errors.New("injected capture root close failure")
+			calls := 0
+			closeRootOperation = func(root *os.Root) error {
+				calls++
+				return errors.Join(originalRoot(root), closeSentinel, typedClose)
+			}
+			capture, err := captureConfinedSource(test.path, rootPath, true)
+			if capture.identity != nil {
+				t.Fatalf("capture = %#v, want no transferred identity", capture)
+			}
+			if !errors.Is(err, closeSentinel) || !isCleanupFailure(err) || (test.wantIs != nil && !errors.Is(err, test.wantIs)) {
+				t.Fatalf("captureConfinedSource() error = %v, want primary plus cleanup", err)
+			}
+			var gotTyped *typedInjectedCleanupError
+			if !errors.As(err, &gotTyped) || gotTyped != typedClose {
+				t.Fatalf("captureConfinedSource() error = %v, want errors.As typed cleanup", err)
+			}
+			for _, context := range []string{test.wantPrimary, "close filesystem root " + rootPath} {
+				if !strings.Contains(err.Error(), context) {
+					t.Fatalf("captureConfinedSource() error = %v, want context %q", err, context)
+				}
+			}
+			if calls != 1 {
+				t.Fatalf("root close calls = %d, want exactly one", calls)
+			}
+		})
+	}
+}

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -23,6 +23,128 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// cleanup operations are variables so tests can inject deterministic failures
+// without exhausting process descriptors. Tests that replace them must run
+// serially and restore the original operation.
+var (
+	closeRootOperation    = func(root *os.Root) error { return root.Close() }
+	closeFileOperation    = func(file *os.File) error { return file.Close() }
+	closeFDOperation      = unix.Close
+	newFileOperation      = os.NewFile
+	writeFileOperation    = func(file *os.File, data []byte) (int, error) { return file.Write(data) }
+	writeAllFileOperation = func(file *os.File, data []byte) error { return writeAll(file, data) }
+)
+
+type cleanupFailure struct {
+	err error
+}
+
+func (e *cleanupFailure) Error() string { return e.err.Error() }
+func (e *cleanupFailure) Unwrap() error { return e.err }
+func (e *cleanupFailure) CleanupFailure() bool {
+	return true
+}
+
+type completedActionCleanupFailure struct {
+	err error
+}
+
+func (e *completedActionCleanupFailure) Error() string { return e.err.Error() }
+func (e *completedActionCleanupFailure) Unwrap() error { return e.err }
+
+type errorWithPreservedMessage struct {
+	message string
+	err     error
+}
+
+func (e *errorWithPreservedMessage) Error() string { return e.message }
+func (e *errorWithPreservedMessage) Unwrap() error { return e.err }
+
+func classifyCleanup(err error) error {
+	if err == nil || isCleanupFailure(err) {
+		return err
+	}
+	return &cleanupFailure{err: err}
+}
+
+func completedActionCleanup(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &completedActionCleanupFailure{err: classifyCleanup(err)}
+}
+
+func isCleanupFailure(err error) bool {
+	var classified interface{ CleanupFailure() bool }
+	return errors.As(err, &classified) && classified.CleanupFailure()
+}
+
+func isCompletedActionCleanup(err error) bool {
+	var completed *completedActionCleanupFailure
+	return errors.As(err, &completed)
+}
+
+func withoutCompletedActionMarker(err error) error {
+	if err == nil {
+		return nil
+	}
+	var stripped []error
+	var collect func(error)
+	collect = func(current error) {
+		switch typed := current.(type) {
+		case *completedActionCleanupFailure:
+			collect(typed.err)
+		case interface{ Unwrap() []error }:
+			for _, nested := range typed.Unwrap() {
+				collect(nested)
+			}
+		case interface{ Unwrap() error }:
+			if isCompletedActionCleanup(current) {
+				strippedNested := withoutCompletedActionMarker(typed.Unwrap())
+				if strippedNested != nil {
+					stripped = append(stripped, &errorWithPreservedMessage{
+						message: current.Error(),
+						err:     strippedNested,
+					})
+				}
+				return
+			}
+			stripped = append(stripped, current)
+		default:
+			stripped = append(stripped, current)
+		}
+	}
+	collect(err)
+	return errors.Join(stripped...)
+}
+
+func closeRootOnce(root *os.Root, path string) error {
+	// Never retry a genuine close: the descriptor number may already have been
+	// reused even when close reports an error.
+	if err := closeRootOperation(root); err != nil {
+		return classifyCleanup(fmt.Errorf("close filesystem root %s: %w", path, err))
+	}
+	return nil
+}
+
+func closeFileOnce(file *os.File, path string) error {
+	// Never retry a genuine close: the descriptor number may already have been
+	// reused even when close reports an error.
+	if err := closeFileOperation(file); err != nil {
+		return classifyCleanup(fmt.Errorf("close file %s: %w", path, err))
+	}
+	return nil
+}
+
+func closeFDOnce(fd int, target string) error {
+	// unix.Close is deliberately attempted exactly once because retrying can
+	// close an unrelated descriptor after fd reuse.
+	if err := closeFDOperation(fd); err != nil {
+		return classifyCleanup(fmt.Errorf("close descriptor for %s: %w", target, err))
+	}
+	return nil
+}
+
 // ConflictDecision describes the explicit per-target action selected for a
 // conflict. The zero value is intentionally equivalent to skip so unattended
 // installs preserve existing workstation files.
@@ -104,8 +226,8 @@ func (i *capturedFileIdentity) release() error {
 	}
 	file := i.file
 	i.file = nil
-	if err := file.Close(); err != nil {
-		return fmt.Errorf("close captured identity: %w", err)
+	if err := closeFileOnce(file, file.Name()); err != nil {
+		return fmt.Errorf("close captured identity for %s: %w", file.Name(), err)
 	}
 	return nil
 }
@@ -254,11 +376,23 @@ func applyManagedEntriesWithApply(p plan.Plan, opts Options, applyAction managed
 	for i, action := range p.Actions {
 		action, err = prepareCapturedAction(action, resolvedSources[i], opts)
 		if err != nil {
+			if isCleanupFailure(err) {
+				err = errors.Join(err, persistCompletedPrefix(p, appliedActions, appliedReceipts, resolvedSources, opts, i))
+			}
 			return MetadataCommit{}, err
 		}
 		source := resolvedSources[i][0]
 		prepared, receipt, err := applyActionWithReconciliationReceipt(action, source, resolvedSources[i], opts, applyAction)
 		if err != nil {
+			if isCleanupFailure(err) {
+				completed := i
+				if isCompletedActionCleanup(err) {
+					appliedActions[i] = prepared
+					appliedReceipts[i] = receipt
+					completed++
+				}
+				err = errors.Join(err, persistCompletedPrefix(p, appliedActions, appliedReceipts, resolvedSources, opts, completed))
+			}
 			return MetadataCommit{}, err
 		}
 		appliedActions[i] = prepared
@@ -279,6 +413,26 @@ func applyManagedEntriesWithApply(p plan.Plan, opts Options, applyAction managed
 		return MetadataCommit{}, err
 	}
 	return commit, nil
+}
+
+func persistCompletedPrefix(p plan.Plan, actions []plan.Action, receipts []*state.ReconciliationReceipt, resolvedSources [][]string, opts Options, completed int) error {
+	if completed == 0 {
+		return nil
+	}
+	p.Actions = append([]plan.Action(nil), actions[:completed]...)
+	commit := newMetadataCommit(p, resolvedSources[:completed], opts)
+	for i := range commit.actions {
+		commit.actions[i].pending = receipts[i]
+	}
+	if opts.StateRoot != "" {
+		if err := commit.captureStagedEvidence(); err != nil {
+			return fmt.Errorf("capture completed install prefix evidence: %w", err)
+		}
+	}
+	if err := commit.recordPartialInventory(); err != nil {
+		return fmt.Errorf("persist completed install prefix: %w", err)
+	}
+	return nil
 }
 
 func applyManagedAction(action plan.Action, source string, opts Options) (managedActionResult, error) {
@@ -317,7 +471,16 @@ func applyActionWithReconciliationReceipt(action plan.Action, source string, res
 	if err != nil {
 		return prepared, nil, err
 	}
-	defer func() { resultErr = errors.Join(resultErr, locked.Close()) }()
+	actionCompleted := false
+	defer func() {
+		if closeErr := locked.Close(); closeErr != nil {
+			closeErr = classifyCleanup(fmt.Errorf("close installation metadata lock for %s: %w", action.Target, closeErr))
+			if actionCompleted {
+				closeErr = completedActionCleanup(closeErr)
+			}
+			resultErr = errors.Join(resultErr, closeErr)
+		}
+	}()
 	meta, err := locked.Load()
 	if err != nil {
 		return prepared, nil, err
@@ -330,9 +493,9 @@ func applyActionWithReconciliationReceipt(action plan.Action, source string, res
 	if err != nil {
 		return action, nil, err
 	}
-	result, err := applyAction(prepared, source, opts)
-	if err != nil {
-		return prepared, nil, err
+	result, applyErr := applyAction(prepared, source, opts)
+	if applyErr != nil && !isCompletedActionCleanup(applyErr) {
+		return prepared, nil, applyErr
 	}
 	if !result.ExactTargetContent {
 		return prepared, nil, fmt.Errorf("record reconciliation receipt for %s: apply did not return exact target bytes", action.Target)
@@ -352,7 +515,11 @@ func applyActionWithReconciliationReceipt(action plan.Action, source string, res
 	setPendingReconciliation(&meta, action.Target, receipt)
 	if err := locked.Save(meta); err != nil {
 		rollbackErr := restoreConfinedRegularFile(action.Target, opts.Home, result.TargetContent, result.PreviousTargetContent)
-		return prepared, nil, errors.Join(fmt.Errorf("persist reconciliation receipt for %s: %w", action.Target, err), rollbackErr)
+		return prepared, nil, errors.Join(fmt.Errorf("persist reconciliation receipt for %s: %w", action.Target, err), withoutCompletedActionMarker(applyErr), rollbackErr)
+	}
+	actionCompleted = true
+	if applyErr != nil {
+		return prepared, receipt, completedActionCleanup(applyErr)
 	}
 	return prepared, receipt, nil
 }
@@ -494,24 +661,23 @@ func captureConfinedSource(path, rootPath string, contentRequired bool) (Capture
 	if err != nil {
 		return CapturedSource{}, fmt.Errorf("open source root %s: %w", rootAbs, err)
 	}
-	defer root.Close()
 	observed, err := root.Stat(relative)
 	if err != nil {
-		return CapturedSource{}, fmt.Errorf("inspect confined source %s: %w", path, err)
+		return CapturedSource{}, errors.Join(fmt.Errorf("inspect confined source %s: %w", path, err), closeRootOnce(root, rootAbs))
 	}
 	if contentRequired && !observed.Mode().IsRegular() {
-		return CapturedSource{}, fmt.Errorf("confined source %s does not resolve to a regular file", path)
+		return CapturedSource{}, errors.Join(fmt.Errorf("confined source %s does not resolve to a regular file", path), closeRootOnce(root, rootAbs))
 	}
 	file, err := root.OpenFile(relative, os.O_RDONLY, 0)
 	if err != nil {
-		return CapturedSource{}, fmt.Errorf("open confined source %s: %w", path, err)
+		return CapturedSource{}, errors.Join(fmt.Errorf("open confined source %s: %w", path, err), closeRootOnce(root, rootAbs))
 	}
 	info, err := file.Stat()
 	if err != nil {
-		return CapturedSource{}, errors.Join(fmt.Errorf("stat confined source %s: %w", path, err), file.Close())
+		return CapturedSource{}, errors.Join(fmt.Errorf("stat confined source %s: %w", path, err), closeFileOnce(file, path), closeRootOnce(root, rootAbs))
 	}
 	if (contentRequired && !info.Mode().IsRegular()) || !os.SameFile(observed, info) {
-		return CapturedSource{}, errors.Join(fmt.Errorf("install plan is stale: source %s changed identity before snapshot", path), file.Close())
+		return CapturedSource{}, errors.Join(fmt.Errorf("install plan is stale: source %s changed identity before snapshot", path), closeFileOnce(file, path), closeRootOnce(root, rootAbs))
 	}
 	captured := CapturedSource{
 		Mode:                info.Mode(),
@@ -523,10 +689,15 @@ func captureConfinedSource(path, rootPath string, contentRequired bool) (Capture
 	if contentRequired {
 		data, err := io.ReadAll(file)
 		if err != nil {
-			return CapturedSource{}, errors.Join(fmt.Errorf("read confined source %s: %w", path, err), captured.identity.release())
+			return CapturedSource{}, errors.Join(fmt.Errorf("read confined source %s: %w", path, err), captured.identity.release(), closeRootOnce(root, rootAbs))
 		}
 		captured.Content = append([]byte{}, data...)
 		captured.ContentPresent = true
+	}
+	if err := closeRootOnce(root, rootAbs); err != nil {
+		// The root must be released before ownership of the captured descriptor
+		// transfers to the caller. A root-close fault invalidates the capture.
+		return CapturedSource{}, errors.Join(err, captured.identity.release())
 	}
 	return captured, nil
 }
@@ -1502,7 +1673,7 @@ func createCapturedSymlink(action plan.Action, source string, opts Options) erro
 	return createCapturedSymlinkWithHook(action, source, opts, nil)
 }
 
-func createCapturedSymlinkWithHook(action plan.Action, source string, opts Options, afterCreate func() error) error {
+func createCapturedSymlinkWithHook(action plan.Action, source string, opts Options, afterCreate func() error) (resultErr error) {
 	sourceName := actionSourceList(action)[0]
 	captured, hasCapture := opts.CapturedSources[SourceCaptureKey{Target: action.Target, Source: sourceName}]
 	if hasCapture {
@@ -1526,46 +1697,60 @@ func createCapturedSymlinkWithHook(action plan.Action, source string, opts Optio
 	if err != nil {
 		return fmt.Errorf("open home root %s: %w", homeAbs, err)
 	}
-	defer root.Close()
+	actionCompleted := false
+	defer func() {
+		if closeErr := closeRootOnce(root, homeAbs); closeErr != nil {
+			if actionCompleted {
+				closeErr = completedActionCleanup(closeErr)
+			}
+			resultErr = errors.Join(resultErr, closeErr)
+		}
+	}()
+	var creationCleanup error
 	if err := symlinkAtRoot(root, relative, source); err != nil {
-		return err
+		if !isCompletedActionCleanup(err) {
+			return err
+		}
+		creationCleanup = withoutCompletedActionMarker(err)
 	}
 	created, err := root.Lstat(relative)
 	if err != nil {
-		return fmt.Errorf("inspect created symlink: %w", err)
+		return errors.Join(fmt.Errorf("inspect created symlink %s: %w", action.Target, err), creationCleanup)
 	}
 	if afterCreate != nil {
 		if err := afterCreate(); err != nil {
-			return errors.Join(fmt.Errorf("after symlink creation: %w", err), removeCreatedSymlinkIfMatching(root, relative, source, created))
+			return errors.Join(fmt.Errorf("after symlink creation for %s: %w", action.Target, err), creationCleanup, removeCreatedSymlinkIfMatching(root, relative, source, created))
 		}
 	}
 	if !hasCapture {
-		return nil
+		actionCompleted = true
+		return completedActionCleanup(creationCleanup)
 	}
 	resolved, resolveErr := statSymlinkTargetAtRoot(root, relative)
 	capturedInfo, capturedInfoErr := captured.identity.stat()
-	if resolveErr == nil && capturedInfoErr == nil && os.SameFile(resolved, capturedInfo) {
+	if (resolveErr == nil || isCleanupFailure(resolveErr)) && capturedInfoErr == nil && resolved != nil && os.SameFile(resolved, capturedInfo) {
 		// After terminal commit, a managed symlink intentionally follows later
 		// Source of Truth checkout changes. This identity check only closes the
 		// selector review-to-creation window.
-		return nil
+		actionCompleted = true
+		return completedActionCleanup(errors.Join(creationCleanup, resolveErr))
 	}
 	cleanupErr := removeCreatedSymlinkIfMatching(root, relative, source, created)
 	if capturedInfoErr != nil {
-		return errors.Join(fmt.Errorf("resolve captured source identity: %w", capturedInfoErr), cleanupErr)
+		return errors.Join(fmt.Errorf("resolve captured source identity for %s: %w", action.Target, capturedInfoErr), creationCleanup, resolveErr, cleanupErr)
 	}
 	if resolveErr != nil {
-		return errors.Join(fmt.Errorf("resolve created symlink: %w", resolveErr), cleanupErr)
+		return errors.Join(fmt.Errorf("resolve created symlink %s: %w", action.Target, resolveErr), creationCleanup, cleanupErr)
 	}
-	return errors.Join(fmt.Errorf("created symlink resolved to a different source identity"), cleanupErr)
+	return errors.Join(fmt.Errorf("created symlink %s resolved to a different source identity", action.Target), creationCleanup, cleanupErr)
 }
 
-func createConfinedParent(rootPath, target string) error {
+func createConfinedParent(rootPath, target string) (resultErr error) {
 	root, relative, err := openConfinedRoot(rootPath, target)
 	if err != nil {
 		return err
 	}
-	defer root.Close()
+	defer func() { resultErr = errors.Join(resultErr, closeRootOnce(root, rootPath)) }()
 	parent := filepath.Dir(relative)
 	if parent == "." {
 		return nil
@@ -1577,11 +1762,11 @@ func createConfinedParent(rootPath, target string) error {
 		}
 		current = filepath.Join(current, component)
 		if err := root.Mkdir(current, 0o755); err != nil && !errors.Is(err, os.ErrExist) {
-			return err
+			return fmt.Errorf("create confined parent %s for %s: %w", current, target, err)
 		}
 		info, err := root.Stat(current)
 		if err != nil {
-			return err
+			return fmt.Errorf("stat confined parent %s for %s: %w", current, target, err)
 		}
 		if !info.IsDir() {
 			return fmt.Errorf("parent %s is not a directory", current)
@@ -1595,10 +1780,19 @@ func symlinkAtRoot(root *os.Root, relative, destination string) (resultErr error
 	if err != nil {
 		return fmt.Errorf("open symlink parent: %w", err)
 	}
-	defer func() { resultErr = errors.Join(resultErr, parent.Close()) }()
+	created := false
+	defer func() {
+		if closeErr := closeFileOnce(parent, "parent of "+relative); closeErr != nil {
+			if created {
+				closeErr = completedActionCleanup(closeErr)
+			}
+			resultErr = errors.Join(resultErr, closeErr)
+		}
+	}()
 	if err := unix.Symlinkat(destination, int(parent.Fd()), base); err != nil {
-		return fmt.Errorf("create confined symlink: %w", err)
+		return fmt.Errorf("create confined symlink %s to %s: %w", relative, destination, err)
 	}
+	created = true
 	return nil
 }
 
@@ -1613,39 +1807,42 @@ func openRootParent(root *os.Root, relative string) (*os.File, string, error) {
 func statSymlinkTargetAtRoot(root *os.Root, relative string) (result os.FileInfo, resultErr error) {
 	parent, base, err := openRootParent(root, relative)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("open parent of resolved symlink %s: %w", relative, err)
 	}
-	defer func() { resultErr = errors.Join(resultErr, parent.Close()) }()
+	defer func() { resultErr = errors.Join(resultErr, closeFileOnce(parent, "parent of "+relative)) }()
 	fd, err := unix.Openat(int(parent.Fd()), base, unix.O_RDONLY|unix.O_CLOEXEC, 0)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("open resolved symlink %s: %w", relative, err)
 	}
-	resolved := os.NewFile(uintptr(fd), relative)
+	resolved := newFileOperation(uintptr(fd), relative)
 	if resolved == nil {
-		_ = unix.Close(fd)
-		return nil, fmt.Errorf("open resolved symlink descriptor")
+		return nil, errors.Join(fmt.Errorf("open resolved symlink descriptor for %s", relative), closeFDOnce(fd, relative))
 	}
-	defer func() { resultErr = errors.Join(resultErr, resolved.Close()) }()
-	return resolved.Stat()
+	defer func() { resultErr = errors.Join(resultErr, closeFileOnce(resolved, relative)) }()
+	result, err = resolved.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat resolved symlink %s: %w", relative, err)
+	}
+	return result, nil
 }
 
 func readlinkAtRoot(root *os.Root, relative string) (result string, resultErr error) {
 	parent, base, err := openRootParent(root, relative)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("open parent of confined symlink %s: %w", relative, err)
 	}
-	defer func() { resultErr = errors.Join(resultErr, parent.Close()) }()
+	defer func() { resultErr = errors.Join(resultErr, closeFileOnce(parent, "parent of "+relative)) }()
 	for size := 256; size <= 1<<20; size *= 2 {
 		buffer := make([]byte, size)
 		n, err := unix.Readlinkat(int(parent.Fd()), base, buffer)
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("read confined symlink %s: %w", relative, err)
 		}
 		if n < len(buffer) {
 			return string(buffer[:n]), nil
 		}
 	}
-	return "", fmt.Errorf("symlink destination exceeds supported length")
+	return "", fmt.Errorf("read confined symlink %s: destination exceeds supported length", relative)
 }
 
 func removeCreatedSymlinkIfMatching(root *os.Root, relative, destination string, created os.FileInfo) error {
@@ -1659,17 +1856,17 @@ func removeCreatedSymlinkIfMatching(root *os.Root, relative, destination string,
 	if current.Mode()&os.ModeSymlink == 0 || !os.SameFile(current, created) {
 		return fmt.Errorf("created symlink changed before compensation; refusing removal")
 	}
-	currentDestination, err := readlinkAtRoot(root, relative)
-	if err != nil {
-		return fmt.Errorf("read created symlink for compensation: %w", err)
+	currentDestination, readErr := readlinkAtRoot(root, relative)
+	if readErr != nil && !isCleanupFailure(readErr) {
+		return fmt.Errorf("read created symlink %s for compensation: %w", relative, readErr)
 	}
 	if currentDestination != destination {
-		return fmt.Errorf("created symlink destination changed before compensation; refusing removal")
+		return errors.Join(fmt.Errorf("created symlink %s destination changed before compensation; refusing removal", relative), readErr)
 	}
 	if err := root.Remove(relative); err != nil {
-		return fmt.Errorf("remove created symlink during compensation: %w", err)
+		return errors.Join(fmt.Errorf("remove created symlink %s during compensation: %w", relative, err), readErr)
 	}
-	return nil
+	return readErr
 }
 
 func applyReplace(action plan.Action, source string, opts Options) error {
@@ -1702,13 +1899,13 @@ func applyUpdate(action plan.Action, source string, opts Options) (managedAction
 		if len(action.PreviousContent) > 0 {
 			result, err := reconcileJSONContentFile(action.Target, action.PreviousContent, current, opts.Home)
 			if err != nil {
-				return managedActionResult{}, fmt.Errorf("reconcile JSON update for %s: %w", action.Target, err)
+				return result, fmt.Errorf("reconcile JSON update for %s: %w", action.Target, err)
 			}
 			return result, nil
 		}
 		result, err := mergeJSONContentFile(action.Target, current, opts.Home)
 		if err != nil {
-			return managedActionResult{}, fmt.Errorf("merge JSON update for %s: %w", action.Target, err)
+			return result, fmt.Errorf("merge JSON update for %s: %w", action.Target, err)
 		}
 		return result, nil
 	case "jsonc-subset":
@@ -1723,13 +1920,13 @@ func applyUpdate(action plan.Action, source string, opts Options) (managedAction
 		if len(action.PreviousContent) > 0 {
 			result, err := reconcileJSONCContentFile(action.Target, action.PreviousContent, current, opts.Home)
 			if err != nil {
-				return managedActionResult{}, fmt.Errorf("reconcile JSONC update for %s: %w", action.Target, err)
+				return result, fmt.Errorf("reconcile JSONC update for %s: %w", action.Target, err)
 			}
 			return result, nil
 		}
 		result, err := mergeJSONCContentFile(action.Target, current, opts.Home)
 		if err != nil {
-			return managedActionResult{}, fmt.Errorf("merge JSONC update for %s: %w", action.Target, err)
+			return result, fmt.Errorf("merge JSONC update for %s: %w", action.Target, err)
 		}
 		return result, nil
 	case "toml-subset":
@@ -1744,13 +1941,13 @@ func applyUpdate(action plan.Action, source string, opts Options) (managedAction
 		if len(action.PreviousContent) > 0 {
 			result, err := reconcileTOMLContentFile(action.Target, action.PreviousContent, current, opts.Home)
 			if err != nil {
-				return managedActionResult{}, fmt.Errorf("reconcile TOML update for %s: %w", action.Target, err)
+				return result, fmt.Errorf("reconcile TOML update for %s: %w", action.Target, err)
 			}
 			return result, nil
 		}
 		result, err := mergeTOMLContentFile(action.Target, current, opts.Home)
 		if err != nil {
-			return managedActionResult{}, fmt.Errorf("merge TOML update for %s: %w", action.Target, err)
+			return result, fmt.Errorf("merge TOML update for %s: %w", action.Target, err)
 		}
 		return result, nil
 	case "seeded":
@@ -1769,7 +1966,7 @@ func applyUpdate(action plan.Action, source string, opts Options) (managedAction
 			return current, !bytes.Equal(live, current), nil
 		})
 		if err != nil {
-			return managedActionResult{}, fmt.Errorf("advance seeded target %s: %w", action.Target, err)
+			return result, fmt.Errorf("advance seeded target %s: %w", action.Target, err)
 		}
 		return result, nil
 	case "marked-block":
@@ -1789,7 +1986,7 @@ func applyUpdate(action plan.Action, source string, opts Options) (managedAction
 			return reconciliation.Content, !bytes.Equal(reconciliation.Content, live), nil
 		})
 		if err != nil {
-			return managedActionResult{}, fmt.Errorf("update marked block %s: %w", action.Target, err)
+			return result, fmt.Errorf("update marked block %s: %w", action.Target, err)
 		}
 		return result, nil
 	case "", "whole":
@@ -1830,7 +2027,7 @@ func updateWholeTargetWithResult(action plan.Action, source, home string) (manag
 
 type confinedTransform func([]byte) ([]byte, bool, error)
 
-func updateConfinedRegularFile(target, home string, transform confinedTransform) (managedActionResult, error) {
+func updateConfinedRegularFile(target, home string, transform confinedTransform) (result managedActionResult, resultErr error) {
 	homeAbs, err := cleanAbs(home)
 	if err != nil {
 		return managedActionResult{}, fmt.Errorf("resolve home for target %s: %w", target, err)
@@ -1847,7 +2044,15 @@ func updateConfinedRegularFile(target, home string, transform confinedTransform)
 	if err != nil {
 		return managedActionResult{}, fmt.Errorf("open home root %s: %w", homeAbs, err)
 	}
-	defer root.Close()
+	actionCompleted := false
+	defer func() {
+		if closeErr := closeRootOnce(root, homeAbs); closeErr != nil {
+			if actionCompleted {
+				closeErr = completedActionCleanup(closeErr)
+			}
+			resultErr = errors.Join(resultErr, closeErr)
+		}
+	}()
 	observed, err := root.Lstat(relative)
 	if err != nil {
 		return managedActionResult{}, fmt.Errorf("inspect confined target %s: %w", target, err)
@@ -1859,7 +2064,14 @@ func updateConfinedRegularFile(target, home string, transform confinedTransform)
 	if err != nil {
 		return managedActionResult{}, fmt.Errorf("open confined target %s: %w", target, err)
 	}
-	defer file.Close()
+	defer func() {
+		if closeErr := closeFileOnce(file, target); closeErr != nil {
+			if actionCompleted {
+				closeErr = completedActionCleanup(closeErr)
+			}
+			resultErr = errors.Join(resultErr, closeErr)
+		}
+	}()
 	info, err := file.Stat()
 	if err != nil {
 		return managedActionResult{}, fmt.Errorf("stat confined target %s: %w", target, err)
@@ -1875,18 +2087,20 @@ func updateConfinedRegularFile(target, home string, transform confinedTransform)
 	if err != nil {
 		return managedActionResult{}, err
 	}
-	result := managedActionResult{
+	result = managedActionResult{
 		PreviousTargetContent: append([]byte(nil), live...),
 		TargetContent:         append([]byte(nil), updated...),
 		ExactTargetContent:    true,
 	}
 	if !changed {
 		result.TargetContent = append([]byte(nil), live...)
+		actionCompleted = true
 		return result, nil
 	}
 	if err := rewriteOpenedRegularFile(file, target, updated, live); err != nil {
 		return managedActionResult{}, err
 	}
+	actionCompleted = true
 	return result, nil
 }
 
@@ -2064,6 +2278,7 @@ func applyAdopt(action plan.Action, source string, opts Options) error {
 }
 
 func applyCapturedAdopt(action plan.Action, source string, opts Options, snapshot AdoptSnapshot) (resultErr error) {
+	actionCompleted := false
 	if err := validateCapturedFile(action.Target, opts.Home, "adopt target", snapshot.target); err != nil {
 		return fmt.Errorf("install plan is stale: %w", err)
 	}
@@ -2075,12 +2290,26 @@ func applyCapturedAdopt(action plan.Action, source string, opts Options, snapsho
 	if err != nil {
 		return fmt.Errorf("open adopt source root: %w", err)
 	}
-	defer func() { resultErr = errors.Join(resultErr, sourceRoot.Close()) }()
+	defer func() {
+		if closeErr := closeRootOnce(sourceRoot, opts.SourceRoot); closeErr != nil {
+			if actionCompleted {
+				closeErr = completedActionCleanup(closeErr)
+			}
+			resultErr = errors.Join(resultErr, closeErr)
+		}
+	}()
 	sourceFile, err := sourceRoot.OpenFile(sourceRelative, os.O_RDWR, 0)
 	if err != nil {
 		return fmt.Errorf("open adopt source %s: %w", source, err)
 	}
-	defer func() { resultErr = errors.Join(resultErr, sourceFile.Close()) }()
+	defer func() {
+		if closeErr := closeFileOnce(sourceFile, source); closeErr != nil {
+			if actionCompleted {
+				closeErr = completedActionCleanup(closeErr)
+			}
+			resultErr = errors.Join(resultErr, closeErr)
+		}
+	}()
 	sourceInfo, sourceData, err := readCapturedDescriptor(sourceFile, "adopt source", snapshot.source)
 	if err != nil {
 		return err
@@ -2090,21 +2319,29 @@ func applyCapturedAdopt(action plan.Action, source string, opts Options, snapsho
 	if err != nil {
 		return fmt.Errorf("open adopt target root: %w", err)
 	}
-	defer func() { resultErr = errors.Join(resultErr, homeRoot.Close()) }()
+	defer func() {
+		if closeErr := closeRootOnce(homeRoot, opts.Home); closeErr != nil {
+			if actionCompleted {
+				closeErr = completedActionCleanup(closeErr)
+			}
+			resultErr = errors.Join(resultErr, closeErr)
+		}
+	}()
 	targetFile, err := homeRoot.OpenFile(targetRelative, os.O_RDONLY, 0)
 	if err != nil {
 		return fmt.Errorf("open adopt target %s: %w", action.Target, err)
 	}
 	_, targetData, targetReadErr := readCapturedDescriptor(targetFile, "adopt target", snapshot.target)
-	targetCloseErr := targetFile.Close()
+	targetCloseErr := closeFileOnce(targetFile, action.Target)
 	if err := errors.Join(targetReadErr, targetCloseErr); err != nil {
-		return err
+		return fmt.Errorf("read captured adopt target %s: %w", action.Target, err)
 	}
 
 	if err := rewriteOpenedRegularFile(sourceFile, source, targetData, sourceData); err != nil {
 		return fmt.Errorf("write captured adopt source %s: %w", source, err)
 	}
 	if action.Strategy != "symlink" {
+		actionCompleted = true
 		return nil
 	}
 	rollbackSource := func() error {
@@ -2141,11 +2378,13 @@ func applyCapturedAdopt(action plan.Action, source string, opts Options, snapsho
 	createOpts.CapturedSources = map[SourceCaptureKey]CapturedSource{
 		{Target: action.Target, Source: action.Source}: adoptedSource,
 	}
-	if err := applyCreate(action, source, createOpts); err != nil {
+	createErr := applyCreate(action, source, createOpts)
+	if createErr != nil && !isCompletedActionCleanup(createErr) {
 		restoreErr := restoreCapturedTargetIfAbsent(homeRoot, targetRelative, snapshot.target)
-		return errors.Join(err, restoreErr, rollbackSource())
+		return errors.Join(createErr, restoreErr, rollbackSource())
 	}
-	return nil
+	actionCompleted = true
+	return completedActionCleanup(createErr)
 }
 
 func openConfinedRoot(rootPath, path string) (*os.Root, string, error) {
@@ -2209,9 +2448,15 @@ func restoreCapturedTargetIfAbsent(root *os.Root, relative string, snapshot Capt
 		}
 		return fmt.Errorf("restore adopted target: %w", err)
 	}
-	writeErr := writeAll(file, snapshot.Content)
+	writeErr := writeAllFileOperation(file, snapshot.Content)
 	chmodErr := file.Chmod(snapshot.Mode.Perm())
-	closeErr := file.Close()
+	closeErr := closeFileOnce(file, relative)
+	if writeErr != nil {
+		writeErr = fmt.Errorf("restore adopted target %s: write: %w", relative, writeErr)
+	}
+	if chmodErr != nil {
+		chmodErr = fmt.Errorf("restore adopted target %s: chmod: %w", relative, chmodErr)
+	}
 	return errors.Join(writeErr, chmodErr, closeErr)
 }
 
@@ -2276,48 +2521,52 @@ func createBackupSet(opts Options, target string) error {
 func copyRegularFile(source, target string) error {
 	info, err := os.Stat(source)
 	if err != nil {
-		return err
+		return fmt.Errorf("stat copy source %s: %w", source, err)
 	}
 	if !info.Mode().IsRegular() {
 		return fmt.Errorf("source is not a regular file")
 	}
 	data, err := os.ReadFile(source)
 	if err != nil {
-		return err
+		return fmt.Errorf("read copy source %s: %w", source, err)
 	}
 	file, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_EXCL, info.Mode().Perm())
 	if err != nil {
-		return err
+		return fmt.Errorf("open copy target %s: %w", target, err)
 	}
-	if _, err := file.Write(data); err != nil {
-		_ = file.Close()
-		_ = os.Remove(target)
-		return err
+	if _, err := writeFileOperation(file, data); err != nil {
+		return errors.Join(fmt.Errorf("write copy target %s: %w", target, err), closeFileOnce(file, target), removePathForCompensation(target))
 	}
-	if err := file.Close(); err != nil {
-		_ = os.Remove(target)
-		return err
+	if err := closeFileOnce(file, target); err != nil {
+		return errors.Join(err, removePathForCompensation(target))
 	}
-	return os.Chmod(target, info.Mode().Perm())
+	if err := os.Chmod(target, info.Mode().Perm()); err != nil {
+		return fmt.Errorf("chmod copy target %s: %w", target, err)
+	}
+	return nil
 }
 
 func writeNewFileFromSourceMode(source, target string, data []byte) error {
 	info, err := os.Stat(source)
 	if err != nil {
-		return err
+		return fmt.Errorf("stat source mode %s: %w", source, err)
 	}
 	file, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_EXCL, info.Mode().Perm())
 	if err != nil {
-		return err
+		return fmt.Errorf("open new target %s: %w", target, err)
 	}
-	if _, err := file.Write(data); err != nil {
-		_ = file.Close()
-		_ = os.Remove(target)
-		return err
+	if _, err := writeFileOperation(file, data); err != nil {
+		return errors.Join(fmt.Errorf("write new target %s: %w", target, err), closeFileOnce(file, target), removePathForCompensation(target))
 	}
-	if err := file.Close(); err != nil {
-		_ = os.Remove(target)
-		return err
+	if err := closeFileOnce(file, target); err != nil {
+		return errors.Join(err, removePathForCompensation(target))
+	}
+	return nil
+}
+
+func removePathForCompensation(path string) error {
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove target %s during compensation: %w", path, err)
 	}
 	return nil
 }
@@ -2331,7 +2580,15 @@ func writeNewFileWithModeAtRoot(rootPath, target string, data []byte, mode os.Fi
 	if err != nil {
 		return err
 	}
-	defer func() { resultErr = errors.Join(resultErr, root.Close()) }()
+	actionCompleted := false
+	defer func() {
+		if closeErr := closeRootOnce(root, rootPath); closeErr != nil {
+			if actionCompleted {
+				closeErr = completedActionCleanup(closeErr)
+			}
+			resultErr = errors.Join(resultErr, closeErr)
+		}
+	}()
 	if beforeOpen != nil {
 		if err := beforeOpen(); err != nil {
 			return fmt.Errorf("before confined target create: %w", err)
@@ -2339,21 +2596,22 @@ func writeNewFileWithModeAtRoot(rootPath, target string, data []byte, mode os.Fi
 	}
 	file, err := root.OpenFile(relative, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode.Perm())
 	if err != nil {
-		return err
+		return fmt.Errorf("open confined target %s: %w", target, err)
 	}
 	created, err := file.Stat()
 	if err != nil {
-		return errors.Join(fmt.Errorf("stat created target: %w", err), file.Close())
+		return errors.Join(fmt.Errorf("stat created target %s: %w", target, err), closeFileOnce(file, target))
 	}
 	if err := writeAll(file, data); err != nil {
-		return errors.Join(err, file.Close(), removeCreatedFileIfMatching(root, relative, created))
+		return errors.Join(fmt.Errorf("write confined target %s: %w", target, err), closeFileOnce(file, target), removeCreatedFileIfMatching(root, relative, created))
 	}
 	if err := file.Chmod(mode.Perm()); err != nil {
-		return errors.Join(err, file.Close(), removeCreatedFileIfMatching(root, relative, created))
+		return errors.Join(fmt.Errorf("chmod confined target %s: %w", target, err), closeFileOnce(file, target), removeCreatedFileIfMatching(root, relative, created))
 	}
-	if err := file.Close(); err != nil {
+	if err := closeFileOnce(file, target); err != nil {
 		return errors.Join(err, removeCreatedFileIfMatching(root, relative, created))
 	}
+	actionCompleted = true
 	return nil
 }
 

--- a/internal/state/cleanup_test.go
+++ b/internal/state/cleanup_test.go
@@ -1,0 +1,596 @@
+package state
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+type cleanupMarker interface {
+	CleanupFailure() bool
+}
+
+func replaceStateFileOps(t *testing.T, mutate func(*fileOperations)) func() {
+	t.Helper()
+	original := stateFileOps
+	mutate(&stateFileOps)
+	restored := false
+	restore := func() {
+		if restored {
+			return
+		}
+		stateFileOps = original
+		restored = true
+	}
+	t.Cleanup(restore)
+	return restore
+}
+
+func requireCleanupMarker(t *testing.T, err error) {
+	t.Helper()
+	var marker cleanupMarker
+	if !errors.As(err, &marker) || !marker.CleanupFailure() {
+		t.Fatalf("error = %v, want structural cleanup marker", err)
+	}
+}
+
+type modeFileInfo struct {
+	mode os.FileMode
+}
+
+func (i modeFileInfo) Name() string       { return "installed.json.lock" }
+func (i modeFileInfo) Size() int64        { return 0 }
+func (i modeFileInfo) Mode() os.FileMode  { return i.mode }
+func (i modeFileInfo) ModTime() time.Time { return time.Time{} }
+func (i modeFileInfo) IsDir() bool        { return i.mode.IsDir() }
+func (i modeFileInfo) Sys() any           { return nil }
+
+func TestLockMetadataJoinsInitializationCleanupFailures(t *testing.T) {
+	primaryErr := errors.New("injected primary failure")
+	cleanupErr := errors.New("injected cleanup failure")
+	tests := []struct {
+		name           string
+		primaryContext string
+		wantPrimary    bool
+		mutate         func(*fileOperations, *int)
+	}{
+		{
+			name:           "new file returns nil",
+			primaryContext: "open lock file",
+			mutate: func(ops *fileOperations, closeCalls *int) {
+				newFileCalls := 0
+				ops.newFile = func(fd uintptr, name string) *os.File {
+					newFileCalls++
+					if newFileCalls == 1 {
+						return nil
+					}
+					return os.NewFile(fd, name)
+				}
+				ops.closeFD = func(fd int) error {
+					(*closeCalls)++
+					if err := unix.Close(fd); err != nil {
+						return err
+					}
+					return cleanupErr
+				}
+			},
+		},
+		{
+			name:           "stat",
+			primaryContext: "stat lock file",
+			wantPrimary:    true,
+			mutate: func(ops *fileOperations, closeCalls *int) {
+				statCalls := 0
+				ops.stat = func(file *os.File) (os.FileInfo, error) {
+					statCalls++
+					if statCalls == 1 {
+						return nil, primaryErr
+					}
+					return file.Stat()
+				}
+				ops.closeFile = closeFileOnceWithFailure(closeCalls, cleanupErr)
+			},
+		},
+		{
+			name:           "non regular",
+			primaryContext: "is not a regular file",
+			mutate: func(ops *fileOperations, closeCalls *int) {
+				statCalls := 0
+				ops.stat = func(file *os.File) (os.FileInfo, error) {
+					statCalls++
+					if statCalls == 1 {
+						return modeFileInfo{mode: os.ModeDir | 0o700}, nil
+					}
+					return file.Stat()
+				}
+				ops.closeFile = closeFileOnceWithFailure(closeCalls, cleanupErr)
+			},
+		},
+		{
+			name:           "flock",
+			primaryContext: "acquire lock file",
+			wantPrimary:    true,
+			mutate: func(ops *fileOperations, closeCalls *int) {
+				lockCalls := 0
+				ops.flock = func(fd, operation int) error {
+					if operation == unix.LOCK_EX {
+						lockCalls++
+						if lockCalls == 1 {
+							return primaryErr
+						}
+					}
+					return unix.Flock(fd, operation)
+				}
+				ops.closeFile = closeFileOnceWithFailure(closeCalls, cleanupErr)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := Path(t.TempDir())
+			closeCalls := 0
+			restore := replaceStateFileOps(t, func(ops *fileOperations) {
+				tt.mutate(ops, &closeCalls)
+			})
+
+			locked, err := LockMetadata(path)
+			if locked != nil || err == nil {
+				t.Fatalf("LockMetadata() = %#v, %v, want nil lock and error", locked, err)
+			}
+			if !errors.Is(err, cleanupErr) {
+				t.Fatalf("error = %v, want cleanup failure", err)
+			}
+			if tt.wantPrimary && !errors.Is(err, primaryErr) {
+				t.Fatalf("error = %v, want primary failure", err)
+			}
+			if !strings.Contains(err.Error(), tt.primaryContext) || !strings.Contains(err.Error(), path+".lock") {
+				t.Fatalf("error = %q, want operation and lock path", err)
+			}
+			requireCleanupMarker(t, err)
+			if closeCalls != 1 {
+				t.Fatalf("close calls = %d, want exactly 1", closeCalls)
+			}
+
+			restore()
+			next, err := LockMetadata(path)
+			if err != nil {
+				t.Fatalf("LockMetadata() after cleanup error = %v", err)
+			}
+			if err := next.Close(); err != nil {
+				t.Fatalf("Close() after cleanup error = %v", err)
+			}
+		})
+	}
+}
+
+func closeFileOnceWithFailure(closeCalls *int, injected error) func(*os.File) error {
+	return func(file *os.File) error {
+		(*closeCalls)++
+		if err := file.Close(); err != nil {
+			return err
+		}
+		if *closeCalls == 1 {
+			return injected
+		}
+		return nil
+	}
+}
+
+func TestPrimaryFailureIsNotMarkedAsCleanup(t *testing.T) {
+	path := Path(t.TempDir())
+	primaryErr := errors.New("injected write failure")
+	replaceStateFileOps(t, func(ops *fileOperations) {
+		ops.write = func(*os.File, []byte) (int, error) { return 0, primaryErr }
+	})
+
+	err := save(path, Metadata{Version: CurrentVersion})
+	if !errors.Is(err, primaryErr) {
+		t.Fatalf("save() error = %v, want primary failure", err)
+	}
+	var marker cleanupMarker
+	if errors.As(err, &marker) {
+		t.Fatalf("save() error = %v, pure primary failure must not be marked as cleanup", err)
+	}
+}
+
+func TestLockedMetadataCloseJoinsIndependentCleanupFailuresOnce(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		failUnlock bool
+		failClose  bool
+	}{
+		{name: "unlock", failUnlock: true},
+		{name: "close", failClose: true},
+		{name: "unlock and close", failUnlock: true, failClose: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			path := Path(t.TempDir())
+			locked, err := LockMetadata(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			unlockErr := errors.New("injected unlock failure")
+			closeErr := errors.New("injected close failure")
+			unlockCalls := 0
+			closeCalls := 0
+			restore := replaceStateFileOps(t, func(ops *fileOperations) {
+				ops.flock = func(fd, operation int) error {
+					if operation != unix.LOCK_UN {
+						return unix.Flock(fd, operation)
+					}
+					unlockCalls++
+					if err := unix.Flock(fd, operation); err != nil {
+						return err
+					}
+					if tt.failUnlock {
+						return unlockErr
+					}
+					return nil
+				}
+				ops.closeFile = func(file *os.File) error {
+					closeCalls++
+					if err := file.Close(); err != nil {
+						return err
+					}
+					if tt.failClose {
+						return closeErr
+					}
+					return nil
+				}
+			})
+
+			err = locked.Close()
+			if err == nil {
+				t.Fatal("Close() error = nil, want injected cleanup failure")
+			}
+			if tt.failUnlock && (!errors.Is(err, unlockErr) || !strings.Contains(err.Error(), "unlock installation metadata lock "+path+".lock")) {
+				t.Fatalf("Close() error = %v, want contextual unlock failure", err)
+			}
+			if tt.failClose && (!errors.Is(err, closeErr) || !strings.Contains(err.Error(), "close installation metadata lock "+path+".lock")) {
+				t.Fatalf("Close() error = %v, want contextual close failure", err)
+			}
+			requireCleanupMarker(t, err)
+			if unlockCalls != 1 || closeCalls != 1 {
+				t.Fatalf("cleanup calls = unlock %d, close %d, want exactly 1 each", unlockCalls, closeCalls)
+			}
+			if err := locked.Close(); err != nil {
+				t.Fatalf("second Close() error = %v, want nil", err)
+			}
+			if unlockCalls != 1 || closeCalls != 1 {
+				t.Fatalf("cleanup calls after second Close = unlock %d, close %d, want unchanged", unlockCalls, closeCalls)
+			}
+
+			restore()
+			next, err := LockMetadata(path)
+			if err != nil {
+				t.Fatalf("LockMetadata() after real release = %v", err)
+			}
+			if err := next.Close(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestSaveTempPrimaryFailureJoinsCloseAndPreservesPreviousMetadata(t *testing.T) {
+	for _, operation := range []string{"chmod", "write"} {
+		t.Run(operation, func(t *testing.T) {
+			path := Path(t.TempDir())
+			previous := []byte("{\"version\":7,\"entries\":[]}\n")
+			if err := os.WriteFile(path, previous, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			primaryErr := errors.New("injected " + operation + " failure")
+			closeErr := errors.New("injected temp close failure")
+			closeCalls := 0
+			restore := replaceStateFileOps(t, func(ops *fileOperations) {
+				if operation == "chmod" {
+					ops.chmod = func(*os.File, os.FileMode) error { return primaryErr }
+				} else {
+					ops.write = func(*os.File, []byte) (int, error) { return 0, primaryErr }
+				}
+				ops.closeFile = func(file *os.File) error {
+					closeCalls++
+					if err := file.Close(); err != nil {
+						return err
+					}
+					return closeErr
+				}
+			})
+
+			err := save(path, Metadata{Version: CurrentVersion})
+			if !errors.Is(err, primaryErr) || !errors.Is(err, closeErr) {
+				t.Fatalf("save() error = %v, want primary and close failures", err)
+			}
+			if !strings.Contains(err.Error(), operation+" installation metadata temporary file ") || !strings.Contains(err.Error(), "close installation metadata temporary file ") {
+				t.Fatalf("save() error = %q, want lowercase operation and temp path contexts", err)
+			}
+			requireCleanupMarker(t, err)
+			if closeCalls != 1 {
+				t.Fatalf("temp close calls = %d, want exactly 1", closeCalls)
+			}
+			got, readErr := os.ReadFile(path)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if string(got) != string(previous) {
+				t.Fatalf("installed metadata = %q, want prior bytes %q", got, previous)
+			}
+
+			restore()
+			if err := save(path, Metadata{Version: CurrentVersion}); err != nil {
+				t.Fatalf("save() rerun error = %v", err)
+			}
+		})
+	}
+}
+
+func TestSaveTempPrimaryFailureJoinsRemoveCleanup(t *testing.T) {
+	path := Path(t.TempDir())
+	previous := []byte("{\"version\":7,\"entries\":[]}\n")
+	if err := os.WriteFile(path, previous, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	primaryErr := errors.New("injected write failure")
+	removeErr := errors.New("injected remove failure")
+	removeCalls := 0
+	restore := replaceStateFileOps(t, func(ops *fileOperations) {
+		ops.write = func(*os.File, []byte) (int, error) { return 0, primaryErr }
+		originalRemove := ops.remove
+		ops.remove = func(path string) error {
+			removeCalls++
+			if err := originalRemove(path); err != nil {
+				return err
+			}
+			return removeErr
+		}
+	})
+
+	err := save(path, Metadata{Version: CurrentVersion})
+	if !errors.Is(err, primaryErr) || !errors.Is(err, removeErr) {
+		t.Fatalf("save() error = %v, want primary and remove failures", err)
+	}
+	if !strings.Contains(err.Error(), "write installation metadata temporary file ") || !strings.Contains(err.Error(), "remove installation metadata temporary file ") {
+		t.Fatalf("save() error = %q, want lowercase operation and temp path contexts", err)
+	}
+	requireCleanupMarker(t, err)
+	if removeCalls != 1 {
+		t.Fatalf("remove calls = %d, want exactly 1", removeCalls)
+	}
+	got, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(got) != string(previous) {
+		t.Fatalf("installed metadata = %q, want prior bytes %q", got, previous)
+	}
+
+	restore()
+	if err := save(path, Metadata{Version: CurrentVersion}); err != nil {
+		t.Fatalf("save() rerun error = %v", err)
+	}
+}
+
+func TestSaveTempCloseFailureBeforeRenamePreservesPreviousMetadata(t *testing.T) {
+	path := Path(t.TempDir())
+	previous := []byte("{\"version\":7,\"entries\":[]}\n")
+	if err := os.WriteFile(path, previous, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	closeErr := errors.New("injected temp close failure")
+	closeCalls := 0
+	replaceStateFileOps(t, func(ops *fileOperations) {
+		ops.closeFile = func(file *os.File) error {
+			closeCalls++
+			if err := file.Close(); err != nil {
+				return err
+			}
+			return closeErr
+		}
+	})
+
+	err := save(path, Metadata{Version: CurrentVersion})
+	if !errors.Is(err, closeErr) || !strings.Contains(err.Error(), "close installation metadata temporary file ") {
+		t.Fatalf("save() error = %v, want contextual close failure", err)
+	}
+	requireCleanupMarker(t, err)
+	if closeCalls != 1 {
+		t.Fatalf("temp close calls = %d, want exactly 1", closeCalls)
+	}
+	got, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(got) != string(previous) {
+		t.Fatalf("installed metadata = %q, want prior bytes %q", got, previous)
+	}
+}
+
+func TestSaveJoinsPrimaryAndLockCleanupFailuresOnce(t *testing.T) {
+	path := Path(t.TempDir())
+	previous := []byte("{\"version\":7,\"entries\":[]}\n")
+	if err := os.WriteFile(path, previous, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writeErr := errors.New("injected write failure")
+	lockCloseErr := errors.New("injected lock close failure")
+	tempCloseCalls := 0
+	lockCloseCalls := 0
+	restore := replaceStateFileOps(t, func(ops *fileOperations) {
+		ops.write = func(*os.File, []byte) (int, error) { return 0, writeErr }
+		ops.closeFile = func(file *os.File) error {
+			if strings.HasSuffix(file.Name(), ".lock") {
+				lockCloseCalls++
+				if err := file.Close(); err != nil {
+					return err
+				}
+				return lockCloseErr
+			}
+			tempCloseCalls++
+			return file.Close()
+		}
+	})
+
+	err := Save(path, Metadata{Version: CurrentVersion})
+	if !errors.Is(err, writeErr) || !errors.Is(err, lockCloseErr) {
+		t.Fatalf("Save() error = %v, want write and lock close failures", err)
+	}
+	requireCleanupMarker(t, err)
+	if tempCloseCalls != 1 || lockCloseCalls != 1 {
+		t.Fatalf("close calls = temp %d, lock %d, want exactly 1 each", tempCloseCalls, lockCloseCalls)
+	}
+	got, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(got) != string(previous) {
+		t.Fatalf("installed metadata = %q, want prior bytes %q", got, previous)
+	}
+
+	restore()
+	if err := Save(path, Metadata{Version: CurrentVersion}); err != nil {
+		t.Fatalf("Save() rerun error = %v", err)
+	}
+}
+
+func TestUpdateJoinsCallbackAndLockCleanupFailuresOnce(t *testing.T) {
+	path := Path(t.TempDir())
+	if err := Save(path, Metadata{Version: CurrentVersion}); err != nil {
+		t.Fatal(err)
+	}
+	updateErr := errors.New("injected update failure")
+	lockCloseErr := errors.New("injected lock close failure")
+	closeCalls := 0
+	restore := replaceStateFileOps(t, func(ops *fileOperations) {
+		ops.closeFile = func(file *os.File) error {
+			closeCalls++
+			if err := file.Close(); err != nil {
+				return err
+			}
+			return lockCloseErr
+		}
+	})
+
+	err := Update(path, func(*Metadata) error { return updateErr })
+	if !errors.Is(err, updateErr) || !errors.Is(err, lockCloseErr) {
+		t.Fatalf("Update() error = %v, want callback and lock close failures", err)
+	}
+	requireCleanupMarker(t, err)
+	if closeCalls != 1 {
+		t.Fatalf("lock close calls = %d, want exactly 1", closeCalls)
+	}
+
+	restore()
+	if err := Update(path, func(meta *Metadata) error {
+		meta.Entries = append(meta.Entries, Record{Target: "/rerun"})
+		return nil
+	}); err != nil {
+		t.Fatalf("Update() rerun error = %v", err)
+	}
+}
+
+func TestSaveReturnsLockCleanupFailuresAfterDurableMetadata(t *testing.T) {
+	path := Path(t.TempDir())
+	want := Metadata{Version: CurrentVersion, Entries: []Record{{Target: "/durable", Strategy: "copy"}}}
+	unlockErr := errors.New("injected unlock failure")
+	closeErr := errors.New("injected close failure")
+	unlockCalls := 0
+	lockCloseCalls := 0
+	tempCloseCalls := 0
+	restore := replaceStateFileOps(t, func(ops *fileOperations) {
+		ops.flock = func(fd, operation int) error {
+			if operation != unix.LOCK_UN {
+				return unix.Flock(fd, operation)
+			}
+			unlockCalls++
+			if err := unix.Flock(fd, operation); err != nil {
+				return err
+			}
+			return unlockErr
+		}
+		ops.closeFile = func(file *os.File) error {
+			if strings.HasSuffix(file.Name(), ".lock") {
+				lockCloseCalls++
+				if err := file.Close(); err != nil {
+					return err
+				}
+				return closeErr
+			}
+			tempCloseCalls++
+			return file.Close()
+		}
+	})
+
+	err := Save(path, want)
+	if !errors.Is(err, unlockErr) || !errors.Is(err, closeErr) {
+		t.Fatalf("Save() error = %v, want unlock and close failures", err)
+	}
+	requireCleanupMarker(t, err)
+	if unlockCalls != 1 || lockCloseCalls != 1 || tempCloseCalls != 1 {
+		t.Fatalf("cleanup calls = unlock %d, lock close %d, temp close %d, want 1 each", unlockCalls, lockCloseCalls, tempCloseCalls)
+	}
+	wantBytes, marshalErr := json.MarshalIndent(want, "", "  ")
+	if marshalErr != nil {
+		t.Fatal(marshalErr)
+	}
+	wantBytes = append(wantBytes, '\n')
+	gotBytes, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(gotBytes) != string(wantBytes) {
+		t.Fatalf("durable metadata = %q, want exact bytes %q", gotBytes, wantBytes)
+	}
+
+	restore()
+	locked, err := LockMetadata(path)
+	if err != nil {
+		t.Fatalf("LockMetadata() after durable cleanup error = %v", err)
+	}
+	if err := locked.Close(); err != nil {
+		t.Fatal(err)
+	}
+	next := Metadata{Version: CurrentVersion, Entries: []Record{{Target: "/rerun", Strategy: "copy"}}}
+	if err := Save(path, next); err != nil {
+		t.Fatalf("Save() rerun error = %v", err)
+	}
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded.Entries) != 1 || loaded.Entries[0].Target != "/rerun" {
+		t.Fatalf("metadata after rerun = %#v, want rerun record", loaded)
+	}
+}
+
+func TestSaveShortWriteJoinsTempCloseFailure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "installed.json")
+	closeErr := errors.New("injected close failure")
+	closeCalls := 0
+	replaceStateFileOps(t, func(ops *fileOperations) {
+		ops.write = func(*os.File, []byte) (int, error) { return 0, nil }
+		ops.closeFile = func(file *os.File) error {
+			closeCalls++
+			if err := file.Close(); err != nil {
+				return err
+			}
+			return closeErr
+		}
+	})
+
+	err := save(path, Metadata{Version: CurrentVersion})
+	if !errors.Is(err, io.ErrShortWrite) || !errors.Is(err, closeErr) {
+		t.Fatalf("save() error = %v, want short write and close failures", err)
+	}
+	if closeCalls != 1 {
+		t.Fatalf("temp close calls = %d, want exactly 1", closeCalls)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -23,6 +23,47 @@ import (
 // CurrentVersion is the current Installation Metadata schema version.
 const CurrentVersion = 8
 
+type fileOperations struct {
+	open       func(string, int, uint32) (int, error)
+	newFile    func(uintptr, string) *os.File
+	stat       func(*os.File) (os.FileInfo, error)
+	flock      func(int, int) error
+	closeFD    func(int) error
+	closeFile  func(*os.File) error
+	createTemp func(string, string) (*os.File, error)
+	chmod      func(*os.File, os.FileMode) error
+	write      func(*os.File, []byte) (int, error)
+	remove     func(string) error
+}
+
+var stateFileOps = fileOperations{
+	open:       unix.Open,
+	newFile:    os.NewFile,
+	stat:       func(file *os.File) (os.FileInfo, error) { return file.Stat() },
+	flock:      unix.Flock,
+	closeFD:    unix.Close,
+	closeFile:  func(file *os.File) error { return file.Close() },
+	createTemp: os.CreateTemp,
+	chmod:      func(file *os.File, mode os.FileMode) error { return file.Chmod(mode) },
+	write:      func(file *os.File, data []byte) (int, error) { return file.Write(data) },
+	remove:     os.Remove,
+}
+
+type cleanupFailure struct {
+	err error
+}
+
+func (e cleanupFailure) Error() string        { return e.err.Error() }
+func (e cleanupFailure) Unwrap() error        { return e.err }
+func (e cleanupFailure) CleanupFailure() bool { return true }
+
+func asCleanupFailure(err error) error {
+	if err == nil {
+		return nil
+	}
+	return cleanupFailure{err: err}
+}
+
 // Metadata is the machine-readable record of installed managed targets.
 type Metadata struct {
 	Version            int                 `json:"version"`
@@ -290,29 +331,40 @@ func LockMetadata(path string) (*LockedMetadata, error) {
 		return nil, fmt.Errorf("lock installation metadata: create state directory: %w", err)
 	}
 	lockPath := path + ".lock"
-	fd, err := unix.Open(lockPath, unix.O_CREAT|unix.O_RDWR|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0o600)
+	fd, err := stateFileOps.open(lockPath, unix.O_CREAT|unix.O_RDWR|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0o600)
 	if err != nil {
-		return nil, fmt.Errorf("lock installation metadata: open lock file: %w", err)
+		return nil, fmt.Errorf("lock installation metadata: open lock file %s: %w", lockPath, err)
 	}
-	file := os.NewFile(uintptr(fd), lockPath)
+	file := stateFileOps.newFile(uintptr(fd), lockPath)
 	if file == nil {
-		_ = unix.Close(fd)
-		return nil, fmt.Errorf("lock installation metadata: open lock file returned no handle")
+		primaryErr := fmt.Errorf("lock installation metadata: open lock file %s returned no handle", lockPath)
+		closeErr := stateFileOps.closeFD(fd)
+		if closeErr != nil {
+			closeErr = asCleanupFailure(fmt.Errorf("lock installation metadata: close lock file descriptor %s: %w", lockPath, closeErr))
+		}
+		return nil, errors.Join(primaryErr, closeErr)
 	}
-	info, err := file.Stat()
+	info, err := stateFileOps.stat(file)
 	if err != nil {
-		_ = file.Close()
-		return nil, fmt.Errorf("lock installation metadata: stat lock file: %w", err)
+		primaryErr := fmt.Errorf("lock installation metadata: stat lock file %s: %w", lockPath, err)
+		return nil, errors.Join(primaryErr, closeLockFile(file, lockPath))
 	}
 	if !info.Mode().IsRegular() {
-		_ = file.Close()
-		return nil, fmt.Errorf("lock installation metadata: lock path is not a regular file")
+		primaryErr := fmt.Errorf("lock installation metadata: lock path %s is not a regular file", lockPath)
+		return nil, errors.Join(primaryErr, closeLockFile(file, lockPath))
 	}
-	if err := unix.Flock(fd, unix.LOCK_EX); err != nil {
-		_ = file.Close()
-		return nil, fmt.Errorf("lock installation metadata: acquire: %w", err)
+	if err := stateFileOps.flock(fd, unix.LOCK_EX); err != nil {
+		primaryErr := fmt.Errorf("lock installation metadata: acquire lock file %s: %w", lockPath, err)
+		return nil, errors.Join(primaryErr, closeLockFile(file, lockPath))
 	}
 	return &LockedMetadata{path: path, file: file}, nil
+}
+
+func closeLockFile(file *os.File, lockPath string) error {
+	if err := stateFileOps.closeFile(file); err != nil {
+		return asCleanupFailure(fmt.Errorf("lock installation metadata: close lock file %s: %w", lockPath, err))
+	}
+	return nil
 }
 
 // Load reads the metadata while the exclusive lock is held.
@@ -348,13 +400,14 @@ func (l *LockedMetadata) Close() error {
 		return nil
 	}
 	l.closed = true
-	unlockErr := unix.Flock(int(l.file.Fd()), unix.LOCK_UN)
-	closeErr := l.file.Close()
+	lockPath := l.path + ".lock"
+	unlockErr := stateFileOps.flock(int(l.file.Fd()), unix.LOCK_UN)
+	closeErr := stateFileOps.closeFile(l.file)
 	if unlockErr != nil {
-		unlockErr = fmt.Errorf("unlock installation metadata: %w", unlockErr)
+		unlockErr = asCleanupFailure(fmt.Errorf("unlock installation metadata lock %s: %w", lockPath, unlockErr))
 	}
 	if closeErr != nil {
-		closeErr = fmt.Errorf("close installation metadata lock: %w", closeErr)
+		closeErr = asCleanupFailure(fmt.Errorf("close installation metadata lock %s: %w", lockPath, closeErr))
 	}
 	return errors.Join(unlockErr, closeErr)
 }
@@ -391,7 +444,7 @@ func Save(path string, meta Metadata) error {
 	return errors.Join(saveErr, locked.Close())
 }
 
-func save(path string, meta Metadata) error {
+func save(path string, meta Metadata) (resultErr error) {
 	data, err := json.MarshalIndent(meta, "", "  ")
 	if err != nil {
 		return fmt.Errorf("encode installation metadata: %w", err)
@@ -401,25 +454,39 @@ func save(path string, meta Metadata) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("create state directory: %w", err)
 	}
-	temp, err := os.CreateTemp(dir, ".installed-*.tmp")
+	temp, err := stateFileOps.createTemp(dir, ".installed-*.tmp")
 	if err != nil {
-		return fmt.Errorf("write installation metadata: %w", err)
+		return fmt.Errorf("create installation metadata temporary file for %s: %w", path, err)
 	}
 	tempPath := temp.Name()
-	defer os.Remove(tempPath)
-	if err := temp.Chmod(0o600); err != nil {
-		temp.Close()
-		return fmt.Errorf("write installation metadata: %w", err)
+	defer func() {
+		if err := stateFileOps.remove(tempPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			resultErr = errors.Join(resultErr, asCleanupFailure(fmt.Errorf("remove installation metadata temporary file %s: %w", tempPath, err)))
+		}
+	}()
+	if err := stateFileOps.chmod(temp, 0o600); err != nil {
+		primaryErr := fmt.Errorf("chmod installation metadata temporary file %s: %w", tempPath, err)
+		return errors.Join(primaryErr, closeTemporaryMetadata(temp, tempPath))
 	}
-	if _, err := temp.Write(data); err != nil {
-		temp.Close()
-		return fmt.Errorf("write installation metadata: %w", err)
+	if n, err := stateFileOps.write(temp, data); err != nil {
+		primaryErr := fmt.Errorf("write installation metadata temporary file %s: %w", tempPath, err)
+		return errors.Join(primaryErr, closeTemporaryMetadata(temp, tempPath))
+	} else if n != len(data) {
+		primaryErr := fmt.Errorf("write installation metadata temporary file %s: %w", tempPath, io.ErrShortWrite)
+		return errors.Join(primaryErr, closeTemporaryMetadata(temp, tempPath))
 	}
-	if err := temp.Close(); err != nil {
-		return fmt.Errorf("write installation metadata: %w", err)
+	if err := closeTemporaryMetadata(temp, tempPath); err != nil {
+		return err
 	}
 	if err := os.Rename(tempPath, path); err != nil {
-		return fmt.Errorf("write installation metadata: %w", err)
+		return fmt.Errorf("rename installation metadata temporary file %s to %s: %w", tempPath, path, err)
+	}
+	return nil
+}
+
+func closeTemporaryMetadata(temp *os.File, tempPath string) error {
+	if err := stateFileOps.closeFile(temp); err != nil {
+		return asCleanupFailure(fmt.Errorf("close installation metadata temporary file %s: %w", tempPath, err))
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #490

## PR Type

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Propagates filesystem, descriptor, lock, and temporary-file cleanup failures with lowercase operation/path context.
- Delivers selector cleanup failures exactly once and preserves exact post-mutation Installation Metadata evidence before returning them.
- Adds deterministic fault-injection coverage for simultaneous primary/cleanup failures, typed `errors.Is`/`errors.As`, compensation, safe reruns, and accepted-candidate lifecycles.

## Changes

| File | Change |
|------|--------|
| `internal/install/install.go` | Classifies and joins confined descriptor cleanup, preserves completed-action evidence, and adds private deterministic fault seams. |
| `internal/install/cleanup_internal_test.go` | Covers cleanup-only and simultaneous primary/cleanup failures, exactly-once close behavior, compensation, receipts, partial inventory, external edits, and safe reruns. |
| `internal/state/state.go` | Propagates lock, file, descriptor, and temporary-removal cleanup failures without changing metadata schema. |
| `internal/state/cleanup_test.go` | Covers lock/temp cleanup combinations, durable bytes, re-locking, typed cleanup classification, and reruns. |
| `internal/cli/install_tag_selector.go` | Separates synchronous cleanup return from genuinely late sink delivery and prevents duplicate reporting. |
| `internal/cli/install_tag_selector_internal_test.go` | Covers synchronous and late selector lifecycle transitions exactly once. |
| `internal/cli/testdata/install_tag_selector_mixed_result.golden` | Removes the extra trailing blank line. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go build ./...`
- [x] `git diff --check origin/main...HEAD`
- [x] `go test -race ./internal/install ./internal/state ./internal/cli ./internal/tui/tagselector -count=1`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml`
- [x] Sandboxed plan: real binary `plan --file dots.yaml --profile core --source-root "$PWD" --home <tmp>/home --state-root <tmp>/state` exited 0 with no writes.
- [x] Sandboxed install preview: real binary `install --dry-run --yes --skip-deps ...` exited 0 with no writes.
- [x] Sandboxed status: real binary `status --output json ...` exited 2 with `schema_version: "10"`, `status: "findings"`, and no writes.

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] All CLI validation used temporary directories with explicit `--home`, `--source-root`, and `--state-root` flags.
- [x] Validation did not invoke package managers, Provisioners, or the network.

## Contributor Checklist

- [x] Linked one issue with an admitted Delivery Contract using `Closes #490`.
- [x] Added exactly one `type:*` label.
- [x] Delivery Evidence records the Contract Source snapshot, Acceptance coverage, and Independent review.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Docs or agent instructions were not changed because public workflow and schema remain unchanged.
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

### Contract Source snapshot

- Kind: standalone GitHub Issue body.
- Source: `I_kwDOSzLlmM8AAAABN42IIQ`, https://github.com/yersonargotev/dots/issues/490.
- `updatedAt`: `2026-08-23T12:58:09Z`.
- Exact body SHA-256: `2741b7e3ea4598bc99a2dea87c111aea66d994239b15441d0d0723e7f111807c`.
- Category/readiness: `bug`, `ready-for-agent`.
- Native relationships: no parent, sub-issues, blockers, or blocking issues; no comments after snapshot.
- Reviewed HEAD: `216741bdf9fd7535ca70a3f93af3bda82d8e631f` against base `2993ddbe45c0b57ff4854bb8dca6df4ca7f0727b`.

### Mutation safety

- Result: `required-mutation`.
- Safety invariant: before any cleanup error is surfaced, completed mutations retain an exact receipt or completed-prefix inventory; pre-completion failures remain fail-closed; every cleanup attempt is delivered once and genuine Close failures are never retried because descriptors may be reused.
- Mutation map: install target/backup/receipt/partial-metadata writes; Installation Metadata lock/temp/rename lifecycle; selector candidate ownership transfer and release.
- Decision matrix: pre-mutation cleanup joins the primary error without claiming completion; post-mutation cleanup first persists exact evidence then returns; a persistence failure joins contextual cleanup/rollback errors; genuinely late selector cleanup uses only the late sink.
- Fault seams: root/file/fd/new-file/write operations in `internal/install`; lock/file/fd/temp/chmod/write/remove operations in `internal/state`; selector provider close and late-error sink transitions in `internal/cli`.
- Independent safety challenge: PASS, zero actionable findings. Residual close-state uncertainty is handled by exactly-once/no-retry semantics and deterministic seams release the real resource before returning injected faults.

### Acceptance coverage

- All scoped Close/remove failures are checked, classified, contextualized, and joined while retaining `errors.Is`/`errors.As`.
- Synchronous versus late selector cleanup is exclusive and tested across active, rejected, superseded, replaced, and stored-close transitions.
- Exact accepted-candidate lifecycle, fail-closed authority, reconciliation receipts, completed-prefix inventory, Installed Selection, schema 10, semantic exits, and uninstall behavior are preserved.
- Golden output has one terminal newline and diff checks pass.

### Automated validation

- PASS: `gofmt -l .` (no output), `git diff --check origin/main...HEAD`, `go vet ./...`, `go build ./...`, `go test ./...`.
- PASS: `go test -race ./internal/install ./internal/state ./internal/cli ./internal/tui/tagselector -count=1`.
- PASS: focused package and fault-injection tests for install, state, selector CLI, and TUI.

### Manual verification

- PASS: built a real `dots` binary and used only explicit temporary Home/Source of Truth/state roots.
- `manifest validate` passed; sandboxed `plan` and `install --dry-run --yes --skip-deps` exited 0; JSON `status` exited 2 with schema 10/findings.
- Fingerprints before and after plan/install/status were identical: no files were written under temporary Home or state roots.

### Independent review

- Spec: PASS, zero actionable findings; all requirements/non-goals and the repaired simultaneous primary+cleanup coverage verified.
- Standards: PASS, zero actionable findings; prior unchecked cleanup/context findings fixed. The repeated lifecycle-local defer shape is a non-actionable judgement observation because extracting it would hide completion boundaries.
<!-- delivery-issue:evidence:end -->
