### PR TITLE
feat(herdr): add Vim navigation to workspace picker

### DIFF
--- a/configs/herdr/config-adaptive.toml
+++ b/configs/herdr/config-adaptive.toml
@@ -63,6 +63,9 @@ prefix = "ctrl+a"
 # Keep Herdr's default detach plus dots' tmux/Zellij capital-D muscle memory.
 detach = ["prefix+q", "prefix+shift+d"]
 workspace_picker = "prefix+w"
+# Keep the workspace picker usable with both arrow keys and Vim movement.
+navigate_workspace_up = ["up", "k"]
+navigate_workspace_down = ["down", "j"]
 goto = "prefix+g"
 new_workspace = "prefix+shift+n"
 rename_workspace = "prefix+shift+w"

--- a/configs/herdr/config.toml
+++ b/configs/herdr/config.toml
@@ -57,6 +57,9 @@ prefix = "ctrl+a"
 # Keep Herdr's default detach plus dots' tmux/Zellij capital-D muscle memory.
 detach = ["prefix+q", "prefix+shift+d"]
 workspace_picker = "prefix+w"
+# Keep the workspace picker usable with both arrow keys and Vim movement.
+navigate_workspace_up = ["up", "k"]
+navigate_workspace_down = ["down", "j"]
 goto = "prefix+g"
 new_workspace = "prefix+shift+n"
 rename_workspace = "prefix+shift+w"

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -3939,6 +3939,8 @@ rows = [
 		}
 	}
 	for _, want := range []string{
+		`navigate_workspace_up = ["up", "k"]`,
+		`navigate_workspace_down = ["down", "j"]`,
 		`previous_workspace = "prefix+alt+k"`,
 		`next_workspace = "prefix+alt+j"`,
 		`previous_agent = "prefix+alt+h"`,


### PR DESCRIPTION
Closes #495

## PR Type

Check exactly one and add the matching `type:*` label to the PR.

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Add Vim-style `j`/`k` movement to Herdr's `prefix+w` workspace picker.
- Preserve the existing down/up arrow bindings.
- Guard both default and adaptive Managed Configuration variants against drift.

## Changes

| File | Change |
|------|--------|
| `configs/herdr/config.toml` | Bind workspace selection to `up`/`k` and `down`/`j`. |
| `configs/herdr/config-adaptive.toml` | Mirror the portable picker bindings in the adaptive variant. |
| `internal/manifest/manifest_test.go` | Assert the exact bindings while retaining whole non-theme synchronization coverage. |

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go run ./cmd/dots manifest validate --file dots.yaml` (validated with the same temporary built binary instead of `go run`)
- [x] Sandboxed plan only when dotfiles behavior changes: built binary `plan --file dots.yaml --tag herdr --source-root "$PWD" --home <tmp> --state-root <tmp> --output json`

## Dotfiles Safety

- [x] I did not run `dots install` against the real home directory.
- [x] I did not write to real local configuration such as `~/.zshrc`, `~/.tmux.conf`, `~/.gitconfig`, or `~/.config/starship.toml`.
- [x] Any CLI validation that targets home/config paths used temporary directories and explicit flags such as `--home <tmp>`, `--source-root "$PWD"`, and `--state-root <tmp>` where supported.

## Contributor Checklist

- [x] Linked one issue with an admitted Delivery Contract using `Closes #495`.
- [x] Added exactly one `type:*` label.
- [x] Delivery Evidence records the Contract Source snapshot, Acceptance coverage, and Independent review.
- [x] Kept the PR scoped to one reviewable work unit.
- [x] Updated docs or agent instructions when workflow behavior changed. (Not applicable: no workflow behavior changed.)
- [x] Used conventional commit format.
- [x] Did not add `Co-Authored-By` or AI attribution trailers.

<!-- delivery-issue:evidence:start -->
## Delivery Evidence

### Contract Source snapshot

- Kind: standalone issue body.
- Source: body ID `I_kwDOSzLlmM8AAAABOHZmiQ`, https://github.com/yersonargotev/dots/issues/495.
- `updatedAt`: `2026-08-25T05:03:00Z`.
- SHA-256: `e83372c7b0de2ea581dfdc59d474600f0f676b5eb6d3882b07b574033ed2cd11`.
- Category/readiness: `enhancement`, `ready-for-agent`.
- Relationships at admission: no parent, sub-issues, blocked-by, or blocking issues.
- Comments at admission: none.

### Candidate identity

- Base: `8898b791355b62db77b316a5d11d4a9699af2977` (`origin/main`).
- Reviewed head: `867a859157839e5e5b6db4747bb0944195a01595`.

### Mutation safety

- Result: `not applicable`.
- Direct evidence: the diff changes only two declarative Herdr TOML Source of Truth files and their manifest regression assertion. It does not change managed filesystem mutation, Installation Metadata or receipts, recovery/rollback, or concurrently changing authority/identity.

### Acceptance coverage

- `k`/`up` movement: both managed configs declare `navigate_workspace_up = ["up", "k"]`.
- `j`/`down` movement: both managed configs declare `navigate_workspace_down = ["down", "j"]`.
- Existing entry binding: `workspace_picker = "prefix+w"` remains unchanged.
- Variant synchronization: `TestRepositoryHerdrConfigSupportsAdaptiveThemeOverride` asserts exact default bindings and whole non-theme equality with the adaptive variant.
- Parser acceptance: Herdr 0.8.2 reports `config: ok` for both managed configs.

### Automated validation

- `HERDR_CONFIG_PATH="$PWD/configs/herdr/config.toml" herdr config check` — pass.
- `HERDR_CONFIG_PATH="$PWD/configs/herdr/config-adaptive.toml" herdr config check` — pass.
- `go test ./internal/manifest -run TestRepositoryHerdrConfigSupportsAdaptiveThemeOverride` — pass.
- `gofmt -l .` — pass, no output.
- `go vet ./...` — pass.
- `go build ./...` — pass.
- `go test ./...` — pass.
- Temporary built binary `manifest validate --file dots.yaml --output json` — `status: ok`, manifest valid.

### Manual verification

- A temporary real `dots` binary ran `plan --file dots.yaml --tag herdr --source-root "$PWD" --home <tmp> --state-root <tmp> --output json`; exit 0 selected the Herdr Managed Entry as a `copy` action to the temporary home.
- Interactive Herdr TUI keypress automation is not part of this repository. The supported Herdr 0.8.2 parser accepted the exact documented navigation bindings in both artifacts; no live Herdr config was read, written, or reloaded.

### Independent review

- Spec: 0 actionable findings. All requirements and non-goals in #495 are satisfied; low residual risk is limited to the absence of an external interactive picker automation test.
- Standards: 0 actionable findings and 0 code-smell findings. Intentional duplication across theme variants is governed by the repository's documented no-include seam and equality test.
<!-- delivery-issue:evidence:end -->
